### PR TITLE
Fix protected hunt fields

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -50,6 +50,9 @@ function modifierChampSimple(champ, valeur, postId, cpt = 'enigme') {
 // 📝 initChampTexte
 // ==============================
 function initChampTexte(bloc) {
+  if (bloc.classList.contains('champ-desactive')) {
+    return; // champ non éditable
+  }
   const champ = bloc.dataset.champ;
   const cpt = bloc.dataset.cpt;
   const postId = bloc.dataset.postId;

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -263,6 +263,9 @@ initAffichageBoutonsCout();
 // ================================
 function initChampCoutPoints() {
   document.querySelectorAll('.champ-cout-points').forEach(bloc => {
+    if (bloc.classList.contains('champ-desactive')) {
+      return; // champ verrouillé
+    }
     const input = bloc.querySelector('.champ-input.champ-cout[type="number"]');
     const checkbox = bloc.querySelector('input[type="checkbox"]');
     if (!input || !checkbox) return;

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -762,9 +762,13 @@ function champ_est_editable($champ, $post_id, $user_id = null)
         return false;
     }
 
-    // 💡 Exemple : titre de chasse non modifiable après publication
-    if ($post_type === 'chasse' && $champ === 'post_title') {
-        return $status !== 'publish';
+    // 💡 Chasse : certains champs ne sont éditables que durant la phase
+    //     de création/correction. On se base sur la même logique que
+    //     `utilisateur_peut_editer_champs()`.
+    if ($post_type === 'chasse') {
+        if (in_array($champ, ['post_title', 'caracteristiques.chasse_infos_cout_points'], true)) {
+            return utilisateur_peut_editer_champs($post_id);
+        }
     }
 
     // 🔒 Le nom d'organisateur est verrouillé sauf pour certaines étapes de création

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -14,6 +14,8 @@ if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
 
 $peut_modifier = utilisateur_peut_voir_panneau($chasse_id);
 $peut_editer   = utilisateur_peut_editer_champs($chasse_id);
+$peut_editer_titre = champ_est_editable('post_title', $chasse_id);
+$peut_editer_cout  = champ_est_editable('caracteristiques.chasse_infos_cout_points', $chasse_id);
 
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
 
@@ -79,14 +81,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <ul class="resume-infos">
 
                 <!-- Titre -->
-                <li class="champ-chasse champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                <li class="champ-chasse champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
                   data-champ="post_title"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
                   <div class="champ-affichage">
                     <label for="champ-titre-chasse">Titre de la chasse</label>
-                    <?php if ($peut_editer) : ?>
+                    <?php if ($peut_editer_titre) : ?>
                       <button type="button" class="champ-modifier" aria-label="Modifier le titre">
                         ✏️
                       </button>
@@ -94,7 +96,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   </div>
 
                   <div class="champ-edition" style="display: none;">
-                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse" <?= $peut_editer ? '' : 'disabled'; ?>>
+                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>>
                     <button type="button" class="champ-enregistrer">✓</button>
                     <button type="button" class="champ-annuler">✖</button>
                   </div>
@@ -223,7 +225,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
 
                 <!-- Coût -->
-                <li class="champ-chasse champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                <li class="champ-chasse champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer_cout ? '' : ' champ-desactive'; ?>"
                   data-champ="chasse_infos_cout_points"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
@@ -238,13 +240,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       min="0"
                       step="1"
                       value="<?= esc_attr($cout); ?>"
-                      placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
+                      placeholder="0" <?= $peut_editer_cout ? '' : 'disabled'; ?> />
 
                     <div class="champ-option-gratuit" style="margin-left: 15px;">
                       <input type="checkbox"
                         id="cout-gratuit"
                         name="cout-gratuit"
-                        <?= ((int)$cout === 0) ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                        <?= ((int)$cout === 0) ? 'checked' : ''; ?> <?= $peut_editer_cout ? '' : 'disabled'; ?>>
                       <label for="cout-gratuit">Gratuit</label>
                     </div>
                   </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -87,7 +87,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
                   <div class="champ-affichage">
-                    <label for="champ-titre-chasse">Titre de la chasse</label>
+                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre de la chasse</label>
                     <?php if ($peut_editer_titre) : ?>
                       <button type="button" class="champ-modifier" aria-label="Modifier le titre">
                         ✏️
@@ -95,11 +95,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <?php endif; ?>
                   </div>
 
-                  <div class="champ-edition" style="display: none;">
-                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>>
-                    <button type="button" class="champ-enregistrer">✓</button>
-                    <button type="button" class="champ-annuler">✖</button>
-                  </div>
+                  <?php if ($peut_editer_titre) : ?>
+                    <div class="champ-edition" style="display: none;">
+                      <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse">
+                      <button type="button" class="champ-enregistrer">✓</button>
+                      <button type="button" class="champ-annuler">✖</button>
+                    </div>
+                  <?php endif; ?>
 
                   <div class="champ-feedback"></div>
                 </li>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -95,13 +95,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <?php endif; ?>
                   </div>
 
-                  <?php if ($peut_editer_titre) : ?>
-                    <div class="champ-edition" style="display: none;">
-                      <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse">
+                  <div class="champ-edition" style="display: none;">
+                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>>
+                    <?php if ($peut_editer_titre) : ?>
                       <button type="button" class="champ-enregistrer">✓</button>
                       <button type="button" class="champ-annuler">✖</button>
-                    </div>
-                  <?php endif; ?>
+                    <?php endif; ?>
+                  </div>
 
                   <div class="champ-feedback"></div>
                 </li>


### PR DESCRIPTION
## Summary
- respect per-field permissions in hunt editor
- skip cost input initialization when field is locked

## Testing
- `composer install`
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*
- `php -l wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php`
- `node --check wp-content/themes/chassesautresor/assets/js/core/champ-init.js`

------
https://chatgpt.com/codex/tasks/task_e_6889a9c32ea08332b508ee26017af8ba