### PR TITLE
Add translation domain loading and update strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ composer test
 
 La commande composer test exécute PHPUnit à l’aide de la configuration du plugin hostinger.
 
+Gestion des traductions du thème
+--------------------------------
+
+Les fichiers de langues du thème sont placés dans `wp-content/themes/chassesautresor/languages/`.
+Pour générer ou mettre à jour le fichier POT, utilisez WP‑CLI :
+
+```bash
+wp i18n make-pot ./wp-content/themes/chassesautresor ./wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+```
+
+Ajoutez ensuite vos fichiers `.mo` compilés dans ce même dossier pour charger les traductions en front‑end.
+

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -13,6 +13,14 @@ defined( 'ABSPATH' ) || exit;
  */
 define( 'CHILD_THEME_CHASSESAUTRESOR_COM_VERSION', '1.0.0' );
 
+/**
+ * Charge le domaine de traduction du thème enfant.
+ */
+function cta_load_textdomain() {
+    load_child_theme_textdomain( 'chassesautresor-com', get_stylesheet_directory() . '/languages' );
+}
+add_action( 'after_setup_theme', 'cta_load_textdomain' );
+
 
 /**
  * Chargement des styles du thème parent et enfant avec prise en charge d'Astra.

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -34,14 +34,14 @@ defined( 'ABSPATH' ) || exit;
 function rechercher_utilisateur_ajax() {
     // ✅ Vérifier que la requête est bien envoyée par un administrateur
     if (!current_user_can('administrator')) {
-        wp_send_json_error(['message' => '⛔ Accès refusé.']);
+        wp_send_json_error(['message' => __( '⛔ Accès refusé.', 'chassesautresor-com' )]);
     }
 
     // ✅ Vérifier la présence du paramètre de recherche
     $search = isset($_GET['term']) ? sanitize_text_field($_GET['term']) : '';
 
     if (empty($search)) {
-        wp_send_json_error(['message' => '❌ Requête vide.']);
+        wp_send_json_error(['message' => __( '❌ Requête vide.', 'chassesautresor-com' )]);
     }
 
     // ✅ Requête pour récupérer tous les utilisateurs sans restriction de rôle
@@ -52,7 +52,7 @@ function rechercher_utilisateur_ajax() {
 
     // ✅ Vérifier que des utilisateurs sont trouvés
     if (empty($users)) {
-        wp_send_json_error(['message' => '❌ Aucun utilisateur trouvé.']);
+        wp_send_json_error(['message' => __( '❌ Aucun utilisateur trouvé.', 'chassesautresor-com' )]);
     }
 
     // ✅ Formatage des résultats en JSON
@@ -79,12 +79,12 @@ function traiter_gestion_points() {
     
     // ✅ Vérification du nonce pour la sécurité
     if (!isset($_POST['gestion_points_nonce']) || !wp_verify_nonce($_POST['gestion_points_nonce'], 'gestion_points_action')) {
-        wp_die('❌ Vérification du nonce échouée.');
+        wp_die( __( '❌ Vérification du nonce échouée.', 'chassesautresor-com' ) );
     }
 
     // ✅ Vérification que l'utilisateur est administrateur
     if (!current_user_can('administrator')) {
-        wp_die('❌ Accès refusé.');
+        wp_die( __( '❌ Accès refusé.', 'chassesautresor-com' ) );
     }
 
     // ✅ Vérification et assainissement des données
@@ -93,13 +93,13 @@ function traiter_gestion_points() {
     $nombre_points = intval($_POST['nombre_points']);
 
     if (!$utilisateur || !$type_modification || $nombre_points <= 0) {
-        wp_die('❌ Données invalides.');
+        wp_die( __( '❌ Données invalides.', 'chassesautresor-com' ) );
     }
 
     // Récupérer l'ID de l'utilisateur
     $user = get_user_by('ID', intval($utilisateur));
     if (!$user) {
-        wp_die('❌ Utilisateur introuvable.');
+        wp_die( __( '❌ Utilisateur introuvable.', 'chassesautresor-com' ) );
     }
 
     $user_id = $user->ID;
@@ -110,11 +110,11 @@ function traiter_gestion_points() {
         $nouveau_solde = $solde_actuel + $nombre_points;
     } elseif ($type_modification === "retirer") {
         if ($nombre_points > $solde_actuel) {
-            wp_die('❌ Impossible de retirer plus de points que l’utilisateur en possède.');
+            wp_die( __( '❌ Impossible de retirer plus de points que l’utilisateur en possède.', 'chassesautresor-com' ) );
         }
         $nouveau_solde = $solde_actuel - $nombre_points;
     } else {
-        wp_die('❌ Action invalide.');
+        wp_die( __( '❌ Action invalide.', 'chassesautresor-com' ) );
     }
 
     // Mettre à jour les points de l'utilisateur
@@ -166,7 +166,7 @@ function gerer_organisateur() {
     
 
     if (!current_user_can('manage_options')) {
-        wp_send_json_error(array("message" => "Permission refusée."));
+        wp_send_json_error( array( 'message' => __( 'Permission refusée.', 'chassesautresor-com' ) ) );
         exit;
     }
 
@@ -174,7 +174,7 @@ function gerer_organisateur() {
     $type = sanitize_text_field($_POST['type']);
 
     if (!$post_id || empty($type)) {
-        wp_send_json_error(array("message" => "Requête invalide."));
+        wp_send_json_error( array( 'message' => __( 'Requête invalide.', 'chassesautresor-com' ) ) );
         exit;
     }
 
@@ -216,7 +216,7 @@ function gerer_organisateur() {
         wp_send_json_success(array("message" => "Demande refusée et supprimée."));
     }
 
-    wp_send_json_error(array("message" => "Action inconnue."));
+    wp_send_json_error( array( 'message' => __( 'Action inconnue.', 'chassesautresor-com' ) ) );
 }
 
 
@@ -338,18 +338,18 @@ function traiter_mise_a_jour_taux_conversion() {
         
         // Vérifier le nonce pour la sécurité
         if (!isset($_POST['modifier_taux_conversion_nonce']) || !wp_verify_nonce($_POST['modifier_taux_conversion_nonce'], 'modifier_taux_conversion_action')) {
-            wp_die('❌ Vérification du nonce échouée.');
+            wp_die( __( '❌ Vérification du nonce échouée.', 'chassesautresor-com' ) );
         }
 
         // Vérifier que l'utilisateur est bien un administrateur
         if (!current_user_can('administrator')) {
-            wp_die('❌ Accès refusé.');
+            wp_die( __( '❌ Accès refusé.', 'chassesautresor-com' ) );
         }
 
         // Vérifier et assainir la valeur entrée
         $nouveau_taux = isset($_POST['nouveau_taux']) ? floatval($_POST['nouveau_taux']) : null;
         if ($nouveau_taux === null || $nouveau_taux <= 0) {
-            wp_die('❌ Veuillez entrer un taux de conversion valide.');
+            wp_die( __( '❌ Veuillez entrer un taux de conversion valide.', 'chassesautresor-com' ) );
         }
 
         // Mettre à jour le taux dans les options WordPress
@@ -498,12 +498,12 @@ function traiter_demande_paiement() {
 
     // ✅ Vérification du nonce pour la sécurité
     if (!isset($_POST['demande_paiement_nonce']) || !wp_verify_nonce($_POST['demande_paiement_nonce'], 'demande_paiement_action')) {
-        wp_die('❌ Vérification du nonce échouée.');
+        wp_die( __( '❌ Vérification du nonce échouée.', 'chassesautresor-com' ) );
     }
 
     // ✅ Vérification de l'utilisateur connecté
     if (!is_user_logged_in()) {
-        wp_die('❌ Vous devez être connecté pour effectuer cette action.');
+        wp_die( __( '❌ Vous devez être connecté pour effectuer cette action.', 'chassesautresor-com' ) );
     }
 
     $user_id = get_current_user_id();
@@ -514,11 +514,11 @@ function traiter_demande_paiement() {
     $points_a_convertir = isset($_POST['points_a_convertir']) ? intval($_POST['points_a_convertir']) : 0;
 
     if ($points_a_convertir < 500) {
-        wp_die('❌ Le minimum pour une conversion est de 500 points.');
+        wp_die( __( '❌ Le minimum pour une conversion est de 500 points.', 'chassesautresor-com' ) );
     }
 
     if ($points_a_convertir > $solde_actuel) {
-        wp_die('❌ Vous n\'avez pas assez de points pour effectuer cette conversion.');
+        wp_die( __( '❌ Vous n\'avez pas assez de points pour effectuer cette conversion.', 'chassesautresor-com' ) );
     }
 
     // ✅ Calcul du montant en euros
@@ -780,14 +780,14 @@ function gerer_activation_reinitialisation_stats() {
     // ✅ Vérification des permissions administrateur
     if (!current_user_can('manage_options')) {
         error_log("⛔ Problème de permission : utilisateur non autorisé.");
-        wp_die(__('⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action.', 'textdomain'));
+        wp_die( __( '⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action.', 'chassesautresor-com' ) );
     }
     error_log("🔎 Permission OK");
 
     // ✅ Vérification de la requête POST et de la sécurité
     if (!isset($_POST['enregistrer_reinit']) || !check_admin_referer('toggle_reinit_stats_action', 'toggle_reinit_stats_nonce')) {
         error_log("⛔ Problème de nonce ou bouton non soumis.");
-        wp_die(__('⛔ Erreur de sécurité. Veuillez réessayer.', 'textdomain'));
+        wp_die( __( '⛔ Erreur de sécurité. Veuillez réessayer.', 'chassesautresor-com' ) );
     }
     error_log("🔎 Nonce OK");
 
@@ -1228,7 +1228,7 @@ add_action('admin_notices', function() {
 // =============================================
 function recuperer_details_acf() {
     if (!current_user_can('administrator')) {
-        wp_send_json_error('Non autorisé');
+        wp_send_json_error( __( 'Non autorisé', 'chassesautresor-com' ) );
     }
 
     // Utilisation des "keys" ACF directement car les IDs ne sont pas fiables
@@ -1504,18 +1504,18 @@ function traiter_validation_chasse_admin() {
     }
 
     if (!current_user_can('administrator')) {
-        wp_die('Accès refusé.');
+        wp_die( __( 'Accès refusé.', 'chassesautresor-com' ) );
     }
 
     $chasse_id = isset($_POST['chasse_id']) ? intval($_POST['chasse_id']) : 0;
     $action    = sanitize_text_field($_POST['validation_admin_action']);
 
     if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
-        wp_die('ID de chasse invalide.');
+        wp_die( __( 'ID de chasse invalide.', 'chassesautresor-com' ) );
     }
 
     if (!isset($_POST['validation_admin_nonce']) || !wp_verify_nonce($_POST['validation_admin_nonce'], 'validation_admin_' . $chasse_id)) {
-        wp_die('Nonce invalide.');
+        wp_die( __( 'Nonce invalide.', 'chassesautresor-com' ) );
     }
 
     $enigmes = recuperer_enigmes_associees($chasse_id);

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -159,13 +159,13 @@ add_filter('acf/validate_value/name=date_de_fin', function ($valid, $value, $fie
 
     // ✅ Vérification : La date de fin ne peut pas être avant la date de début
     if (!empty($date_debut) && !empty($value) && strtotime($value) < strtotime($date_debut)) {
-        return __('⚠️ Erreur : La date de fin ne peut pas être antérieure à la date de début.', 'textdomain');
+        return __( '⚠️ Erreur : La date de fin ne peut pas être antérieure à la date de début.', 'chassesautresor-com' );
     }
 
     // ✅ Vérification : Si "maintenant" est sélectionné, date_de_fin ne peut pas être antérieure à aujourd'hui
     if ($_POST['acf'][$caracteristiques_key]['field_67ca858935c21'] === 'maintenant' &&
         !empty($value) && strtotime($value) < strtotime(date('Y-m-d'))) {
-        return __('⚠️ Erreur : La date de fin ne peut pas être antérieure à la date du jour si la chasse commence maintenant.', 'textdomain');
+        return __( '⚠️ Erreur : La date de fin ne peut pas être antérieure à la date du jour si la chasse commence maintenant.', 'chassesautresor-com' );
     }
 
     return $valid;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -95,7 +95,7 @@ function creer_chasse_et_rediriger_si_appel()
   $organisateur_id = get_organisateur_from_user($user_id);
   if (!$organisateur_id) {
     cat_debug("🛑 Aucun organisateur trouvé pour l'utilisateur {$user_id}");
-    wp_die('Aucun organisateur associé.');
+    wp_die( __( 'Aucun organisateur associé.', 'chassesautresor-com' ) );
   }
   cat_debug("✅ Organisateur trouvé : {$organisateur_id}");
 
@@ -103,10 +103,10 @@ function creer_chasse_et_rediriger_si_appel()
   if (!current_user_can('administrator') && !current_user_can(ROLE_ORGANISATEUR)) {
     if (in_array(ROLE_ORGANISATEUR_CREATION, $roles, true)) {
       if (organisateur_a_des_chasses($organisateur_id)) {
-        wp_die('Limite atteinte');
+        wp_die( __( 'Limite atteinte', 'chassesautresor-com' ) );
       }
     } else {
-      wp_die('Accès refusé');
+      wp_die( __( 'Accès refusé', 'chassesautresor-com' ) );
     }
   }
 
@@ -116,7 +116,7 @@ function creer_chasse_et_rediriger_si_appel()
     get_post_status($organisateur_id) === 'publish' &&
     organisateur_a_chasse_pending($organisateur_id)
   ) {
-    wp_die('Une chasse est déjà en attente de validation.');
+    wp_die( __( 'Une chasse est déjà en attente de validation.', 'chassesautresor-com' ) );
   }
 
   // 📝 Création du post "chasse"
@@ -129,7 +129,7 @@ function creer_chasse_et_rediriger_si_appel()
 
   if (is_wp_error($post_id)) {
     cat_debug("🛑 Erreur création post : " . $post_id->get_error_message());
-    wp_die('Erreur lors de la création de la chasse.');
+    wp_die( __( 'Erreur lors de la création de la chasse.', 'chassesautresor-com' ) );
   }
 
   cat_debug("✅ Chasse créée avec l’ID : {$post_id}");

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -153,7 +153,7 @@ function creer_enigme_et_rediriger_si_appel()
   $chasse_id = isset($_GET['chasse_id']) ? absint($_GET['chasse_id']) : 0;
 
   if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
-    wp_die('Chasse non spécifiée ou invalide.', 'Erreur', ['response' => 400]);
+    wp_die( __( 'Chasse non spécifiée ou invalide.', 'chassesautresor-com' ), 'Erreur', ['response' => 400] );
   }
 
   $enigme_id = creer_enigme_pour_chasse($chasse_id, $user_id);

--- a/wp-content/themes/chassesautresor/inc/stat-functions-old.php
+++ b/wp-content/themes/chassesautresor/inc/stat-functions-old.php
@@ -1172,7 +1172,7 @@ function mettre_a_jour_points_en_circulation() {
  */
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['verifier_points_circulation'])) {
     if (!current_user_can('administrator') || !check_admin_referer('verifier_points_circulation_action', 'verifier_points_circulation_nonce')) {
-        wp_die(__('Accès non autorisé.'));
+        wp_die( __( 'Accès non autorisé.', 'chassesautresor-com' ) );
     }
 
     mettre_a_jour_points_en_circulation();

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -9,7 +9,7 @@ defined('ABSPATH') || exit;
 // 🧠 LOGIQUE MÉTIER
 $chasse_id = get_the_ID();
 if (!$chasse_id) {
-  wp_die('Chasse introuvable.');
+  wp_die( __( 'Chasse introuvable.', 'chassesautresor-com' ) );
 }
 
 verifier_ou_recalculer_statut_chasse($chasse_id);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-description.php
@@ -12,26 +12,26 @@ $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 ?>
 
-<div id="panneau-description-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
-  <div class="panneau-lateral__contenu">
+  <div id="panneau-description-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
+    <div class="panneau-lateral__contenu">
 
-    <header class="panneau-lateral__header">
-      <h2>Modifier la description de la chasse</h2>
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
-    </header>
+      <header class="panneau-lateral__header">
+        <h2><?php echo esc_html__( 'Modifier la description de la chasse', 'chassesautresor-com' ); ?></h2>
+        <button type="button" class="panneau-fermer" aria-label="<?php echo esc_attr__( 'Fermer le panneau', 'chassesautresor-com' ); ?>">✖</button>
+      </header>
 
     <?php
     acf_form([
       'post_id'             => $chasse_id,
       'fields'              => ['chasse_principale_description'],
       'form'                => true,
-      'submit_value'        => '💾 Enregistrer',
+        'submit_value'        => __( '💾 Enregistrer', 'chassesautresor-com' ),
       'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
       'html_before_fields'  => '<div class="champ-wrapper">',
       'html_after_fields'   => '</div>',
       'return'              => get_permalink() . '#chasse-description',
-      'updated_message'     => __('Description mise à jour.', 'chassesautresor')
-    ]);
+        'updated_message'     => __( 'Description mise à jour.', 'chassesautresor-com' )
+      ]);
     ?>
 
   </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-description.php
