### PR TITLE
Déplacer la récompense vers l'onglet Informations

### DIFF
--- a/tests/manual/chasse-recompense.md
+++ b/tests/manual/chasse-recompense.md
@@ -1,0 +1,14 @@
+# Vérification du champ "Récompense" dans le panneau d'édition de chasse
+
+## Objectif
+S'assurer que le champ **Récompense** est correctement positionné dans l'onglet Paramètres du panneau d'édition.
+
+## Étapes
+1. Ouvrir une chasse existante avec des droits d'édition.
+2. Aller dans l'onglet **Paramètres** du panneau d'édition.
+3. Dans la section **Informations**, vérifier que le champ **Récompense** est affiché en dernière position, après l'image.
+4. Dans la section **Réglages**, confirmer que le champ **Récompense** n'apparaît plus.
+
+## Résultat attendu
+- Le champ **Récompense** est visible en bas de la section **Informations**.
+- Aucun champ **Récompense** n'est présent dans la section **Réglages**.

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -137,14 +137,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   <?php endif; ?>
                 </li>
 
-              </ul>
-            </div>
-
-            <!-- SECTION 2 : Réglages -->
-            <div class="resume-bloc resume-reglages">
-              <h3>Réglages</h3>
-              <ul class="resume-infos">
-
                 <!-- Récompense -->
                 <li class="champ-chasse champ-rempli<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
                   Récompense
@@ -155,11 +147,19 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   <?php endif; ?>
                 </li>
 
+              </ul>
+            </div>
+
+              <!-- SECTION 2 : Réglages -->
+              <div class="resume-bloc resume-reglages">
+                <h3>Réglages</h3>
+                <ul class="resume-infos">
+
                 <!-- Mode de fin de chasse -->
-                <li
-                  class="champ-chasse champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="chasse_mode_fin"
-                  data-cpt="chasse"
+                  <li
+                    class="champ-chasse champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                    data-champ="chasse_mode_fin"
+                    data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>"
                   data-no-edit="1"
                   data-no-icon="1"


### PR DESCRIPTION
## Résumé
- Déplace la gestion de la récompense dans la section Informations du panneau d'édition de chasse.
- Retire l'affichage de la récompense de la section Réglages.

## Testing
- `source ./setup-env.sh`
- `php bin/composer.phar install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6899f6e7d0b48332a177eef0ae2f1b86