### PR TITLE
Use templates for organiser chasse loop

### DIFF
--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -94,27 +94,26 @@ get_header();
                 </div>
                 <div class="ligne-chasses"></div>
                 <div class="liste-chasses">
-                    <div class="grille-3">
-                            <?php foreach ($chasses as $post) :
-                                $chasse_id = $post->ID; ?>
-                                <article class="carte-chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
-                                    <div class="carte-core">
-                                        <?php afficher_picture_vignette_chasse($chasse_id); ?>
-                                        <h2><?= esc_html(get_the_title($chasse_id)); ?></h2>
-                                    </div>
-                                </article>
-                            <?php endforeach; ?>
+                    <?php
+                    ob_start();
+                    if ($peut_ajouter && $statut_organisateur !== 'publish') {
+                        get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
+                            'has_chasses'     => $has_chasses,
+                            'organisateur_id' => $organisateur_id,
+                            'highlight_pulse' => $highlight_pulse,
+                        ]);
+                    }
+                    $after_items = ob_get_clean();
 
-                            <?php if ($peut_ajouter && $statut_organisateur !== 'publish') :
-                                get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
-                                    'has_chasses'     => $has_chasses,
-                                    'organisateur_id' => $organisateur_id,
-                                    'highlight_pulse' => $highlight_pulse,
-                                ]);
-                            endif; ?>
-                        </div>
-                    </div>
+                    get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [
+                        'organisateur_id' => $organisateur_id,
+                        'show_header'     => false,
+                        'grid_class'      => 'grille-3',
+                        'after_items'     => $after_items,
+                    ]);
+                    ?>
                 </div>
+            </div>
         </section>
 
     </main>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -1,10 +1,16 @@
 <?php
 defined('ABSPATH') || exit;
 
+
 $organisateur_id = $args['organisateur_id'] ?? null;
 if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
   return;
 }
+
+$show_header  = $args['show_header'] ?? true;
+$grid_class   = $args['grid_class'] ?? 'grille-liste';
+$before_items = $args['before_items'] ?? '';
+$after_items  = $args['after_items'] ?? '';
 
 $query = get_chasses_de_organisateur($organisateur_id);
 $posts = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
@@ -17,9 +23,12 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
 
 ?>
 
+<?php if ($show_header) : ?>
 <h2>Ses chasses</h2>
 <div class="separateur-2"></div>
-<div class="grille-liste">
+<?php endif; ?>
+<div class="<?php echo esc_attr($grid_class); ?>">
+<?php echo $before_items; ?>
   <?php foreach ($posts as $post) : ?>
     <?php
     $chasse_id = $post->ID;
@@ -37,4 +46,5 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
     ]);
     ?>
   <?php endforeach; ?>
+<?php echo $after_items; ?>
 </div>


### PR DESCRIPTION
## Summary
- reuse template `organisateur-partial-boucle-chasses.php` inside `single-organisateur.php`
- make organiser chasse loop template flexible for use in different contexts

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9d699298833289f8489081b12171