### PR TITLE
Adjust validation messages

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -687,6 +687,16 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     margin-top: 15px;
 }
 
+/* ========== ℹ️ MESSAGE INFO ========== */
+
+.message-info {
+    text-align: center;
+    font-weight: bold;
+    color: #333;
+    font-size: 16px;
+    margin-top: 15px;
+}
+
 /* ========== 🖼️ ICONES SVG ========== */
 .icone-aces-casino, .icone-compass-rose {
   color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -73,6 +73,7 @@ get_header();
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
 $validation_envoyee = !empty($_GET['validation_demandee']);
+$en_attente = ($statut_validation === 'en_attente');
 ?>
 
 <div id="primary" class="content-area">
@@ -99,6 +100,9 @@ $validation_envoyee = !empty($_GET['validation_demandee']);
       }
       if ($validation_envoyee) {
         echo '<p class="message-succes">✅ Votre demande de validation a bien été envoyée. Elle sera traitée par l’équipe.</p>';
+        echo '<script>if(window.history.replaceState){const u=new URL(window.location);u.searchParams.delete("validation_demandee");window.history.replaceState({},"",u);}</script>';
+      } elseif ($en_attente) {
+        echo '<p class="message-info">✅ Votre demande de validation est en cours de traitement par l’équipe.</p>';
       }
       ?>
 


### PR DESCRIPTION
## Summary
- show processing message while a chasse is pending validation
- ensure single-use display of the "request sent" message
- add basic styling for info messages

## Testing
- `./setup.sh` *(fails: repository not signed)*
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e92d5a9288332ab891e68c53850ec