### PR TITLE
Apply automatic response logic to manual mode

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
@@ -36,28 +36,16 @@ function initFormulaireManuel() {
         feedback.style.display = 'none';
 
         if (res.success) {
-          form.reset();
           if (headerPoints && typeof res.data.points !== 'undefined') {
             headerPoints.textContent = res.data.points;
           }
-          if (res.data.points < cout) {
-            if (input) input.remove();
-            if (pointsMsg) {
-              pointsMsg.style.display = 'block';
-              pointsMsg.textContent = `${cout - res.data.points} points manquants`;
-            } else {
-              const p = document.createElement('p');
-              p.className = 'message-limite';
-              p.dataset.points = 'manquants';
-              p.textContent = `${cout - res.data.points} points manquants`;
-              form.insertBefore(p, form.querySelector('input[name="enigme_id"]'));
-            }
-            const btn = form.querySelector('button[type="submit"]');
-            if (btn) btn.disabled = true;
-          }
-          feedback.textContent = 'Réponse envoyée !';
-          feedback.style.display = 'block';
-          hideTimer = setTimeout(() => { feedback.style.display = 'none'; }, 5000);
+
+          const msg = document.createElement('p');
+          msg.className = 'message-joueur-statut';
+          msg.textContent = 'Votre tentative est en cours de traitement.';
+
+          if (feedback) feedback.remove();
+          form.replaceWith(msg);
         } else {
           feedback.textContent = res.data;
           feedback.style.display = 'block';

--- a/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
@@ -1,0 +1,70 @@
+function initFormulaireManuel() {
+  const form = document.querySelector('.formulaire-reponse-manuelle');
+  if (!form) return;
+  const feedback = form.nextElementSibling;
+  const input = form.querySelector('textarea[name="reponse_manuelle"]');
+  const pointsMsg = form.querySelector('.message-limite');
+  const badgeCout = form.querySelector('.badge-cout');
+  const headerPoints = document.querySelector('.zone-points .points-value');
+  const cout = badgeCout ? parseInt(badgeCout.textContent, 10) : 0;
+  let hideTimer = null;
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = new URLSearchParams(new FormData(form));
+    data.append('action', 'soumettre_reponse_manuelle');
+
+    fetch('/wp-admin/admin-ajax.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: data
+    })
+      .then(async r => {
+        const text = await r.text();
+        try { return JSON.parse(text); } catch (e) {
+          if (feedback) {
+            feedback.textContent = 'Erreur serveur';
+            feedback.style.display = 'block';
+            hideTimer = setTimeout(() => { feedback.style.display = 'none'; }, 5000);
+          }
+          throw e;
+        }
+      })
+      .then(res => {
+        if (!feedback) return;
+        if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+        feedback.style.display = 'none';
+
+        if (res.success) {
+          form.reset();
+          if (headerPoints && typeof res.data.points !== 'undefined') {
+            headerPoints.textContent = res.data.points;
+          }
+          if (res.data.points < cout) {
+            if (input) input.remove();
+            if (pointsMsg) {
+              pointsMsg.style.display = 'block';
+              pointsMsg.textContent = `${cout - res.data.points} points manquants`;
+            } else {
+              const p = document.createElement('p');
+              p.className = 'message-limite';
+              p.dataset.points = 'manquants';
+              p.textContent = `${cout - res.data.points} points manquants`;
+              form.insertBefore(p, form.querySelector('input[name="enigme_id"]'));
+            }
+            const btn = form.querySelector('button[type="submit"]');
+            if (btn) btn.disabled = true;
+          }
+          feedback.textContent = 'Réponse envoyée !';
+          feedback.style.display = 'block';
+          hideTimer = setTimeout(() => { feedback.style.display = 'none'; }, 5000);
+        } else {
+          feedback.textContent = res.data;
+          feedback.style.display = 'block';
+          hideTimer = setTimeout(() => { feedback.style.display = 'none'; }, 5000);
+        }
+      });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initFormulaireManuel);

--- a/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
@@ -9,6 +9,10 @@ function initFormulaireManuel() {
   const cout = badgeCout ? parseInt(badgeCout.textContent, 10) : 0;
   let hideTimer = null;
 
+  const i18n = window.REPONSE_MANUELLE_I18N || {};
+  const txtSuccess = i18n.success || 'Tentative bien reçue.';
+  const txtProcessing = i18n.processing || 'Votre tentative est en cours de traitement.';
+
   form.addEventListener('submit', e => {
     e.preventDefault();
     const data = new URLSearchParams(new FormData(form));
@@ -40,12 +44,21 @@ function initFormulaireManuel() {
             headerPoints.textContent = res.data.points;
           }
 
-          const msg = document.createElement('p');
-          msg.className = 'message-joueur-statut';
-          msg.textContent = 'Votre tentative est en cours de traitement.';
+          const msgProcessing = document.createElement('p');
+          msgProcessing.className = 'message-joueur-statut';
+          msgProcessing.textContent = txtProcessing;
+
+          const msgSuccess = document.createElement('p');
+          msgSuccess.className = 'message-feedback-success';
+          msgSuccess.textContent = txtSuccess;
 
           if (feedback) feedback.remove();
-          form.replaceWith(msg);
+          const parent = form.parentNode;
+          parent.insertBefore(msgSuccess, form);
+          parent.insertBefore(msgProcessing, form);
+          form.remove();
+
+          setTimeout(() => { msgSuccess.remove(); }, 5000);
         } else {
           feedback.textContent = res.data;
           feedback.style.display = 'block';

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -38,7 +38,7 @@ defined('ABSPATH') || exit;
         <label for="reponse_manuelle_<?php echo esc_attr($enigme_id); ?>">Votre réponse :</label>
         <?php if ($data['points_manquants'] > 0) : ?>
             <p class="message-limite" data-points="manquants">
-                <?php echo esc_html(sprintf('%d points manquants', $data['points_manquants'])); ?>
+                <?php echo esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $data['points_manquants'])); ?>
                 <a href="<?php echo esc_url($data['boutique_url']); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
                     <span class="points-plus-circle">+</span>
                 </a>

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -30,17 +30,33 @@ defined('ABSPATH') || exit;
             return '<p>Vous ne pouvez plus répondre à cette énigme.</p>';
         }
 
+        $data = calculer_contexte_points($user_id, $enigme_id);
         $nonce = wp_create_nonce('reponse_manuelle_nonce');
         ob_start();
     ?>
-     <form method="post" class="formulaire-reponse-manuelle">
-         <label for="reponse_manuelle">Votre réponse :</label>
-         <textarea name="reponse_manuelle" id="reponse_manuelle" rows="3" required></textarea>
-         <input type="hidden" name="enigme_id" value="<?php echo esc_attr($enigme_id); ?>">
-         <input type="hidden" name="reponse_manuelle_nonce" value="<?php echo esc_attr($nonce); ?>">
-         <button type="submit">Envoyer la réponse</button>
-     </form>
- <?php
+    <form method="post" class="bloc-reponse formulaire-reponse-manuelle">
+        <label for="reponse_manuelle_<?php echo esc_attr($enigme_id); ?>">Votre réponse :</label>
+        <?php if ($data['points_manquants'] > 0) : ?>
+            <p class="message-limite" data-points="manquants">
+                <?php echo esc_html(sprintf('%d points manquants', $data['points_manquants'])); ?>
+                <a href="<?php echo esc_url($data['boutique_url']); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
+                    <span class="points-plus-circle">+</span>
+                </a>
+            </p>
+        <?php else : ?>
+            <textarea name="reponse_manuelle" id="reponse_manuelle_<?php echo esc_attr($enigme_id); ?>" rows="3" required></textarea>
+        <?php endif; ?>
+        <input type="hidden" name="enigme_id" value="<?php echo esc_attr($enigme_id); ?>">
+        <input type="hidden" name="reponse_manuelle_nonce" value="<?php echo esc_attr($nonce); ?>">
+        <div class="reponse-cta-row">
+            <button type="submit" class="bouton-cta" <?php echo $data['disabled']; ?>>Envoyer</button>
+            <?php if ($data['cout'] > 0) : ?>
+                <span class="badge-cout"><?php echo esc_html($data['cout']); ?> pts</span>
+            <?php endif; ?>
+        </div>
+    </form>
+    <div class="reponse-feedback" style="display:none"></div>
+    <?php
         return ob_get_clean();
     }
 
