### PR TITLE
Remove completion badges for published hunts

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -42,7 +42,10 @@ $has_enigmes = !empty($posts_visibles);
     $cta = get_cta_enigme($enigme_id);
 
     $est_orga = est_organisateur();
-    $voir_bordure = $est_orga && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+    $wp_statut = get_post_status($chasse_id);
+    $voir_bordure = $est_orga &&
+      utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id) &&
+      $wp_statut !== 'publish';
     $classe_completion = '';
     if ($voir_bordure) {
       verifier_ou_mettre_a_jour_cache_complet($enigme_id);


### PR DESCRIPTION
## Summary
- only show completion borders for riddle cards while the hunt is not published

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0472be1c8332bbd85e9d012de387