### PR TITLE
Affichage dynamique du badge de statut

### DIFF
--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -929,9 +929,22 @@ function recuperer_statut_chasse()
     }
 
     $statut_str = is_string($statut) ? $statut : '';
+    $statut_label = ucfirst(str_replace('_', ' ', $statut_str));
+
+    if ($statut_str === 'revision') {
+        $validation = get_field('chasse_cache_statut_validation', $post_id);
+        if ($validation === 'creation') {
+            $statut_label = 'création';
+        } elseif ($validation === 'correction') {
+            $statut_label = 'correction';
+        } elseif ($validation === 'en_attente') {
+            $statut_label = 'en attente';
+        }
+    }
+
     wp_send_json_success([
         'statut' => $statut_str,
-        'statut_label' => ucfirst(str_replace('_', ' ', $statut_str))
+        'statut_label' => $statut_label
     ]);
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -83,9 +83,21 @@ if ($edition_active && !$est_complet) {
   <div class="chasse-fiche-container flex-row">
     <?php
     $statut = get_field('chasse_cache_statut', $chasse_id) ?? 'revision';
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+    $statut_label = ucfirst(str_replace('_', ' ', $statut));
+
+    if ($statut === 'revision') {
+      if ($statut_validation === 'creation') {
+        $statut_label = 'création';
+      } elseif ($statut_validation === 'correction') {
+        $statut_label = 'correction';
+      } elseif ($statut_validation === 'en_attente') {
+        $statut_label = 'en attente';
+      }
+    }
     ?>
       <span class="badge-statut statut-<?= esc_attr($statut); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
-        <?= ucfirst(str_replace('_', ' ', $statut)); ?>
+        <?= esc_html($statut_label); ?>
       </span>
 
     <!-- 🔧 Bouton panneau édition -->


### PR DESCRIPTION
## Summary
- show validation status when chasse is in revision
- return matching badge label in AJAX status endpoint

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f81a8ac34833297799cc2d27ae61b