### PR TITLE
Refonte pages mon compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -2,12 +2,27 @@
 📌 Styles Généraux - Conteneur & Typographie
 ========================================================== */
 .dashboard-container {
-    max-width: 1200px;
-    margin: 0 auto;
+    width: 100%;
+    margin: 0;
     padding: 20px;
     font-family: var(--font-main);
     background: var(--color-background);
     color: var(--color-text-primary);
+}
+
+/* ==========================================================
+📌 Messages importants
+========================================================== */
+.important-messages {
+    background: rgba(255, 215, 0, 0.1);
+    border: 1px solid rgba(255, 215, 0, 0.4);
+    padding: 15px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+}
+
+.important-message {
+    margin-bottom: 8px;
 }
 
 

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -438,3 +438,13 @@ function ajouter_role_organisateur_creation($post_id, $post, $update) {
 }
 add_action('save_post', 'ajouter_role_organisateur_creation', 10, 3);
 
+
+/**
+ * Retourne la liste des messages importants à afficher dans l'espace utilisateur.
+ *
+ * @return array Liste de messages.
+ */
+function cta_get_important_messages() {
+    $messages = [];
+    return apply_filters('cta_important_messages', $messages);
+}

--- a/wp-content/themes/chassesautresor/template-parts/myaccount/important-messages.php
+++ b/wp-content/themes/chassesautresor/template-parts/myaccount/important-messages.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Affiche les messages importants dans l'espace Mon Compte.
+ */
+defined('ABSPATH') || exit;
+$messages = function_exists('cta_get_important_messages') ? cta_get_important_messages() : [];
+if (!empty($messages)) : ?>
+<div class="important-messages">
+  <?php foreach ($messages as $message) : ?>
+    <div class="important-message"><?php echo esc_html($message); ?></div>
+  <?php endforeach; ?>
+</div>
+<?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/myaccount/navigation.php
+++ b/wp-content/themes/chassesautresor/template-parts/myaccount/navigation.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Bloc profil et navigation pour l'espace compte.
+ */
+defined('ABSPATH') || exit;
+$current_user = wp_get_current_user();
+?>
+<div class="dashboard-profile-wrapper">
+    <div class="dashboard-profile">
+        <div class="profile-avatar-container">
+            <div class="profile-avatar">
+                <?php echo get_avatar($current_user->ID, 80); ?>
+            </div>
+            <label for="upload-avatar" class="upload-avatar-btn"><?php _e('Modifier', 'chassesautresor-com'); ?></label>
+            <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display:none;">
+            <div class="message-upload-avatar">
+                <div class="message-size-file-avatar"><?php _e('❗ Taille maximum : 2 Mo', 'chassesautresor-com'); ?></div>
+                <div class="message-format-file-avatar"><?php _e('📌 Formats autorisés : JPG, PNG, GIF', 'chassesautresor-com'); ?></div>
+            </div>
+        </div>
+        <div class="profile-info">
+            <h2><?php echo esc_html($current_user->display_name); ?></h2>
+            <p><?php echo esc_html($current_user->user_email); ?></p>
+        </div>
+    </div>
+    <div class="user-points">
+        <?php echo afficher_points_utilisateur_callback(); ?>
+    </div>
+</div>
+<nav class="dashboard-nav">
+    <ul>
+        <li class="<?php echo is_account_page() && !is_wc_endpoint_url() ? 'active' : ''; ?>">
+            <a href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>">
+                <i class="fas fa-home"></i> <span><?php _e('Accueil', 'chassesautresor-com'); ?></span>
+            </a>
+        </li>
+        <li class="<?php echo is_wc_endpoint_url('orders') ? 'active' : ''; ?>">
+            <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">
+                <i class="fas fa-box"></i> <span><?php _e('Commandes', 'chassesautresor-com'); ?></span>
+            </a>
+        </li>
+        <li class="<?php echo is_wc_endpoint_url('edit-address') ? 'active' : ''; ?>">
+            <a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">
+                <i class="fas fa-map-marker-alt"></i> <span><?php _e('Adresses', 'chassesautresor-com'); ?></span>
+            </a>
+        </li>
+        <li class="<?php echo is_wc_endpoint_url('edit-account') ? 'active' : ''; ?>">
+            <a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">
+                <i class="fas fa-cog"></i> <span><?php _e('Paramètres', 'chassesautresor-com'); ?></span>
+            </a>
+        </li>
+        <li>
+            <a href="<?php echo esc_url(wc_logout_url()); ?>">
+                <i class="fas fa-sign-out-alt"></i> <span><?php _e('Déconnexion', 'chassesautresor-com'); ?></span>
+            </a>
+        </li>
+    </ul>
+</nav>

