### PR TITLE
Allow editing published organizer details

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -699,7 +699,9 @@ function utilisateur_peut_editer_champs(int $post_id): bool
 
     switch ($type) {
         case 'organisateur':
-            return in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $status === 'pending';
+            // Les organisateurs confirmés peuvent éditer les champs de leur CPT
+            // (sauf restrictions spécifiques gérées ailleurs).
+            return utilisateur_peut_modifier_post($post_id);
 
         case 'chasse':
             $val  = get_field('chasse_cache_statut_validation', $post_id) ?? '';

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -171,9 +171,8 @@ function ajax_modifier_champ_organisateur()
     wp_send_json_error('⚠️ organisateur_introuvable');
   }
 
-  // 🔒 Vérifie que l’utilisateur est bien auteur du post
-  $auteur = (int) get_post_field('post_author', $post_id);
-  if ($auteur !== $user_id) {
+  // 🔒 Vérifie que l’utilisateur est autorisé à modifier ce post
+  if (!utilisateur_peut_modifier_post($post_id)) {
     wp_send_json_error('⚠️ acces_refuse');
   }
 


### PR DESCRIPTION
## Summary
- permit associated users to update organizer fields even when published
- use general permission check in organizer AJAX handler

## Testing
- `composer install`
- `composer test` *(fails: Could not find functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_688afb9b65f0833295b66e937e64e69b