### PR TITLE
Add stats helpers for enigmes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme-functions.php
+++ b/wp-content/themes/chassesautresor/inc/enigme-functions.php
@@ -8,3 +8,4 @@ require_once $base . 'visuels.php';
 require_once $base . 'affichage.php';
 require_once $base . 'reponses.php';
 require_once $base . 'tentatives.php';
+require_once $base . 'stats.php';

--- a/wp-content/themes/chassesautresor/inc/enigme/stats.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/stats.php
@@ -1,0 +1,138 @@
+<?php
+defined('ABSPATH') || exit;
+
+/**
+ * Compte le nombre de joueurs ayant engagé une énigme.
+ *
+ * @param int         $id     ID de l'énigme.
+ * @param string|null $debut  Date de début au format 'Y-m-d H:i:s'.
+ * @param string|null $fin    Date de fin au format 'Y-m-d H:i:s'.
+ * @return int Nombre de joueurs distincts.
+ */
+function compter_joueurs_engages_enigme(int $id, ?string $debut = null, ?string $fin = null): int
+{
+    if (!$id || get_post_type($id) !== 'enigme') {
+        return 0;
+    }
+
+    global $wpdb;
+    $table  = $wpdb->prefix . 'engagements';
+    $sql    = "SELECT COUNT(DISTINCT user_id) FROM $table WHERE enigme_id = %d";
+    $params = [$id];
+
+    if ($debut && $fin) {
+        $sql .= " AND date_engagement BETWEEN %s AND %s";
+        $params[] = $debut;
+        $params[] = $fin;
+    } elseif ($debut) {
+        $sql .= " AND date_engagement >= %s";
+        $params[] = $debut;
+    } elseif ($fin) {
+        $sql .= " AND date_engagement <= %s";
+        $params[] = $fin;
+    }
+
+    return (int) $wpdb->get_var($wpdb->prepare($sql, ...$params));
+}
+
+/**
+ * Compte le nombre de tentatives pour une énigme durant une période.
+ *
+ * @param int         $id     ID de l'énigme.
+ * @param string|null $debut  Date de début au format 'Y-m-d H:i:s'.
+ * @param string|null $fin    Date de fin au format 'Y-m-d H:i:s'.
+ * @return int Nombre de tentatives.
+ */
+function compter_tentatives_enigme_periode(int $id, ?string $debut = null, ?string $fin = null): int
+{
+    if (!$id || get_post_type($id) !== 'enigme') {
+        return 0;
+    }
+
+    global $wpdb;
+    $table  = $wpdb->prefix . 'enigme_tentatives';
+    $sql    = "SELECT COUNT(*) FROM $table WHERE enigme_id = %d";
+    $params = [$id];
+
+    if ($debut && $fin) {
+        $sql .= " AND date_tentative BETWEEN %s AND %s";
+        $params[] = $debut;
+        $params[] = $fin;
+    } elseif ($debut) {
+        $sql .= " AND date_tentative >= %s";
+        $params[] = $debut;
+    } elseif ($fin) {
+        $sql .= " AND date_tentative <= %s";
+        $params[] = $fin;
+    }
+
+    return (int) $wpdb->get_var($wpdb->prepare($sql, ...$params));
+}
+
+/**
+ * Calcule la somme des points dépensés pour une énigme durant une période.
+ *
+ * @param int         $id     ID de l'énigme.
+ * @param string|null $debut  Date de début au format 'Y-m-d H:i:s'.
+ * @param string|null $fin    Date de fin au format 'Y-m-d H:i:s'.
+ * @return int Somme des points dépensés.
+ */
+function somme_points_depenses_enigme_periode(int $id, ?string $debut = null, ?string $fin = null): int
+{
+    if (!$id || get_post_type($id) !== 'enigme') {
+        return 0;
+    }
+
+    global $wpdb;
+    $table  = $wpdb->prefix . 'enigme_tentatives';
+    $sql    = "SELECT COALESCE(SUM(points_utilises),0) FROM $table WHERE enigme_id = %d";
+    $params = [$id];
+
+    if ($debut && $fin) {
+        $sql .= " AND date_tentative BETWEEN %s AND %s";
+        $params[] = $debut;
+        $params[] = $fin;
+    } elseif ($debut) {
+        $sql .= " AND date_tentative >= %s";
+        $params[] = $debut;
+    } elseif ($fin) {
+        $sql .= " AND date_tentative <= %s";
+        $params[] = $fin;
+    }
+
+    return (int) $wpdb->get_var($wpdb->prepare($sql, ...$params));
+}
+
+/**
+ * Compte les bonnes solutions enregistrées pour une énigme durant une période.
+ *
+ * @param int         $id     ID de l'énigme.
+ * @param string|null $debut  Date de début au format 'Y-m-d H:i:s'.
+ * @param string|null $fin    Date de fin au format 'Y-m-d H:i:s'.
+ * @return int Nombre de solutions correctes.
+ */
+function compter_bonnes_solutions_enigme_periode(int $id, ?string $debut = null, ?string $fin = null): int
+{
+    if (!$id || get_post_type($id) !== 'enigme') {
+        return 0;
+    }
+
+    global $wpdb;
+    $table  = $wpdb->prefix . 'enigme_tentatives';
+    $sql    = "SELECT COUNT(*) FROM $table WHERE enigme_id = %d AND resultat = 'bon'";
+    $params = [$id];
+
+    if ($debut && $fin) {
+        $sql .= " AND date_tentative BETWEEN %s AND %s";
+        $params[] = $debut;
+        $params[] = $fin;
+    } elseif ($debut) {
+        $sql .= " AND date_tentative >= %s";
+        $params[] = $debut;
+    } elseif ($fin) {
+        $sql .= " AND date_tentative <= %s";
+        $params[] = $fin;
+    }
+
+    return (int) $wpdb->get_var($wpdb->prepare($sql, ...$params));
+}


### PR DESCRIPTION
## Summary
- add statistics helpers for enigme engagements and tentatives
- include new helpers in enigme functions

## Testing
- `composer install` *(fails: ext-mbstring missing -> installed)*
- `composer install` again
- `vendor/bin/phpunit` *(fails: Could not find wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68828834ea4483328a032e3af6247be9