--- a/wp-content/themes/chassesautresor/templates/admin/organisateurs.php
+++ b/wp-content/themes/chassesautresor/templates/admin/organisateurs.php
@@ -23,67 +23,8 @@ $organisateurs_liste = recuperer_organisateurs_pending();
             <h1 class="entry-title" itemprop="headline">Organisateurs</h1>
         </header>
         <div class="dashboard-container">
-           <!-- 📌 Conteneur Profil + Points -->
-            <div class="dashboard-profile-wrapper">
-                <!-- 📌 Profil Utilisateur -->
-                <div class="dashboard-profile">
-                    <div class="profile-avatar-container">
-                        <div class="profile-avatar">
-                            <?php echo get_avatar($current_user->ID, 80); ?>
-                        </div>
-                    
-                        <!-- 📌 Bouton pour ouvrir le téléversement -->
-                        <label for="upload-avatar" class="upload-avatar-btn">Modifier</label>
-                        <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display: none;">
-                        
-                        <!-- 📌 Conteneur des messages d’upload -->
-                        <div class="message-upload-avatar">
-                            <div class="message-size-file-avatar">❗ Taille maximum : 2 Mo</div>
-                            <div class="message-format-file-avatar">📌 Formats autorisés : JPG, PNG, GIF</div>
-                        </div>
-                    </div>
-                    <div class="profile-info">
-                        <h2><?php echo esc_html($current_user->display_name); ?></h2>
-                        <p><?php echo esc_html($current_user->user_email); ?></p>
-                    </div>
-                </div>
-                <!-- 📌 Affichage des points -->
-                <div class="user-points">
-                    <?php echo afficher_points_utilisateur_callback(); ?>
-                </div>
-            </div>
-                
-            <!-- 📌 Barre de navigation Desktop -->
-           <nav class="dashboard-nav">
-                <ul>
-                    <li >
-                    <a href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>"><i class="fas fa-home"></i> <span>Tableau de bord</span></a>
-                    </li>
-            
-                    <li>
-                        <a class=" active" href="<?php echo esc_url('/mon-compte/organisateurs/'); ?>"><i class="fas fa-users"></i> <span>Organisateurs</span></a>
-                    </li>
-            
-                    <li>
-                        <a href="<?php echo esc_url('/mon-compte/statistiques/'); ?>"><i class="fas fa-chart-line"></i> <span>Statistiques</span></a>
-                    </li>
-            
-                    <li>
-                        <a href="<?php echo esc_url('/mon-compte/outils/'); ?>"><i class="fas fa-wrench"></i> <span>Outils</span></a>
-                    </li>
-                
-                    <!-- Mon Compte (inchangé) -->
-                    <li class="menu-deroulant">
-                        <a href="#" id="menu-account-toggle"><i class="fas fa-user-circle"></i> <span>Mon compte</span> <span class="dropdown-indicator">▼</span></a>
-                        <ul class="submenu">
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">Mes Commandes</a></li>
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">Mes Adresses</a></li>
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">Paramètres</a></li>
-                            <li><a href="<?php echo esc_url(wc_logout_url()); ?>">Déconnexion</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </nav>
+            <?php get_template_part('template-parts/myaccount/navigation'); ?>
+            <?php get_template_part('template-parts/myaccount/important-messages'); ?>
         
             <!-- 📌 Contenu Principal -->
             <div class="dashboard-content">

--- a/wp-content/themes/chassesautresor/templates/admin/outils.php
+++ b/wp-content/themes/chassesautresor/templates/admin/outils.php
@@ -19,67 +19,8 @@ $logout_url = wc_get_account_endpoint_url('customer-logout'); // Lien déconnexi
             <h1 class="entry-title" itemprop="headline">Inscriptions</h1>
         </header>
         <div class="dashboard-container">
