### PR TITLE
Déplacer la récompense vers l'onglet Informations

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -304,7 +304,9 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
 function mettreAJourLigneResume(ligne, champ, estRempli, type) {
   ligne.classList.toggle('champ-rempli', estRempli);
   ligne.classList.toggle('champ-vide', !estRempli);
-  const estObligatoire = ligne.closest('.resume-bloc')?.classList.contains('resume-obligatoire');
+  const estObligatoire =
+    ligne.closest('.resume-bloc')?.classList.contains('resume-obligatoire') &&
+    !(type === 'chasse' && champ === 'chasse_infos_recompense_valeur');
   ligne.classList.toggle('champ-attention', estObligatoire && !estRempli);
 
   // Nettoyer anciennes icônes

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -137,29 +137,34 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   <?php endif; ?>
                 </li>
 
-              </ul>
-            </div>
-
-            <!-- SECTION 2 : Réglages -->
-            <div class="resume-bloc resume-reglages">
-              <h3>Réglages</h3>
-              <ul class="resume-infos">
-
                 <!-- Récompense -->
-                <li class="champ-chasse champ-rempli<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
+                <li class="champ-chasse <?= empty($recompense) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
                   Récompense
                   <?php if ($peut_editer) : ?>
-
-                    <button type="button" class="champ-modifier ouvrir-panneau-recompense" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>" aria-label="Modifier la récompense">✏️</button>
-
+                    <button
+                      type="button"
+                      class="champ-modifier ouvrir-panneau-recompense"
+                      data-champ="chasse_infos_recompense_valeur"
+                      data-cpt="chasse"
+                      data-post-id="<?= esc_attr($chasse_id); ?>"
+                      aria-label="Modifier la récompense"
+                    >✏️</button>
                   <?php endif; ?>
                 </li>
 
+              </ul>
+            </div>
+
+              <!-- SECTION 2 : Réglages -->
+              <div class="resume-bloc resume-reglages">
+                <h3>Réglages</h3>
+                <ul class="resume-infos">
+
                 <!-- Mode de fin de chasse -->
-                <li
-                  class="champ-chasse champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="chasse_mode_fin"
-                  data-cpt="chasse"
+                  <li
+                    class="champ-chasse champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                    data-champ="chasse_mode_fin"
+                    data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>"
                   data-no-edit="1"
                   data-no-icon="1"


### PR DESCRIPTION
## Résumé
- Déplace la gestion de la récompense dans la section Informations du panneau d’édition de chasse.
- Retire la mise en évidence automatique de la récompense lorsqu’elle est vide.

## Testing
- `source ./setup-env.sh`
- `/usr/bin/php8.3 bin/composer.phar install`
- `/usr/bin/php8.3 vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6899f6e7d0b48332a177eef0ae2f1b86