### PR TITLE
Ensure free checkbox active on new chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -136,6 +136,8 @@ function creer_chasse_et_rediriger_si_appel()
   update_field('chasse_infos_date_debut', $today, $post_id);
   update_field('chasse_infos_date_fin', $in_two_years, $post_id);
   update_field('chasse_infos_duree_illimitee', false, $post_id);
+  // Coût par défaut à 0 (mode gratuit)
+  update_field('chasse_infos_cout_points', 0, $post_id);
 
   update_field('chasse_cache_statut', 'revision', $post_id);
   update_field('chasse_cache_statut_validation', 'creation', $post_id);


### PR DESCRIPTION
## Summary
- set `chasse_infos_cout_points` to 0 when a new chasse is created

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685e47538b848332a7fac3df52796756