-           <!-- 📌 Conteneur Profil + Points -->
-            <div class="dashboard-profile-wrapper">
-                <!-- 📌 Profil Utilisateur -->
-                <div class="dashboard-profile">
-                    <div class="profile-avatar-container">
-                        <div class="profile-avatar">
-                            <?php echo get_avatar($current_user->ID, 80); ?>
-                        </div>
-                    
-                        <!-- 📌 Bouton pour ouvrir le téléversement -->
-                        <label for="upload-avatar" class="upload-avatar-btn">Modifier</label>
-                        <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display: none;">
-                        
-                        <!-- 📌 Conteneur des messages d’upload -->
-                        <div class="message-upload-avatar">
-                            <div class="message-size-file-avatar">❗ Taille maximum : 2 Mo</div>
-                            <div class="message-format-file-avatar">📌 Formats autorisés : JPG, PNG, GIF</div>
-                        </div>
-                    </div>
-                    <div class="profile-info">
-                        <h2><?php echo esc_html($current_user->display_name); ?></h2>
-                        <p><?php echo esc_html($current_user->user_email); ?></p>
-                    </div>
-                </div>
-                <!-- 📌 Affichage des points -->
-                <div class="user-points">
-                    <?php echo afficher_points_utilisateur_callback(); ?>
-                </div>
-            </div>
-                
-            <!-- 📌 Barre de navigation Desktop -->
-           <nav class="dashboard-nav">
-                <ul>
-                    <li >
-                    <a href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>"><i class="fas fa-home"></i> <span>Tableau de bord</span></a>
-                    </li>
-            
-                    <li class="menu-deroulant">
-                        <a href="<?php echo esc_url('/mon-compte/organisateurs/'); ?>"><i class="fas fa-users"></i> <span>Organisateurs</span></a>
-                    </li>
-            
-                    <li>
-                        <a href="<?php echo esc_url('/mon-compte/statistiques/'); ?>"><i class="fas fa-chart-line"></i> <span>Statistiques</span></a>
-                    </li>
-            
-                    <li>
-                        <a class="active" href="<?php echo esc_url('/mon-compte/outils/'); ?>"><i class="fas fa-wrench"></i> <span>Outils</span></a>
-                    </li>
-                
-                    <!-- Mon Compte (inchangé) -->
-                    <li class="menu-deroulant">
-                        <a href="#" id="menu-account-toggle"><i class="fas fa-user-circle"></i> <span>Mon compte</span> <span class="dropdown-indicator">▼</span></a>
-                        <ul class="submenu">
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">Mes Commandes</a></li>
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">Mes Adresses</a></li>
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">Paramètres</a></li>
-                            <li><a href="<?php echo esc_url(wc_logout_url()); ?>">Déconnexion</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </nav>
+            <?php get_template_part('template-parts/myaccount/navigation'); ?>
+            <?php get_template_part('template-parts/myaccount/important-messages'); ?>
         
             <!-- 📌 Contenu Principal -->
             <div class="dashboard-content">

--- a/wp-content/themes/chassesautresor/templates/admin/statistiques.php
+++ b/wp-content/themes/chassesautresor/templates/admin/statistiques.php
@@ -19,67 +19,8 @@ $logout_url = wc_get_account_endpoint_url('customer-logout'); // Lien déconnexi
             <h1 class="entry-title" itemprop="headline">Inscriptions</h1>
         </header>
         <div class="dashboard-container">
