### PR TITLE
Désactivation des bordures de complétion après publication

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -52,10 +52,12 @@ foreach ($posts as $p) {
     $cta = get_cta_enigme($enigme_id);
 
     $est_orga = est_organisateur();
-    $wp_statut = get_post_status($chasse_id);
+    $statut_chasse = get_post_status($chasse_id);
+    $statut_enigme = get_post_status($enigme_id);
     $voir_bordure = $est_orga &&
       utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id) &&
-      $wp_statut !== 'publish';
+      $statut_chasse !== 'publish' &&
+      $statut_enigme !== 'publish';
     $classe_completion = '';
     if ($voir_bordure) {
       verifier_ou_mettre_a_jour_cache_complet($enigme_id);

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -33,7 +33,10 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
     <?php
     $chasse_id = $post->ID;
     $est_orga = est_organisateur();
-    $voir_bordure = $est_orga && utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
+    $wp_status = get_post_status($chasse_id);
+    $voir_bordure = $est_orga &&
+      utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id) &&
+      $wp_status !== 'publish';
     $classe_completion = '';
     if ($voir_bordure) {
       verifier_ou_mettre_a_jour_cache_complet($chasse_id);


### PR DESCRIPTION
## Summary
- disable completion border for published enigmes
- disable completion border for published chasses

## Testing
- `composer test` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685fcfe6153c8332a668ae91b5298586