### PR TITLE
Update solved enigma message

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -30,8 +30,8 @@ if ($mode_validation === 'manuelle') {
   if (!utilisateur_peut_repondre_manuelle($user_id, $post_id)) {
     $statut = enigme_get_statut_utilisateur($post_id, $user_id);
     $texte = $statut === 'soumis'
-      ? 'Votre tentative est en cours de traitement.'
-      : 'Vous avez déjà répondu ou résolu cette énigme.';
+      ? __('Votre tentative est en cours de traitement.', 'chassesautresor-com')
+      : __('Énigme résolue', 'chassesautresor-com');
     echo '<p class="message-joueur-statut">' . esc_html($texte) . '</p>';
     return;
   }


### PR DESCRIPTION
## Summary
- internationalize the manual response status message
- show `Énigme résolue` when a player already solved a puzzle

## Testing
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php, have you run bin/install-wp-tests.sh ?)*

------
https://chatgpt.com/codex/tasks/task_e_6881c14176b4833281280cd5a0417763