### PR TITLE
Add status column and sorting for organisers

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/tri-organisateurs.js
+++ b/wp-content/themes/chassesautresor/assets/js/tri-organisateurs.js
@@ -1,0 +1,21 @@
+// Tri dynamique du tableau des organisateurs par colonne "\xC3\x89tat"
+document.addEventListener('DOMContentLoaded', () => {
+  const table = document.querySelector('.table-organisateurs');
+  if (!table) return;
+  const header = table.querySelector('th[data-col="etat"]');
+  if (!header) return;
+  header.style.cursor = 'pointer';
+  let asc = true;
+  header.addEventListener('click', () => {
+    const tbody = table.querySelector('tbody');
+    if (!tbody) return;
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    rows.sort((a, b) => {
+      const va = a.querySelector('td[data-col="etat"]').textContent.trim();
+      const vb = b.querySelector('td[data-col="etat"]').textContent.trim();
+      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+    });
+    rows.forEach(r => tbody.appendChild(r));
+    asc = !asc;
+  });
+});

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1480,7 +1480,7 @@ function afficher_tableau_organisateurs_pending() {
     }
 
     echo '<table class="table-organisateurs">';
-    echo '<thead><tr><th>Organisateur</th><th>Chasse</th><th>Utilisateur</th><th>Créé le</th></tr></thead><tbody>';
+    echo '<thead><tr><th>Organisateur</th><th>Chasse</th><th>État</th><th>Utilisateur</th><th>Créé le</th></tr></thead><tbody>';
 
     foreach ($liste as $entry) {
         $class_org = $entry['organisateur_complet'] ? 'carte-complete' : 'carte-incomplete';
@@ -1498,6 +1498,7 @@ function afficher_tableau_organisateurs_pending() {
         } else {
             echo '<td>-</td>';
         }
+        echo '<td>' . esc_html($entry['validation']) . '</td>';
         if ($entry['user_id']) {
             echo '<td><a href="' . esc_url($entry['user_link']) . '" target="_blank">' . esc_html($entry['user_name']) . '</a></td>';
         } else {

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -155,6 +155,13 @@ function charger_scripts_personnalises() {
       filemtime(get_stylesheet_directory() . '/assets/js/validation-admin.js'),
       true
     );
+    wp_enqueue_script(
+      'tri-organisateurs',
+      $theme_dir . 'tri-organisateurs.js',
+      [],
+      filemtime(get_stylesheet_directory() . '/assets/js/tri-organisateurs.js'),
+      true
+    );
 }
 // ✅ Ajout des scripts au chargement de WordPress
 add_action('wp_enqueue_scripts', 'charger_scripts_personnalises');

--- a/wp-content/themes/chassesautresor/templates/admin/organisateurs.php
+++ b/wp-content/themes/chassesautresor/templates/admin/organisateurs.php
@@ -100,6 +100,7 @@ if (!empty($organisateurs_liste)) :
             <tr>
                 <th>Organisateur</th>
                 <th>Chasse</th>
+                <th data-col="etat">État</th>
                 <th>Utilisateur</th>
                 <th>Créé le</th>
             </tr>
@@ -127,6 +128,7 @@ if (!empty($organisateurs_liste)) :
                             -
                         <?php endif; ?>
                     </td>
+                    <td data-col="etat"><?php echo esc_html($entry['validation']); ?></td>
                     <td>
                         <?php if ($entry['user_id']) : ?>
                             <a href="<?php echo esc_url($entry['user_link']); ?>" target="_blank">


### PR DESCRIPTION
## Summary
- show organiser validation status in admin table
- enable dynamic sort on status column
- enqueue new script

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ebf488e588332b92bd1dd23df66da