### PR TITLE
feat: add winner selection before ending hunt

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
+++ b/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
@@ -22,6 +22,7 @@
     input.parentNode.insertBefore(list, input.nextSibling);
 
     input.addEventListener('input', () => {
+      input.dataset.userId = '';
       const term = input.value.trim();
       if (term.length < 2) {
         list.innerHTML = '';
@@ -43,7 +44,8 @@
               item.style.cursor = 'pointer';
               item.style.listStyle = 'none';
               item.addEventListener('click', () => {
-                input.value = user.id;
+                input.value = user.text;
+                input.dataset.userId = user.id;
                 list.innerHTML = '';
                 list.style.display = 'none';
               });

--- a/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
+++ b/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
@@ -1,10 +1,16 @@
 
 (function () {
   const DEBUG = window.DEBUG || false;
+  const AJAX_URL =
+    window.ajaxurl || (window.ajax_object ? window.ajax_object.ajax_url : null);
 
   function initAutocompleteUtilisateurs(input) {
     if (!input) {
       DEBUG && console.log('❌ Élément introuvable');
+      return;
+    }
+    if (!AJAX_URL) {
+      DEBUG && console.warn('❌ URL AJAX non définie');
       return;
     }
     DEBUG && console.log('✅ initAutocompleteUtilisateurs', input);
@@ -30,7 +36,11 @@
         return;
       }
 
-      fetch(ajaxurl + `?action=rechercher_utilisateur&term=${encodeURIComponent(term)}`)
+      fetch(
+        `${AJAX_URL}?action=rechercher_utilisateur&term=${encodeURIComponent(
+          term
+        )}`
+      )
         .then((res) => res.json())
         .then((data) => {
           list.innerHTML = '';

--- a/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
+++ b/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
@@ -1,89 +1,76 @@
-document.addEventListener("DOMContentLoaded", function () {
-    var DEBUG = window.DEBUG || false;
-    DEBUG && console.log("✅ gestion-points.js chargé");
 
-    setTimeout(function() {
-        const userInput = document.getElementById("utilisateur-points");
+(function () {
+  const DEBUG = window.DEBUG || false;
 
-        if (!userInput) {
-            DEBUG && console.log("❌ Élément introuvable : Vérifie l'ID du champ input.");
-            return;
-        }
+  function initAutocompleteUtilisateurs(input) {
+    if (!input) {
+      DEBUG && console.log('❌ Élément introuvable');
+      return;
+    }
+    DEBUG && console.log('✅ initAutocompleteUtilisateurs', input);
 
-        DEBUG && console.log("✅ Élément trouvé : utilisateur-points");
+    const list = document.createElement('ul');
+    list.className = 'suggestions-list';
+    list.style.position = 'absolute';
+    list.style.background = 'white';
+    list.style.border = '1px solid #ccc';
+    list.style.width = input.offsetWidth + 'px';
+    list.style.maxHeight = '200px';
+    list.style.overflowY = 'auto';
+    list.style.display = 'none';
+    list.style.zIndex = '1000';
+    input.parentNode.insertBefore(list, input.nextSibling);
 
-        // ✅ Vérifier si #suggestions-list existe, sinon le créer dynamiquement
-        let suggestionsList = document.getElementById("suggestions-list");
-        if (!suggestionsList) {
-            suggestionsList = document.createElement("ul");
-            suggestionsList.id = "suggestions-list";
-            suggestionsList.style.position = "absolute";
-            suggestionsList.style.background = "white";
-            suggestionsList.style.border = "1px solid #ccc";
-            suggestionsList.style.width = userInput.offsetWidth + "px";
-            suggestionsList.style.maxHeight = "200px";
-            suggestionsList.style.overflowY = "auto";
-            suggestionsList.style.display = "none";
-            suggestionsList.style.zIndex = "1000";
-            userInput.parentNode.insertBefore(suggestionsList, userInput.nextSibling);
-            DEBUG && console.log("✅ Élément #suggestions-list ajouté au DOM.");
-        }
+    input.addEventListener('input', () => {
+      const term = input.value.trim();
+      if (term.length < 2) {
+        list.innerHTML = '';
+        list.style.display = 'none';
+        return;
+      }
 
-        userInput.addEventListener("input", function () {
-            let searchTerm = userInput.value.trim();
-            if (searchTerm.length < 2) {
-                DEBUG && console.log("❌ Trop court, pas de requête AJAX");
-                suggestionsList.innerHTML = ""; // Effacer la liste si trop court
-                suggestionsList.style.display = "none"; // Cacher la liste
-                return;
-            }
-
-            DEBUG && console.log("🔍 Recherche AJAX envoyée :", searchTerm);
-
-            fetch(ajax_object.ajax_url + "?action=rechercher_utilisateur&term=" + encodeURIComponent(searchTerm))
-                .then(response => response.json())
-                .then(data => {
-                    DEBUG && console.log("✅ Réponse AJAX reçue :", data);
-
-                    suggestionsList.innerHTML = ""; // Réinitialiser la liste
-                    suggestionsList.style.display = "block"; // Afficher la liste
-
-                    if (data.success && data.data.length > 0) {
-                        data.data.forEach(user => {
-                            let listItem = document.createElement("li");
-                            listItem.textContent = user.text;
-                            listItem.dataset.userId = user.id;
-                            listItem.style.padding = "8px";
-                            listItem.style.cursor = "pointer";
-                            listItem.style.listStyle = "none";
-
-                            listItem.addEventListener("click", function () {
-                                userInput.value = user.id; // ✅ Insère l'ID utilisateur directement
-                                suggestionsList.innerHTML = ""; // Effacer la liste
-                                suggestionsList.style.display = "none"; // Cacher la liste
-                            });
-
-                            suggestionsList.appendChild(listItem);
-                        });
-
-                        DEBUG && console.log("✅ Suggestions mises à jour.");
-                    } else {
-                        DEBUG && console.log("❌ Aucune donnée reçue.");
-                        suggestionsList.style.display = "none"; // Cacher la liste si vide
-                    }
-                })
-                .catch(error => {
-                    console.error("❌ Erreur AJAX :", error);
-                    suggestionsList.style.display = "none"; // Cacher la liste en cas d'erreur
-                });
+      fetch(ajaxurl + `?action=rechercher_utilisateur&term=${encodeURIComponent(term)}`)
+        .then((res) => res.json())
+        .then((data) => {
+          list.innerHTML = '';
+          if (data.success && data.data.length > 0) {
+            list.style.display = 'block';
+            data.data.forEach((user) => {
+              const item = document.createElement('li');
+              item.textContent = user.text;
+              item.dataset.userId = user.id;
+              item.style.padding = '8px';
+              item.style.cursor = 'pointer';
+              item.style.listStyle = 'none';
+              item.addEventListener('click', () => {
+                input.value = user.id;
+                list.innerHTML = '';
+                list.style.display = 'none';
+              });
+              list.appendChild(item);
+            });
+          } else {
+            list.style.display = 'none';
+          }
+        })
+        .catch(() => {
+          list.style.display = 'none';
         });
+    });
 
-        // Cacher la liste si on clique ailleurs
-        document.addEventListener("click", function (e) {
-            if (e.target !== userInput && e.target !== suggestionsList) {
-                suggestionsList.style.display = "none";
-            }
-        });
+    document.addEventListener('click', (e) => {
+      if (e.target !== input && e.target.parentNode !== list) {
+        list.style.display = 'none';
+      }
+    });
+  }
 
-    }, 500);
-});
+  window.initAutocompleteUtilisateurs = initAutocompleteUtilisateurs;
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const input = document.getElementById('utilisateur-points');
+    if (input) {
+      initAutocompleteUtilisateurs(input);
+    }
+  });
+})();

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -412,7 +412,17 @@ function initChasseEdit() {
           })
           .then((ok3) => {
             if (ok3) {
-              btn.textContent = 'Chasse terminée';
+              const names = Array.from(inputs)
+                .map((i) => i.value.trim())
+                .join(', ');
+              const template = window.wp?.i18n?.__(
+                'Chasse terminée, gagnée par %1$s le %2$s',
+                'chassesautresor-com'
+              ) || 'Chasse terminée, gagnée par %1$s le %2$s';
+              const message = window.wp?.i18n?.sprintf
+                ? window.wp.i18n.sprintf(template, names, dateStr)
+                : `Chasse terminée, gagnée par ${names} le ${dateStr}`;
+              wrapper.innerHTML = `<p class="chasse-terminee-msg">${message}</p>`;
             } else {
               btn.disabled = false;
               validerBtn.disabled = false;

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -368,7 +368,7 @@ function initChasseEdit() {
       let valid = true;
       const checks = [];
       inputs.forEach((input) => {
-        const val = input.value.trim();
+        const val = input.dataset.userId;
         if (!val) {
           valid = false;
           return;
@@ -379,7 +379,10 @@ function initChasseEdit() {
 
       Promise.all(checks).then((results) => {
         if (!valid || results.includes(false) || ids.length !== maxGagnants) {
-          alert('Identifiant utilisateur invalide');
+          const errMsg = window.wp?.i18n
+            ? window.wp.i18n.__('Utilisateur introuvable', 'chassesautresor-com')
+            : 'Utilisateur introuvable';
+          alert(errMsg);
           return;
         }
 

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -330,7 +330,11 @@ function initChasseEdit() {
   // 🏁 Bouton de terminaison manuelle
   // ==============================
   function verifierUtilisateur(id) {
-    return fetch(`${ajaxurl}?action=rechercher_utilisateur&term=${encodeURIComponent(id)}`)
+    const ajaxUrl = window.ajaxurl || (window.ajax_object ? window.ajax_object.ajax_url : null);
+    if (!ajaxUrl) {
+      return Promise.resolve(false);
+    }
+    return fetch(`${ajaxUrl}?action=rechercher_utilisateur&term=${encodeURIComponent(id)}`)
       .then((res) => res.json())
       .then((data) => data.success && data.data.some((u) => String(u.id) === String(id)))
       .catch(() => false);

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -32,8 +32,12 @@ defined( 'ABSPATH' ) || exit;
  * - Retour JSON des résultats.
  */
 function rechercher_utilisateur_ajax() {
-    // ✅ Vérifier que la requête est bien envoyée par un administrateur
-    if (!current_user_can('administrator')) {
+    // ✅ Vérifier que la requête est bien envoyée par un utilisateur autorisé
+    if (
+        !current_user_can('administrator') &&
+        !current_user_can(ROLE_ORGANISATEUR) &&
+        !current_user_can(ROLE_ORGANISATEUR_CREATION)
+    ) {
         wp_send_json_error(['message' => __( '⛔ Accès refusé.', 'chassesautresor-com' )]);
     }
 

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -48,6 +48,20 @@ function rechercher_utilisateur_ajax() {
         wp_send_json_error(['message' => __( '❌ Requête vide.', 'chassesautresor-com' )]);
     }
 
+    // ✅ Recherche directe par ID si terme numérique
+    if (is_numeric($search)) {
+        $user = get_user_by('ID', (int) $search);
+        if (!$user) {
+            wp_send_json_error(['message' => __( '❌ Aucun utilisateur trouvé.', 'chassesautresor-com' )]);
+        }
+        wp_send_json_success([
+            [
+                'id'   => $user->ID,
+                'text' => esc_html($user->display_name) . ' (' . esc_html($user->user_login) . ')'
+            ]
+        ]);
+    }
+
     // ✅ Requête pour récupérer tous les utilisateurs sans restriction de rôle
     $users = get_users([
         'search'         => '*' . esc_attr($search) . '*',

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -327,9 +327,16 @@ function modifier_champ_chasse()
     wp_send_json_error('⚠️ acces_refuse');
   }
 
-  $demande_terminer = ($champ === 'champs_caches.chasse_cache_statut' && $valeur === 'termine');
+  $champs_terminaison = [
+    'champs_caches.chasse_cache_statut',
+    'champs_caches.chasse_cache_gagnants',
+    'champs_caches.chasse_cache_date_decouverte'
+  ];
 
-  if (!$demande_terminer && !utilisateur_peut_editer_champs($post_id)) {
+  $demande_fin = in_array($champ, $champs_terminaison, true)
+    && ($champ !== 'champs_caches.chasse_cache_statut' || $valeur === 'termine');
+
+  if (!$demande_fin && !utilisateur_peut_editer_champs($post_id)) {
     wp_send_json_error('⚠️ acces_refuse');
   }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -478,6 +478,26 @@ function modifier_champ_chasse()
     }
   }
 
+  // 🔹 Liste des gagnants
+  if ($champ === 'champs_caches.chasse_cache_gagnants') {
+    $valeur = sanitize_text_field($valeur);
+    $ok = update_field('chasse_cache_gagnants', $valeur, $post_id);
+    if ($ok !== false) {
+      $champ_valide = true;
+    }
+  }
+
+  // 🔹 Date de découverte
+  if ($champ === 'champs_caches.chasse_cache_date_decouverte') {
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $valeur)) {
+      wp_send_json_error('⚠️ format_date_invalide');
+    }
+    $ok = update_field('chasse_cache_date_decouverte', $valeur, $post_id);
+    if ($ok !== false) {
+      $champ_valide = true;
+    }
+  }
+
   // 🔹 Nb gagnants
   if ($champ === 'caracteristiques.chasse_infos_nb_max_gagants') {
     $sous_champ = 'chasse_infos_nb_max_gagants';

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -19,27 +19,31 @@ defined('ABSPATH') || exit;
  */
 function enqueue_script_chasse_edit()
 {
-  if (!is_singular('chasse')) {
-    return;
-  }
+    if (!is_singular('chasse')) {
+        return;
+    }
 
-  $chasse_id = get_the_ID();
+    $chasse_id = get_the_ID();
 
-  if (!utilisateur_peut_modifier_post($chasse_id)) {
-    return;
-  }
+    if (!utilisateur_peut_modifier_post($chasse_id)) {
+        return;
+    }
 
-  // Enfile les scripts nécessaires
-  enqueue_core_edit_scripts(['chasse-edit']);
+    // Enfile les scripts nécessaires
+    enqueue_core_edit_scripts(['autocomplete-utilisateurs', 'chasse-edit']);
 
-  // Injecte les valeurs par défaut pour JS
-  wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [
-    'titre' => strtolower(TITRE_DEFAUT_CHASSE),
-    'image_slug' => 'defaut-chasse-2',
-  ]);
+    wp_localize_script('autocomplete-utilisateurs', 'ajax_object', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+    ]);
 
-  // Charge les médias pour les champs image
-  wp_enqueue_media();
+    // Injecte les valeurs par défaut pour JS
+    wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [
+        'titre' => strtolower(TITRE_DEFAUT_CHASSE),
+        'image_slug' => 'defaut-chasse-2',
+    ]);
+
+    // Charge les médias pour les champs image
+    wp_enqueue_media();
 }
 add_action('wp_enqueue_scripts', 'enqueue_script_chasse_edit');
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -325,7 +325,29 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
         <h2><i class="fa-solid fa-ranking-star"></i> Progression</h2>
       </div>
       <?php if ($mode_fin === 'manuelle' && in_array($statut_metier, ['payante', 'en_cours', 'revision'], true)) : ?>
-        <button type="button" class="terminer-chasse-btn" data-post-id="<?= esc_attr($chasse_id); ?>" data-cpt="chasse" <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>><?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?></button>
+        <div class="terminer-chasse-wrapper">
+          <button type="button"
+            class="terminer-chasse-btn"
+            data-post-id="<?= esc_attr($chasse_id); ?>"
+            data-cpt="chasse"
+            data-max-gagnants="<?= esc_attr($nb_max); ?>"
+            <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>>
+            <?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?>
+          </button>
+          <div class="terminer-chasse-form" style="display:none;">
+            <label>
+              <?= ($nb_max > 1)
+                ? esc_html__('Nom des gagnants', 'chassesautresor-com')
+                : esc_html__('Nom du gagnant', 'chassesautresor-com'); ?>
+            </label>
+            <?php for ($i = 0; $i < $nb_max; $i++) : ?>
+              <input type="text" class="gagnant-input" />
+            <?php endfor; ?>
+            <button type="button" class="valider-fin-btn">
+              <?= esc_html__('Valider la fin', 'chassesautresor-com'); ?>
+            </button>
+          </div>
+        </div>
       <?php endif; ?>
     </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -324,29 +324,58 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       <div class="edition-panel-header">
         <h2><i class="fa-solid fa-ranking-star"></i> Progression</h2>
       </div>
-      <?php if ($mode_fin === 'manuelle' && in_array($statut_metier, ['payante', 'en_cours', 'revision'], true)) : ?>
+      <?php if ($mode_fin === 'manuelle') : ?>
         <div class="terminer-chasse-wrapper">
-          <button type="button"
-            class="terminer-chasse-btn"
-            data-post-id="<?= esc_attr($chasse_id); ?>"
-            data-cpt="chasse"
-            data-max-gagnants="<?= esc_attr($nb_max); ?>"
-            <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>>
-            <?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?>
-          </button>
-          <div class="terminer-chasse-form" style="display:none;">
-            <label>
-              <?= ($nb_max > 1)
-                ? esc_html__('Nom des gagnants', 'chassesautresor-com')
-                : esc_html__('Nom du gagnant', 'chassesautresor-com'); ?>
-            </label>
-            <?php for ($i = 0; $i < $nb_max; $i++) : ?>
-              <input type="text" class="gagnant-input" />
-            <?php endfor; ?>
-            <button type="button" class="valider-fin-btn">
-              <?= esc_html__('Valider la fin', 'chassesautresor-com'); ?>
+          <?php if ($statut_metier === 'termine') : ?>
+            <?php
+            $gagnants_raw    = get_field('chasse_cache_gagnants', $chasse_id);
+            $date_decouverte = get_field('chasse_cache_date_decouverte', $chasse_id);
+            $noms            = [];
+            if ($gagnants_raw) {
+                foreach (explode(',', $gagnants_raw) as $uid) {
+                    $user = get_user_by('id', trim($uid));
+                    if ($user) {
+                        $noms[] = $user->display_name;
+                    }
+                }
+            }
+            $gagnants_str = implode(', ', $noms);
+            ?>
+            <p class="chasse-terminee-msg">
+              <?php
+              printf(
+                  esc_html__(
+                      'Chasse terminée, gagnée par %1$s le %2$s',
+                      'chassesautresor-com'
+                  ),
+                  esc_html($gagnants_str),
+                  esc_html($date_decouverte)
+              );
+              ?>
+            </p>
+          <?php elseif (in_array($statut_metier, ['payante', 'en_cours', 'revision'], true)) : ?>
+            <button type="button"
+              class="terminer-chasse-btn"
+              data-post-id="<?= esc_attr($chasse_id); ?>"
+              data-cpt="chasse"
+              data-max-gagnants="<?= esc_attr($nb_max); ?>"
+              <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>>
+              <?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?>
             </button>
-          </div>
+            <div class="terminer-chasse-form" style="display:none;">
+              <label>
+                <?= ($nb_max > 1)
+                  ? esc_html__('Nom des gagnants', 'chassesautresor-com')
+                  : esc_html__('Nom du gagnant', 'chassesautresor-com'); ?>
+              </label>
+              <?php for ($i = 0; $i < $nb_max; $i++) : ?>
+                <input type="text" class="gagnant-input" />
+              <?php endfor; ?>
+              <button type="button" class="valider-fin-btn">
+                <?= esc_html__('Valider la fin', 'chassesautresor-com'); ?>
+              </button>
+            </div>
+          <?php endif; ?>
         </div>
       <?php endif; ?>
     </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -332,8 +332,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             $date_decouverte = get_field('chasse_cache_date_decouverte', $chasse_id);
             $noms            = [];
             if ($gagnants_raw) {
-                foreach (explode(',', $gagnants_raw) as $uid) {
-                    $user = get_user_by('id', trim($uid));
+                $ids = is_array($gagnants_raw)
+                    ? $gagnants_raw
+                    : explode(',', (string) $gagnants_raw);
+                foreach ($ids as $uid) {
+                    $id   = is_array($uid) ? ($uid['ID'] ?? 0) : (int) trim((string) $uid);
+                    $user = $id ? get_user_by('id', $id) : false;
                     if ($user) {
                         $noms[] = $user->display_name;
                     }


### PR DESCRIPTION
## Résumé
- ajoute un formulaire de sélection des gagnants avant de terminer une chasse
- généralise l'autocomplétion des utilisateurs et l'intègre lors de la validation

## Changements
- bouton de fin de chasse enrichi d'un formulaire pour saisir les gagnants
- logique JS pour vérifier les gagnants, enregistrer la date de découverte et le statut
- utilitaire d'autocomplétion réutilisable pour plusieurs champs

## Testing
- `composer install` *(commande introuvable : Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(bash: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689709e2b9f08332a1a47648fde0aea6