### PR TITLE
Fix redirect after creating new chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -9,7 +9,7 @@ let erreurFin;
 let checkboxIllimitee;
 
 
-document.addEventListener('DOMContentLoaded', () => {
+function initChasseEdit() {
   if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
   inputDateDebut = document.getElementById('chasse-date-debut');
   inputDateFin = document.getElementById('chasse-date-fin');
@@ -304,7 +304,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
   }
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initChasseEdit);
+} else {
+  initChasseEdit();
+}
 
 
 // ==============================

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -7,7 +7,7 @@ let panneauEdition;
 
 
 
-document.addEventListener('DOMContentLoaded', () => {
+function initEnigmeEdit() {
   if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
   boutonToggle = document.getElementById('toggle-mode-edition-enigme');
   panneauEdition = document.querySelector('.edition-panel-enigme');
@@ -301,7 +301,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initEnigmeEdit);
+} else {
+  initEnigmeEdit();
+}
 
 // ================================
 // 🖼️ Panneau images galerie (ACF gallery)
@@ -490,7 +496,7 @@ window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
 // ==============================
 // 🔐 Champ bonne réponse – Limite 75 caractères + message d’alerte
 // ==============================
-document.addEventListener('DOMContentLoaded', () => {
+function initChampBonneReponse() {
   const bloc = document.querySelector('[data-champ="enigme_reponse_bonne"]');
   if (!bloc) return;
 
@@ -538,7 +544,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }, 400);
     }
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initChampBonneReponse);
+} else {
+  initChampBonneReponse();
+}
 
 
 // ==============================
@@ -1006,7 +1018,7 @@ document.querySelector('#panneau-solution-enigme .panneau-fermer')?.addEventList
 // ==============================
 // ✅ Enregistrement condition "pré-requis" à la sélection du radio
 // ==============================
-document.addEventListener('DOMContentLoaded', () => {
+function initEnregistrementPreRequis() {
   const radioPreRequis = document.querySelector('input[name="acf[enigme_acces_condition]"][value="pre_requis"]');
   const champBloc = document.querySelector('[data-champ="enigme_acces_pre_requis"]');
   const postId = champBloc?.dataset.postId;
@@ -1042,7 +1054,13 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('❌ Erreur réseau lors de l’enregistrement de la condition pré-requis', err);
       });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initEnregistrementPreRequis);
+} else {
+  initEnregistrementPreRequis();
+}
 
 function appliquerEtatGratuitEnLive() {
   DEBUG && console.log('✅ enappliquerEtatGratuit() chargé');

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -152,8 +152,8 @@ function creer_chasse_et_rediriger_si_appel()
   update_field('chasse_cache_statut_validation', 'creation', $post_id);
   update_field('chasse_cache_organisateur', [$organisateur_id], $post_id);
 
-  // 🚀 Redirection vers la prévisualisation frontale avec panneau ouvert
-  $preview_url = add_query_arg('edition', 'open', get_preview_post_link($post_id));
+  // 🚀 Redirection vers la prévisualisation frontale
+  $preview_url = get_preview_post_link($post_id);
   cat_debug("➡️ Redirection vers : {$preview_url}");
   wp_redirect($preview_url);
   exit;


### PR DESCRIPTION
## Summary
- remove `edition=open` from new chasse preview redirect

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe0c5a80c8332ba8d956733f0503b