@@ -15,8 +15,8 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
   <div class="panneau-lateral__contenu">
 
     <header class="panneau-lateral__header">
-      <h2>Modifier le texte de l’énigme</h2>
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+      <h2><?php echo esc_html__( 'Modifier le texte de l’énigme', 'chassesautresor-com' ); ?></h2>
+      <button type="button" class="panneau-fermer" aria-label="<?php echo esc_attr__( 'Fermer le panneau', 'chassesautresor-com' ); ?>">✖</button>
     </header>
 
     <?php
@@ -24,12 +24,12 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
       'post_id'             => $enigme_id,
       'fields'              => ['enigme_visuel_texte'],
       'form'                => true,
-      'submit_value'        => '💾 Enregistrer',
+      'submit_value'        => __( '💾 Enregistrer', 'chassesautresor-com' ),
       'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
       'html_before_fields'  => '<div class="champ-wrapper">',
       'html_after_fields'   => '</div>',
       'return' => add_query_arg('panneau', 'description-enigme', get_permalink()),
-      'updated_message'     => __('Texte de l’énigme mis à jour.', 'chassesautresor')
+      'updated_message'     => __( 'Texte de l’énigme mis à jour.', 'chassesautresor-com' )
     ]);
     ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-images.php
@@ -8,8 +8,8 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
 <div id="panneau-images-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
     <header class="panneau-lateral__header">
