### PR TITLE
Replace payante status label with en cours

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -714,6 +714,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     $statut            = get_field('chasse_cache_statut', $chasse_id) ?: 'revision';
     $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
     $statut_label      = ucfirst(str_replace('_', ' ', $statut));
+    $badge_class       = 'statut-' . $statut;
+
     if ($statut === 'revision') {
         if ($statut_validation === 'creation') {
             $statut_label = 'création';
@@ -722,8 +724,10 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
         } elseif ($statut_validation === 'en_attente') {
             $statut_label = 'en attente';
         }
+    } elseif ($statut === 'payante') {
+        $statut_label = 'en cours';
+        $badge_class   = 'statut-en_cours';
     }
-    $badge_class = 'statut-' . $statut;
 
     $enigmes_associees = recuperer_enigmes_associees($chasse_id);
     $total_enigmes     = count($enigmes_associees);

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -952,6 +952,10 @@ function recuperer_statut_chasse()
 
     $statut_str = is_string($statut) ? $statut : '';
     $statut_label = ucfirst(str_replace('_', ' ', $statut_str));
+    if ($statut_str === 'payante') {
+        $statut_str = 'en_cours';
+        $statut_label = 'en cours';
+    }
 
     if ($statut_str === 'revision') {
         $validation = get_field('chasse_cache_statut_validation', $post_id);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -85,6 +85,7 @@ if ($edition_active && !$est_complet) {
     $statut = $infos_chasse['statut'];
     $statut_validation = $infos_chasse['statut_validation'];
     $statut_label = ucfirst(str_replace('_', ' ', $statut));
+    $statut_for_class = $statut;
 
     if ($statut === 'revision') {
       if ($statut_validation === 'creation') {
@@ -94,9 +95,12 @@ if ($edition_active && !$est_complet) {
       } elseif ($statut_validation === 'en_attente') {
         $statut_label = 'en attente';
       }
+    } elseif ($statut === 'payante') {
+      $statut_label = 'en cours';
+      $statut_for_class = 'en_cours';
     }
     ?>
-      <span class="badge-statut statut-<?= esc_attr($statut); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
+      <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
         <?= esc_html($statut_label); ?>
       </span>
 


### PR DESCRIPTION
## Summary
- update full view badge to display `en cours` instead of `payante`
- change card badge label/class when status is `payante`
- adjust AJAX status endpoint to output `en cours` when applicable

## Testing
- `composer install` *(fails: Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68899dee39cc83329f0af083cf99abff