### PR TITLE
Add cancel option for manual hunt termination

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -330,6 +330,29 @@ function initChasseEdit() {
   // ==============================
   // 🏁 Terminaison manuelle
   // ==============================
+  let zoneFinChasse;
+  let btnFinChasse;
+
+  function resetFinChasse() {
+    if (zoneFinChasse) {
+      const textarea = zoneFinChasse.querySelector('#chasse-gagnants');
+      const valider = zoneFinChasse.querySelector('.valider-fin-chasse-btn');
+      zoneFinChasse.style.display = 'none';
+      if (textarea) textarea.value = '';
+      if (valider) valider.disabled = true;
+    }
+    if (btnFinChasse) btnFinChasse.style.display = 'inline-block';
+    document.removeEventListener('keydown', onEscapeFinChasse);
+    zoneFinChasse = null;
+    btnFinChasse = null;
+  }
+
+  function onEscapeFinChasse(e) {
+    if (e.key === 'Escape') {
+      resetFinChasse();
+    }
+  }
+
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.terminer-chasse-btn');
     if (btn) {
@@ -341,13 +364,23 @@ function initChasseEdit() {
         textarea.addEventListener('input', () => {
           valider.disabled = textarea.value.trim() === '';
         });
+        zoneFinChasse = zone;
+        btnFinChasse = btn;
+        document.addEventListener('keydown', onEscapeFinChasse);
       }
       btn.style.display = 'none';
       return;
     }
 
+    const annuler = e.target.closest('.annuler-fin-chasse-btn');
+    if (annuler) {
+      resetFinChasse();
+      return;
+    }
+
     const valider = e.target.closest('.valider-fin-chasse-btn');
     if (valider) {
+      document.removeEventListener('keydown', onEscapeFinChasse);
       const postId = valider.dataset.postId;
       const zone = valider.closest('.zone-validation-fin');
       const textarea = zone.querySelector('#chasse-gagnants');

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -349,6 +349,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 data-cpt="chasse"
                 disabled
               ><?= esc_html__('Valider la fin de chasse', 'chassesautresor-com'); ?></button>
+              <button
+                type="button"
+                class="annuler-fin-chasse-btn"
+              ><?= esc_html__('Annuler', 'chassesautresor-com'); ?></button>
           </div>
         <?php elseif ($statut_metier === 'termine') : ?>
           <p class="message-chasse-terminee">


### PR DESCRIPTION
Ajoute une option pour annuler la terminaison manuelle d'une chasse.

- Ajout d'un bouton **Annuler** dans la zone de validation de fin de chasse
- Gestion de la touche **Échap** pour fermer cette zone et réafficher le bouton initial
- Réinitialisation du formulaire des gagnants lors de l'annulation

**Testing**
- `source ./setup-env.sh`
- `/root/.local/share/mise/installs/php/8.4.11/bin/php bin/composer.phar install`
- `/root/.local/share/mise/installs/php/8.4.11/bin/php vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_689852b866ec8332997e9d2c0a772e98