### PR TITLE
Restreint le bouton d'édition organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -89,9 +89,11 @@ if ($peut_modifier && !$est_complet) {
         <a href="<?= esc_url($url_contact); ?>" class="lien-contact" aria-label="Contact">
           <i class="fa-solid fa-envelope"></i>
         </a>
-        <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="Paramètres organisateur">
-          <i class="fa-solid fa-sliders"></i>
-        </button>
+        <?php if ($peut_modifier) : ?>
+          <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="Paramètres organisateur">
+            <i class="fa-solid fa-sliders"></i>
+          </button>
+        <?php endif; ?>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- n'afficher le bouton _toggle-mode-edition_ du header organisateur que si l'utilisateur peut modifier l'organisateur

## Testing
- `composer install`
- `composer test` *(échoue : `Could not find /tmp/wordpress-tests-lib/includes/functions.php`)*

------
https://chatgpt.com/codex/tasks/task_e_687109f16f7c83329007268c84541f66