### PR TITLE
Sauvegarde du mode de fin de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -690,9 +690,13 @@ function initModeFinChasse() {
 
   const postId = modeFinLi.dataset.postId;
 
-  function update() {
+  function update(save = false) {
     const selected = document.querySelector('input[name="acf[chasse_mode_fin]"]:checked')?.value;
     const existing = document.querySelector('.champ-nb-gagnants');
+
+    if (save && selected) {
+      modifierChampSimple('chasse_mode_fin', selected, postId, 'chasse');
+    }
 
     if (selected === 'automatique') {
       if (!existing) {
@@ -711,7 +715,7 @@ function initModeFinChasse() {
   }
 
   radios.forEach(radio => {
-    radio.addEventListener('change', update);
+    radio.addEventListener('change', () => update(true));
   });
 
   update();


### PR DESCRIPTION
## Résumé
- Correction de l'enregistrement du mode de fin de chasse

## Changements notables
- Mise à jour du script d'édition pour persister le champ `chasse_mode_fin`

## Testing
- `source ./setup-env.sh`
- `/root/.local/share/mise/installs/php/8.4.11/bin/php bin/composer.phar install`
- `/root/.local/share/mise/installs/php/8.4.11/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68997d3594fc83328fbbdb09e063b0ce