-           <!-- 📌 Conteneur Profil + Points -->
-            <div class="dashboard-profile-wrapper">
-                <!-- 📌 Profil Utilisateur -->
-                <div class="dashboard-profile">
-                    <div class="profile-avatar-container">
-                        <div class="profile-avatar">
-                            <?php echo get_avatar($current_user->ID, 80); ?>
-                        </div>
-                    
-                        <!-- 📌 Bouton pour ouvrir le téléversement -->
-                        <label for="upload-avatar" class="upload-avatar-btn">Modifier</label>
-                        <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display: none;">
-                        
-                        <!-- 📌 Conteneur des messages d’upload -->
-                        <div class="message-upload-avatar">
-                            <div class="message-size-file-avatar">❗ Taille maximum : 2 Mo</div>
-                            <div class="message-format-file-avatar">📌 Formats autorisés : JPG, PNG, GIF</div>
-                        </div>
-                    </div>
-                    <div class="profile-info">
-                        <h2><?php echo esc_html($current_user->display_name); ?></h2>
-                        <p><?php echo esc_html($current_user->user_email); ?></p>
-                    </div>
-                </div>
-                <!-- 📌 Affichage des points -->
-                <div class="user-points">
-                    <?php echo afficher_points_utilisateur_callback(); ?>
-                </div>
-            </div>
-                
-            <!-- 📌 Barre de navigation Desktop -->
-           <nav class="dashboard-nav">
-                <ul>
-                    <li >
-                    <a href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>"><i class="fas fa-home"></i> <span>Tableau de bord</span></a>
-                    </li>
-            
-                    <li class="menu-deroulant">
-                        <a href="<?php echo esc_url('/mon-compte/organisateurs/'); ?>"><i class="fas fa-users"></i> <span>Organisateurs</span></a>
-                    </li>
-            
-                    <li>
-                        <a class=" active" href="<?php echo esc_url('/mon-compte/statistiques/'); ?>"><i class="fas fa-chart-line"></i> <span>Statistiques</span></a>
-                    </li>
-            
-                    <li>
-                        <a href="<?php echo esc_url('/mon-compte/outils/'); ?>"><i class="fas fa-wrench"></i> <span>Outils</span></a>
-                    </li>
-                
-                    <!-- Mon Compte (inchangé) -->
-                    <li class="menu-deroulant">
-                        <a href="#" id="menu-account-toggle"><i class="fas fa-user-circle"></i> <span>Mon compte</span> <span class="dropdown-indicator">▼</span></a>
-                        <ul class="submenu">
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">Mes Commandes</a></li>
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">Mes Adresses</a></li>
-                            <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">Paramètres</a></li>
-                            <li><a href="<?php echo esc_url(wc_logout_url()); ?>">Déconnexion</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </nav>
+            <?php get_template_part('template-parts/myaccount/navigation'); ?>
+            <?php get_template_part('template-parts/myaccount/important-messages'); ?>
         
             <!-- 📌 Contenu Principal -->
             <div class="dashboard-content">

--- a/wp-content/themes/chassesautresor/templates/page-mon-compte.php
+++ b/wp-content/themes/chassesautresor/templates/page-mon-compte.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Template Name: Mon Compte
+ * Description: Mise en page unifiée pour l'espace utilisateur.
+ */
+
+defined('ABSPATH') || exit;
+
+add_filter('body_class', function ($classes) {
+    $classes[] = 'has-hero';
+    return $classes;
+});
+
+$image_url = has_post_thumbnail() ? get_the_post_thumbnail_url(null, 'full') : '';
+
+get_header();
+?>
+<section class="bandeau-hero">
+  <div class="hero-overlay" style="background-image:url('<?php echo esc_url($image_url); ?>');">
+    <div class="contenu-hero">
+      <h1><?php the_title(); ?></h1>
+    </div>
+  </div>
+</section>
+<?php get_template_part('template-parts/myaccount/important-messages'); ?>
+<main id="primary" class="site-main">
+<?php
+while (have_posts()) :
+    the_post();
+    the_content();
+endwhile;
+?>
+</main>
+<?php get_footer(); ?>

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/admin.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/admin.php
@@ -16,65 +16,8 @@ $taux_conversion = get_taux_conversion_actuel();
 
 ?>
 
