### PR TITLE
Limit concurrent chasse creation

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -585,8 +585,11 @@ function utilisateur_peut_ajouter_chasse(int $organisateur_id): bool
         return false;
     }
 
-    // Organisateur : aucune limite
+    // Organisateur : une seule chasse en attente à la fois une fois publié
     if (in_array(ROLE_ORGANISATEUR, $roles, true)) {
+        if (get_post_status($organisateur_id) === 'publish' && organisateur_a_chasse_pending($organisateur_id)) {
+            return false;
+        }
         return true;
     }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -110,6 +110,15 @@ function creer_chasse_et_rediriger_si_appel()
     }
   }
 
+  // 🔒 Organisateur publié : une seule chasse en attente à la fois
+  if (
+    !current_user_can('manage_options') &&
+    get_post_status($organisateur_id) === 'publish' &&
+    organisateur_a_chasse_pending($organisateur_id)
+  ) {
+    wp_die('Une chasse est déjà en attente de validation.');
+  }
+
   // 📝 Création du post "chasse"
   $post_id = wp_insert_post([
     'post_type'   => 'chasse',

--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -235,6 +235,36 @@ function organisateur_a_des_chasses($organisateur_id)
 }
 
 /**
+ * Vérifie si un organisateur possède au moins une chasse en attente (status "pending").
+ *
+ * @param int $organisateur_id ID de l'organisateur.
+ * @return bool True si une chasse en attente existe, False sinon.
+ */
+function organisateur_a_chasse_pending(int $organisateur_id): bool
+{
+  $query = new WP_Query([
+    'post_type'      => 'chasse',
+    'posts_per_page' => 1,
+    'post_status'    => 'pending',
+    'meta_query'     => [
+      'relation' => 'AND',
+      [
+        'key'     => 'chasse_cache_organisateur',
+        'value'   => '"' . $organisateur_id . '"',
+        'compare' => 'LIKE'
+      ],
+      [
+        'key'     => 'chasse_cache_statut_validation',
+        'value'   => 'banni',
+        'compare' => '!='
+      ]
+    ]
+  ]);
+
+  return $query->have_posts();
+}
+
+/**
  * Récupère les chasses associées à un organisateur.
  *
  * @param int $organisateur_id ID de l'organisateur.


### PR DESCRIPTION
## Summary
- restrict adding a new chasse when an organiser already has a pending one
- enforce same check during automatic chasse creation
- add helper function to detect pending chasses

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7c5f1d9483329b03bdca03998cee