### PR TITLE
Create root agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ wp-config.php
 *.sql
 vendor/
 composer.phar
+tests/.phpunit.result.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Instructions
+
+## Code Style
+- Follow **PSR-12** for PHP files: 4 spaces for indentation, and lines under 120 characters.
+- Keep function and variable names in English when possible.
+- Place opening braces on the same line as declarations.
+
+## Testing
+- Before committing any change, run the project tests.
+- Use the provided helper script to get the correct PHP and Composer executables:
+  ```bash
+  source ./setup-env.sh
+  composer install
+  vendor/bin/phpunit -c tests/phpunit.xml
+  ```
+- Ensure the test suite passes.
+
+## Pull Request Messages
+- Begin the PR body with a short summary in French.
+- Provide a bullet list of notable changes.
+- Add a **Testing** section summarizing the commands executed and their results.
+


### PR DESCRIPTION
## Summary
- add agent instructions with code style and testing guidance
- ignore PHPUnit cache

## Testing
- `/root/.local/share/mise/installs/php/8.4.10/bin/php vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688b0a5e529883328f58510f67752665