### PR TITLE
check user engagement before showing puzzle

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -28,11 +28,10 @@ defined('ABSPATH') || exit;
         $etat = get_field('enigme_cache_etat_systeme', $enigme_id) ?? 'accessible';
 
         if ($etat !== 'accessible' && !utilisateur_peut_modifier_enigme($enigme_id)) {
-            echo '<div class="enigme-inaccessible">';
-            echo '<p>🔒 Cette énigme n’est pas accessible actuellement.</p>';
-            echo '<p><a href="' . esc_url(home_url('/')) . '" class="bouton-retour-home">← Retour à l’accueil</a></p>';
-            echo '</div>';
-            return;
+            $chasse_id = recuperer_id_chasse_associee($enigme_id);
+            $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+            wp_safe_redirect($url);
+            exit;
         }
 
         if (!empty($statut_data['afficher_message'])) {

--- a/wp-content/themes/chassesautresor/inc/enigme/engagements.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/engagements.php
@@ -50,3 +50,26 @@ defined('ABSPATH') || exit;
         $ok2 = enregistrer_engagement_enigme($user_id, $enigme_id);
         return $ok1 && $ok2;
     }
+
+    /**
+     * Vérifie si un utilisateur est déjà engagé sur une énigme donnée.
+     *
+     * @param int $user_id   ID de l'utilisateur
+     * @param int $enigme_id ID de l'énigme
+     * @return bool True si un engagement existe
+     */
+    function utilisateur_est_engage_dans_enigme(int $user_id, int $enigme_id): bool
+    {
+        global $wpdb;
+        if (!$user_id || !$enigme_id) {
+            return false;
+        }
+
+        $table = $wpdb->prefix . 'engagements';
+
+        return (bool) $wpdb->get_var($wpdb->prepare(
+            "SELECT 1 FROM $table WHERE user_id = %d AND enigme_id = %d LIMIT 1",
+            $user_id,
+            $enigme_id
+        ));
+    }

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -327,6 +327,21 @@ function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
         ];
     }
 
+    // 🔒 Joueur non engagé dans la chasse ou l'énigme
+    if (
+        !utilisateur_est_engage_dans_chasse($user_id, $chasse_id) ||
+        !utilisateur_est_engage_dans_enigme($user_id, $enigme_id)
+    ) {
+        return [
+            'etat' => $statut,
+            'rediriger' => true,
+            'url' => $chasse_id ? get_permalink($chasse_id) : home_url('/'),
+            'afficher_formulaire' => false,
+            'afficher_message' => false,
+            'message_html' => '',
+        ];
+    }
+
     // 🔁 Cas interdits : accès refusé
     if ($statut === 'abandonnee') {
         return [

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -19,16 +19,24 @@ if ($chasse_id) {
 
 // 🔹 Accès invité : redirection systématique vers la chasse associée
 if (!is_user_logged_in()) {
-  $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
-  wp_redirect($url);
-  exit;
+    $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+    wp_redirect($url);
+    exit;
 }
 
 // 🔹 Redirection si non visible
 if (!enigme_est_visible_pour($user_id, $enigme_id)) {
-  $fallback_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
-  wp_redirect($fallback_url);
-  exit;
+    $fallback_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+    wp_redirect($fallback_url);
+    exit;
+}
+
+// 🔒 Énigme inaccessible : redirection vers la chasse liée
+$etat_systeme = get_field('enigme_cache_etat_systeme', $enigme_id) ?? 'accessible';
+if ($etat_systeme !== 'accessible' && !utilisateur_peut_modifier_enigme($enigme_id)) {
+    $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+    wp_safe_redirect($url);
+    exit;
 }
 
 // 🔹 Mode édition auto


### PR DESCRIPTION
Empêche l'accès aux énigmes sans engagement préalable.

- ajoute un contrôle d'engagement spécifique aux énigmes
- refuse l'accès aux joueurs non engagés dans la chasse ou l'énigme

### Testing
- `source ./setup-env.sh` (aucune sortie)
- `composer install` *(échoue : Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(échoue : No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed795cb88332b4dd759706000bd8