### PR TITLE
Fix dynamic subtitle update for enigme CPT

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -115,7 +115,12 @@ function initChampTexte(bloc) {
     }
 
     if (champ === 'enigme_visuel_legende') {
-      const legendeDOM = document.querySelector('.enigme-legende');
+      // Mise à jour dynamique du sous-titre affiché sous le titre de l'énigme.
+      // ​​Supporte à la fois l'ancien sélecteur `.enigme-legende` et
+      // le nouveau `.enigme-soustitre` utilisé dans les templates.
+      const legendeDOM =
+        document.querySelector('.enigme-soustitre') ||
+        document.querySelector('.enigme-legende');
       if (legendeDOM) {
         legendeDOM.textContent = valeur;
         legendeDOM.classList.add('modifiee');


### PR DESCRIPTION
## Summary
- ensure subtitle updates live in enigme edition

## Testing
- `composer test` *(fails: `vendor/bin/phpunit: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6860be31ddf0833282ef91bae48875e4