### PR TITLE
Enable edition=open for organizer editing panel

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -150,16 +150,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 🔑 Ouverture automatique via les paramètres d'URL
   const params = new URLSearchParams(window.location.search);
-  if (params.get('edition') === 'open' && params.get('onglet') === 'revenus') {
-    const toggle = document.getElementById('toggle-mode-edition');
-    const tabBtn = document.querySelector('.edition-tab[data-target="organisateur-tab-revenus"]');
-    toggle?.click();
-    tabBtn?.click();
 
-    if (params.get('highlight') === 'coordonnees') {
-      document
-        .getElementById('ligne-coordonnees')
-        ?.classList.add('champ-vide-obligatoire');
+  if (params.get('edition') === 'open') {
+    const toggle = document.getElementById('toggle-mode-edition');
+    toggle?.click();
+
+    if (params.get('onglet') === 'revenus') {
+      const tabBtn = document.querySelector(
+        '.edition-tab[data-target="organisateur-tab-revenus"]'
+      );
+      tabBtn?.click();
+
+      if (params.get('highlight') === 'coordonnees') {
+        document
+          .getElementById('ligne-coordonnees')
+          ?.classList.add('champ-vide-obligatoire');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- open organizer edit panel whenever `edition=open` is found
- keep revenues tab and highlight handling when `onglet=revenus`

## Testing
- `composer test` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68640fcd312083328dcd1a78f0f8c6d0