### PR TITLE
Redirect reward save with edition parameter

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -293,7 +293,9 @@ function initChasseEdit() {
               document.body.focus(); // 🔥 Correction ultime ici
             }
 
-            location.reload();
+            const url = new URL(window.location.href);
+            url.searchParams.set('edition', 'open');
+            window.location.href = url.toString();
 
           } else {
             console.error('❌ Erreur valeur récompense', res.data);


### PR DESCRIPTION
## Summary
- keep reward edit page open by adding `edition=open` parameter after saving

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604c653c3083329c41834f46fb5ffa