### PR TITLE
Fix reward description encoding

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -225,8 +225,8 @@ function initChasseEdit() {
         return;
       }
 
-      if (isNaN(valeur) || valeur <= 0) {
-        alert('Veuillez saisir une valeur en euros strictement supérieure à 0.');
+      if (isNaN(valeur) || valeur <= 0 || valeur > 5000000) {
+        alert('Veuillez saisir une valeur en euros comprise entre 0 et 5\u00a0000\u00a0000.');
         return;
       }
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -46,7 +46,7 @@ function recuperer_infos_chasse($chasse_id) {
  */
 function chasse_get_champs($chasse_id) {
     return [
-        'lot' => get_field('chasse_infos_recompense_texte', $chasse_id) ?? '',
+        'lot' => get_field('chasse_infos_recompense_texte', $chasse_id, false) ?? '',
         'titre_recompense' => get_field('chasse_infos_recompense_titre', $chasse_id) ?? '',
         'valeur_recompense' => get_field('chasse_infos_recompense_valeur', $chasse_id) ?? '',
         'cout_points' => get_field('chasse_infos_cout_points', $chasse_id) ?? 0,

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -419,6 +419,14 @@ function modifier_champ_chasse()
   ];
   if (in_array($champ, $champs_recompense, true)) {
     $sous_champ = str_replace('caracteristiques.', '', $champ);
+
+    // Validation spécifique pour la valeur monétaire
+    if ($sous_champ === 'chasse_infos_recompense_valeur') {
+      if (!is_numeric($valeur) || $valeur <= 0 || $valeur > 5000000) {
+        wp_send_json_error('valeur_invalide');
+      }
+    }
+
     $ok = update_field($sous_champ, $valeur, $post_id);
     if ($ok !== false) $champ_valide = true;
     $doit_recalculer_statut = true;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-recompense.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-recompense.php
@@ -3,7 +3,7 @@ defined('ABSPATH') || exit;
 $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
-$texte_recompense  = get_field('chasse_infos_recompense_texte', $chasse_id);
+$texte_recompense  = get_field('chasse_infos_recompense_texte', $chasse_id, false);
 $valeur_recompense = get_field('chasse_infos_recompense_valeur', $chasse_id);
 ?>
 
@@ -26,7 +26,7 @@ $valeur_recompense = get_field('chasse_infos_recompense_valeur', $chasse_id);
 
 
       <label for="champ-recompense-valeur">Valeur en euros (€) <span class="champ-obligatoire">*</span></label>
-      <input id="champ-recompense-valeur" class="w-175" type="number" min="0" step="0.01" placeholder="Ex : 50" value="<?= esc_attr($valeur_recompense); ?>">
+      <input id="champ-recompense-valeur" class="w-175" type="number" min="0" max="5000000" step="0.01" placeholder="Ex : 50" value="<?= esc_attr($valeur_recompense); ?>">
 
       <div class="panneau-lateral__actions">
         <button id="bouton-enregistrer-recompense" type="button" class="bouton-enregistrer-description bouton-enregistrer-liens">💾 Enregistrer</button>


### PR DESCRIPTION
## Summary
- avoid formatted ACF value for reward text
- cap reward value at 5,000,000€ via HTML, JS and server validation

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604bfdb97c8332a220d94fb6f9b414