### PR TITLE
docs: ajouter notice champs ACF

### DIFF
--- a/wp-content/themes/chassesautresor/notices/README.md
+++ b/wp-content/themes/chassesautresor/notices/README.md
@@ -5,10 +5,15 @@ Ce dossier centralise les fiches techniques du projet.
 ## Organisation
 
 - **global.md** : vue d'ensemble et règles générales.
+- **champs-acf-liste.md** : export brut des groupes et champs ACF.
 - **chasses/** : notices spécifiques aux chasses.
 - **fields/** : guides d'intégration pour les champs ACF utilisés en édition frontale.
 
 ### Liste des notices
+
+#### global
+- `global.md` : vue d'ensemble et règles générales.
+- `champs-acf-liste.md` : export détaillé des groupes de champs ACF.
 
 #### chasses
 - `statuts-chasses-recalcul.md` : recalcul automatique du statut des chasses.

--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -1,0 +1,454 @@
+# 📋 Liste des groupes de champs ACF
+
+🔹 Groupe : paramètre de la chasse
+🆔 ID : 27
+🔑 Key : group_67b58c51b9a49
+📦 Champs trouvés : 20
+
+— chasse_principale_image —
+Type : image
+Label : image chasse
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_principale_description —
+Type : wysiwyg
+Label : Description de la chasse
+Instructions : (vide)
+Requis : oui
+----------------------------------------
+— chasse_infos_recompense_titre —
+Type : text
+Label : Titre de la récompense
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_recompense_valeur —
+Type : number
+Label : valeur en €
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_nb_max_gagants —
+Type : number
+Label : Nombre maximum de gagants
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_cout_points —
+Type : number
+Label : coût en points
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_recompense_texte —
+Type : wysiwyg
+Label : Description de la récompense
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_date_debut —
+Type : date_time_picker
+Label : Date de début
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_date_fin —
+Type : date_picker
+Label : date de fin
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_infos_duree_illimitee —
+Type : true_false
+Label : Durée illlimitée
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_principale_liens —
+Type : repeater
+Label : liens publics de la chasse
+Instructions : (vide)
+Requis : non
+Contenu imbriqué :
+  — chasse_principale_liens_type —
+  Type : select
+  Label : Type de lien
+  Instructions : (vide)
+  Requis : non
+  Choices :
+    - site_web : Site Web
+    - discord : Discord
+    - facebook : Facebook
+    - twitter : Twitter/X
+    - instagram : Instagram
+  ----------------------------------------
+  — chasse_principale_liens_url —
+  Type : url
+  Label : url lien
+  Instructions : (vide)
+  Requis : non
+  ----------------------------------------
+----------------------------------------
+— chasse_cache_gagnants —
+Type : user
+Label : Gagnants
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_cache_date_decouverte —
+Type : date_picker
+Label : Date de découverte
+Instructions : Permet de terminer manuellement la chasse.
+Requis : non
+----------------------------------------
+— chasse_cache_statut —
+Type : select
+Label : Statut de la chasse
+Instructions : (vide)
+Requis : non
+Choices :
+  - revision : en cours de révision
+  - a_venir : à venir
+  - payante : payante
+  - termine : terminée
+  - en_cours : en cours
+----------------------------------------
+— chasse_cache_statut_validation —
+Type : select
+Label : statut_validation
+Instructions : (vide)
+Requis : non
+Choices :
+  - creation : Création
+  - en_attente : En attente
+  - valide : Valide
+  - correction : Correction
+  - banni : Banni
+----------------------------------------
+— chasse_cache_enigmes —
+Type : relationship
+Label : Énigmes associées
+Instructions : Sélectionnez les énigmes associées à cette chasse
+Requis : non
+----------------------------------------
+— chasse_cache_commentaire —
+Type : textarea
+Label : commentaire validation
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_cache_organisateur —
+Type : relationship
+Label : organisateur chasse
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_cache_complet —
+Type : true_false
+Label : chasse_cache_complet
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_mode_fin —
+Type : radio
+Label : chasse mode fin
+Instructions : (vide)
+Requis : non
+Choices :
+  - manuelle : Manuelle
+  - automatique : Automatique
+----------------------------------------
+
+🔹 Groupe : Paramètres de l’énigme
+🆔 ID : 9
+🔑 Key : group_67b58134d7647
+📦 Champs trouvés : 32
+
+— enigme_visuel_image —
+Type : gallery
+Label : image principale
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— enigme_visuel_texte —
+Type : wysiwyg
+Label : texte enigme
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— enigme_mode_validation —
+Type : radio
+Label : enigme_mode_validation
+Instructions : (vide)
+Requis : non
+Choices :
+  - aucune : Aucune validation
+  - manuelle : Validation manuelle
+  - automatique : Validation automatique
+----------------------------------------
+— enigme_visuel_legende —
+Type : text
+Label : sous titre
+Instructions : Texte court facultatif affiché sous l’image principale.
+Requis : non
+----------------------------------------
+— enigme_style_affichage —
+Type : select
+Label : enigme_style_affichage
+Instructions : (vide)
+Requis : non
+Choices :
+  - defaut : Défaut
+  - pirate : Pirate
+  - vintage : Vintage
+----------------------------------------
+— enigme_tentative_cout_points —
+Type : number
+Label : coût en points d'une tentative
+Instructions : coût en points de l'énigme
+Requis : non
+----------------------------------------
+— enigme_tentative_max —
+Type : number
+Label : Nb max de tentatives quotidiennes
+Instructions : Nb max de tentatives quotidiennes
+Requis : non
+----------------------------------------
+— enigme_reponse_bonne —
+Type : text
+Label : bonne réponse
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— enigme_reponse_casse —
+Type : true_false
+Label : Respecter la casse
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— texte_1 —
+Type : text
+Label : texte_1
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— message_1 —
+Type : text
+Label : message 1
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— respecter_casse_1 —
+Type : true_false
+Label : respecter casse 1
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— texte_2 —
+Type : text
+Label : texte 2
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— message_2 —
+Type : text
+Label : message 2
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— respecter_casse_2 —
+Type : true_false
+Label : respecter casse 2
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— texte_3 —
+Type : text
+Label : texte 3
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— message_3 —
+Type : text
+Label : message 3
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— respecter_casse_3 —
+Type : text
+Label : respecter casse 3
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— texte_4 —
+Type : text
+Label : texte 4
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— message_4 —
+Type : text
+Label : message 4
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— respecter_casse_4 —
+Type : text
+Label : respecter casse 4
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— enigme_acces_condition —
+Type : radio
+Label : conditions de déblocage
+Instructions : (vide)
+Requis : non
+Choices :
+  - immediat : Immédiat
+  - date_programmee : Date Programmée
+  - pre_requis : Pré Requis
+----------------------------------------
+— enigme_acces_date —
+Type : date_picker
+Label : date de déblocage
+Instructions : possibilité de programmer la parution de l'énigme dans le futur
+Requis : non
+----------------------------------------
+— enigme_acces_pre_requis —
+Type : relationship
+Label : pré requis
+Instructions : autre(s) énigme(s) devant être résolues pour débloquer celle là
+Requis : non
+----------------------------------------
+— enigme_cache_etat_systeme —
+Type : select
+Label : enigme_cache_etat_systeme
+Instructions : (vide)
+Requis : non
+Choices :
+  - accessible : Accessible
+  - bloquee_date : Bloquée - à venir
+  - bloquee_chasse : Bloquée - chasse indisponible
+  - invalide : Invalide (données manquantes)
+  - cache_invalide : Erreur de configuration
+  - bloquee_pre_requis : bloquee_pre_requis
+----------------------------------------
+— enigme_chasse_associee —
+Type : relationship
+Label : chasse associée
+Instructions : (vide)
+Requis : oui
+----------------------------------------
+— enigme_solution_mode —
+Type : radio
+Label : Mode de publication des solutions
+Instructions : (vide)
+Requis : non
+Choices :
+  - pdf : Télécharger un PDF
+  - texte : Rédiger la solution
+----------------------------------------
+— enigme_solution_delai —
+Type : number
+Label : délai de publication des solutions
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— enigme_solution_heure —
+Type : time_picker
+Label : Heure de publication
+Instructions : Heure à laquelle la solution sera publiée, X jours après la fin de la chasse
+Requis : non
+----------------------------------------
+— enigme_solution_fichier —
+Type : file
+Label : Fichier PDF de solution
+Instructions : Ajoutez un fichier PDF contenant la solution complète, si vous ne souhaitez pas utiliser l’éditeur texte.
+Requis : non
+----------------------------------------
+— enigme_solution_explication —
+Type : wysiwyg
+Label : Solution expliquée
+Instructions : La solution ne sera publiée que si la chasse est terminée, et selon le délai de votre choix
+Requis : non
+----------------------------------------
+— enigme_cache_complet —
+Type : true_false
+Label : enigme_cache_complet
+Instructions : (vide)
+Requis : non
+----------------------------------------
+
+🔹 Groupe : Paramètres organisateur
+🆔 ID : 657
+🔑 Key : group_67c7dbfea4a39
+📦 Champs trouvés : 8
+
+— email_contact —
+Type : email
+Label : Adresse email de contact
+Instructions : Adresse à laquelle les joueurs peuvent vous écrire. Si vous ne la renseignez pas, votre adresse principale sera utilisée par défaut. Elle ne sera jamais utilisée pour des envois promotionnels ou des prélèvements.
+Requis : non
+----------------------------------------
+— logo_organisateur —
+Type : image
+Label : Votre Logo
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— liens_publics —
+Type : repeater
+Label : Liens publics
+Instructions : (vide)
+Requis : non
+Contenu imbriqué :
+  — type_de_lien —
+  Type : select
+  Label : Type de lien
+  Instructions : (vide)
+  Requis : non
+  Choices :
+    - site_web : Site Web
+    - discord : Discord
+    - facebook : Facebook
+    - twitter : Twitter/X
+    - instagram : Instagram
+  ----------------------------------------
+  — url_lien —
+  Type : url
+  Label : url lien
+  Instructions : (vide)
+  Requis : non
+  ----------------------------------------
+----------------------------------------
+— iban —
+Type : text
+Label : IBAN
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— bic —
+Type : text
+Label : BIC
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— utilisateurs_associes —
+Type : select
+Label : utilisateurs associes
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— description_longue —
+Type : wysiwyg
+Label : 
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— organisateur_cache_complet —
+Type : true_false
+Label : organisateur_cache_complet
+Instructions : (vide)
+Requis : non
+----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -329,119 +329,78 @@ ACF – Champs personnalisés par CPT
 CPT : organisateur
 Groupe : Paramètres organisateur
 
-* message\_acf\_organisateur (group)
-
-  * (message vide)
-
-* profil\_public (group)
-
-  * logo\_organisateur (image)
-  * description\_courte (text)
-  * email\_contact (email)
-
-* liens\_publics (repeater)
-
-  * type\_de\_lien (select)
-  * url\_lien (url)
-
-* coordonnees\_bancaires (group)
-
-  * iban (text)
-  * bic (text)
-
-* utilisateurs\_associes (select)
-
-* description\_longue (wysiwyg)
+* email_contact (email)
+* logo_organisateur (image)
+* liens_publics (repeater)
+  * type_de_lien (select)
+  * url_lien (url)
+* iban (text)
+* bic (text)
+* utilisateurs_associes (select)
+* description_longue (wysiwyg)
+* organisateur_cache_complet (true_false)
 
 CPT : chasse
 Groupe : paramètre de la chasse
 
-* chasse\_principale\_image (image)
-
-* chasse\_principale\_description (wysiwyg)
-
-* chasse\_principale\_liens (repeater)
-
-  * chasse\_principale\_liens\_type (select)
-  * chasse\_principale\_liens\_url (url)
-
-* caracteristiques (group)
-
-  * chasse\_infos\_recompense\_titre (text)
-  * chasse\_infos\_recompense\_texte (wysiwyg)
-  * chasse\_infos\_recompense\_valeur (number)
-  * chasse\_infos\_cout\_points (number)
-  * chasse\_infos\_date\_debut (date\_picker)
-  * chasse\_infos\_duree\_illimitee (true\_false)
-  * chasse\_infos\_date\_fin (date\_picker)
-  * chasse\_infos\_nb\_max\_gagants (number)
-
-* champs\_caches (group)
-
-  * chasse\_cache\_gagnants (user)
-  * chasse\_cache\_date\_decouverte (date\_picker)
-  * chasse\_cache\_statut (select)
-  * chasse\_cache\_statut\_validation (select)
-  * chasse\_cache\_commentaire (textarea)
-  * chasse\_cache\_enigmes (relationship)
-  * chasse\_cache\_organisateur (relationship)
+* chasse_principale_image (image)
+* chasse_principale_description (wysiwyg)
+* chasse_infos_recompense_titre (text)
+* chasse_infos_recompense_valeur (number)
+* chasse_infos_nb_max_gagants (number)
+* chasse_infos_cout_points (number)
+* chasse_infos_recompense_texte (wysiwyg)
+* chasse_infos_date_debut (date_time_picker)
+* chasse_infos_date_fin (date_picker)
+* chasse_infos_duree_illimitee (true_false)
+* chasse_principale_liens (repeater)
+  * chasse_principale_liens_type (select)
+  * chasse_principale_liens_url (url)
+* chasse_cache_gagnants (user)
+* chasse_cache_date_decouverte (date_picker)
+* chasse_cache_statut (select)
+* chasse_cache_statut_validation (select)
+* chasse_cache_enigmes (relationship)
+* chasse_cache_commentaire (textarea)
+* chasse_cache_organisateur (relationship)
+* chasse_cache_complet (true_false)
+* chasse_mode_fin (radio)
 
 CPT : enigme
 Groupe : Paramètres de l’énigme
 
-* enigme\_visuel\_image (gallery)
-
-* enigme\_visuel\_texte (wysiwyg)
-
-* enigme\_visuel\_legende (text)
-
-* enigme\_mode\_validation (radio)
-
-* enigme\_tentative (group)
-
-  * enigme\_tentative\_cout\_points (number)
-  * enigme\_tentative\_max (number)
-
-* enigme\_reponse\_texte\_manuelle (textarea)  \[a supprimer]
-
-* enigme\_reponse\_bonne (text)
-
-* enigme\_reponse\_casse (true\_false)
-
-* variantes de réponse :
-
-  * texte\_1 (text)
-  * message\_1 (text)
-  * respecter\_casse\_1 (true\_false)
-  * texte\_2 (text)
-  * message\_2 (text)
-  * respecter\_casse\_2 (true\_false)
-  * texte\_3 (text)
-  * message\_3 (text)
-  * respecter\_casse\_3 (true\_false)
-  * texte\_4 (text)
-  * message\_4 (text)
-  * respecter\_casse\_4 (true\_false)
-
-
-* enigme\_acces\_condition (radio)
-* enigme\_acces\_pre\_requis (relationship)
-* enigme\_acces\_date (date\_time\_picker)
-
-* enigme\_style\_affichage (select)
-
-* enigme\_solution (group)
-
-  * enigme\_solution\_mode (radio)
-  * enigme\_solution\_delai (number)
-  * enigme\_solution\_date (date\_time\_picker)
-  * enigme\_solution\_explication (wysiwyg)
-
-* enigme\_chasse\_associee (relationship)
-
-* enigme\_cache\_etat\_systeme (select)
-
-* enigme\_statut\_utilisateur (select)
+* enigme_visuel_image (gallery)
+* enigme_visuel_texte (wysiwyg)
+* enigme_mode_validation (radio)
+* enigme_visuel_legende (text)
+* enigme_style_affichage (select)
+* enigme_tentative_cout_points (number)
+* enigme_tentative_max (number)
+* enigme_reponse_bonne (text)
+* enigme_reponse_casse (true_false)
+* texte_1 (text)
+* message_1 (text)
+* respecter_casse_1 (true_false)
+* texte_2 (text)
+* message_2 (text)
+* respecter_casse_2 (true_false)
+* texte_3 (text)
+* message_3 (text)
+* respecter_casse_3 (text)
+* texte_4 (text)
+* message_4 (text)
+* respecter_casse_4 (text)
+* enigme_acces_condition (radio)
+* enigme_acces_date (date_picker)
+* enigme_acces_pre_requis (relationship)
+* enigme_cache_etat_systeme (select)
+* enigme_chasse_associee (relationship)
+* enigme_solution_mode (radio)
+* enigme_solution_delai (number)
+* enigme_solution_heure (time_picker)
+* enigme_solution_fichier (file)
+* enigme_solution_explication (wysiwyg)
+* enigme_cache_complet (true_false)
 
 liste avec tous les détails des groupes de champs ACF dans champs-acf-liste.md
 


### PR DESCRIPTION
## Résumé
- Ajout d'une notice listant les groupes de champs ACF avec leurs détails.

## Changements notables
- Ajout du fichier `champs-acf-liste.md` avec l'export complet des groupes ACF.
- Mise à jour de `global.md` pour refléter la structure actuelle des champs.
- Ajout des références correspondantes dans le README des notices.

## Testing
- `/usr/bin/php /usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_688df71ac99c83329325c7d064760afd