### PR TITLE
Move winners field below end mode and toggle with hunt mode

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -670,8 +670,48 @@ function initChampNbGagnants() {
   });
 }
 
+// ================================
+// 🔚 Gestion dynamique du mode de fin
+// ================================
+function initModeFinChasse() {
+  const radios = document.querySelectorAll('input[name="acf[chasse_mode_fin]"]');
+  const template = document.getElementById('template-nb-gagnants');
+  const modeFinLi = document.querySelector('.champ-mode-fin');
+
+  if (!radios.length || !template || !modeFinLi) return;
+
+  const postId = modeFinLi.dataset.postId;
+
+  function update() {
+    const selected = document.querySelector('input[name="acf[chasse_mode_fin]"]:checked')?.value;
+    const existing = document.querySelector('.champ-nb-gagnants');
+
+    if (selected === 'automatique') {
+      if (!existing) {
+        const clone = template.content.firstElementChild.cloneNode(true);
+        modeFinLi.insertAdjacentElement('afterend', clone);
+        initChampNbGagnants();
+      }
+      const inputNb = document.getElementById('chasse-nb-gagnants');
+      if (inputNb) {
+        mettreAJourAffichageNbGagnants(postId, inputNb.value.trim());
+      }
+    } else {
+      if (existing) existing.remove();
+      mettreAJourAffichageNbGagnants(postId, 0);
+    }
+  }
+
+  radios.forEach(radio => {
+    radio.addEventListener('change', update);
+  });
+
+  update();
+}
+
 // À appeler :
 initChampNbGagnants();
+initModeFinChasse();
 
 // ==============================
 // ➕ Mise à jour de la carte d'ajout d'énigme

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -235,6 +235,44 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   </div>
                 </li>
 
+                <?php ob_start(); ?>
+                <!-- Nombre de gagnants -->
+                <li class="champ-chasse champ-nb-gagnants <?= empty($nb_max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                  data-champ="chasse_infos_nb_max_gagants"
+                  data-cpt="chasse"
+                  data-post-id="<?= esc_attr($chasse_id); ?>">
+
+                  <label for="chasse-nb-gagnants">Nb gagnants</label>
+
+                  <input type="number"
+                    id="chasse-nb-gagnants"
+                    name="chasse-nb-gagnants"
+                    value="<?= esc_attr($nb_max); ?>"
+                    min="1"
+                    class="champ-inline-nb champ-nb-edit"
+                    <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
+
+                  <div class="champ-option-illimitee ">
+                    <input type="checkbox"
+                      id="nb-gagnants-illimite"
+                      name="nb-gagnants-illimite"
+                      <?= ($nb_max == 0 ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>
+                      data-champ="chasse_infos_nb_max_gagants">
+                    <label for="nb-gagnants-illimite">Illimité</label>
+                  </div>
+
+                  <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                </li>
+                <?php $bloc_nb_gagnants = ob_get_clean(); ?>
+
+                <?php if ($mode_fin === 'automatique') : ?>
+                  <?= $bloc_nb_gagnants; ?>
+                <?php endif; ?>
+
+                <template id="template-nb-gagnants">
+                  <?= $bloc_nb_gagnants; ?>
+                </template>
+
                 <!-- Date de début (édition inline) -->
                 <li class="champ-chasse champ-date-debut<?= $peut_editer ? '' : ' champ-desactive'; ?>"
                   data-champ="chasse_infos_date_debut"
@@ -305,35 +343,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   </div>
 
                   <div class="champ-feedback"></div>
-                </li>
-
-
-                <!-- Nombre de gagnants -->
-                <li class="champ-chasse champ-nb-gagnants <?= empty($nb_max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="chasse_infos_nb_max_gagants"
-                  data-cpt="chasse"
-                  data-post-id="<?= esc_attr($chasse_id); ?>">
-
-                  <label for="chasse-nb-gagnants">Nb gagnants</label>
-
-                  <input type="number"
-                    id="chasse-nb-gagnants"
-                    name="chasse-nb-gagnants"
-                    value="<?= esc_attr($nb_max); ?>"
-                    min="1"
-                    class="champ-inline-nb champ-nb-edit"
-                    <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
-
-                  <div class="champ-option-illimitee ">
-                    <input type="checkbox"
-                      id="nb-gagnants-illimite"
-                      name="nb-gagnants-illimite"
-                      <?= ($nb_max == 0 ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>
-                      data-champ="chasse_infos_nb_max_gagants">
-                    <label for="nb-gagnants-illimite">Illimité</label>
-                  </div>
-
-                  <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
                 </li>
 
               </ul>


### PR DESCRIPTION
### Résumé
- Place le champ "Nb gagnants" directement sous le choix du mode de fin.
- Affiche ou supprime ce champ dynamiquement selon le mode de fin de la chasse.

### Changements notables
- Conditionnement du champ en PHP avec un `<template>` pour réinsertion.
- Gestion JS pour insérer ou retirer le champ lors du changement de mode.

### Testing
- `/usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6898f0563f8c83328da69bb1ecba8361