### PR TITLE
Optimize chasse display by caching fields

### DIFF
--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -22,8 +22,11 @@ $user_id            = get_current_user_id();
 $est_orga_associe   = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
 $points_utilisateur = get_user_points($user_id);
 
+// Récupération centralisée des infos
+$infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
+
 // Champs principaux
-$champs = chasse_get_champs($chasse_id);
+$champs = $infos_chasse['champs'];
 $lot = $champs['lot'];
 $titre_recompense = $champs['titre_recompense'];
 $valeur_recompense = $champs['valeur_recompense'];
@@ -50,15 +53,15 @@ $organisateur_nom = $organisateur_id ? get_the_title($organisateur_id) : get_the
 
 
 // Contenu
-$description = get_field('chasse_principale_description', $chasse_id);
-$extrait = wp_trim_words(wp_strip_all_tags($description), 30, '...');
+$description = $infos_chasse['description'];
+$extrait = wp_trim_words($infos_chasse['texte_complet'], 30, '...');
 
-$image_raw = get_field('chasse_principale_image', $chasse_id);
-$image_id = is_array($image_raw) ? ($image_raw['ID'] ?? null) : $image_raw;
-$image_url = $image_id ? wp_get_attachment_image_src($image_id, 'large')[0] : null;
+$image_raw = $infos_chasse['image_raw'];
+$image_id  = $infos_chasse['image_id'];
+$image_url = $infos_chasse['image_url'];
 
-$enigmes_associees = recuperer_enigmes_associees($chasse_id);
-$total_enigmes = count($enigmes_associees);
+$enigmes_associees = $infos_chasse['enigmes_associees'];
+$total_enigmes     = $infos_chasse['total_enigmes'];
 $enigmes_resolues = compter_enigmes_resolues($chasse_id, $user_id);
 $peut_ajouter_enigme = utilisateur_peut_ajouter_enigme($chasse_id);
 $has_incomplete_enigme = false;
@@ -70,9 +73,9 @@ foreach ($enigmes_associees as $eid) {
   }
 }
 
-$statut = get_field('champs_caches')['chasse_cache_statut'] ?? 'revision';
-$statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
-$nb_joueurs = 0;
+$statut = $infos_chasse['statut'];
+$statut_validation = $infos_chasse['statut_validation'];
+$nb_joueurs = $infos_chasse['nb_joueurs'];
 
 get_header();
 error_log("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
@@ -124,7 +127,8 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     <!-- 📦 Fiche complète (images + méta + actions) -->
     <?php
     get_template_part('template-parts/chasse/chasse-affichage-complet', null, [
-      'chasse_id' => $chasse_id
+      'chasse_id'   => $chasse_id,
+      'infos_chasse'=> $infos_chasse,
     ]);
     ?>
 
@@ -145,7 +149,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
 
     <!-- 🎯 Appel à l’action principal -->
     <?php
-    $cta_data = generer_cta_chasse($chasse_id, $user_id);
+    $cta_data = $infos_chasse['cta_data'];
 
     if (($cta_data['type'] ?? '') !== 'engage') :
     ?>
@@ -168,8 +172,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         <?php endif; ?>
 
         <?php
-        $liens = get_field('chasse_principale_liens', $chasse_id);
-        $liens = is_array($liens) ? $liens : [];
+        $liens = $infos_chasse['liens'];
         $vide  = empty($liens);
         ?>
         <div class="champ-chasse champ-liens champ-fiche-publication <?= $vide ? 'champ-vide' : 'champ-rempli'; ?>"
@@ -200,6 +203,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [
           'chasse_id'       => $chasse_id,
           'est_orga_associe'=> $est_orga_associe,
+          'infos_chasse'    => $infos_chasse,
         ]);
         ?>
       </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -10,9 +10,12 @@ $titre = get_the_title($chasse_id);
 $champTitreParDefaut = 'nouvelle chasse';
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut);
 
+// Récupération centralisée des informations
+$infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
+
 
 // Champs principaux (avec fallback direct en meta)
-$champs = chasse_get_champs($chasse_id);
+$champs = $infos_chasse['champs'];
 $lot               = $champs['lot'];
 $titre_recompense  = $champs['titre_recompense'];
 $valeur_recompense = $champs['valeur_recompense'];
@@ -27,19 +30,19 @@ $date_decouverte      = $champs['date_decouverte'];
 $current_stored_statut = $champs['current_stored_statut'];
 
 // Données supplémentaires
-$description = get_field('chasse_principale_description', $chasse_id);
-$texte_complet = wp_strip_all_tags($description);
-$extrait = wp_trim_words($texte_complet, 60, '...');
-$est_tronque = ($extrait !== $texte_complet);
+$description   = $infos_chasse['description'];
+$texte_complet = $infos_chasse['texte_complet'];
+$extrait       = $infos_chasse['extrait'];
+$est_tronque   = ($extrait !== $texte_complet);
 