@@ -56,17 +72,34 @@ defined('ABSPATH') || exit;
      * @param int $enigme_id
      * @return bool
      */
-    function utilisateur_peut_repondre_manuelle(int $user_id, int $enigme_id): bool
-    {
-        if (!$user_id || !$enigme_id) return false;
+function utilisateur_peut_repondre_manuelle(int $user_id, int $enigme_id): bool
+{
+    if (!$user_id || !$enigme_id) return false;
 
         $statut = enigme_get_statut_utilisateur($enigme_id, $user_id);
 
         // Autoriser uniquement les statuts actifs
         $autorisés = ['en_cours', 'echouee', 'abandonnee'];
 
-        return in_array($statut, $autorisés, true);
-    }
+    return in_array($statut, $autorisés, true);
+}
+
+/**
+ * Calcule les informations de coût et de points pour le joueur.
+ */
+function calculer_contexte_points(int $user_id, int $enigme_id): array
+{
+    $cout = (int) get_field('enigme_tentative_cout_points', $enigme_id);
+    $solde = get_user_points($user_id);
+    $points_manquants = max(0, $cout - $solde);
+
+    return [
+        'cout'            => $cout,
+        'boutique_url'    => esc_url(home_url('/boutique/')),
+        'disabled'        => $points_manquants > 0 ? 'disabled' : '',
+        'points_manquants' => $points_manquants,
+    ];
+}
 
 
     /**
@@ -77,50 +110,61 @@ defined('ABSPATH') || exit;
      * - champ réponse + nonce + enigme_id présents
      * - nonce valide
      */
