### PR TITLE
Add stats table for enigma edition

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/stats.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/stats.php
@@ -1,0 +1,86 @@
+<?php
+defined('ABSPATH') || exit;
+
+function enigme_stats_date_range(string $periode): array {
+    $tz = new DateTimeZone('Europe/Paris');
+    $now = new DateTime('now', $tz);
+    switch ($periode) {
+        case 'jour':
+            $start = (clone $now)->setTime(0,0);
+            break;
+        case 'semaine':
+            $start = (clone $now)->modify('monday this week')->setTime(0,0);
+            break;
+        case 'mois':
+            $start = (clone $now)->modify('first day of this month')->setTime(0,0);
+            break;
+        default:
+            return [null, null];
+    }
+    return [$start->format('Y-m-d H:i:s'), $now->format('Y-m-d H:i:s')];
+}
+
+function enigme_compter_joueurs_engages(int $enigme_id, string $periode = 'total'): int {
+    global $wpdb;
+    $table = $wpdb->prefix . 'engagements';
+    $where = 'enigme_id = %d';
+    $params = [$enigme_id];
+    if ($periode !== 'total') {
+        list($debut, $fin) = enigme_stats_date_range($periode);
+        if ($debut && $fin) {
+            $where .= ' AND date_engagement BETWEEN %s AND %s';
+            array_push($params, $debut, $fin);
+        }
+    }
+    $sql = $wpdb->prepare("SELECT COUNT(DISTINCT user_id) FROM $table WHERE $where", ...$params);
+    return (int) $wpdb->get_var($sql);
+}
+
+function enigme_compter_tentatives(int $enigme_id, string $mode = 'automatique', string $periode = 'total'): int {
+    global $wpdb;
+    $table = $wpdb->prefix . 'enigme_tentatives';
+    $where = 'enigme_id = %d';
+    $params = [$enigme_id];
+    if ($periode !== 'total') {
+        list($debut, $fin) = enigme_stats_date_range($periode);
+        if ($debut && $fin) {
+            $where .= ' AND date_tentative BETWEEN %s AND %s';
+            array_push($params, $debut, $fin);
+        }
+    }
+    $sql = $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE $where", ...$params);
+    return (int) $wpdb->get_var($sql);
+}
+
+function enigme_compter_points_depenses(int $enigme_id, string $mode = 'automatique', string $periode = 'total'): int {
+    global $wpdb;
+    $table = $wpdb->prefix . 'enigme_tentatives';
+    $where = 'enigme_id = %d';
+    $params = [$enigme_id];
+    if ($periode !== 'total') {
+        list($debut, $fin) = enigme_stats_date_range($periode);
+        if ($debut && $fin) {
+            $where .= ' AND date_tentative BETWEEN %s AND %s';
+            array_push($params, $debut, $fin);
+        }
+    }
+    $sql = $wpdb->prepare("SELECT SUM(points_utilises) FROM $table WHERE $where", ...$params);
+    $res = $wpdb->get_var($sql);
+    return $res ? (int) $res : 0;
+}
+
+function enigme_compter_bonnes_solutions(int $enigme_id, string $mode = 'automatique', string $periode = 'total'): int {
+    global $wpdb;
+    $table = $wpdb->prefix . 'enigme_tentatives';
+    $where = "enigme_id = %d AND resultat = 'bon'";
+    $params = [$enigme_id];
+    if ($periode !== 'total') {
+        list($debut, $fin) = enigme_stats_date_range($periode);
+        if ($debut && $fin) {
+            $where .= ' AND date_tentative BETWEEN %s AND %s';
+            array_push($params, $debut, $fin);
+        }
+    }
+    $sql = $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE $where", ...$params);
+    return (int) $wpdb->get_var($sql);
+}

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -414,7 +414,52 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       <div class="edition-panel-header">
         <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
       </div>
-      <p class="edition-placeholder">La section « Statistiques » sera bientôt disponible.</p>
+      <?php
+      if (!function_exists('enigme_compter_joueurs_engages')) {
+        require_once get_stylesheet_directory() . '/inc/enigme/stats.php';
+      }
+      ?>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>Total</th>
+            <th>Aujourd’hui</th>
+            <th>Semaine</th>
+            <th>Mois</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Nombre de joueurs engagés</td>
+            <td><?= enigme_compter_joueurs_engages($enigme_id, 'total'); ?></td>
+            <td><?= enigme_compter_joueurs_engages($enigme_id, 'jour'); ?></td>
+            <td><?= enigme_compter_joueurs_engages($enigme_id, 'semaine'); ?></td>
+            <td><?= enigme_compter_joueurs_engages($enigme_id, 'mois'); ?></td>
+          </tr>
+          <tr>
+            <td>Nombre de tentatives</td>
+            <td><?= enigme_compter_tentatives($enigme_id, $mode_validation, 'total'); ?></td>
+            <td><?= enigme_compter_tentatives($enigme_id, $mode_validation, 'jour'); ?></td>
+            <td><?= enigme_compter_tentatives($enigme_id, $mode_validation, 'semaine'); ?></td>
+            <td><?= enigme_compter_tentatives($enigme_id, $mode_validation, 'mois'); ?></td>
+          </tr>
+          <tr>
+            <td>Nombre de points dépensés</td>
+            <td><?= enigme_compter_points_depenses($enigme_id, $mode_validation, 'total'); ?></td>
+            <td><?= enigme_compter_points_depenses($enigme_id, $mode_validation, 'jour'); ?></td>
+            <td><?= enigme_compter_points_depenses($enigme_id, $mode_validation, 'semaine'); ?></td>
+            <td><?= enigme_compter_points_depenses($enigme_id, $mode_validation, 'mois'); ?></td>
+          </tr>
+          <tr>
+            <td>Nombre de bonnes solutions</td>
+            <td><?= enigme_compter_bonnes_solutions($enigme_id, $mode_validation, 'total'); ?></td>
+            <td><?= enigme_compter_bonnes_solutions($enigme_id, $mode_validation, 'jour'); ?></td>
+            <td><?= enigme_compter_bonnes_solutions($enigme_id, $mode_validation, 'semaine'); ?></td>
+            <td><?= enigme_compter_bonnes_solutions($enigme_id, $mode_validation, 'mois'); ?></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
 
 <div id="enigme-tab-soumission" class="edition-tab-content" style="display:none;">


### PR DESCRIPTION
## Summary
- add helper functions to compute basic enigma statistics
- replace stats placeholder with table showing counts

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68828835cac483329df395a3f29f7f02