### PR TITLE
Respect edit restrictions on hunt end date

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -115,12 +115,13 @@ function initChasseEdit() {
   // ==============================
   if (inputDateFin) {
     if (checkboxIllimitee) {
-      inputDateFin.disabled = checkboxIllimitee.checked;
-      
+      const initialDisabled = inputDateFin.disabled;
+      inputDateFin.disabled = initialDisabled || checkboxIllimitee.checked;
+
       const postId = inputDateFin.closest('.champ-chasse')?.dataset.postId;
 
       checkboxIllimitee.addEventListener('change', function () {
-        inputDateFin.disabled = this.checked;
+        inputDateFin.disabled = initialDisabled || this.checked;
 
         // Si la case est décochée et les dates incohérentes, corriger la date de fin
         if (!this.checked) {


### PR DESCRIPTION
## Summary
- Empêche l'activation visuelle du champ de date de fin lorsque son édition est interdite
- Préserve l'état `disabled` initial du champ et synchronise l'activation avec la case « Durée illimitée »

## Testing
- `/usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6898504525f08332b41d30159d952763