### PR TITLE
Ajout d'une aide contextuelle pour le mode de fin de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1102,3 +1102,21 @@ body.panneau-ouvert::before {
   padding: 8px;
   font-weight: bold;
 }
+
+/* ====== Mode de fin ====== */
+.mode-fin-aide {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 0.3em;
+  color: inherit;
+  padding: 0;
+}
+
+.mode-fin-aide i {
+  pointer-events: none;
+}
+
+.champ-explication-mode-fin[hidden] {
+  display: none;
+}

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1104,6 +1104,18 @@ body.panneau-ouvert::before {
 }
 
 /* ====== Mode de fin ====== */
+.champ-mode-options {
+  margin-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.champ-mode-options label {
+  display: flex;
+  align-items: center;
+}
+
 .mode-fin-aide {
   background: none;
   border: none;
@@ -1115,8 +1127,4 @@ body.panneau-ouvert::before {
 
 .mode-fin-aide i {
   pointer-events: none;
-}
-
-.champ-explication-mode-fin[hidden] {
-  display: none;
 }

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -59,6 +59,11 @@
   color: var(--color-editor-success);
 }
 
+/* Alignement des lignes sans icône */
+.resume-infos li[data-no-icon] {
+  padding-left: 1.3rem;
+}
+
 .cache {
   display: none;
 }

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -312,11 +312,15 @@ function initChasseEdit() {
   // 🧠 Explication – Mode de fin de chasse
   // ==============================
   const explicationModeFin = {
-    automatique:
-      "La chasse sera considérée comme terminée lorsque toutes les énigmes avec validation " +
-      "auront été résolues. Le système prendra également en compte le nombre maximum de gagnants défini.",
-    manuelle:
-      "Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau."
+    automatique: wp.i18n.__(
+      "La chasse sera considérée comme terminée dès que les gagnants ont résolu l'intégralité des énigmes. " +
+        "En mode automatique, vous paramétrez librement le nombre de gagnants.",
+      "chassesautresor-com"
+    ),
+    manuelle: wp.i18n.__(
+      "Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau.",
+      "chassesautresor-com"
+    )
   };
   document.querySelectorAll('.mode-fin-aide').forEach((btn) => {
     btn.addEventListener('click', () => {

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -318,26 +318,15 @@ function initChasseEdit() {
     manuelle:
       "Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau."
   };
-  const zoneExplicationModeFin = document.querySelector('.champ-explication-mode-fin');
-  if (zoneExplicationModeFin) {
-    zoneExplicationModeFin.setAttribute('hidden', 'hidden');
-    document.querySelectorAll('.mode-fin-aide').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const mode = btn.dataset.mode;
-        const message = explicationModeFin[mode] || '';
-        const dejaVisible =
-          !zoneExplicationModeFin.hasAttribute('hidden') &&
-          zoneExplicationModeFin.textContent === message;
-        if (dejaVisible) {
-          zoneExplicationModeFin.setAttribute('hidden', 'hidden');
-          zoneExplicationModeFin.textContent = '';
-        } else {
-          zoneExplicationModeFin.textContent = message;
-          zoneExplicationModeFin.removeAttribute('hidden');
-        }
-      });
+  document.querySelectorAll('.mode-fin-aide').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const mode = btn.dataset.mode;
+      const message = explicationModeFin[mode];
+      if (message) {
+        alert(message);
+      }
     });
-  }
+  });
 
   // ==============================
   // 🏁 Terminaison manuelle

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -309,21 +309,33 @@ function initChasseEdit() {
   }
 
   // ==============================
-  // 🧠 Explication dynamique – Mode de fin de chasse
+  // 🧠 Explication – Mode de fin de chasse
   // ==============================
   const explicationModeFin = {
-    automatique: "La chasse sera considérée comme terminée lorsque toutes les énigmes avec validation auront été résolues. Le système prendra également en compte le nombre maximum de gagnants défini.",
-    manuelle: "Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau."
+    automatique:
+      "La chasse sera considérée comme terminée lorsque toutes les énigmes avec validation " +
+      "auront été résolues. Le système prendra également en compte le nombre maximum de gagnants défini.",
+    manuelle:
+      "Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau."
   };
   const zoneExplicationModeFin = document.querySelector('.champ-explication-mode-fin');
   if (zoneExplicationModeFin) {
-    document.querySelectorAll('input[name="acf[chasse_mode_fin]"]').forEach((radio) => {
-      radio.addEventListener('change', () => {
-        zoneExplicationModeFin.textContent = explicationModeFin[radio.value] || '';
+    zoneExplicationModeFin.setAttribute('hidden', 'hidden');
+    document.querySelectorAll('.mode-fin-aide').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const mode = btn.dataset.mode;
+        const message = explicationModeFin[mode] || '';
+        const dejaVisible =
+          !zoneExplicationModeFin.hasAttribute('hidden') &&
+          zoneExplicationModeFin.textContent === message;
+        if (dejaVisible) {
+          zoneExplicationModeFin.setAttribute('hidden', 'hidden');
+          zoneExplicationModeFin.textContent = '';
+        } else {
+          zoneExplicationModeFin.textContent = message;
+          zoneExplicationModeFin.removeAttribute('hidden');
+        }
       });
-      if (radio.checked) {
-        zoneExplicationModeFin.textContent = explicationModeFin[radio.value] || '';
-      }
     });
   }
 

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -310,13 +310,15 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
   // Nettoyer anciennes icônes
   ligne.querySelectorAll(':scope > .icone-check, :scope > .icon-attente').forEach((i) => i.remove());
 
-  // Ajouter nouvelle icône
-  const icone = document.createElement('i');
-  icone.className = estRempli
-    ? 'fa-solid fa-circle-check icone-check'
-    : 'fa-regular fa-circle icon-attente';
-  icone.setAttribute('aria-hidden', 'true');
-  ligne.prepend(icone);
+  // Ajouter nouvelle icône si autorisé
+  if (ligne.dataset.noIcon === undefined) {
+    const icone = document.createElement('i');
+    icone.className = estRempli
+      ? 'fa-solid fa-circle-check icone-check'
+      : 'fa-regular fa-circle icon-attente';
+    icone.setAttribute('aria-hidden', 'true');
+    ligne.prepend(icone);
+  }
 
   // Ajouter bouton édition ✏️ si besoin
   const dejaBouton = ligne.querySelector('.champ-modifier');

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -320,8 +320,9 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
 
   // Ajouter bouton édition ✏️ si besoin
   const dejaBouton = ligne.querySelector('.champ-modifier');
+  const pasDEdition = ligne.dataset.noEdit !== undefined;
 
-  if (!dejaBouton) {
+  if (!dejaBouton && !pasDEdition) {
     const bouton = document.createElement('button');
     bouton.type = 'button';
     bouton.className = 'champ-modifier';

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -42,9 +42,6 @@ $illimitee  = $infos_chasse['champs']['illimitee'];
 $nb_max     = $infos_chasse['champs']['nb_max'] ?: 1;
 $mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'automatique';
 $statut_metier = $infos_chasse['statut'] ?? 'revision';
-$aide_mode_fin = $mode_fin === 'manuelle'
-  ? __('Vous pourrez arrêter la chasse manuellement depuis l’onglet Progression de ce panneau.', 'chassesautresor-com')
-  : __('La chasse sera considérée comme terminée lorsque toutes les énigmes avec validation auront été résolues. Le système prendra également en compte le nombre maximum de gagnants défini.', 'chassesautresor-com');
 
 $champTitreParDefaut = 'nouvelle chasse'; // À adapter si besoin
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut);
@@ -200,8 +197,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-post-id="<?= esc_attr($chasse_id); ?>"
                   data-no-edit="1"
                 >
-                  <fieldset>
-                    <legend><?= esc_html__('Mode de fin de chasse', 'chassesautresor-com'); ?></legend>
+                  <span class="champ-label"><?= esc_html__('Mode', 'chassesautresor-com'); ?></span>
+                  <div class="champ-mode-options">
                     <label>
                       <input
                         type="radio"
@@ -238,8 +235,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         <i class="fa-regular fa-circle-question"></i>
                       </button>
                     </label>
-                    <div class="champ-explication champ-explication-mode-fin" aria-live="polite" hidden></div>
-                  </fieldset>
+                  </div>
                 </li>
 
                 <!-- Date de début (édition inline) -->

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -193,12 +193,52 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <ul class="resume-infos">
 
                 <!-- Mode de fin de chasse -->
-                <li class="champ-chasse champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="chasse_mode_fin" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
+                <li
+                  class="champ-chasse champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                  data-champ="chasse_mode_fin"
+                  data-cpt="chasse"
+                  data-post-id="<?= esc_attr($chasse_id); ?>"
+                  data-no-edit="1"
+                >
                   <fieldset>
                     <legend><?= esc_html__('Mode de fin de chasse', 'chassesautresor-com'); ?></legend>
-                    <label><input type="radio" name="acf[chasse_mode_fin]" value="automatique" <?= $mode_fin === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> <?= esc_html__('Automatique', 'chassesautresor-com'); ?></label>
-                    <label><input type="radio" name="acf[chasse_mode_fin]" value="manuelle" <?= $mode_fin === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> <?= esc_html__('Manuelle', 'chassesautresor-com'); ?></label>
-                    <div class="champ-explication champ-explication-mode-fin" aria-live="polite"><?= esc_html($aide_mode_fin); ?></div>
+                    <label>
+                      <input
+                        type="radio"
+                        name="acf[chasse_mode_fin]"
+                        value="automatique"
+                        <?= $mode_fin === 'automatique' ? 'checked' : ''; ?>
+                        <?= $peut_editer ? '' : 'disabled'; ?>
+                      >
+                      <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
+                      <button
+                        type="button"
+                        class="mode-fin-aide"
+                        data-mode="automatique"
+                        aria-label="<?= esc_attr__('Explication du mode automatique', 'chassesautresor-com'); ?>"
+                      >
+                        <i class="fa-regular fa-circle-question"></i>
+                      </button>
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        name="acf[chasse_mode_fin]"
+                        value="manuelle"
+                        <?= $mode_fin === 'manuelle' ? 'checked' : ''; ?>
+                        <?= $peut_editer ? '' : 'disabled'; ?>
+                      >
+                      <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
+                      <button
+                        type="button"
+                        class="mode-fin-aide"
+                        data-mode="manuelle"
+                        aria-label="<?= esc_attr__('Explication du mode manuel', 'chassesautresor-com'); ?>"
+                      >
+                        <i class="fa-regular fa-circle-question"></i>
+                      </button>
+                    </label>
+                    <div class="champ-explication champ-explication-mode-fin" aria-live="polite" hidden></div>
                   </fieldset>
                 </li>
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -196,11 +196,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>"
                   data-no-edit="1"
+                  data-no-icon="1"
                 >
-                  <span class="champ-label"><?= esc_html__('Mode', 'chassesautresor-com'); ?></span>
+                  <label for="chasse_mode_fin"><?= esc_html__('Mode', 'chassesautresor-com'); ?></label>
                   <div class="champ-mode-options">
                     <label>
                       <input
+                        id="chasse_mode_fin"
                         type="radio"
                         name="acf[chasse_mode_fin]"
                         value="automatique"


### PR DESCRIPTION
## Résumé
- remplacement du message dynamique par des icônes d'aide pour le mode de fin
- suppression du stylo d'édition sur le champ de mode de fin
- styles et scripts associés pour l'affichage des messages

## Testing
- `source ./setup-env.sh` *(sans sortie)*
- `/usr/bin/php bin/composer.phar install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68985b4862e88332bc0c855686bd6859