### PR TITLE
Ajout d’une confirmation lors de la fin de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -72,6 +72,7 @@ function chasse_get_champs($chasse_id)
         'illimitee' => get_field('chasse_infos_duree_illimitee', $chasse_id) ?? false,
         'nb_max' => get_field('chasse_infos_nb_max_gagants', $chasse_id) ?? 0,
         'date_decouverte' => get_field('chasse_cache_date_decouverte', $chasse_id),
+        'gagnants' => get_field('chasse_cache_gagnants', $chasse_id) ?? '',
         'mode_fin' => get_field('chasse_mode_fin', $chasse_id) ?? 'manuelle',
         'current_stored_statut' => get_field('chasse_cache_statut', $chasse_id),
     ];

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -323,15 +323,16 @@ function modifier_champ_chasse()
     wp_send_json_error('⚠️ acces_refuse');
   }
 
-  $demande_terminer = ($champ === 'champs_caches.chasse_cache_statut' && $valeur === 'termine');
+    $demande_terminer = ($champ === 'champs_caches.chasse_cache_statut' && $valeur === 'termine');
+    $champ_fin = in_array($champ, ['champs_caches.chasse_cache_gagnants', 'champs_caches.chasse_cache_date_decouverte'], true);
 
-  if (!$demande_terminer && !utilisateur_peut_editer_champs($post_id)) {
-    wp_send_json_error('⚠️ acces_refuse');
-  }
+    if (!$demande_terminer && !$champ_fin && !utilisateur_peut_editer_champs($post_id)) {
+        wp_send_json_error('⚠️ acces_refuse');
+    }
 
-  $doit_recalculer_statut = false;
-  $champ_valide = false;
-  $reponse = ['champ' => $champ, 'valeur' => $valeur];
+    $doit_recalculer_statut = false;
+    $champ_valide = false;
+    $reponse = ['champ' => $champ, 'valeur' => $valeur];
   // 🛡️ Initialisation sécurisée (champ simple)
 
 
@@ -466,6 +467,26 @@ function modifier_champ_chasse()
       gerer_chasse_terminee($post_id);
     }
   }
+
+    // 🔹 Gagnants (texte libre)
+    if ($champ === 'champs_caches.chasse_cache_gagnants') {
+        $ok = update_field('chasse_cache_gagnants', $valeur, $post_id);
+        if ($ok !== false) {
+            $champ_valide = true;
+        }
+    }
+
+    // 🔹 Date de découverte
+    if ($champ === 'champs_caches.chasse_cache_date_decouverte') {
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $valeur)) {
+            wp_send_json_error('⚠️ format_date_invalide');
+        }
+        $ok = update_field('chasse_cache_date_decouverte', $valeur, $post_id);
+        if ($ok !== false) {
+            $champ_valide = true;
+            $doit_recalculer_statut = true;
+        }
+    }
 
   // 🔹 Nb gagnants
   if ($champ === 'caracteristiques.chasse_infos_nb_max_gagants') {

--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -91,9 +91,9 @@ Contenu imbriqué :
   ----------------------------------------
 ----------------------------------------
 — chasse_cache_gagnants —
-Type : user
+Type : text
 Label : Gagnants
-Instructions : (vide)
+Instructions : Texte libre listant les gagnants
 Requis : non
 ----------------------------------------
 — chasse_cache_date_decouverte —

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -356,7 +356,7 @@ Groupe : paramètre de la chasse
 * chasse_principale_liens (repeater)
   * chasse_principale_liens_type (select)
   * chasse_principale_liens_url (url)
-* chasse_cache_gagnants (user)
+* chasse_cache_gagnants (text)
 * chasse_cache_date_decouverte (date_picker)
 * chasse_cache_statut (select)
 * chasse_cache_statut_validation (select)

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -28,6 +28,9 @@ $valeur     = $infos_chasse['champs']['valeur_recompense'];
 $cout       = $infos_chasse['champs']['cout_points'];
 $date_debut = $infos_chasse['champs']['date_debut'];
 $date_fin   = $infos_chasse['champs']['date_fin'];
+$date_decouverte = $infos_chasse['champs']['date_decouverte'];
+$date_decouverte_formatee = $date_decouverte ? formater_date($date_decouverte) : '';
+$gagnants = $infos_chasse['champs']['gagnants'];
 
 // 🎯 Conversion des dates pour les champs <input>
 $date_debut_obj = convertir_en_datetime($date_debut);
@@ -324,9 +327,35 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       <div class="edition-panel-header">
         <h2><i class="fa-solid fa-ranking-star"></i> Progression</h2>
       </div>
-      <?php if ($mode_fin === 'manuelle' && in_array($statut_metier, ['payante', 'en_cours', 'revision'], true)) : ?>
-        <button type="button" class="terminer-chasse-btn" data-post-id="<?= esc_attr($chasse_id); ?>" data-cpt="chasse" <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>><?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?></button>
-      <?php endif; ?>
+      <div class="progression-actions">
+          <?php if (
+            $mode_fin === 'manuelle' &&
+            in_array($statut_metier, ['payante', 'en_cours', 'revision'], true)
+          ) : ?>
+          <button
+            type="button"
+            class="terminer-chasse-btn"
+            data-post-id="<?= esc_attr($chasse_id); ?>"
+            data-cpt="chasse"
+            <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>
+          ><?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?></button>
+          <div class="zone-validation-fin" style="display:none;">
+            <label for="chasse-gagnants"><?= esc_html__('Gagnants', 'chassesautresor-com'); ?></label>
+            <textarea id="chasse-gagnants" required></textarea>
+              <button
+                type="button"
+                class="valider-fin-chasse-btn"
+                data-post-id="<?= esc_attr($chasse_id); ?>"
+                data-cpt="chasse"
+                disabled
+              ><?= esc_html__('Valider la fin de chasse', 'chassesautresor-com'); ?></button>
+          </div>
+        <?php elseif ($statut_metier === 'termine') : ?>
+          <p class="message-chasse-terminee">
+            <?= sprintf(__('Chasse gagnée le %s par %s', 'chassesautresor-com'), esc_html($date_decouverte_formatee), esc_html($gagnants)); ?>
+          </p>
+        <?php endif; ?>
+      </div>
     </div>
 
     <div id="chasse-tab-indices" class="edition-tab-content" style="display:none;">


### PR DESCRIPTION
## Résumé
- ajoute une confirmation avec saisie des gagnants avant de clôturer une chasse
- affiche la date et les gagnants une fois la chasse terminée
- documente le champ ACF `chasse_cache_gagnants`

## Testing
- `/usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6898496af0888332bfef2c6a1c2c494c