### PR TITLE
Fix free cost logic for enigme edit

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1069,8 +1069,10 @@ function appliquerEtatGratuitEnLive() {
   if (!$cout || !$checkbox) return;
 
   function syncGratuit() {
-    const val = parseInt($cout.value.trim(), 10);
-    const estGratuit = val === 0;
+    const raw = $cout.value;
+    const trimmed = raw.trim();
+    const valeur = trimmed === '' ? 0 : parseInt(trimmed, 10);
+    const estGratuit = valeur === 0;
 
     DEBUG && console.log('[🎯 syncGratuit] coût =', $cout.value, '| gratuit ?', estGratuit);
     $checkbox.checked = estGratuit;


### PR DESCRIPTION
## Summary
- treat empty cost input as zero when toggling the 'Free' checkbox for enigmes

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b50022a8833297077a773487280b