### PR TITLE
Enregistre la date de découverte lors de la fin d'une chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -211,6 +211,12 @@ function gerer_chasse_terminee($chasse_id)
         return;
     }
 
+    $date = current_time('Y-m-d');
+    $date_obj = DateTime::createFromFormat('Y-m-d', $date);
+    if ($date_obj && $date_obj->format('Y-m-d') === $date) {
+        update_field('chasse_cache_date_decouverte', $date, $chasse_id);
+    }
+
     global $wpdb;
     $table = $wpdb->prefix . 'enigme_statuts_utilisateur';
     $now   = current_time('mysql');


### PR DESCRIPTION
## Résumé
Ajoute la date de découverte au moment de la clôture d'une chasse.

## Modifications
- Récupération de la date courante au format `Y-m-d`.
- Vérification du format et mise à jour du champ ACF `chasse_cache_date_decouverte`.

## Testing
- `source ./setup-env.sh`
- `/usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6898f73bb1988332b0c176df8f033e36