### PR TITLE
Bloque l'engagement d'une chasse sans points suffisants

### DIFF
--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -34,7 +34,20 @@ if ($chasse_id) {
 
     require_once get_theme_file_path('inc/chasse-functions.php');
 
+    $cout_points = (int) get_field('chasse_infos_cout_points', $chasse_id);
+
+    if ($cout_points > 0 && !utilisateur_a_assez_de_points($current_user_id, $cout_points)) {
+        wp_safe_redirect(
+            add_query_arg('erreur', 'points_insuffisants', get_permalink($chasse_id))
+        );
+        exit;
+    }
+
     enregistrer_engagement_chasse($current_user_id, $chasse_id);
+
+    if ($cout_points > 0) {
+        deduire_points_utilisateur($current_user_id, $cout_points);
+    }
 
     wp_safe_redirect(get_permalink($chasse_id));
     exit;


### PR DESCRIPTION
## Résumé
- désactive le CTA d'une chasse payante si le solde de points est insuffisant
- vérifie le solde lors de l'engagement et déduit les points requis

## Testing
- `source ./setup-env.sh`
- `/usr/bin/php bin/composer.phar install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6899ada34ba88332bef6b2793ea4062d