### PR TITLE
Fix chasse date update check

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -327,8 +327,12 @@ function validerDatesAvantEnvoi(champModifie) {
   const dateMaximum = new Date();
   dateMaximum.setFullYear(dateMaximum.getFullYear() + 5);
 
+  console.log('[validerDatesAvantEnvoi] bornes=', dateMinimum.toISOString(), dateMaximum.toISOString());
+
   const debut = new Date(inputDateDebut.value);
   const fin = new Date(inputDateFin.value);
+
+  console.log('[validerDatesAvantEnvoi] debut=', debut.toISOString(), 'fin=', fin.toISOString());
 
   if (debut < dateMinimum || debut > dateMaximum) {
     if (champModifie === 'debut' && erreurDebut) {
@@ -683,6 +687,7 @@ function enregistrerDatesChasse() {
     date_fin: checkboxIllimitee?.checked ? '' : inputDateFin.value.trim(),
     illimitee: checkboxIllimitee?.checked ? 1 : 0
   });
+  console.log('[enregistrerDatesChasse] params=', params.toString());
 
   return fetch(ajaxurl, {
     method: 'POST',
@@ -691,6 +696,7 @@ function enregistrerDatesChasse() {
   })
     .then(r => r.json())
     .then(res => {
+      console.log('[enregistrerDatesChasse] reponse=', res);
       if (res.success) {
         rafraichirStatutChasse(postId);
         mettreAJourAffichageDateFin();

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -312,7 +312,7 @@ function initLiensChasse(bloc) {
 // 🔎 Validation logique entre date de début et date de fin
 // ==============================
 function validerDatesAvantEnvoi(champModifie) {
-  console.log('[validerDatesAvantEnvoi] champModifie=', champModifie);
+  DEBUG && console.log('[validerDatesAvantEnvoi] champModifie=', champModifie);
   // ✅ Si illimité, on n'applique aucun contrôle
   if (checkboxIllimitee?.checked) return true;
 
@@ -327,12 +327,9 @@ function validerDatesAvantEnvoi(champModifie) {
   const dateMaximum = new Date();
   dateMaximum.setFullYear(dateMaximum.getFullYear() + 5);
 
-  console.log('[validerDatesAvantEnvoi] bornes=', dateMinimum.toISOString(), dateMaximum.toISOString());
 
   const debut = new Date(inputDateDebut.value);
   const fin = new Date(inputDateFin.value);
-
-  console.log('[validerDatesAvantEnvoi] debut=', debut.toISOString(), 'fin=', fin.toISOString());
 
   if (debut < dateMinimum || debut > dateMaximum) {
     if (champModifie === 'debut' && erreurDebut) {
@@ -384,7 +381,7 @@ function validerDatesAvantEnvoi(champModifie) {
 // 🔥 Affichage d'un message global temporaire
 // ==============================
 function afficherErreurGlobale(message) {
-  console.log('[afficherErreurGlobale]', message);
+  DEBUG && console.log('[afficherErreurGlobale]', message);
   const erreurGlobal = document.getElementById('erreur-global');
   if (!erreurGlobal) return;
 
@@ -617,7 +614,7 @@ document.addEventListener('acf/submit_success', function (e) {
 // 🔁 Rafraîchissement dynamique du statut de la chasse
 // ================================
 function rafraichirStatutChasse(postId) {
-  console.log('[rafraichirStatutChasse] postId=', postId);
+  DEBUG && console.log('[rafraichirStatutChasse] postId=', postId);
   if (!postId) return;
 
   fetch(ajaxurl, {
@@ -674,7 +671,7 @@ function rafraichirStatutChasse(postId) {
 // 💾 Enregistrement groupé des dates de chasse
 // ================================
 function enregistrerDatesChasse() {
-  console.log('[enregistrerDatesChasse]');
+  DEBUG && console.log('[enregistrerDatesChasse]');
   if (!inputDateDebut || !inputDateFin) return Promise.resolve(false);
 
   const postId = inputDateDebut.closest('.champ-chasse')?.dataset.postId;
@@ -687,7 +684,6 @@ function enregistrerDatesChasse() {
     date_fin: checkboxIllimitee?.checked ? '' : inputDateFin.value.trim(),
     illimitee: checkboxIllimitee?.checked ? 1 : 0
   });
-  console.log('[enregistrerDatesChasse] params=', params.toString());
 
   return fetch(ajaxurl, {
     method: 'POST',
@@ -696,7 +692,7 @@ function enregistrerDatesChasse() {
   })
     .then(r => r.json())
     .then(res => {
-      console.log('[enregistrerDatesChasse] reponse=', res);
+      DEBUG && console.log('[enregistrerDatesChasse] reponse=', res);
       if (res.success) {
         rafraichirStatutChasse(postId);
         mettreAJourAffichageDateFin();

--- a/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
@@ -72,7 +72,7 @@ function initChampDate(input) {
 
   const enregistrer = () => {
     const valeurBrute = input.value.trim();
-    console.log('[🧪 initChampDate]', champ, '| valeur saisie :', valeurBrute);
+    console.log('[🧪 initChampDate]', champ, '| valeur saisie :', valeurBrute, '| previous :', input.dataset.previous);
     const regexDate = /^\d{4}-\d{2}-\d{2}$/;
     const regexDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
     if (!regexDate.test(valeurBrute) && !regexDateTime.test(valeurBrute)) {
@@ -101,6 +101,7 @@ function initChampDate(input) {
       typeof window.enregistrerDatesChasse === 'function' &&
       (champ.endsWith('_date_debut') || champ.endsWith('_date_fin'))
     ) {
+      console.log('[initChampDate] appel enregistrerDatesChasse pour', champ);
       window.enregistrerDatesChasse().then(success => {
         if (success) {
           input.dataset.previous = valeurBrute;

--- a/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
@@ -70,7 +70,11 @@ function initChampDate(input) {
     }
   }
 
+  let saving = false;
+
   const enregistrer = () => {
+    if (saving) return;
+    saving = true;
     const valeurBrute = input.value.trim();
     console.log('[🧪 initChampDate]', champ, '| valeur saisie :', valeurBrute, '| previous :', input.dataset.previous);
     const regexDate = /^\d{4}-\d{2}-\d{2}$/;
@@ -103,6 +107,7 @@ function initChampDate(input) {
     ) {
       console.log('[initChampDate] appel enregistrerDatesChasse pour', champ);
       window.enregistrerDatesChasse().then(success => {
+        saving = false;
         if (success) {
           input.dataset.previous = valeurBrute;
           if (typeof window.onDateFieldUpdated === 'function') {
@@ -114,6 +119,7 @@ function initChampDate(input) {
       });
     } else {
       modifierChampSimple(champ, valeur, postId, cpt).then(success => {
+        saving = false;
         if (success) {
           input.dataset.previous = valeurBrute;
           if (typeof window.onDateFieldUpdated === 'function') {
@@ -132,6 +138,7 @@ function initChampDate(input) {
   // sélection dans le datepicker. On ajoute donc un fallback sur "blur" si la
   // valeur a effectivement été modifiée.
   input.addEventListener('blur', () => {
+    if (saving) return;
     if (input.value.trim() !== (input.dataset.previous || '')) {
       enregistrer();
     }

--- a/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
@@ -13,7 +13,6 @@ document.addEventListener('DOMContentLoaded', () => {
 // 📅 Formatage des dates Y-m-d ➔ d/m/Y
 // ==============================
 function formatDateFr(dateStr) {
-  console.log('[formatDateFr] input=', dateStr);
   if (!dateStr) return '';
   if (dateStr.includes('T')) {
     const [datePart] = dateStr.split('T');
@@ -32,7 +31,6 @@ function formatDateFr(dateStr) {
 // 📅 Mise à jour affichage Date Fin
 // ==============================
 function mettreAJourAffichageDateFin() {
-  console.log('[mettreAJourAffichageDateFin]');
   const spanDateFin = document.querySelector('.chasse-date-plage .date-fin');
   const inputDateFin = document.getElementById('chasse-date-fin');
   const checkboxIllimitee = document.getElementById('duree-illimitee');
@@ -49,7 +47,6 @@ function mettreAJourAffichageDateFin() {
 // 📅 initChampDate
 // ==============================
 function initChampDate(input) {
-  console.log('⏱️ Attachement initChampDate à', input, '→ ID:', input.id);
 
   if (input.disabled) {
     return;
@@ -76,7 +73,6 @@ function initChampDate(input) {
     if (saving) return;
     saving = true;
     const valeurBrute = input.value.trim();
-    console.log('[🧪 initChampDate]', champ, '| valeur saisie :', valeurBrute, '| previous :', input.dataset.previous);
     const regexDate = /^\d{4}-\d{2}-\d{2}$/;
     const regexDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
     if (!regexDate.test(valeurBrute) && !regexDateTime.test(valeurBrute)) {
@@ -105,7 +101,6 @@ function initChampDate(input) {
       typeof window.enregistrerDatesChasse === 'function' &&
       (champ.endsWith('_date_debut') || champ.endsWith('_date_fin'))
     ) {
-      console.log('[initChampDate] appel enregistrerDatesChasse pour', champ);
       window.enregistrerDatesChasse().then(success => {
         saving = false;
         if (success) {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -174,11 +174,6 @@ function modifier_dates_chasse()
 
   error_log("[modifier_dates_chasse] post_id={$post_id} date_debut={$date_debut} date_fin={$date_fin} illimitee={$illimitee}");
 
-  // 📦 Valeurs existantes avant mise à jour (pour debug)
-  $old_debut = get_post_meta($post_id, 'chasse_infos_date_debut', true);
-  $old_fin   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
-  $old_illim = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
-  error_log("[modifier_dates_chasse] metas_avant: debut={$old_debut} fin={$old_fin} illim={$old_illim}");
 
   if (!$post_id || get_post_type($post_id) !== 'chasse') {
     wp_send_json_error('post_invalide');
@@ -231,30 +226,7 @@ function modifier_dates_chasse()
   $ok3 = update_field('chasse_infos_date_fin', $illimitee ? '' : $dt_fin->format('Y-m-d'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
-  // 🔎 Métas après mise à jour
-  $new_debut = get_post_meta($post_id, 'chasse_infos_date_debut', true);
-  $new_fin   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
-  $new_illim = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
-  error_log("[modifier_dates_chasse] metas_apres: debut={$new_debut} fin={$new_fin} illim={$new_illim}");
-
-  // Lecture directe pour éviter un cache ACF éventuel
-  $saved_debut_raw = get_post_meta($post_id, 'chasse_infos_date_debut', true);
-  $saved_fin_raw   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
-  $saved_illim     = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
-
-  $saved_debut_dt = convertir_en_datetime($saved_debut_raw, ['Y-m-d H:i:s', 'Y-m-d\TH:i', 'Y-m-d', 'YmdHis', 'Ymd']);
-  $saved_fin_dt   = convertir_en_datetime($saved_fin_raw, ['Y-m-d', 'Ymd', 'Y-m-d H:i:s', 'Y-m-d\TH:i']);
-  if ($saved_fin_dt) {
-    $saved_fin_dt->setTime(0, 0, 0);
-  }
-
-  $debut_ok = $saved_debut_dt && $saved_debut_dt->format('Y-m-d H:i:s') === $dt_debut->format('Y-m-d H:i:s');
-  $fin_ok   = $illimitee ? empty($saved_fin_raw) : ($saved_fin_dt && $saved_fin_dt->format('Y-m-d H:i:s') === $dt_fin->format('Y-m-d H:i:s'));
-  $illim_ok = (int) $saved_illim === ($illimitee ? 1 : 0);
-
-  error_log("[modifier_dates_chasse] verifs: debut_ok=" . var_export($debut_ok, true) . ' fin_ok=' . var_export($fin_ok, true) . ' illim_ok=' . var_export($illim_ok, true));
-
-  if (($ok1 || $debut_ok) && ($ok2 || $illim_ok) && ($ok3 || $fin_ok)) {
+  if ($ok1 && $ok2 && $ok3) {
     mettre_a_jour_statuts_chasse($post_id);
     error_log('[modifier_dates_chasse] mise a jour reussie');
     wp_send_json_success([
@@ -264,7 +236,6 @@ function modifier_dates_chasse()
     ]);
   }
 
-  error_log('[modifier_dates_chasse] conditions: ok1=' . var_export($ok1, true) . ' ok2=' . var_export($ok2, true) . ' ok3=' . var_export($ok3, true));
   error_log('[modifier_dates_chasse] echec mise a jour');
   wp_send_json_error('echec_mise_a_jour');
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -174,6 +174,12 @@ function modifier_dates_chasse()
 
   error_log("[modifier_dates_chasse] post_id={$post_id} date_debut={$date_debut} date_fin={$date_fin} illimitee={$illimitee}");
 
+  // 📦 Valeurs existantes avant mise à jour (pour debug)
+  $old_debut = get_post_meta($post_id, 'chasse_infos_date_debut', true);
+  $old_fin   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
+  $old_illim = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
+  error_log("[modifier_dates_chasse] metas_avant: debut={$old_debut} fin={$old_fin} illim={$old_illim}");
+
   if (!$post_id || get_post_type($post_id) !== 'chasse') {
     wp_send_json_error('post_invalide');
   }
@@ -225,6 +231,12 @@ function modifier_dates_chasse()
   $ok3 = update_field('chasse_infos_date_fin', $illimitee ? '' : $dt_fin->format('Y-m-d'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
+  // 🔎 Métas après mise à jour
+  $new_debut = get_post_meta($post_id, 'chasse_infos_date_debut', true);
+  $new_fin   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
+  $new_illim = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
+  error_log("[modifier_dates_chasse] metas_apres: debut={$new_debut} fin={$new_fin} illim={$new_illim}");
+
   // Lecture directe pour éviter un cache ACF éventuel
   $saved_debut_raw = get_post_meta($post_id, 'chasse_infos_date_debut', true);
   $saved_fin_raw   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
@@ -240,6 +252,8 @@ function modifier_dates_chasse()
   $fin_ok   = $illimitee ? empty($saved_fin_raw) : ($saved_fin_dt && $saved_fin_dt->format('Y-m-d H:i:s') === $dt_fin->format('Y-m-d H:i:s'));
   $illim_ok = (int) $saved_illim === ($illimitee ? 1 : 0);
 
+  error_log("[modifier_dates_chasse] verifs: debut_ok=" . var_export($debut_ok, true) . ' fin_ok=' . var_export($fin_ok, true) . ' illim_ok=' . var_export($illim_ok, true));
+
   if (($ok1 || $debut_ok) && ($ok2 || $illim_ok) && ($ok3 || $fin_ok)) {
     mettre_a_jour_statuts_chasse($post_id);
     error_log('[modifier_dates_chasse] mise a jour reussie');
@@ -250,6 +264,7 @@ function modifier_dates_chasse()
     ]);
   }
 
+  error_log('[modifier_dates_chasse] conditions: ok1=' . var_export($ok1, true) . ' ok2=' . var_export($ok2, true) . ' ok3=' . var_export($ok3, true));
   error_log('[modifier_dates_chasse] echec mise a jour');
   wp_send_json_error('echec_mise_a_jour');
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -223,12 +223,15 @@ function modifier_dates_chasse()
   $ok3 = update_field('chasse_infos_date_fin', $illimitee ? '' : $dt_fin->format('Y-m-d'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
-  $saved_debut = get_field('chasse_infos_date_debut', $post_id);
-  $saved_fin   = get_field('chasse_infos_date_fin', $post_id);
-  $saved_illim = get_field('chasse_infos_duree_illimitee', $post_id);
+  $saved_debut_raw = get_field('chasse_infos_date_debut', $post_id);
+  $saved_fin_raw   = get_field('chasse_infos_date_fin', $post_id);
+  $saved_illim     = get_field('chasse_infos_duree_illimitee', $post_id);
 
-  $debut_ok = $saved_debut === $dt_debut->format('Y-m-d H:i:s');
-  $fin_ok   = $saved_fin === ($illimitee ? '' : $dt_fin->format('Y-m-d'));
+  $saved_debut_dt = convertir_en_datetime($saved_debut_raw, ['Y-m-d H:i:s', 'Y-m-d\TH:i', 'Y-m-d']);
+  $saved_fin_dt   = convertir_en_datetime($saved_fin_raw, ['Y-m-d', 'Y-m-d H:i:s', 'Y-m-d\TH:i']);
+
+  $debut_ok = $saved_debut_dt && $saved_debut_dt->format('Y-m-d H:i:s') === $dt_debut->format('Y-m-d H:i:s');
+  $fin_ok   = $illimitee ? empty($saved_fin_raw) : ($saved_fin_dt && $saved_fin_dt->format('Y-m-d') === $dt_fin->format('Y-m-d'));
   $illim_ok = (int) $saved_illim === ($illimitee ? 1 : 0);
 
   if (($ok1 || $debut_ok) && ($ok2 || $illim_ok) && ($ok3 || $fin_ok)) {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -223,7 +223,15 @@ function modifier_dates_chasse()
   $ok3 = update_field('chasse_infos_date_fin', $illimitee ? '' : $dt_fin->format('Y-m-d'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
-  if ($ok1 && $ok2 && $ok3) {
+  $saved_debut = get_field('chasse_infos_date_debut', $post_id);
+  $saved_fin   = get_field('chasse_infos_date_fin', $post_id);
+  $saved_illim = get_field('chasse_infos_duree_illimitee', $post_id);
+
+  $debut_ok = $saved_debut === $dt_debut->format('Y-m-d H:i:s');
+  $fin_ok   = $saved_fin === ($illimitee ? '' : $dt_fin->format('Y-m-d'));
+  $illim_ok = (int) $saved_illim === ($illimitee ? 1 : 0);
+
+  if (($ok1 || $debut_ok) && ($ok2 || $illim_ok) && ($ok3 || $fin_ok)) {
     mettre_a_jour_statuts_chasse($post_id);
     error_log('[modifier_dates_chasse] mise a jour reussie');
     wp_send_json_success([

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -225,9 +225,10 @@ function modifier_dates_chasse()
   $ok3 = update_field('chasse_infos_date_fin', $illimitee ? '' : $dt_fin->format('Y-m-d'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
-  $saved_debut_raw = get_field('chasse_infos_date_debut', $post_id, false);
-  $saved_fin_raw   = get_field('chasse_infos_date_fin', $post_id, false);
-  $saved_illim     = get_field('chasse_infos_duree_illimitee', $post_id, false);
+  // Lecture directe pour éviter un cache ACF éventuel
+  $saved_debut_raw = get_post_meta($post_id, 'chasse_infos_date_debut', true);
+  $saved_fin_raw   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
+  $saved_illim     = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
 
   $saved_debut_dt = convertir_en_datetime($saved_debut_raw, ['Y-m-d H:i:s', 'Y-m-d\TH:i', 'Y-m-d', 'YmdHis', 'Ymd']);
   $saved_fin_dt   = convertir_en_datetime($saved_fin_raw, ['Y-m-d', 'Ymd', 'Y-m-d H:i:s', 'Y-m-d\TH:i']);


### PR DESCRIPTION
## Summary
- ensure chasse date updates succeed even when `update_field` returns false

## Testing
- `php -l wp-content/themes/chassesautresor/inc/edition/edition-chasse.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3305f92483328e18aedb5a00533b