### PR TITLE
Fix readability for pending organiser rows

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -534,6 +534,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   border: 2px dashed #D93025 !important;
   animation: pulse-attention 1.2s ease-in-out infinite;
   background-color: #fff5f5;
+  color: var(--color-editor-text);
   border-radius: 8px;
   padding-left: 5px;
 }


### PR DESCRIPTION
## Summary
- ensure `.champ-attention` rows use dark text

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed5c46e70833288bf40310162e74c