### PR TITLE
Add root composer config for PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ Ce script installe PHP et Composer sur la machine locale :
 Il télécharge PHP via le gestionnaire de paquets `apt` puis installe Composer et le place dans `/usr/local/bin`.
 
 Le script permet d'obtenir rapidement un environnement prêt pour exécuter des commandes PHP ou Composer.
+
+## Utilisation de Composer pour les tests
+
+Un fichier `composer.json` est présent à la racine pour installer PHPUnit et les dépendances de développement. Une fois PHP et Composer disponibles (via `setup.sh`), exécutez :
+
+```bash
+composer install
+composer test
+```
+
+La commande `composer test` lance PHPUnit à l'aide de la configuration du plugin **hostinger**.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "chassesautresor/wordpress",
+  "require": {},
+  "require-dev": {
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^2.0"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Hostinger\\Tests\\": "wp-content/plugins/hostinger/vendor/hostinger/hostinger-wp-helper/tests/phpunit"
+    }
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit -c wp-content/plugins/hostinger/vendor/hostinger/hostinger-wp-helper/phpunit.xml.dist"
+  },
+  "config": {
+    "platform-check": false
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `composer.json` to install PHPUnit and set up plugin tests
- explain how to install dependencies and run `composer test` in README

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7e1d007083329c74ed4153dd88a7