### PR TITLE
Aligner le mode de fin de chasse sur une ligne

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1118,14 +1118,25 @@ body.panneau-ouvert::before {
 }
 
 /* ====== Mode de fin ====== */
-.champ-mode-options {
-  margin-left: 1.5rem;
+.champ-mode-fin {
   display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+  align-items: center;
+  gap: 1rem;
+}
+
+.champ-mode-options {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
 }
 
 .champ-mode-options label {
+  display: flex;
+  align-items: center;
+}
+
+.fin-chasse-actions {
+  margin-left: auto;
   display: flex;
   align-items: center;
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -240,12 +240,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       </p>
                     <?php endif; ?>
                   </div>
-                  <?php if ($bloc_fin_chasse !== '') : ?>
-                    <template id="template-fin-chasse-actions">
-                      <?= $bloc_fin_chasse; ?>
-                    </template>
-                  <?php endif; ?>
                 </li>
+                <?php if ($bloc_fin_chasse !== '') : ?>
+                  <template id="template-fin-chasse-actions">
+                    <?= $bloc_fin_chasse; ?>
+                  </template>
+                <?php endif; ?>
 
                 <?php ob_start(); ?>
                 <!-- Nombre de gagnants -->


### PR DESCRIPTION
## Résumé
- uniformise la ligne du mode de fin en plaçant libellé, options et bouton sur une seule ligne
- positionne le bouton de terminaison à l’extrémité droite

## Testing
- `source ./setup-env.sh` *(aucune sortie)*
- `composer install` *(échoue : Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(échoue : No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6899a2c622488332b90368dbb204c7a9