-      <h2>Modifier les images de l’énigme</h2>
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+      <h2><?php echo esc_html__( 'Modifier les images de l’énigme', 'chassesautresor-com' ); ?></h2>
+      <button type="button" class="panneau-fermer" aria-label="<?php echo esc_attr__( 'Fermer le panneau', 'chassesautresor-com' ); ?>">✖</button>
     </header>
 
     <?php
@@ -17,7 +17,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
       'post_id'             => $enigme_id,
       'fields'              => ['enigme_visuel_image'],
       'form'                => true,
-      'submit_value'        => '💾 Enregistrer',
+      'submit_value'        => __( '💾 Enregistrer', 'chassesautresor-com' ),
       'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
       'html_before_fields'  => '<div class="champ-wrapper">',
       'html_after_fields'   => '</div>',
@@ -26,7 +26,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
       // ?edition=open. L'ancre #images-enigme permet de scroller
       // directement sur le panneau images.
       'return'              => add_query_arg('edition', 'open', get_permalink()) . '#images-enigme',
-      'updated_message'     => __('Images mises à jour.', 'chassesautresor')
+      'updated_message'     => __( 'Images mises à jour.', 'chassesautresor-com' )
     ]);
     ?>
   </div>

--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -25,7 +25,7 @@ if (
   !isset($_POST['engager_enigme_nonce']) ||
   !wp_verify_nonce($_POST['engager_enigme_nonce'], 'engager_enigme_' . $enigme_id)
 ) {
-  wp_die('Échec de vérification de sécurité');
+  wp_die( __( 'Échec de vérification de sécurité', 'chassesautresor-com' ) );
 }
 
 // Chargement des fonctions critiques

