### PR TITLE
Add pulsation on add riddle card

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -7,9 +7,10 @@ defined('ABSPATH') || exit;
  * - $args['has_enigmes'] (bool) : indique s’il y a déjà des énigmes
  */
 
-$has_enigmes = $args['has_enigmes'] ?? false;
-$chasse_id   = $args['chasse_id'] ?? null;
-$disabled    = $args['disabled'] ?? true;
+$has_enigmes     = $args['has_enigmes'] ?? false;
+$chasse_id       = $args['chasse_id'] ?? null;
+$disabled        = $args['disabled'] ?? true;
+$highlight_pulse = $args['highlight_pulse'] ?? false;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
 $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-enigme/')));
@@ -19,7 +20,7 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
 <a
   href="<?php echo $ajout_url; ?>"
   id="carte-ajout-enigme"
-  class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?>"
+  class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?><?php echo $highlight_pulse ? ' pulsation' : ''; ?>"
   data-post-id="0">
   <div class="contenu-carte">
     ➕ <?php echo $has_enigmes ? 'Ajouter une énigme' : 'Créer la première énigme'; ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -68,10 +68,27 @@ $has_enigmes = !empty($posts_visibles);
   if (utilisateur_peut_ajouter_enigme($chasse_id, $utilisateur_id)) {
     verifier_ou_mettre_a_jour_cache_complet($chasse_id);
     $complete = (bool) get_field('chasse_cache_complet', $chasse_id);
+
+    $highlight_pulse = false;
+    if (!$has_enigmes) {
+      $wp_status         = get_post_status($chasse_id);
+      $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
+      $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+
+      if (
+        $wp_status === 'pending' &&
+        $statut_metier === 'revision' &&
+        in_array($statut_validation, ['creation', 'correction'], true)
+      ) {
+        $highlight_pulse = true;
+      }
+    }
+
     get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
-      'has_enigmes' => $has_enigmes,
-      'chasse_id'   => $chasse_id,
-      'disabled'    => !$complete,
+      'has_enigmes'     => $has_enigmes,
+      'chasse_id'       => $chasse_id,
+      'disabled'        => !$complete,
+      'highlight_pulse' => $highlight_pulse,
     ]);
   }
   ?>


### PR DESCRIPTION
## Summary
- animate riddle add card with pulsation
- highlight when hunt is pending revision

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ef5e5abcc8332bd3288401eaeac29