### PR TITLE
Fix date parsing for hunts

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -500,6 +500,11 @@ function formater_date($date): string
     return $date; // Déjà formatée
   }
 
+  $datetime = convertir_en_datetime($date);
+  if ($datetime) {
+    return $datetime->format('d/m/Y');
+  }
+
   $timestamp = strtotime($date);
   return ($timestamp !== false) ? date_i18n('d/m/Y', $timestamp) : 'Non spécifiée';
 }


### PR DESCRIPTION
## Summary
- handle more date formats when converting hunt dates

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit -c wp-content/plugins/hostinger/vendor/hostinger/hostinger-wp-helper/phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb04a42ac8332bb41c8fc780e3634