### PR TITLE
Affichage dynamique du nombre de chasses publiées

### DIFF
--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -257,6 +257,49 @@ function get_chasses_de_organisateur($organisateur_id)
 }
 
 /**
+ * Retourne le nombre de chasses publiées pour un organisateur donné.
+ *
+ * Utilise un cache statique pour éviter des requêtes répétées.
+ *
+ * @param int $organisateur_id ID de l'organisateur.
+ * @return int Nombre de chasses publiées.
+ */
+function organisateur_get_nb_chasses_publiees(int $organisateur_id): int
+{
+  static $cache = [];
+
+  if (isset($cache[$organisateur_id])) {
+    return $cache[$organisateur_id];
+  }
+
+  if ($organisateur_id <= 0) {
+    return $cache[$organisateur_id] = 0;
+  }
+
+  $query = new WP_Query([
+    'post_type'              => 'chasse',
+    'posts_per_page'         => 1,
+    'post_status'            => 'publish',
+    'fields'                 => 'ids',
+    'no_found_rows'          => false,
+    'update_post_meta_cache' => false,
+    'update_post_term_cache' => false,
+    'meta_query'             => [
+      [
+        'key'     => 'chasse_cache_organisateur',
+        'value'   => '"' . $organisateur_id . '"',
+        'compare' => 'LIKE',
+      ],
+    ],
+  ]);
+
+  $count = (int) $query->found_posts;
+  $cache[$organisateur_id] = $count;
+
+  return $count;
+}
+
+/**
  * 🔹 get_chasses_en_creation() → Récupère les chasses en création pour un organisateur donné.
  *
  * @param int $organisateur_id

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
@@ -4,6 +4,7 @@ defined('ABSPATH') || exit;
 
 $organisateur_id = get_organisateur_id_from_context($args ?? []);
 $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
+$nb_chasses     = organisateur_get_nb_chasses_publiees($organisateur_id);
 
 $description = get_field('description_longue', $organisateur_id);
 $date_inscription = get_the_date('d/m/Y', $organisateur_id);
@@ -101,7 +102,7 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
           <div class="meta-etiquette" title="Nombre de chasses publiées">
             <i class="fa-solid fa-compass-drafting"></i>
             <strong>Chasses :</strong>
-            <span data-champ="nb_chasses">—</span>
+            <span data-champ="nb_chasses"><?php echo intval($nb_chasses); ?></span>
           </div>
         
           <div class="meta-etiquette" title="Nombre de joueurs ayant participé à ses chasses">


### PR DESCRIPTION
## Summary
- calcule le nombre de chasses publiées pour un organisateur
- affiche ce nombre dans la présentation de l'organisateur

## Testing
- `composer test` *(fails: Command "composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f76418acc8332bc2b4eba52f26c79