### PR TITLE
Fix auto-open condition for hunt edit panel

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -462,11 +462,12 @@ function injection_classe_edition_active(array $classes): array
       verifier_ou_mettre_a_jour_cache_complet($post->ID);
 
       $validation = get_field('chasse_cache_statut_validation', $post->ID);
-      $statut = get_field('chasse_cache_statut', $post->ID);
+      $statut     = get_field('chasse_cache_statut', $post->ID);
 
       if (
         $statut === 'revision' &&
-        in_array($validation, ['creation', 'correction'], true)
+        in_array($validation, ['creation', 'correction'], true) &&
+        !get_field('chasse_cache_complet', $post->ID)
       ) {
         $classes[] = 'edition-active-chasse';
       }


### PR DESCRIPTION
## Summary
- prevent automatic opening of hunt edit panel when the hunt is complete

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8a060d748332aa439fd7e97da463