### PR TITLE
Fix enigme thumbnail size

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -68,7 +68,7 @@ foreach ($posts as $p) {
     <article class="carte carte-enigme <?= esc_attr($classe_completion); ?>">
       <div class="carte-core">
         <div class="carte-enigme-image">
-          <?php afficher_picture_vignette_enigme($enigme_id, 'Vignette de l’énigme'); ?>
+          <?php afficher_picture_vignette_enigme($enigme_id, 'Vignette de l’énigme', ['medium']); ?>
           <div class="carte-enigme-cta">
             <?php render_cta_enigme($cta, $enigme_id); ?>
           </div>


### PR DESCRIPTION
## Summary
- set medium size as the native format for enigme thumbnails

## Testing
- `composer install` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*
- `composer test` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6860d161b9b4833288675e9cfc7c1149