-    function soumettre_reponse_manuelle()
-    {
-        global $wpdb;
+function soumettre_reponse_manuelle()
+{
+    global $wpdb;
 
-        if (
-            isset($_POST['reponse_manuelle_nonce'], $_POST['reponse_manuelle'], $_POST['enigme_id']) &&
-            wp_verify_nonce($_POST['reponse_manuelle_nonce'], 'reponse_manuelle_nonce') &&
-            is_user_logged_in()
-        ) {
-            $user_id   = get_current_user_id();
-            $enigme_id = (int) $_POST['enigme_id'];
-            $reponse   = sanitize_textarea_field($_POST['reponse_manuelle']);
-
-            // Blocage si interdiction de répondre
-            if (!utilisateur_peut_repondre_manuelle($user_id, $enigme_id)) {
-                return;
-            }
-
-            // Vérifie si l'utilisateur a déjà résolu l'énigme
-            $current_statut = $wpdb->get_var($wpdb->prepare(
-                "SELECT statut FROM {$wpdb->prefix}enigme_statuts_utilisateur WHERE user_id = %d AND enigme_id = %d",
-                $user_id,
-                $enigme_id
-            ));
-
-            if (in_array($current_statut, ['resolue', 'terminee'], true)) {
-                error_log("❌ Tentative rejetée car joueur a déjà résolu l’énigme (UID=$user_id / Enigme=$enigme_id).");
-                return;
-            }
-
-            // Insertion tentative + mise à jour statut = "soumis"
-            $uid = inserer_tentative($user_id, $enigme_id, $reponse);
-            enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'soumis', true);
-
-            envoyer_mail_reponse_manuelle($user_id, $enigme_id, $reponse, $uid);
-            envoyer_mail_accuse_reception_joueur($user_id, $enigme_id, $uid);
-
-            add_action('template_redirect', function () {
-                wp_redirect(add_query_arg('reponse_envoyee', '1'));
-                exit;
-            });
-        }
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
     }
