### PR TITLE
feat: améliorer design bouton terminer la chasse

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -12,12 +12,12 @@ const html = `
       <li class="champ-nb-gagnants"><input id="chasse-nb-gagnants" value="0"></li>
     </template>
     <template id="template-fin-chasse-actions">
-      <button type="button" class="terminer-chasse-btn" data-post-id="1" data-cpt="chasse"></button>
+      <button type="button" class="terminer-chasse-btn bouton-cta" data-post-id="1" data-cpt="chasse">Terminer la chasse</button>
       <div class="zone-validation-fin" style="display:none;">
         <label for="chasse-gagnants">Gagnants</label>
         <textarea id="chasse-gagnants"></textarea>
-        <button type="button" class="valider-fin-chasse-btn" data-post-id="1" data-cpt="chasse" disabled></button>
-        <button type="button" class="annuler-fin-chasse-btn"></button>
+        <button type="button" class="valider-fin-chasse-btn bouton-cta" data-post-id="1" data-cpt="chasse" disabled>Valider la fin de chasse</button>
+        <button type="button" class="annuler-fin-chasse-btn bouton-secondaire">Annuler</button>
       </div>
     </template>
   </div>

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1152,6 +1152,11 @@ body.panneau-ouvert::before {
   opacity: 1;
 }
 
+.fin-chasse-actions .terminer-chasse-btn:not(:disabled):hover {
+  background-color: var(--color-secondary);
+  color: var(--color-background-button);
+}
+
 .zone-validation-fin {
   margin-top: 1rem;
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1147,6 +1147,11 @@ body.panneau-ouvert::before {
   margin-left: 1rem;
 }
 
+.fin-chasse-actions .terminer-chasse-btn:not(:disabled) {
+  color: var(--color-text-primary);
+  opacity: 1;
+}
+
 .zone-validation-fin {
   margin-top: 1rem;
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1141,18 +1141,24 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
-.fin-chasse-actions .terminer-chasse-btn {
+.fin-chasse-actions .terminer-chasse-btn,
+.zone-validation-fin .valider-fin-chasse-btn {
   font-size: 1.1rem;
   padding: 12px 20px;
+}
+
+.fin-chasse-actions .terminer-chasse-btn {
   margin-left: 1rem;
 }
 
-.fin-chasse-actions .terminer-chasse-btn:not(:disabled) {
+.fin-chasse-actions .terminer-chasse-btn:not(:disabled),
+.zone-validation-fin .valider-fin-chasse-btn:not(:disabled) {
   color: var(--color-text-primary);
   opacity: 1;
 }
 
-.fin-chasse-actions .terminer-chasse-btn:not(:disabled):hover {
+.fin-chasse-actions .terminer-chasse-btn:not(:disabled):hover,
+.zone-validation-fin .valider-fin-chasse-btn:not(:disabled):hover {
   background-color: var(--color-secondary);
   color: var(--color-background-button);
 }

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1141,6 +1141,23 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
+.fin-chasse-actions .terminer-chasse-btn {
+  font-size: 1.1rem;
+  padding: 12px 20px;
+  margin-left: 1rem;
+}
+
+.zone-validation-fin {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.zone-validation-fin .annuler-fin-chasse-btn {
+  margin-left: 0.5rem;
+}
+
 .mode-fin-aide {
   background: none;
   border: none;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -208,24 +208,24 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   <?php if (in_array($statut_metier, ['payante', 'en_cours', 'revision'], true)) : ?>
                     <button
                       type="button"
-                      class="terminer-chasse-btn"
+                      class="terminer-chasse-btn bouton-cta"
                       data-post-id="<?= esc_attr($chasse_id); ?>"
                       data-cpt="chasse"
                       <?= ($statut_metier === 'revision') ? 'disabled' : ''; ?>
-                    ><?= esc_html__('✅ Terminer la chasse', 'chassesautresor-com'); ?></button>
+                    ><?= esc_html__('Terminer la chasse', 'chassesautresor-com'); ?></button>
                     <div class="zone-validation-fin" style="display:none;">
                       <label for="chasse-gagnants"><?= esc_html__('Gagnants', 'chassesautresor-com'); ?></label>
                       <textarea id="chasse-gagnants" required></textarea>
                       <button
                         type="button"
-                        class="valider-fin-chasse-btn"
+                        class="valider-fin-chasse-btn bouton-cta"
                         data-post-id="<?= esc_attr($chasse_id); ?>"
                         data-cpt="chasse"
                         disabled
                       ><?= esc_html__('Valider la fin de chasse', 'chassesautresor-com'); ?></button>
                       <button
                         type="button"
-                        class="annuler-fin-chasse-btn"
+                        class="annuler-fin-chasse-btn bouton-secondaire"
                       ><?= esc_html__('Annuler', 'chassesautresor-com'); ?></button>
                     </div>
                   <?php endif; ?>


### PR DESCRIPTION
## Résumé
- Améliore le style du bouton de fin de chasse et des actions associées
- Adapte les tests au nouveau balisage

## Changements notables
- Bouton "Terminer la chasse" sans icône et avec style CTA
- Styles CSS pour la zone de validation et le bouton d’annulation
- Mise à jour des tests front-end

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899aac074e883329b75b35e2370422f