### PR TITLE
Enable auto-open for chasse edit panel

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -55,6 +55,16 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // ==============================
+  // 🧭 Déclencheur automatique
+  // ==============================
+  const params = new URLSearchParams(window.location.search);
+  const doitOuvrir = params.get('edition') === 'open';
+  if (doitOuvrir) {
+    document.getElementById('toggle-mode-edition-chasse')?.click();
+    DEBUG && console.log('🔧 Ouverture auto du panneau édition chasse via ?edition=open');
+  }
+
+  // ==============================
   // 📜 Panneau description (wysiwyg)
   // ==============================
   document.addEventListener('click', (e) => {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -452,7 +452,7 @@ function injection_classe_edition_active(array $classes): array
   // === CHASSE ===
   if (
     $post->post_type === 'chasse' &&
-    in_array(ROLE_ORGANISATEUR_CREATION, $roles, true)
+    (in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) || in_array(ROLE_ORGANISATEUR, $roles, true))
   ) {
     $organisateur_id = get_organisateur_from_chasse($post->ID);
     $associes = get_field('utilisateurs_associes', $organisateur_id, false);
@@ -461,9 +461,12 @@ function injection_classe_edition_active(array $classes): array
     if (in_array((string) $user_id, $associes, true)) {
       verifier_ou_mettre_a_jour_cache_complet($post->ID);
 
+      $validation = get_field('chasse_cache_statut_validation', $post->ID);
+      $statut = get_field('chasse_cache_statut', $post->ID);
+
       if (
-        get_post_status($post) === 'pending' &&
-        !get_field('chasse_cache_complet', $post->ID)
+        $statut === 'revision' &&
+        in_array($validation, ['creation', 'correction'], true)
       ) {
         $classes[] = 'edition-active-chasse';
       }


### PR DESCRIPTION
## Summary
- auto-open the chasse edition panel via `?edition=open`
- enable edition panel when organisers or creators view a chasse in revision

## Testing
- `composer test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f835646788332b2b16d1863033eb5