### PR TITLE
Fix organizer link edit icon

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -199,7 +199,7 @@ function initLiensPublics(bloc, { panneauId, formId, action, reload = false }) {
         if (zoneAffichage && typeof renderLiensPublicsJS === 'function') {
           zoneAffichage.innerHTML = renderLiensPublicsJS(donnees);
 
-          if (!bloc.querySelector('.champ-modifier')) {
+          if (!zoneAffichage.dataset.noEdit && !bloc.querySelector('.champ-modifier')) {
             const btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'champ-modifier ouvrir-panneau-liens';
@@ -228,7 +228,7 @@ function initLiensPublics(bloc, { panneauId, formId, action, reload = false }) {
             if (zone && typeof renderLiensPublicsJS === 'function') {
               zone.innerHTML = renderLiensPublicsJS(donnees);
 
-              if (!blocCible.querySelector('.champ-modifier')) {
+              if (!zone.dataset.noEdit && !blocCible.querySelector('.champ-modifier')) {
                 const btn = document.createElement('button');
                 btn.type = 'button';
                 btn.className = 'champ-modifier ouvrir-panneau-liens';

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
@@ -40,7 +40,7 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
              data-cpt="organisateur"
              data-post-id="<?= esc_attr($organisateur_id); ?>">
         
-            <div class="champ-affichage champ-affichage-liens bloc-liens-publics header-organisateur__liens <?= count($liens_actifs) >= 3 ? 'liens-compacts' : ''; ?>">
+            <div class="champ-affichage champ-affichage-liens bloc-liens-publics header-organisateur__liens <?= count($liens_actifs) >= 3 ? 'liens-compacts' : ''; ?>" data-no-edit="1">
         
             <?php if (!empty($liens_actifs)) : ?>
               <ul class="liste-liens-publics">


### PR DESCRIPTION
## Summary
- prevent JS from inserting an edit button when `data-no-edit` is set
- mark organiser presentation block as `data-no-edit`

## Testing
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686043b4bc2c8332a9fd00db545bf717