--- a/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
@@ -6,10 +6,10 @@
 require_once get_stylesheet_directory() . '/inc/enigme-functions.php';
 
 $uid = sanitize_text_field($_GET['uid'] ?? '');
-if (!$uid) wp_die("Paramètre UID manquant.");
+if (!$uid) wp_die( __( 'Paramètre UID manquant.', 'chassesautresor-com' ) );
 
 $tentative = get_tentative_by_uid($uid);
-if (!$tentative) wp_die("Tentative introuvable.");
+if (!$tentative) wp_die( __( 'Tentative introuvable.', 'chassesautresor-com' ) );
 
 $enigme_id = (int) $tentative->enigme_id;
 $infos = recuperer_infos_tentative($uid);
@@ -26,7 +26,7 @@ if (
   !current_user_can('manage_options') &&
   !in_array($current_user_id, array_map('intval', $organisateur_user_ids), true)
 ) {
-  wp_die("⛔️ Accès refusé.");
+  wp_die( __( '⛔️ Accès refusé.', 'chassesautresor-com' ) );
 }
 
 // 💚 Réinitialisations

--- a/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
@@ -25,11 +25,11 @@ if (
     !isset($_POST['validation_chasse_nonce']) ||
     !wp_verify_nonce($_POST['validation_chasse_nonce'], 'validation_chasse_' . $chasse_id)
 ) {
-    wp_die('Vérification de sécurité échouée.');
+    wp_die( __( 'Vérification de sécurité échouée.', 'chassesautresor-com' ) );
 }
 
 if (!peut_valider_chasse($chasse_id, $user_id)) {
-    wp_die('Conditions non remplies.');
+    wp_die( __( 'Conditions non remplies.', 'chassesautresor-com' ) );
 }
 
 forcer_statut_apres_acf($chasse_id, 'en_attente');


### PR DESCRIPTION
## Summary
- add languages directory and load textdomain
- update translation strings to use `chassesautresor-com`
- document translation workflow in README

## Testing
- `composer install` *(fails: `/usr/bin/php: No such file or directory`)*
- `composer test` *(fails: `/usr/bin/php: No such file or directory`)*
- `php ./wp-cli.phar i18n make-pot` *(fails: `Command "./wp-cli.phar" is not defined.`)*

------
https://chatgpt.com/codex/tasks/task_e_6860e025a24c8332aaeedb4c4bfbaf6a