-$image_raw = get_field('chasse_principale_image', $chasse_id);
-$image_id = is_array($image_raw) ? ($image_raw['ID'] ?? null) : $image_raw;
-$image_url = $image_id ? wp_get_attachment_image_src($image_id, 'large')[0] : null;
+$image_raw = $infos_chasse['image_raw'];
+$image_id  = $infos_chasse['image_id'];
+$image_url = $infos_chasse['image_url'];
 
 // Enigmes
-$enigmes_associees = recuperer_enigmes_associees($chasse_id);
-$total_enigmes = count($enigmes_associees);
-$nb_joueurs = 0;
+$enigmes_associees = $infos_chasse['enigmes_associees'];
+$total_enigmes     = $infos_chasse['total_enigmes'];
+$nb_joueurs        = $infos_chasse['nb_joueurs'];
 
 // Dates
 $date_debut_formatee = formater_date($date_debut);
@@ -79,8 +82,8 @@ if ($edition_active && !$est_complet) {
 
   <div class="chasse-fiche-container flex-row">
     <?php
-    $statut = get_field('chasse_cache_statut', $chasse_id) ?? 'revision';
-    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+    $statut = $infos_chasse['statut'];
+    $statut_validation = $infos_chasse['statut_validation'];
     $statut_label = ucfirst(str_replace('_', ' ', $statut));
 
     if ($statut === 'revision') {
@@ -224,7 +227,8 @@ if ($edition_active && !$est_complet) {
 // Inclure le panneau si édition active
 if ($edition_active) {
   get_template_part('template-parts/chasse/chasse-edition-main', null, [
-    'chasse_id' => $chasse_id
+    'chasse_id'   => $chasse_id,
+    'infos_chasse' => $infos_chasse
   ]);
 }
 ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -15,15 +15,17 @@ if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
 $peut_modifier = utilisateur_peut_voir_panneau($chasse_id);
 $peut_editer   = utilisateur_peut_editer_champs($chasse_id);
 
-$image = get_field('chasse_principale_image', $chasse_id);
-$description = get_field('chasse_principale_description', $chasse_id);
+$infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
+
+$image = $infos_chasse['image_raw'];
+$description = $infos_chasse['description'];
 $titre = get_the_title($chasse_id);
-$liens = get_field('chasse_principale_liens', $chasse_id);
-$recompense = get_field('chasse_infos_recompense_texte', $chasse_id);
-$valeur     = get_field('chasse_infos_recompense_valeur', $chasse_id);
-$cout       = get_field('chasse_infos_cout_points', $chasse_id);
-$date_debut = get_field('chasse_infos_date_debut', $chasse_id);
-$date_fin   = get_field('chasse_infos_date_fin', $chasse_id);
+$liens = $infos_chasse['liens'];
+$recompense = $infos_chasse['champs']['lot'];
+$valeur     = $infos_chasse['champs']['valeur_recompense'];
+$cout       = $infos_chasse['champs']['cout_points'];
+$date_debut = $infos_chasse['champs']['date_debut'];
+$date_fin   = $infos_chasse['champs']['date_fin'];
 
 // 🎯 Conversion des dates pour les champs <input>
 $date_debut_obj = convertir_en_datetime($date_debut);
@@ -31,8 +33,8 @@ $date_debut_iso = $date_debut_obj ? $date_debut_obj->format('Y-m-d\TH:i') : '';
 
 $date_fin_obj = convertir_en_datetime($date_fin);
 $date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
-$illimitee  = get_field('chasse_infos_duree_illimitee', $chasse_id);
-$nb_max     = get_field('chasse_infos_nb_max_gagants', $chasse_id) ?: 1;
+$illimitee  = $infos_chasse['champs']['illimitee'];
+$nb_max     = $infos_chasse['champs']['nb_max'] ?: 1;
 
 $champTitreParDefaut = 'nouvelle chasse'; // À adapter si besoin
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut);

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -10,6 +10,8 @@ defined('ABSPATH') || exit;
 $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
+$infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
+
 $utilisateur_id = get_current_user_id();
 
 // 🔒 Vérification d'accès à la chasse
@@ -130,8 +132,8 @@ foreach ($posts as $p) {
       $highlight_pulse = false;
       if (!$has_enigmes) {
         $wp_status         = get_post_status($chasse_id);
-        $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
-        $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+        $statut_metier     = $infos_chasse['statut'];
+        $statut_validation = $infos_chasse['statut_validation'];
 
         if (
           $wp_status === 'pending' &&


### PR DESCRIPTION
## Summary
- centralize retrieval of ACF fields with `preparer_infos_affichage_chasse`
- use the cached info in `single-chasse.php` and all chasse templates
- pass precomputed data to edition/partial templates

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641c2cfe4083328ec139ab30cbf77f