### PR TITLE
Clean up Docker references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ wp-config.php
 .env
 *.log
 *.sql
+vendor/
+composer.phar

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# WordPress Project
+
+Ce dépôt contient une installation locale de WordPress. Pour exécuter du code PHP ou utiliser Composer dans un environnement reproductible, deux solutions sont proposées :
+
+## Script `setup.sh`
+
+Ce script installe PHP et Composer sur la machine locale :
+
+```bash
+./setup.sh
+```
+
+Il télécharge PHP via le gestionnaire de paquets `apt` puis installe Composer et le place dans `/usr/local/bin`.
+
+Le script permet d'obtenir rapidement un environnement prêt pour exécuter des commandes PHP ou Composer.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Installe PHP et Composer
+
+set -e
+
+sudo apt-get update
+sudo apt-get install -y php php-cli unzip curl
+
+EXPECTED_CHECKSUM="$(curl -fsSL https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+rm composer-setup.php
+sudo mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
## Summary
- remove Docker setup and documentation
- keep local `setup.sh` instructions for installing PHP & Composer

## Testing
- `bash -n setup.sh`
- `bash setup.sh` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_685e36f0647083329b47d36243854a60