### PR TITLE
Move image init logic to JS

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -90,7 +90,5 @@ function initChampImage(bloc) {
   };
 
   // ✅ On expose la fonction pour la déclencher manuellement
-  bloc.dataset.imageInitReady = '1';
-  bloc.dataset.imageInitTrigger = ouvrirMedia;
   bloc.__ouvrirMedia = ouvrirMedia;
 }

--- a/wp-content/themes/chassesautresor/notices/fields/image-edit.md
+++ b/wp-content/themes/chassesautresor/notices/fields/image-edit.md
@@ -58,6 +58,10 @@ fetch('/wp-admin/admin-ajax.php', {
 })
 ```
 
+La fonction stocke le déclencheur dans `bloc.__ouvrirMedia` pour être rappelé
+depuis d'autres modules. Aucun script inline n'est injecté dans le DOM : les
+attributs `data-image-init-*` ne sont plus utilisés.
+
 ---
 
 ## ✅ 3. PHP – Traitement dans `modifier_champ_enigme()`


### PR DESCRIPTION
## Summary
- drop `data-image-init-*` on image fields
- document `bloc.__ouvrirMedia` in image-edit notice

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd951a8808332aead06a4fbedd1a6