### PR TITLE
Update default riddle title

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -101,7 +101,7 @@ window.mettreAJourResumeInfos = function () {
       // Règles spécifiques pour les énigmes
       if (champ === 'post_title') {
         const valeur = blocEdition?.querySelector('.champ-input')?.value.trim().toLowerCase();
-        const titreParDefaut = 'nouvelle énigme';
+        const titreParDefaut = 'en création';
         estRempli = valeur && valeur !== titreParDefaut;
       }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -162,7 +162,7 @@ function creer_enigme_et_rediriger_si_appel()
     wp_die($enigme_id->get_error_message(), 'Erreur', ['response' => 500]);
   }
 
-  // Redirige vers la nouvelle énigme
+  // Redirige vers l’énigme en création
   $preview_url = add_query_arg('edition', 'open', get_preview_post_link($enigme_id));
   wp_redirect($preview_url);
 

--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -54,7 +54,7 @@ defined('ABSPATH') || exit;
             if (
                 $mode !== 'aucune' &&
                 $mode !== null &&
-                stripos($titre, 'nouvelle énigme') !== 0
+                stripos($titre, TITRE_DEFAUT_ENIGME) !== 0
             ) {
                 $resultats[$id] = $titre;
             }

--- a/wp-content/themes/chassesautresor/inc/utils/titres.php
+++ b/wp-content/themes/chassesautresor/inc/utils/titres.php
@@ -14,7 +14,7 @@ defined('ABSPATH') || exit;
 // Valeurs par défaut des titres lors de la création des CPT
 define('TITRE_DEFAUT_ORGANISATEUR', 'Votre nom d’organisateur');
 define('TITRE_DEFAUT_CHASSE', 'Nouvelle chasse');
-define('TITRE_DEFAUT_ENIGME', 'Nouvelle énigme');
+define('TITRE_DEFAUT_ENIGME', 'en création');
 
 /**
  * Retourne le titre par défaut associé à un type de post donné.

--- a/wp-content/themes/chassesautresor/notices/fields/titre-edition.md
+++ b/wp-content/themes/chassesautresor/notices/fields/titre-edition.md
@@ -112,7 +112,7 @@ Exemple dans JS :
 ```js
 if (champ === 'post_title') {
   const valeurTitre = bloc?.querySelector('.champ-input')?.value.trim().toLowerCase();
-  const titreParDefaut = window.CHP_ENIGME_DEFAUT?.titre || 'nouvelle énigme';
+  const titreParDefaut = window.CHP_ENIGME_DEFAUT?.titre || 'en création';
   estRempli = valeurTitre && valeurTitre !== titreParDefaut;
 }
 ```

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -47,7 +47,7 @@ $pre_requis_ok   = enigme_pre_requis_remplis($enigme_id, $user_id);
 
 // 🔹 Données affichables
 $titre              = get_the_title($enigme_id);
-$titre_defaut       = 'nouvelle énigme';
+$titre_defaut       = TITRE_DEFAUT_ENIGME;
 $isTitreParDefaut   = strtolower(trim($titre)) === strtolower($titre_defaut);
 $legende            = get_field('enigme_visuel_legende', $enigme_id);
 $image_url = get_image_enigme($enigme_id, 'large');


### PR DESCRIPTION
## Summary
- change default title of a riddle to `en création`
- use this constant throughout code and docs

## Testing
- `./setup.sh` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e5052d4c88332b3241f5444b7676e