### PR TITLE
Open description panel after saving

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-description.php
@@ -22,7 +22,11 @@ $organisateur_id = $args['organisateur_id'] ?? null;
             'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
             'html_before_fields'  => '<div class="champ-wrapper">',
             'html_after_fields'   => '</div>',
-            'return'              => get_permalink() . '#presentation', // ✅ ajout de l’ancre
+            // Après sauvegarde, on revient sur la même page en ouvrant
+            // automatiquement le panneau principal grâce au paramètre
+            // ?edition=open. L'ancre #presentation permet de scroller
+            // directement sur la section description.
+            'return'              => add_query_arg('edition', 'open', get_permalink()) . '#presentation',
             'updated_message'     => false
         ]);
         ?>


### PR DESCRIPTION
## Summary
- reopen the description panel after saving an organiser's long description

## Testing
- `composer install --no-interaction` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*
- `composer test` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68640a3fca18833287d5d6a38f762124