### PR TITLE
Fix duplicate message when manual answer pending

### DIFF
--- a/tests/EnigmeFunctionsTest.php
+++ b/tests/EnigmeFunctionsTest.php
@@ -2,6 +2,9 @@
 use PHPUnit\Framework\TestCase;
 
 define('ABSPATH', __DIR__ . '/../');
+if (!function_exists('add_action')) {
+    function add_action(...$args) {}
+}
 require_once __DIR__.'/../wp-content/themes/chassesautresor/inc/enigme/tentatives.php';
 
 class EnigmeFunctionsTest extends TestCase {

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -369,8 +369,8 @@ function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
             'rediriger' => false,
             'url' => null,
             'afficher_formulaire' => false,
-            'afficher_message' => true,
-            'message_html' => '<p class="message-statut">Votre tentative est en cours de traitement.</p>',
+            'afficher_message' => false,
+            'message_html' => '',
         ];
     }
 


### PR DESCRIPTION
## Summary
- avoid showing global message while a manual answer is awaiting processing
- fix PHPUnit test bootstrap to stub `add_action`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit tests/EnigmeFunctionsTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6882536635ac8332aad0847fd5931c4a