### PR TITLE
Fix validation status update

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1555,6 +1555,7 @@ function traiter_validation_chasse_admin() {
         $cache = get_field('champs_caches', $chasse_id) ?: [];
         $cache['chasse_cache_statut_validation'] = 'valide';
         update_field('champs_caches', $cache, $chasse_id);
+        update_field('chasse_cache_statut_validation', 'valide', $chasse_id);
         mettre_a_jour_statuts_chasse($chasse_id);
 
         foreach ($enigmes as $eid) {
@@ -1583,6 +1584,7 @@ function traiter_validation_chasse_admin() {
         $cache = get_field('champs_caches', $chasse_id) ?: [];
         $cache['chasse_cache_statut_validation'] = 'correction';
         update_field('champs_caches', $cache, $chasse_id);
+        update_field('chasse_cache_statut_validation', 'correction', $chasse_id);
 
         $message = isset($_POST['validation_admin_message'])
             ? sanitize_textarea_field(wp_unslash($_POST['validation_admin_message']))
@@ -1600,6 +1602,7 @@ function traiter_validation_chasse_admin() {
         $cache = get_field('champs_caches', $chasse_id) ?: [];
         $cache['chasse_cache_statut_validation'] = 'banni';
         update_field('champs_caches', $cache, $chasse_id);
+        update_field('chasse_cache_statut_validation', 'banni', $chasse_id);
 
         foreach ($enigmes as $eid) {
             wp_update_post(['ID' => $eid, 'post_status' => 'draft']);

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -90,7 +90,10 @@ $validation_envoyee = !empty($_GET['validation_demandee']);
       <?php
       if ($can_validate) {
         echo '<div class="cta-chasse">';
-        echo '<p>Lorsque vous avez finalisé votre chasse, demandez sa validation :</p>';
+        $msg = ($statut_validation === 'correction')
+          ? 'Lorsque vous aurez terminé vos corrections, demandez sa validation :'
+          : 'Lorsque vous avez finalisé votre chasse, demandez sa validation :';
+        echo '<p>' . $msg . '</p>';
         echo render_form_validation_chasse($chasse_id);
         echo '</div>';
       }


### PR DESCRIPTION
## Summary
- ensure `chasse_cache_statut_validation` is updated when processing admin actions

## Testing
- `bash setup.sh` *(fails: repository not signed)*
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e814c02d48332ac5706456832f0c8