### PR TITLE
Redirect anonymous enigma access to linked hunt

### DIFF
--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -17,6 +17,13 @@ if ($chasse_id) {
   verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
 }
 
+// 🔹 Accès invité : redirection systématique vers la chasse associée
+if (!is_user_logged_in()) {
+  $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+  wp_redirect($url);
+  exit;
+}
+
 // 🔹 Redirection si non visible
 if (!enigme_est_visible_pour($user_id, $enigme_id)) {
   $fallback_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');


### PR DESCRIPTION
## Summary
- redirect anonymous visitors from single enigma pages to their related hunt

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6881c11acb008332ad8ed4f279145687