-<!-- 📌 Conteneur Profil + Points -->
-<div class="dashboard-container">
-   <!-- 📌 Conteneur Profil + Points -->
-    <div class="dashboard-profile-wrapper">
-        <!-- 📌 Profil Utilisateur -->
-        <div class="dashboard-profile">
-            <div class="profile-avatar-container">
-                <div class="profile-avatar">
-                    <?php echo get_avatar($current_user->ID, 80); ?>
-                </div>
-            
-                <!-- 📌 Bouton pour ouvrir le téléversement -->
-                <label for="upload-avatar" class="upload-avatar-btn">Modifier</label>
-                <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display: none;">
-                
-                <!-- 📌 Conteneur des messages d’upload -->
-                <div class="message-upload-avatar">
-                    <div class="message-size-file-avatar">❗ Taille maximum : 2 Mo</div>
-                    <div class="message-format-file-avatar">📌 Formats autorisés : JPG, PNG, GIF</div>
-                </div>
-            </div>
-            <div class="profile-info">
-                <h2><?php echo esc_html($current_user->display_name); ?></h2>
-                <p><?php echo esc_html($current_user->user_email); ?></p>
-            </div>
-        </div>
-    </div>
-        
-    <!-- 📌 Barre de navigation Desktop -->
-   <nav class="dashboard-nav">
-        <ul>
-            <li>
-            <a class=" active" href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>"><i class="fas fa-home"></i> <span>Tableau de bord</span></a>
-            </li>
-    
-            <li>
-                <a href="<?php echo esc_url('/mon-compte/organisateurs/'); ?>"><i class="fas fa-users"></i> <span>Organisateurs</span></a>
-            </li>
-    
-            <li>
-                <a href="<?php echo esc_url('/mon-compte/statistiques/'); ?>"><i class="fas fa-chart-line"></i> <span>Statistiques</span></a>
-            </li>
-    
-            <li>
-                <a href="<?php echo esc_url('/mon-compte/outils/'); ?>"><i class="fas fa-wrench"></i> <span>Outils</span></a>
-            </li>
-        
-            <!-- Mon Compte (inchangé) -->
-            <li class="menu-deroulant">
-                <a href="#" id="menu-account-toggle"><i class="fas fa-user-circle"></i> <span>Mon compte</span> <span class="dropdown-indicator">▼</span></a>
-                <ul class="submenu">
-                    <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">Mes Commandes</a></li>
-                    <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">Mes Adresses</a></li>
-                    <li><a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">Paramètres</a></li>
-                    <li><a href="<?php echo esc_url(wc_logout_url()); ?>">Déconnexion</a></li>
-                </ul>
-            </li>
-        </ul>
-    </nav>
+<?php get_template_part('template-parts/myaccount/navigation'); ?>
+<?php get_template_part('template-parts/myaccount/important-messages'); ?>
 
     <!-- 📌 Contenu Principal -->
     <div class="dashboard-content">

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/default.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/default.php
@@ -6,64 +6,8 @@ $current_user = wp_get_current_user();
 $logout_url = wc_get_account_endpoint_url('customer-logout'); // Lien déconnexion
 ?>
 
-<!-- 📌 Conteneur Profil + Points -->
-<div class="dashboard-container">
-   <!-- 📌 Conteneur Profil + Points -->
-    <div class="dashboard-profile-wrapper">
-        <!-- 📌 Profil Utilisateur -->
-        <div class="dashboard-profile">
-            <div class="profile-avatar-container">
-                <div class="profile-avatar">
-                    <?php echo get_avatar($current_user->ID, 80); ?>
-                </div>
-            
-                <!-- 📌 Bouton pour ouvrir le téléversement -->
-                <label for="upload-avatar" class="upload-avatar-btn">Modifier</label>
-                <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display: none;">
-                
-                <!-- 📌 Conteneur des messages d’upload -->
-                <div class="message-upload-avatar">
-                    <div class="message-size-file-avatar">❗ Taille maximum : 2 Mo</div>
-                    <div class="message-format-file-avatar">📌 Formats autorisés : JPG, PNG, GIF</div>
-                </div>
-            </div>
-            <div class="profile-info">
-                <h2><?php echo esc_html($current_user->display_name); ?></h2>
-                <p><?php echo esc_html($current_user->user_email); ?></p>
-            </div>
-        </div>
-    </div>
-        
-    <!-- 📌 Barre de navigation Desktop -->
-   <nav class="dashboard-nav">
-        <ul>
-           <li class="<?php echo is_account_page() && !is_wc_endpoint_url() ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>">
-                    <i class="fas fa-home"></i> <span>Accueil</span>
-                </a>
-            </li>
-            <li class="<?php echo is_wc_endpoint_url('orders') ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">
-                    <i class="fas fa-box"></i> <span>Commandes</span>
-                </a>
-            </li>
-            <li class="<?php echo is_wc_endpoint_url('edit-address') ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">
-                    <i class="fas fa-map-marker-alt"></i> <span>Adresses</span>
-                </a>
-            </li>
-            <li class="<?php echo is_wc_endpoint_url('edit-account') ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">
-                    <i class="fas fa-cog"></i> <span>Paramètres</span>
-                </a>
-            </li>
-            <li>
-                <a href="<?php echo esc_url(wc_logout_url()); ?>">
-                    <i class="fas fa-sign-out-alt"></i> <span>Déconnexion</span>
-                </a>
-            </li>
-        </ul>
-    </nav>
+<?php get_template_part('template-parts/myaccount/navigation'); ?>
+<?php get_template_part('template-parts/myaccount/important-messages'); ?>
 
     <!-- 📌 Contenu Principal -->
     <div class="dashboard-content">

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/organisateur.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/organisateur.php
@@ -47,64 +47,8 @@ $tableau_contenu = ob_get_clean(); // Récupérer la sortie et l'effacer du buff
 
 ?>
 
