### PR TITLE
Implement validation status messages

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -687,6 +687,15 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     margin-top: 15px;
 }
 
+/* ========== ℹ️ MESSAGE INFO ========== */
+.message-info {
+    text-align: center;
+    font-weight: bold;
+    color: #333;
+    font-size: 16px;
+    margin-top: 15px;
+}
+
 /* ========== 🖼️ ICONES SVG ========== */
 .icone-aces-casino, .icone-compass-rose {
   color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -384,6 +384,30 @@ function render_form_validation_chasse(int $chasse_id): string
 }
 
 /**
+ * Affiche un message relatif à la validation d'une chasse.
+ *
+ * - Après l'envoi de la demande via ?validation_demandee=1,
+ *   un message de succès est affiché une seule fois.
+ * - Tant que le statut reste "en_attente", un message
+ *   d'information indique que la demande est en cours.
+ *
+ * @param int $chasse_id ID de la chasse.
+ * @return void
+ */
+function afficher_message_validation_chasse(int $chasse_id): void
+{
+    $validation_envoyee = !empty($_GET['validation_demandee']);
+    $statut_validation  = get_field('chasse_cache_statut_validation', $chasse_id);
+
+    if ($validation_envoyee) {
+        echo '<p class="message-succes">✅ Votre demande de validation est en cours de traitement par l’équipe.</p>';
+        echo '<script>if(window.history.replaceState){const u=new URL(window.location);u.searchParams.delete("validation_demandee");history.replaceState(null,"",u);}</script>';
+    } elseif ($statut_validation === 'en_attente') {
+        echo '<p class="message-info">⏳ Votre demande est en cours de traitement</p>';
+    }
+}
+
+/**
  * Vérifie si la solution d'une énigme peut être affichée.
  *
  * La solution n'est visible que si la chasse associée est terminée

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -477,13 +477,28 @@ function injection_classe_edition_active(array $classes): array
 /**
  * 📅 Formate une date au format `d/m/Y` ou retourne "Non spécifiée".
  *
- * @param string|null $date La date à formater.
+ * @param mixed $date La date à formater.
  * @return string La date formatée ou "Non spécifiée" si invalide.
  */
-function formater_date(?string $date): string
+function formater_date($date): string
 {
-  if (!$date) return 'Non spécifiée';
-  if (preg_match('/^\d{2}\/\d{2}\/\d{4}$/', $date)) return $date; // Déjà formatée
+  if (empty($date)) {
+    return 'Non spécifiée';
+  }
+
+  if ($date instanceof DateTimeInterface) {
+    return $date->format('d/m/Y');
+  }
+
+  if (is_array($date) && isset($date['date'])) {
+    $date = $date['date'];
+  }
+
+  $date = (string) $date;
+
+  if (preg_match('/^\d{2}\/\d{2}\/\d{4}$/', $date)) {
+    return $date; // Déjà formatée
+  }
 
   $timestamp = strtotime($date);
   return ($timestamp !== false) ? date_i18n('d/m/Y', $timestamp) : 'Non spécifiée';

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -72,7 +72,6 @@ $nb_joueurs = 0;
 get_header();
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
-$validation_envoyee = !empty($_GET['validation_demandee']);
 ?>
 
 <div id="primary" class="content-area">
@@ -97,9 +96,8 @@ $validation_envoyee = !empty($_GET['validation_demandee']);
         echo render_form_validation_chasse($chasse_id);
         echo '</div>';
       }
-      if ($validation_envoyee) {
-        echo '<p class="message-succes">✅ Votre demande de validation a bien été envoyée. Elle sera traitée par l’équipe.</p>';
-      }
+
+      afficher_message_validation_chasse($chasse_id);
       ?>
 
       <?php


### PR DESCRIPTION
## Summary
- handle non-string dates in `formater_date`
- add generic `.message-info` style
- show validation status messages with reusable helper
- display the helper on single chasse page

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9b10d7888332a87c15bad01b203e