### PR TITLE
Affichage du QR code de la chasse validée

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -68,6 +68,18 @@
   display: none;
 }
 
+/* ========== 🧾 QR CODE CHASSE ========== */
+.resume-visibilite .qr-code-wrapper {
+  margin-top: 0.5rem;
+}
+
+.resume-visibilite .qr-code-wrapper img {
+  max-width: 150px;
+  height: auto;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */
 
 .champ-edition {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -405,6 +405,31 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <?php endif; ?>
                     <div class="champ-feedback"></div>
                   </li>
+                  <?php
+                  if (
+                      est_organisateur()
+                      && ($infos_chasse['statut'] ?? '') !== 'revision'
+                      && ($infos_chasse['statut_validation'] ?? '') === 'valide'
+                  ) :
+                      $format = isset($_GET['format']) ? sanitize_key($_GET['format']) : 'png';
+                      $formats_autorises = ['png', 'svg', 'eps'];
+                      if (!in_array($format, $formats_autorises, true)) {
+                          $format = 'png';
+                      }
+                      $url = get_permalink($chasse_id);
+                      $url_qr_code = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data='
+                          . rawurlencode($url)
+                          . '&format=' . $format;
+                  ?>
+                  <li class="champ-chasse resume-ligne champ-qr-code">
+                    <span class="champ-label">QR code de la chasse</span>
+                    <div class="qr-code-wrapper">
+                      <img src="<?= esc_url($url_qr_code); ?>" alt="QR code de la chasse">
+                      <a href="<?= esc_url($url_qr_code); ?>"
+                        download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>">Télécharger</a>
+                    </div>
+                  </li>
+                  <?php endif; ?>
                 </ul>
               </div>
 


### PR DESCRIPTION
## Résumé
- Ajout d’un QR code téléchargeable pour les chasses validées

## Changements
- Ajout d’un bloc QR code dans la section "Visibilité" des chasses
- Gestion du paramètre `format` pour choisir le format du QR code
- Styles CSS pour l’intégration visuelle du QR code

## Testing
- `/root/.local/share/mise/installs/php/8.4.11/bin/php bin/composer.phar install`
- `/root/.local/share/mise/installs/php/8.4.11/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6899b1b08a808332be465f715d38d77c