### PR TITLE
Update response block with boutique icon

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/gamification.css
+++ b/wp-content/themes/chassesautresor/assets/css/gamification.css
@@ -324,6 +324,26 @@ header .points-link:hover {
   transform: scale(1.05);
 }
 
+/* ========== ➕ POINTS – BOUTIQUE ICON ========== */
+.points-link.points-boutique-icon {
+  background-color: var(--color-background-button);
+  padding: 2px 6px;
+  border-radius: 24px;
+}
+.points-boutique-icon .points-plus-circle {
+  display: flex;
+  background: white;
+  color: var(--color-background-button);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  font-size: 18px;
+  font-weight: bold;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
 
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */

--- a/wp-content/themes/chassesautresor/assets/css/gamification.css
+++ b/wp-content/themes/chassesautresor/assets/css/gamification.css
@@ -344,6 +344,17 @@ header .points-link:hover {
   line-height: 1;
 }
 
+/* ========== ✅ BLOC RÉPONSE CTA ROW ========== */
+.reponse-cta-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.points-link.points-boutique-icon {
+  margin-left: 8px;
+}
+
 
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -80,6 +80,9 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
   <?php elseif ($points_manquants > 0) : ?>
     <p class="message-limite" data-points="manquants">
       <?= esc_html(sprintf('%d points manquants', $points_manquants)); ?>
+      <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
+        <span class="points-plus-circle">+</span>
+      </a>
     </p>
   <?php else : ?>
     <input type="text" name="reponse" id="reponse_auto_<?= esc_attr($post_id); ?>" required>
@@ -90,11 +93,6 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
     <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
     <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
       <span class="badge-cout"><?= esc_html($cout); ?> pts</span>
-      <?php if ($points_manquants > 0) : ?>
-        <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
-          <span class="points-plus-circle">+</span>
-        </a>
-      <?php endif; ?>
     <?php endif; ?>
   </div>
 </form>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -83,15 +83,17 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
   <?php endif; ?>
   <input type="hidden" name="enigme_id" value="<?= esc_attr($post_id); ?>">
   <input type="hidden" name="nonce" value="<?= esc_attr($nonce); ?>">
-  <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
-  <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
-    <span class="badge-cout"><?= esc_html($cout); ?> pts</span>
-    <?php if ($points_manquants > 0) : ?>
-      <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
-        <span class="points-plus-circle">+</span>
-      </a>
+  <div class="reponse-cta-row">
+    <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
+    <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
+      <span class="badge-cout"><?= esc_html($cout); ?> pts</span>
+      <?php if ($points_manquants > 0) : ?>
+        <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
+          <span class="points-plus-circle">+</span>
+        </a>
+      <?php endif; ?>
     <?php endif; ?>
-  <?php endif; ?>
+  </div>
 </form>
 <div class="reponse-feedback" style="display:none"></div>
 <?php if ($max > 0) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -68,7 +68,6 @@ if ($max && $tentatives_du_jour >= $max) {
 if ($cout > get_user_points($user_id)) {
   $disabled = 'disabled';
   $points_manquants = $cout - get_user_points($user_id);
-  $label_btn = sprintf('%d points manquants', $points_manquants);
 }
 
 $nonce = wp_create_nonce('reponse_auto_nonce');
@@ -78,6 +77,10 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
   <label for="reponse_auto_<?= esc_attr($post_id); ?>">Votre réponse :</label>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
+  <?php elseif ($points_manquants > 0) : ?>
+    <p class="message-limite" data-points="manquants">
+      <?= esc_html(sprintf('%d points manquants', $points_manquants)); ?>
+    </p>
   <?php else : ?>
     <input type="text" name="reponse" id="reponse_auto_<?= esc_attr($post_id); ?>" required>
   <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -68,7 +68,7 @@ if ($max && $tentatives_du_jour >= $max) {
 if ($cout > get_user_points($user_id)) {
   $disabled = 'disabled';
   $points_manquants = $cout - get_user_points($user_id);
-  $label_btn = '<span class="points-link points-manquants"><span class="points-plus-circle">+</span><span class="points-value">' . esc_html($points_manquants) . '</span><span class="points-euro">pts manquants</span></span>';
+  $label_btn = sprintf('%d points manquants', $points_manquants);
 }
 
 $nonce = wp_create_nonce('reponse_auto_nonce');
@@ -86,6 +86,11 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
   <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
   <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
     <span class="badge-cout"><?= esc_html($cout); ?> pts</span>
+    <?php if ($points_manquants > 0) : ?>
+      <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
+        <span class="points-plus-circle">+</span>
+      </a>
+    <?php endif; ?>
   <?php endif; ?>
 </form>
 <div class="reponse-feedback" style="display:none"></div>


### PR DESCRIPTION
## Summary
- show `x points manquants` text on CTA without the plus icon
- add a link to the boutique with a plus icon next to the cost badge
- style the new boutique icon

## Testing
- `composer install` *(fails: Command not defined)*
- `composer test` *(fails: Command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6881122f31f08332ad538d432dbd2e8b