### PR TITLE
Affiche nombre réel de joueurs engagés

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -372,6 +372,34 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
 }
 
 /**
+ * Compte le nombre de joueurs ayant engagé au moins une énigme de la chasse.
+ *
+ * @param int $chasse_id ID de la chasse.
+ * @return int Nombre de joueurs uniques engagés.
+ */
+function compter_joueurs_engages_chasse(int $chasse_id): int
+{
+    if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+        return 0;
+    }
+
+    $enigmes = recuperer_enigmes_associees($chasse_id);
+    if (empty($enigmes)) {
+        return 0;
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'engagements';
+    $placeholders = implode(',', array_fill(0, count($enigmes), '%d'));
+    $query = $wpdb->prepare(
+        "SELECT COUNT(DISTINCT user_id) FROM $table WHERE enigme_id IN ($placeholders)",
+        ...$enigmes
+    );
+
+    return (int) $wpdb->get_var($query);
+}
+
+/**
  * Retourne la première chasse pouvant être soumise à validation pour un utilisateur.
  *
  * @param int $user_id ID utilisateur.

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -400,6 +400,22 @@ function compter_joueurs_engages_chasse(int $chasse_id): int
 }
 
 /**
+ * Formate le libellé internationalisé du nombre de joueurs.
+ *
+ * @param int $nombre Nombre de joueurs.
+ * @return string Libellé formaté.
+ */
+function formater_nombre_joueurs(int $nombre): string
+{
+    $quantite = ($nombre === 0 || $nombre === 1) ? 1 : $nombre;
+
+    return sprintf(
+        _n('%d joueur', '%d joueurs', $quantite, 'chassesautresor'),
+        $nombre
+    );
+}
+
+/**
  * Retourne la première chasse pouvant être soumise à validation pour un utilisateur.
  *
  * @param int $user_id ID utilisateur.

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-chasse-card.php
@@ -82,7 +82,7 @@ $classe_verrouillee = '';
         <div class="meta-row svg-xsmall">
             <div class="meta-regular">
                 <?php echo get_svg_icon('enigme'); ?> <?php echo esc_html($total_enigmes); ?> énigme<?php echo ($total_enigmes > 1 ? 's' : ''); ?> —
-                <?php echo get_svg_icon('participants'); ?><?php echo esc_html(sprintf(_n('%d joueur', '%d joueurs', $nb_joueurs, 'chassesautresor'), $nb_joueurs)); ?>
+                <?php echo get_svg_icon('participants'); ?><?php echo esc_html(formater_nombre_joueurs($nb_joueurs)); ?>
             </div>
             <div class="meta-etiquette">
                 <?php echo get_svg_icon('calendar'); ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-chasse-card.php
@@ -54,7 +54,7 @@ if ($statut === 'revision') {
 }
 
 // 🔹 Informations supplémentaires
-$nb_joueurs = get_field('total_joueurs_souscription_chasse', $chasse_id);
+$nb_joueurs = compter_joueurs_engages_chasse($chasse_id);
 
 
 // 🔹 Préparation du badge de statut
@@ -82,7 +82,7 @@ $classe_verrouillee = '';
         <div class="meta-row svg-xsmall">
             <div class="meta-regular">
                 <?php echo get_svg_icon('enigme'); ?> <?php echo esc_html($total_enigmes); ?> énigme<?php echo ($total_enigmes > 1 ? 's' : ''); ?> —
-                <?php echo get_svg_icon('participants'); ?><?php echo esc_html($nb_joueurs); ?> joueur<?php echo ($nb_joueurs > 1 ? 's' : ''); ?>
+                <?php echo get_svg_icon('participants'); ?><?php echo esc_html(sprintf(_n('%d joueur', '%d joueurs', $nb_joueurs, 'chassesautresor'), $nb_joueurs)); ?>
             </div>
             <div class="meta-etiquette">
                 <?php echo get_svg_icon('calendar'); ?>


### PR DESCRIPTION
## Summary
- ajoute `compter_joueurs_engages_chasse()` pour compter les joueurs depuis `wp_engagements`
- affiche le nombre de joueurs dans la carte chasse avec gestion singulier/pluriel

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68622128196c83329410b8503ce11096