### PR TITLE
Remove legacy edit button from organizer links

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
@@ -66,16 +66,6 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
               </div>
             <?php endif; ?>
         
-            <?php if ($peut_modifier) : ?>
-              <button type="button"
-                      class="champ-modifier modifier-liens"
-                      aria-label="Configurer vos liens"
-                      data-champ="liens_publics"
-                      data-cpt="organisateur"
-                      data-post-id="<?= esc_attr($organisateur_id); ?>">
-                ✏️
-              </button>
-            <?php endif; ?>
           </div>
         
           <div class="champ-feedback"></div>


### PR DESCRIPTION
## Summary
- remove obsolete "modifier-liens" button from organizer presentation partial

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685e31c1bbd48332aaa13852cba168be