-add_action('init', 'soumettre_reponse_manuelle');
+
+    $user_id   = get_current_user_id();
+    $enigme_id = isset($_POST['enigme_id']) ? (int) $_POST['enigme_id'] : 0;
+    $reponse   = isset($_POST['reponse_manuelle']) ? sanitize_textarea_field($_POST['reponse_manuelle']) : '';
+    $nonce     = $_POST['reponse_manuelle_nonce'] ?? '';
+
+    if (!$enigme_id || $reponse === '' || !wp_verify_nonce($nonce, 'reponse_manuelle_nonce')) {
+        wp_send_json_error('invalide');
+    }
+
+    if (!utilisateur_peut_repondre_manuelle($user_id, $enigme_id)) {
+        wp_send_json_error('interdit');
+    }
+
+    $current_statut = $wpdb->get_var($wpdb->prepare(
+        "SELECT statut FROM {$wpdb->prefix}enigme_statuts_utilisateur WHERE user_id = %d AND enigme_id = %d",
+        $user_id,
+        $enigme_id
+    ));
+
+    if (in_array($current_statut, ['resolue', 'terminee'], true)) {
+        wp_send_json_error('deja_resolue');
+    }
+
+    $cout = (int) get_field('enigme_tentative_cout_points', $enigme_id);
+    if ($cout > get_user_points($user_id)) {
+        wp_send_json_error('points_insuffisants');
+    }
+
+    if ($cout > 0) {
+        deduire_points_utilisateur($user_id, $cout);
+    }
+
+    $uid = inserer_tentative($user_id, $enigme_id, $reponse);
+    enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'soumis', true);
+
+    envoyer_mail_reponse_manuelle($user_id, $enigme_id, $reponse, $uid);
+    envoyer_mail_accuse_reception_joueur($user_id, $enigme_id, $uid);
+
+    $solde = get_user_points($user_id);
+
+    wp_send_json_success([
+        'uid'    => $uid,
+        'points' => $solde,
+    ]);
+}
+add_action('wp_ajax_soumettre_reponse_manuelle', 'soumettre_reponse_manuelle');
+add_action('wp_ajax_nopriv_soumettre_reponse_manuelle', 'soumettre_reponse_manuelle');
 
 /**
  * Traite la soumission d'une réponse automatique via AJAX.
@@ -439,4 +483,21 @@ function charger_script_reponse_automatique() {
     }
 }
 add_action('wp_enqueue_scripts', 'charger_script_reponse_automatique');
+
+/**
+ * Charge le script gérant la soumission manuelle des réponses.
+ */
+function charger_script_reponse_manuelle() {
+    if (is_singular('enigme')) {
+        $path = '/assets/js/reponse-manuelle.js';
+        wp_enqueue_script(
+            'reponse-manuelle',
+            get_stylesheet_directory_uri() . $path,
+            [],
+            filemtime(get_stylesheet_directory() . $path),
+            true
+        );
+    }
+}
+add_action('wp_enqueue_scripts', 'charger_script_reponse_manuelle');
 

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -154,7 +154,6 @@ function soumettre_reponse_manuelle()
     enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'soumis', true);
 
     envoyer_mail_reponse_manuelle($user_id, $enigme_id, $reponse, $uid);
-    envoyer_mail_accuse_reception_joueur($user_id, $enigme_id, $uid);
 
     $solde = get_user_points($user_id);
 
@@ -497,6 +496,11 @@ function charger_script_reponse_manuelle() {
             filemtime(get_stylesheet_directory() . $path),
             true
         );
+
+        wp_localize_script('reponse-manuelle', 'REPONSE_MANUELLE_I18N', [
+            'success'    => esc_html__('Tentative bien reçue.', 'chassesautresor-com'),
+            'processing' => esc_html__('Votre tentative est en cours de traitement.', 'chassesautresor-com'),
+        ]);
     }
 }
 add_action('wp_enqueue_scripts', 'charger_script_reponse_manuelle');

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -79,7 +79,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
   <?php elseif ($points_manquants > 0) : ?>
     <p class="message-limite" data-points="manquants">
-      <?= esc_html(sprintf('%d points manquants', $points_manquants)); ?>
+      <?= esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $points_manquants)); ?>
       <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
         <span class="points-plus-circle">+</span>
       </a>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -35,7 +35,7 @@ if ($mode_validation === 'manuelle') {
     echo '<p class="message-joueur-statut">' . esc_html($texte) . '</p>';
     return;
   }
-  echo '<div class="bloc-reponse">' . do_shortcode('[formulaire_reponse_manuelle id="' . esc_attr($post_id) . '"]') . '</div>';
+  echo do_shortcode('[formulaire_reponse_manuelle id="' . esc_attr($post_id) . '"]');
   return;
 }
 


### PR DESCRIPTION
## Summary
- factorize point checks with `calculer_contexte_points`
- enrich manual response form with cost badge and point validation
- switch manual responses to AJAX submission and deduct points immediately
- update partial to use the new manual form markup
- add script `reponse-manuelle.js` to refresh points client-side

## Testing
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_688135cb550883328bc46a5a966ea858