### PR TITLE
Remove admin orders card

### DIFF
--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/admin.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/admin.php
@@ -132,17 +132,6 @@ $taux_conversion = get_taux_conversion_actuel();
             </div>
         <?php endif; ?>
 
-        <?php if (!empty($commandes_output)) : ?>
-            <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>" class="dashboard-card">
-                <div class="dashboard-card-header">
-                    <i class="fas fa-shopping-cart"></i>
-                    <h3>Mes Commandes</h3>
-                </div>
-                <div class="stats-content">
-                    <?php echo $commandes_output; ?>
-                </div>
-            </a>
-        <?php endif; ?>
         <div class="dashboard-card">
             <div class="dashboard-card-header">
                 <i class="fas fa-euro-sign"></i>


### PR DESCRIPTION
## Summary
- remove the "Mes Commandes" dashboard card from the admin account template

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e54a4146c8332a2a7578fba04dff3