### PR TITLE
Allow free engagement on finished hunts

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -512,7 +512,12 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         $message = 'Accès libre à cette chasse. Les tentatives seront tarifées individuellement.';
         $type    = 'engager';
     } elseif ($statut === 'termine') {
-        $html = '<a href="' . esc_url($permalink) . '" class="bouton-cta">Voir</a>';
+        // ✅ Chasse terminée : engagement gratuit et automatique
+        $html  = '<form method="post" action="' . esc_url(site_url('/traitement-engagement')) . '" class="cta-chasse-form">';
+        $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
+        $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
+        $html .= '<button type="submit" class="bouton-cta">Voir</button>';
+        $html .= '</form>';
         $type = 'voir';
         $message = $date_fin
             ? 'Cette chasse est terminée depuis le ' . date_i18n('d/m/Y', strtotime($date_fin))


### PR DESCRIPTION
## Résumé
Permet aux abonnés d'accéder aux chasses terminées sans tenir compte du coût en points.

## Changements
- Conversion du CTA "Voir" en formulaire d'engagement pour les chasses terminées

## Testing
- `source ./setup-env.sh`
- `composer install` *(échec : Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(échec : No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899a4a0ce9c83329229c1a311894d88