### PR TITLE
Définir le mode fin de chasse automatique par défaut

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -73,7 +73,7 @@ function chasse_get_champs($chasse_id)
         'nb_max' => get_field('chasse_infos_nb_max_gagants', $chasse_id) ?? 0,
         'date_decouverte' => get_field('chasse_cache_date_decouverte', $chasse_id),
         'gagnants' => get_field('chasse_cache_gagnants', $chasse_id) ?? '',
-        'mode_fin' => get_field('chasse_mode_fin', $chasse_id) ?? 'manuelle',
+        'mode_fin' => get_field('chasse_mode_fin', $chasse_id) ?? 'automatique',
         'current_stored_statut' => get_field('chasse_cache_statut', $chasse_id),
     ];
 }

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -315,7 +315,7 @@ function verifier_fin_de_chasse($user_id, $enigme_id)
         return;
     }
 
-    $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'manuelle';
+    $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
     if ($mode_fin !== 'automatique') {
         return; // 🔁 La complétion se fait manuellement
     }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -40,7 +40,7 @@ $date_fin_obj = convertir_en_datetime($date_fin);
 $date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
 $illimitee  = $infos_chasse['champs']['illimitee'];
 $nb_max     = $infos_chasse['champs']['nb_max'] ?: 1;
-$mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'manuelle';
+$mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'automatique';
 $statut_metier = $infos_chasse['statut'] ?? 'revision';
 $aide_mode_fin = $mode_fin === 'manuelle'
   ? __('Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau.', 'chassesautresor-com')


### PR DESCRIPTION
## Résumé
- le mode de fin de chasse est désormais automatique par défaut
- l'affichage et la logique serveur utilisent ce nouveau mode

## Changements notables
- sélection automatique du mode de fin dans le panneau d'édition
- utilisation du mode automatique par défaut dans les fonctions métier

## Tests
- `source ./setup-env.sh`
- `/usr/bin/php bin/composer.phar install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689855e3e5d8833290358cf2484e8ad5