### PR TITLE
Optimize organizer check in loop

### DIFF
--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -19,6 +19,7 @@ verifier_ou_mettre_a_jour_cache_complet($chasse_id);
 
 $edition_active     = utilisateur_peut_modifier_post($chasse_id);
 $user_id            = get_current_user_id();
+$est_orga_associe   = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
 $points_utilisateur = get_user_points($user_id);
 
 // Champs principaux
@@ -74,7 +75,7 @@ $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
 $nb_joueurs = 0;
 
 get_header();
-error_log("🧪 test organisateur_associe : " . (utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) ? 'OUI' : 'NON'));
+error_log("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
 ?>
@@ -197,7 +198,8 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
       <div class="chasse-enigmes-liste">
         <?php
         get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [
-          'chasse_id' => $chasse_id
+          'chasse_id'       => $chasse_id,
+          'est_orga_associe'=> $est_orga_associe,
         ]);
         ?>
       </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -15,7 +15,7 @@ $utilisateur_id = get_current_user_id();
 // 🔒 Vérification d'accès à la chasse
 if (!chasse_est_visible_pour_utilisateur($chasse_id, $utilisateur_id)) return;
 
-$est_orga_associe = utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+$est_orga_associe = $args['est_orga_associe'] ?? utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
 
 $autorise_boucle = (
   user_can($utilisateur_id, 'manage_options') ||

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -15,9 +15,11 @@ $utilisateur_id = get_current_user_id();
 // 🔒 Vérification d'accès à la chasse
 if (!chasse_est_visible_pour_utilisateur($chasse_id, $utilisateur_id)) return;
 
+$est_orga_associe = utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+
 $autorise_boucle = (
   user_can($utilisateur_id, 'manage_options') ||
-  utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id) ||
+  $est_orga_associe ||
   utilisateur_est_engage_dans_chasse($utilisateur_id, $chasse_id)
 );
 if (!$autorise_boucle) return;
@@ -38,6 +40,9 @@ $posts = get_posts([
 
 $posts_visibles = $posts;
 $has_enigmes = !empty($posts_visibles);
+
+$est_orga = est_organisateur();
+$statut_chasse = get_post_status($chasse_id);
 
 // 📌 Vérifie si une énigme est incomplète
 $has_incomplete = false;
@@ -60,11 +65,9 @@ foreach ($posts as $p) {
       $classe_cta = 'cta-' . sanitize_html_class($type_cta);
 
       // 🔍 Vérification bordure admin/orga
-      $est_orga = est_organisateur();
-      $statut_chasse = get_post_status($chasse_id);
       $statut_enigme = get_post_status($enigme_id);
       $voir_bordure = $est_orga &&
-        utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id) &&
+        $est_orga_associe &&
         $statut_chasse !== 'publish' &&
         $statut_enigme !== 'publish';
 


### PR DESCRIPTION
## Summary
- precompute organizer association check
- reuse `$est_orga` and `$statut_chasse` in the loop

## Testing
- `composer test` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6863ee6001308332bee48290ce6dabaa