-<!-- 📌 Conteneur Profil + Points -->
-<div class="dashboard-container">
-   <!-- 📌 Conteneur Profil + Points -->
-    <div class="dashboard-profile-wrapper">
-        <!-- 📌 Profil Utilisateur -->
-        <div class="dashboard-profile">
-            <div class="profile-avatar-container">
-                <div class="profile-avatar">
-                    <?php echo get_avatar($current_user->ID, 80); ?>
-                </div>
-            
-                <!-- 📌 Bouton pour ouvrir le téléversement -->
-                <label for="upload-avatar" class="upload-avatar-btn">Modifier</label>
-                <input type="file" id="upload-avatar" class="upload-avatar-input" accept="image/*" style="display: none;">
-                
-                <!-- 📌 Conteneur des messages d’upload -->
-                <div class="message-upload-avatar">
-                    <div class="message-size-file-avatar">❗ Taille maximum : 2 Mo</div>
-                    <div class="message-format-file-avatar">📌 Formats autorisés : JPG, PNG, GIF</div>
-                </div>
-            </div>
-            <div class="profile-info">
-                <h2><?php echo esc_html($current_user->display_name); ?></h2>
-                <p><?php echo esc_html($current_user->user_email); ?></p>
-            </div>
-        </div>
-    </div>
-        
-    <!-- 📌 Barre de navigation Desktop -->
-   <nav class="dashboard-nav">
-        <ul>
-           <li class="<?php echo is_account_page() && !is_wc_endpoint_url() ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('dashboard')); ?>">
-                    <i class="fas fa-home"></i> <span>Accueil</span>
-                </a>
-            </li>
-            <li class="<?php echo is_wc_endpoint_url('orders') ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>">
-                    <i class="fas fa-box"></i> <span>Commandes</span>
-                </a>
-            </li>
-            <li class="<?php echo is_wc_endpoint_url('edit-address') ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-address')); ?>">
-                    <i class="fas fa-map-marker-alt"></i> <span>Adresses</span>
-                </a>
-            </li>
-            <li class="<?php echo is_wc_endpoint_url('edit-account') ? 'active' : ''; ?>">
-                <a href="<?php echo esc_url(wc_get_account_endpoint_url('edit-account')); ?>">
-                    <i class="fas fa-cog"></i> <span>Paramètres</span>
-                </a>
-            </li>
-            <li>
-                <a href="<?php echo esc_url(wc_logout_url()); ?>">
-                    <i class="fas fa-sign-out-alt"></i> <span>Déconnexion</span>
-                </a>
-            </li>
-        </ul>
-    </nav>
+<?php get_template_part('template-parts/myaccount/navigation'); ?>
+<?php get_template_part('template-parts/myaccount/important-messages'); ?>
 
     <!-- 📌 Contenu Principal -->
     <div class="dashboard-content">


### PR DESCRIPTION
## Summary
- add global `page-mon-compte.php` with hero and notifications
- add `important-messages` block and account navigation template parts
- expose `cta_get_important_messages()` helper
- update mon-compte styles for full width layout and notification styling
- integrate new template parts across account pages

## Testing
- `composer install`
- `php vendor/bin/phpunit -c wp-content/plugins/hostinger/vendor/hostinger/hostinger-wp-helper/phpunit.xml.dist` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68825f16667c8332a792ddc9bf79503d