### PR TITLE
Fix dynamic completion style for hunt intro

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -96,6 +96,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof window.mettreAJourCarteAjoutEnigme === 'function') {
     window.mettreAJourCarteAjoutEnigme();
   }
+  if (typeof window.mettreAJourEtatIntroChasse === 'function') {
+    window.mettreAJourEtatIntroChasse();
+  }
 
   // ==============================
   // 📅 Gestion Date de fin + Durée illimitée
@@ -586,6 +589,28 @@ window.mettreAJourCarteAjoutEnigme = function () {
       <p>Complétez d’abord : ${texte}</p>
     `;
   }
+};
+
+// ==============================
+// 🎨 Mise à jour visuelle de l'intro de la chasse
+// ==============================
+window.mettreAJourEtatIntroChasse = function () {
+  const section = document.querySelector('.chasse-section-intro');
+  const panel = document.querySelector('.edition-panel-chasse');
+  if (!section || !panel) return;
+
+  const selectors = [
+    '[data-champ="post_title"]',
+    '[data-champ="chasse_principale_image"]',
+    '[data-champ="chasse_principale_description"]'
+  ];
+
+  const incomplets = selectors.filter(sel => {
+    const li = panel.querySelector('.resume-infos ' + sel);
+    return li && li.classList.contains('champ-vide');
+  });
+
+  section.classList.toggle('champ-vide-obligatoire', incomplets.length > 0);
 };
 
 

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -201,6 +201,9 @@ window.mettreAJourResumeInfos = function () {
   if (typeof window.mettreAJourCarteAjoutEnigme === 'function') {
     window.mettreAJourCarteAjoutEnigme();
   }
+  if (typeof window.mettreAJourEtatIntroChasse === 'function') {
+    window.mettreAJourEtatIntroChasse();
+  }
 };
 
 // ==============================


### PR DESCRIPTION
## Summary
- trigger update of hunt intro completion style when fields change
- add dynamic function to toggle `champ-vide-obligatoire` on the intro section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e4ac983508332891b5b7a24785b55