### PR TITLE
Mise à jour affichage ajout d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -284,3 +284,9 @@ span.champ-obligatoire {
   align-items: center;
   gap: 1rem;
 }
+
+.titre-enigmes-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -60,6 +60,15 @@ $image_url = $image_id ? wp_get_attachment_image_src($image_id, 'large')[0] : nu
 $enigmes_associees = recuperer_enigmes_associees($chasse_id);
 $total_enigmes = count($enigmes_associees);
 $enigmes_resolues = compter_enigmes_resolues($chasse_id, $user_id);
+$peut_ajouter_enigme = utilisateur_peut_ajouter_enigme($chasse_id);
+$has_incomplete_enigme = false;
+foreach ($enigmes_associees as $eid) {
+    verifier_ou_mettre_a_jour_cache_complet($eid);
+    if (!get_field('enigme_cache_complet', $eid)) {
+        $has_incomplete_enigme = true;
+        break;
+    }
+}
 
 $statut = get_field('champs_caches')['chasse_cache_statut'] ?? 'revision';
 $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
@@ -149,7 +158,16 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
           </div>
         </header>
 
-        <h2>Énigmes</h2>
+        <div class="titre-enigmes-wrapper">
+          <h2>Énigmes</h2>
+          <?php if ($peut_ajouter_enigme && $total_enigmes > 0 && !$has_incomplete_enigme) :
+            get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
+              'has_enigmes' => true,
+              'chasse_id'   => $chasse_id,
+              'use_button'  => true,
+            ]);
+          endif; ?>
+        </div>
         <div class="chasse-enigmes-liste">
           <?php
           get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -11,23 +11,35 @@ $has_enigmes     = $args['has_enigmes'] ?? false;
 $chasse_id       = $args['chasse_id'] ?? null;
 $disabled        = $args['disabled'] ?? true;
 $highlight_pulse = $args['highlight_pulse'] ?? false;
+$use_button      = $args['use_button'] ?? false;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
 $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-enigme/')));
 
 ?>
 
-<a
-  href="<?php echo $ajout_url; ?>"
-  id="carte-ajout-enigme"
-  class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?><?php echo $highlight_pulse ? ' pulsation' : ''; ?>"
-  data-post-id="0">
-  <div class="contenu-carte">
-    ➕ <?php echo $has_enigmes ? 'Ajouter une énigme' : 'Créer la première énigme'; ?>
-  </div>
-  <div class="overlay-message">
-    <i class="fa-solid fa-circle-info"></i>
-    <p>Complétez d’abord : titre, image, description</p>
-  </div>
-</a>
+<?php if ($use_button) : ?>
+  <a
+    href="<?php echo $ajout_url; ?>"
+    id="carte-ajout-enigme"
+    data-post-id="0"
+  >
+    <i class="fa-solid fa-circle-plus fa-lg"></i>
+    <span class="screen-reader-text">Ajouter une énigme</span>
+  </a>
+<?php else : ?>
+  <a
+    href="<?php echo $ajout_url; ?>"
+    id="carte-ajout-enigme"
+    class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?><?php echo $highlight_pulse ? ' pulsation' : ''; ?>"
+    data-post-id="0">
+    <div class="contenu-carte">
+      ➕ <?php echo $has_enigmes ? 'Ajouter une énigme' : 'Créer la première énigme'; ?>
+    </div>
+    <div class="overlay-message">
+      <i class="fa-solid fa-circle-info"></i>
+      <p>Complétez d’abord : titre, image, description</p>
+    </div>
+  </a>
+<?php endif; ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -29,6 +29,16 @@ $posts = get_posts([
 // 🔒 Ne garder que les énigmes visibles pour l'utilisateur courant
 $posts_visibles = array_filter($posts, fn($post) => utilisateur_peut_voir_enigme($post->ID, $utilisateur_id));
 $has_enigmes = !empty($posts_visibles);
+
+// 🟠 Détecte la présence d’au moins une énigme incomplète
+$has_incomplete = false;
+foreach ($posts as $p) {
+  verifier_ou_mettre_a_jour_cache_complet($p->ID);
+  if (!get_field('enigme_cache_complet', $p->ID)) {
+    $has_incomplete = true;
+    break;
+  }
+}
 ?>
 
 <div class="bloc-enigmes-chasse">
@@ -68,7 +78,7 @@ $has_enigmes = !empty($posts_visibles);
   <?php endforeach; ?>
 
   <?php
-  if (utilisateur_peut_ajouter_enigme($chasse_id, $utilisateur_id)) {
+  if (utilisateur_peut_ajouter_enigme($chasse_id, $utilisateur_id) && !$has_incomplete && !$has_enigmes) {
     verifier_ou_mettre_a_jour_cache_complet($chasse_id);
     $complete = (bool) get_field('chasse_cache_complet', $chasse_id);
 
@@ -92,6 +102,7 @@ $has_enigmes = !empty($posts_visibles);
       'chasse_id'       => $chasse_id,
       'disabled'        => !$complete,
       'highlight_pulse' => $highlight_pulse,
+      'use_button'      => false,
     ]);
   }
   ?>


### PR DESCRIPTION
## Summary
- afficher un bouton d'ajout d'énigme comme pour les chasses
- insérer ce bouton à côté du titre des énigmes
- cacher la carte d'ajout si une énigme est incomplète
- ajouter le style `.titre-enigmes-wrapper`

## Testing
- `./bin/composer test` *(fails: Permission denied)*
- `./bin/php bin/composer.phar test` *(fails: Command "bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f8f2031688332b60d3cd1379ada86