### PR TITLE
Corrige l’ouverture du panneau chasse après modification de la récompense

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -59,8 +59,14 @@ function initChasseEdit() {
   // ==============================
   const params = new URLSearchParams(window.location.search);
   const doitOuvrir = params.get('edition') === 'open';
+  const tab = params.get('tab');
   if (doitOuvrir) {
-    document.getElementById('toggle-mode-edition-chasse')?.click();
+    const toggle = document.getElementById('toggle-mode-edition-chasse');
+    toggle?.click();
+    if (tab) {
+      const btn = document.querySelector(`.edition-tab[data-target="chasse-tab-${tab}"]`);
+      btn?.click();
+    }
     DEBUG && console.log('🔧 Ouverture auto du panneau édition chasse via ?edition=open');
   }
 
@@ -197,10 +203,13 @@ function initChasseEdit() {
             })
           });
         })
-      ).then(() => {
-        location.reload();
+        ).then(() => {
+          const url = new URL(window.location.href);
+          url.searchParams.set('edition', 'open');
+          url.searchParams.set('tab', 'param');
+          window.location.href = url.toString();
+        });
       });
-    });
 
   }
 
@@ -296,6 +305,7 @@ function initChasseEdit() {
 
             const url = new URL(window.location.href);
             url.searchParams.set('edition', 'open');
+            url.searchParams.set('tab', 'param');
             window.location.href = url.toString();
 
           } else {

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -61,8 +61,7 @@ function initChasseEdit() {
   const doitOuvrir = params.get('edition') === 'open';
   const tab = params.get('tab');
   if (doitOuvrir) {
-    const toggle = document.getElementById('toggle-mode-edition-chasse');
-    toggle?.click();
+    document.body.classList.add('edition-active-chasse', 'panneau-ouvert');
     if (tab) {
       const btn = document.querySelector(`.edition-tab[data-target="chasse-tab-${tab}"]`);
       btn?.click();


### PR DESCRIPTION
## Résumé
- assure la réouverture du panneau d’édition chasse via l’URL `tab`
- réinitialise l’onglet paramètres après sauvegarde ou suppression de la récompense

## Modifications notables
- gère le paramètre `tab` pour cibler l’onglet à activer
- ajoute `tab=param` lors des rechargements après création ou suppression de récompense

## Testing
- `/usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6899066e91c883329107dcef3152ee83