### PR TITLE
Enable WP debug mode

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -88,10 +88,14 @@ $table_prefix = 'wp_';
  * @link https://wordpress.org/support/article/debugging-in-wordpress/
  */
 if ( ! defined( 'WP_DEBUG' ) ) {
-	define( 'WP_DEBUG', false );
+        //define( 'WP_DEBUG', false );
 }
 
 define( 'WP_ENVIRONMENT_TYPE', 'local' );
+
+define( 'WP_DEBUG', true );
+define( 'WP_DEBUG_LOG', true );
+define( 'WP_DEBUG_DISPLAY', false );
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
## Summary
- configure debug mode in `wp-config.php`

## Testing
- `bash setup.sh` *(fails: repository InRelease 403 Forbidden)*
- `php -l wp-config.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e424d34c483328139b5234d61f0f9