### PR TITLE
Amélioration onglet Statistiques pour les chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const table = document.querySelector('#chasse-stats-table');
+  if (table) {
+    table.querySelectorAll('th.sortable').forEach((th) => {
+      th.addEventListener('click', () => {
+        const index = th.cellIndex;
+        const tbody = table.querySelector('tbody');
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        const asc = th.classList.toggle('asc');
+        rows.sort((a, b) => {
+          const aText = a.children[index].textContent.trim();
+          const bText = b.children[index].textContent.trim();
+          const aNum = parseInt(aText, 10);
+          const bNum = parseInt(bText, 10);
+          let comp;
+          if (!isNaN(aNum) && !isNaN(bNum)) {
+            comp = aNum - bNum;
+          } else {
+            comp = aText.localeCompare(bText);
+          }
+          return asc ? comp : -comp;
+        });
+        rows.forEach((row) => tbody.appendChild(row));
+      });
+    });
+  }
+
+  const periodeSelect = document.querySelector('#chasse-periode');
+  if (periodeSelect) {
+    periodeSelect.addEventListener('change', () => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('periode', periodeSelect.value);
+      window.location.href = url.toString();
+    });
+  }
+});

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -80,6 +80,7 @@ require_once $inc_path . 'access-functions.php';
 require_once $inc_path . 'relations-functions.php';
 require_once $inc_path . 'layout-functions.php';
 require_once $inc_path . 'utils/liens.php';
+require_once $inc_path . 'chasse/stats.php';
 
 require_once $inc_path . 'edition/edition-core.php';
 require_once $inc_path . 'edition/edition-organisateur.php';

--- a/wp-content/themes/chassesautresor/inc/chasse/stats.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/stats.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Stats helpers for hunts.
+ */
+
+defined('ABSPATH') || exit;
+
+/**
+ * Récupère les statistiques globales et détaillées d'une chasse.
+ *
+ * @param int    $chasse_id ID de la chasse.
+ * @param string $periode   Période d'analyse: jour, semaine, mois ou total.
+ *
+ * @return array{ kpis: array{joueurs_engages:int, points_depenses:int, indices_debloques:int}, detail: array<int, array<string, mixed>> }
+ */
+function chasse_recuperer_stats(int $chasse_id, string $periode = 'total'): array
+{
+    $periode_valide = in_array($periode, ['jour', 'semaine', 'mois', 'total'], true) ? $periode : 'total';
+    $cache_key = "chasse_stats_{$chasse_id}_{$periode_valide}";
+    $cached = get_transient($cache_key);
+    if ($cached !== false) {
+        return $cached;
+    }
+
+    $enigmes_ids = recuperer_ids_enigmes_pour_chasse($chasse_id);
+    $kpis = [
+        'joueurs_engages' => 0,
+        'points_depenses' => 0,
+        'indices_debloques' => (int) get_field('total_indices_debloques_chasse', $chasse_id),
+    ];
+    $detail = [];
+
+    foreach ($enigmes_ids as $enigme_id) {
+        $joueurs = enigme_compter_joueurs_engages($enigme_id, $periode_valide);
+        $tentatives = enigme_compter_tentatives($enigme_id, 'automatique', $periode_valide);
+        $points = enigme_compter_points_depenses($enigme_id, 'automatique', $periode_valide);
+        $resolus = enigme_compter_bonnes_solutions($enigme_id, 'automatique', $periode_valide);
+
+        $kpis['joueurs_engages'] += $joueurs;
+        $kpis['points_depenses'] += $points;
+
+        $detail[] = [
+            'id' => $enigme_id,
+            'titre' => get_the_title($enigme_id),
+            'joueurs' => $joueurs,
+            'tentatives' => $tentatives,
+            'points' => $points,
+            'resolus' => $resolus,
+        ];
+    }
+
+    $resultat = [
+        'kpis' => $kpis,
+        'detail' => $detail,
+    ];
+    set_transient($cache_key, $resultat, 5 * MINUTE_IN_SECONDS);
+    return $resultat;
+}

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -30,7 +30,7 @@ function enqueue_script_chasse_edit()
   }
 
   // Enfile les scripts nécessaires
-  enqueue_core_edit_scripts(['chasse-edit']);
+  enqueue_core_edit_scripts(['chasse-edit', 'chasse-stats']);
 
   // Injecte les valeurs par défaut pour JS
   wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -373,7 +373,64 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       <div class="edition-panel-header">
         <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
       </div>
-      <p class="edition-placeholder">La section « Statistiques » sera bientôt disponible.</p>
+      <?php if (!utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id)) : ?>
+        <p class="edition-placeholder"><?php esc_html_e('Accès refusé.', 'chassesautresor-com'); ?></p>
+      <?php else :
+        $periode = isset($_GET['periode']) ? sanitize_text_field($_GET['periode']) : 'semaine';
+        $periode = in_array($periode, ['jour', 'semaine', 'mois', 'total'], true) ? $periode : 'semaine';
+        $stats = chasse_recuperer_stats($chasse_id, $periode);
+        $kpis = $stats['kpis'];
+        $details = $stats['detail'];
+      ?>
+        <div class="edition-panel-body">
+          <div class="stats-filtres">
+            <label for="chasse-periode">Période :</label>
+            <select id="chasse-periode">
+              <option value="semaine" <?php selected($periode, 'semaine'); ?>>7&nbsp;derniers jours</option>
+              <option value="mois" <?php selected($periode, 'mois'); ?>>30&nbsp;derniers jours</option>
+              <option value="total" <?php selected($periode, 'total'); ?>>Depuis le début</option>
+            </select>
+          </div>
+          <div class="stats-kpi">
+            <div class="kpi-card" title="Nombre de joueurs ayant engagé au moins une énigme">
+              <span class="kpi-label">Joueurs engagés</span>
+              <span class="kpi-value"><?= esc_html($kpis['joueurs_engages']); ?></span>
+            </div>
+            <div class="kpi-card" title="Total des points utilisés pour les tentatives et indices">
+              <span class="kpi-label">Points dépensés</span>
+              <span class="kpi-value"><?= esc_html($kpis['points_depenses']); ?></span>
+            </div>
+            <div class="kpi-card" title="Nombre d'indices débloqués sur la chasse">
+              <span class="kpi-label">Indices débloqués</span>
+              <span class="kpi-value"><?= esc_html($kpis['indices_debloques']); ?></span>
+            </div>
+          </div>
+          <div class="stats-table-wrapper">
+            <table id="chasse-stats-table">
+              <thead>
+                <tr>
+                  <th class="sortable">Énigme</th>
+                  <th class="sortable">Joueurs engagés</th>
+                  <th class="sortable">Tentatives</th>
+                  <th class="sortable">Points dépensés</th>
+                  <th class="sortable">Résolutions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach ($details as $row) : ?>
+                  <tr>
+                    <td><a href="<?= esc_url(get_edit_post_link($row['id'])); ?>"><?= esc_html($row['titre']); ?></a></td>
+                    <td><?= esc_html($row['joueurs']); ?></td>
+                    <td><?= esc_html($row['tentatives']); ?></td>
+                    <td><?= esc_html($row['points']); ?></td>
+                    <td><?= esc_html($row['resolus']); ?></td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      <?php endif; ?>
     </div>
 
     <div id="chasse-tab-animation" class="edition-tab-content" style="display:none;">


### PR DESCRIPTION
## Résumé
- Ajout d'un module serveur pour agréger les statistiques d'une chasse
- Affichage des KPI et du tableau par énigme dans l'onglet Statistiques
- Tri des colonnes et filtrage par période côté interface

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6899e4d0c1988332bc471dffb602991a