### PR TITLE
Add stats table styling

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1083,3 +1083,22 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-field-hover);
   font-weight: bold;
 }
+
+/* ====== Tableaux de statistiques ====== */
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 0 transparent;
+}
+
+.stats-table tr,
+.stats-table td {
+  border: 0 solid transparent;
+}
+
+.stats-table td {
+  text-align: left;
+  padding: 8px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- extend edition.css to style `.stats-table` like dashboard tables

## Testing
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68828836e570833285a748db010577cf