### PR TITLE
Réorganisation des paramètres d’une chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -575,22 +575,28 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
   color: var(--color-editor-text-muted);
 }
 
-.edition-panel-section .resume-technique {
+.edition-panel-section .resume-technique,
+.edition-panel-section .resume-reglages {
   width: 100%;
 }
 
-.edition-panel-section .resume-technique label {
+.edition-panel-section .resume-technique label,
+.edition-panel-section .resume-reglages label {
   display: inline-block;
   min-width: 150px;
 }
 
 .edition-panel-section .resume-technique input.inline-date,
 .edition-panel-section .resume-technique input.champ-cout,
-.edition-panel-section .resume-technique input.champ-nb-edit {
+.edition-panel-section .resume-technique input.champ-nb-edit,
+.edition-panel-section .resume-reglages input.inline-date,
+.edition-panel-section .resume-reglages input.champ-cout,
+.edition-panel-section .resume-reglages input.champ-nb-edit {
   width: 180px;
 }
 
-.edition-panel-section .resume-technique .champ-select-heure {
+.edition-panel-section .resume-technique .champ-select-heure,
+.edition-panel-section .resume-reglages .champ-select-heure {
   width: auto;
 }
 
@@ -740,11 +746,13 @@ li.ligne-email .champ-organisateur .champ-affichage {
   margin: 0 1rem;
 }
 
-.edition-panel-section .resume-technique .champ-cout-points .champ-edition {
+.edition-panel-section .resume-technique .champ-cout-points .champ-edition,
+.edition-panel-section .resume-reglages .champ-cout-points .champ-edition {
   gap: 0 5px;
 }
 
-.edition-panel-section .resume-technique li {
+.edition-panel-section .resume-technique li,
+.edition-panel-section .resume-reglages li {
   margin-bottom: 0.9rem;
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -73,11 +73,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
       <div class="edition-panel-section edition-panel-section-ligne">
         <div class="section-content">
-          <div class="resume-blocs-grid deux-col-wrapper">
+          <div class="resume-blocs-grid">
 
-            <!-- SECTION 1 : Champs obligatoires -->
-            <div class="resume-bloc resume-obligatoire deux-col-bloc">
-              <h3>Champs obligatoires</h3>
+            <!-- SECTION 1 : Informations -->
+            <div class="resume-bloc resume-obligatoire">
+              <h3>Informations</h3>
               <ul class="resume-infos">
 
                 <!-- Titre -->
@@ -141,9 +141,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               </ul>
             </div>
 
-            <!-- SECTION 2 : Champs recommandés -->
-            <div class="resume-bloc resume-facultatif deux-col-bloc">
-              <h3>Facultatif mais recommandé</h3>
+            <!-- SECTION 2 : Réglages -->
+            <div class="resume-bloc resume-reglages">
+              <h3>Réglages</h3>
               <ul class="resume-infos">
 
                 <!-- Récompense -->
@@ -176,13 +176,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                   <div class="champ-feedback"></div>
                 </li>
-              </ul>
-            </div>
-
-            <!-- SECTION 3 : Caractéristiques -->
-            <div class="resume-bloc resume-technique">
-              <h3>Caractéristiques</h3>
-              <ul class="resume-infos">
 
                 <!-- Mode de fin de chasse -->
                 <li


### PR DESCRIPTION
## Résumé
- Fusion des sections de l’onglet Paramètres en "Informations" et "Réglages" pour les chasses
- Ajout du style associé à la nouvelle section de réglages

## Testing
- `source ./setup-env.sh`
- `/usr/bin/php bin/composer.phar install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6898f32ee5208332b2dd50d96183e7a6