### PR TITLE
Adaptation de la carte d’ajout de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/cartes.css
+++ b/wp-content/themes/chassesautresor/assets/css/cartes.css
@@ -168,6 +168,25 @@
   padding: 0 1rem;
 }
 
+/* ========== 🔘 Bouton circulaire d'ajout de chasse ========== */
+.bouton-ajout-cercle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px dashed var(--color-editor-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-secondary);
+  position: relative;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.bouton-ajout-cercle:hover {
+  transform: scale(1.05);
+}
+
 /* ========== ✅ Indicateurs de complétion ========== */
 .carte-complete {
   border: 2px solid var(--color-editor-success);

--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -277,3 +277,10 @@ span.champ-obligatoire {
 .media-modal-content button {
     color: var(--color-text-fond-clair);
 }
+
+/* ========== 🏷️ Titre chasses et bouton ========== */
+.titre-chasses-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -67,6 +67,14 @@ get_header();
             <div class="conteneur">
                 <div class="titre-chasses-wrapper">
                     <h2>Chasses au Trésor</h2>
+                    <?php if ($peut_ajouter && $has_publish) :
+                        get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
+                            'has_chasses'     => $has_chasses,
+                            'organisateur_id' => $organisateur_id,
+                            'highlight_pulse' => $highlight_pulse,
+                            'use_button'      => true,
+                        ]);
+                    endif; ?>
                     <div class="ligne-chasses"></div>
                     <div class="liste-chasses">
                         <div class="grille-3">
@@ -80,6 +88,13 @@ get_header();
                             }));
                             $peut_ajouter = utilisateur_peut_ajouter_chasse($organisateur_id);
                             $has_chasses = !empty($chasses);
+                            $has_publish  = false;
+                            foreach ($chasses as $cpost) {
+                                if (get_post_status($cpost->ID) === 'publish') {
+                                    $has_publish = true;
+                                    break;
+                                }
+                            }
                             $cache_complet = (bool) get_field('organisateur_cache_complet', $organisateur_id);
                             $highlight_pulse = !$has_chasses && $is_owner && in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $cache_complet;
 
@@ -96,9 +111,9 @@ get_header();
                                 </article>
                             <?php endforeach; ?>
 
-                            <?php if ($peut_ajouter) :
+                            <?php if ($peut_ajouter && !$has_publish) :
                                 get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
-                                    'has_chasses'    => $has_chasses,
+                                    'has_chasses'     => $has_chasses,
                                     'organisateur_id' => $organisateur_id,
                                     'highlight_pulse' => $highlight_pulse,
                                 ]);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php
@@ -2,8 +2,9 @@
 defined('ABSPATH') || exit;
 
 $organisateur_id = $args['organisateur_id'] ?? null;
-$has_chasses = $args['has_chasses'] ?? false;
+$has_chasses     = $args['has_chasses'] ?? false;
 $highlight_pulse = $args['highlight_pulse'] ?? false;
+$use_button      = $args['use_button'] ?? false;
 
 
 if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
@@ -11,21 +12,36 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 }
 ?>
 
-<a
-  href="<?= esc_url(site_url('/creer-chasse/')); ?>"
-  id="carte-ajout-chasse"
-  class="carte-chasse carte-ajout-chasse disabled<?= $highlight_pulse ? ' pulsation' : ''; ?>"
-  data-post-id="0">
-
-  <div class="carte-chasse-contenu">
-    <div class="icone-ajout">
-      <i class="fa-solid fa-circle-plus fa-3x"></i>
+<?php if ($use_button) : ?>
+  <a
+    href="<?= esc_url(site_url('/creer-chasse/')); ?>"
+    id="carte-ajout-chasse"
+    class="carte-ajout-chasse bouton-ajout-cercle disabled<?= $highlight_pulse ? ' pulsation' : ''; ?>"
+    data-post-id="0">
+    <i class="fa-solid fa-circle-plus fa-lg"></i>
+    <span class="screen-reader-text">Ajouter une chasse</span>
+    <div class="overlay-message">
+      <i class="fa-solid fa-circle-info"></i>
+      <p>Complétez d’abord : titre, logo, description</p>
     </div>
-    <h2><?= $has_chasses ? 'Ajouter une nouvelle chasse' : 'Créer ma première chasse'; ?></h2>
-  </div>
+  </a>
+<?php else : ?>
+  <a
+    href="<?= esc_url(site_url('/creer-chasse/')); ?>"
+    id="carte-ajout-chasse"
+    class="carte-chasse carte-ajout-chasse disabled<?= $highlight_pulse ? ' pulsation' : ''; ?>"
+    data-post-id="0">
 
-  <div class="overlay-message">
-    <i class="fa-solid fa-circle-info"></i>
-    <p>Complétez d’abord : titre, logo, description</p>
-  </div>
-</a>
+    <div class="carte-chasse-contenu">
+      <div class="icone-ajout">
+        <i class="fa-solid fa-circle-plus fa-3x"></i>
+      </div>
+      <h2><?= $has_chasses ? 'Ajouter une nouvelle chasse' : 'Créer ma première chasse'; ?></h2>
+    </div>
+
+    <div class="overlay-message">
+      <i class="fa-solid fa-circle-info"></i>
+      <p>Complétez d’abord : titre, logo, description</p>
+    </div>
+  </a>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- ajoute un mode bouton pour `chasse-partial-ajout-chasse`
- place ce bouton à côté du titre sur la page organisateur
- affiche ce bouton seulement lorsqu’une chasse publiée existe
- styles pour le bouton circulaire et alignement du titre

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6b9f8b488332a4af745716abffd2