### PR TITLE
Gestion des réponses automatiques

### DIFF
--- a/tests/EnigmeFunctionsTest.php
+++ b/tests/EnigmeFunctionsTest.php
@@ -1,0 +1,19 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__.'/../wp-content/themes/chassesautresor/inc/enigme/tentatives.php';
+
+class EnigmeFunctionsTest extends TestCase {
+    public function test_compter_tentatives_du_jour() {
+        global $wpdb;
+        $wpdb = new class {
+            public array $params = [];
+            public function prepare($q, ...$args){ $this->params = $args; return $q; }
+            public function get_var($query){ return 2; }
+            public string $prefix = 'wp_';
+        };
+        $res = compter_tentatives_du_jour(1, 5);
+        $this->assertSame(2, $res);
+        $this->assertSame([1,5], [$wpdb->params[0], $wpdb->params[1]]);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+// simple bootstrap
+declare(strict_types=1);

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="bootstrap.php">
+  <testsuites>
+    <testsuite name="theme">
+      <directory>./</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('.formulaire-reponse-auto');
+  if (!form) return;
+  const feedback = document.querySelector('.reponse-feedback');
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = new URLSearchParams(new FormData(form));
+    data.append('action', 'soumettre_reponse_automatique');
+
+    fetch('/wp-admin/admin-ajax.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: data
+    })
+      .then(r => r.json())
+      .then(res => {
+        if (feedback) feedback.style.display = 'none';
+        if (res.success) {
+          if (res.data.resultat === 'variante' && res.data.message) {
+            if (feedback) {
+              feedback.textContent = res.data.message;
+              feedback.style.display = 'block';
+            }
+            form.reset();
+          } else {
+            location.reload();
+          }
+        } else {
+          if (feedback) {
+            feedback.textContent = res.data;
+            feedback.style.display = 'block';
+          }
+        }
+      });
+  });
+});

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -1171,6 +1171,10 @@ organisateur-edit.js	Edition front organisateur (header + liens)	initLiensOrgani
 | `formulaire-liens-chasse`                | initLiensChasse               | Idem orga, côté chasse            |
 | `champ-recompense-*` (champ libre, chasse)| JS personnalisé (saisie + fetch séquencé) | ⚠️ Validation manuelle + reload |
 
+Nouveaux hooks PHP :
+- `soumettre_reponse_automatique()` (AJAX) – enregistre immédiatement la tentative et déduit les points.
+- `traiter_tentative()` – logique commune d’insertion et de mise à jour de statut.
+
 
 ### 🚫 Champs ACF désactivés ou ignorés
 
@@ -1236,6 +1240,10 @@ Index :
 | ip | varchar(45) NULL | adresse IP |
 | user_agent | text NULL | navigateur |
 | traitee | tinyint(1) NULL DEFAULT 0 | état de traitement |
+
+
+Meta utilisateur associé : `enigme_variante_vue_<ID>` stocke l’index du message
+de variante déjà affiché pour éviter les répétitions (réinitialisé chaque nuit).
 
 
 ### 📂 Références internes utiles (template-parts/, data-champ, etc.)

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/bloc-reponse.php
@@ -1,5 +1,6 @@
 <?php
 defined('ABSPATH') || exit;
 
-echo '<div class="test-partial">🏴‍☠️ Bloc réponse (pirate)</div>';
-?>
+get_template_part('template-parts/enigme/partials/enigme-partial-bloc-reponse', null, $args);
+
+


### PR DESCRIPTION
## Summary
- compter et traiter les tentatives d'énigme
- ajouter la soumission automatique avec vérifications
- afficher le formulaire automatique côté front
- mutualiser la logique d'enregistrement des tentatives
- documenter le nouveau fonctionnement
- ajouter un test unitaire minimal

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: Cannot open file)*

------
https://chatgpt.com/codex/tasks/task_e_687f29f4ae688332aa6634b996e98cff