### PR TITLE
Fix hunt completion status check

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -105,6 +105,7 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
     $etat_systeme = enigme_get_etat_systeme($enigme_id);
     $statut_utilisateur = enigme_get_statut_utilisateur($enigme_id, $user_id);
     $points = intval(get_field('enigme_tentative_cout_points', $enigme_id));
+    $mode_validation = get_field('enigme_mode_validation', $enigme_id);
 
     // Base commune
     $cta = [
@@ -181,6 +182,16 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
             ]);
 
         case 'en_cours':
+            if ($mode_validation === 'aucune') {
+                return array_merge($cta, [
+                    'type'       => 'voir',
+                    'label'      => 'Voir',
+                    'action'     => 'link',
+                    'url'        => get_permalink($enigme_id),
+                    'classe_css' => 'cta-voir',
+                    'badge'      => 'Engagée',
+                ]);
+            }
             return array_merge($cta, [
                 'type'       => 'continuer',
                 'label'      => 'Continuer',
@@ -191,6 +202,16 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
             ]);
 
         case 'resolue':
+            if ($mode_validation === 'aucune') {
+                return array_merge($cta, [
+                    'type'       => 'voir',
+                    'label'      => 'Voir',
+                    'action'     => 'link',
+                    'url'        => get_permalink($enigme_id),
+                    'classe_css' => 'cta-voir',
+                    'badge'      => 'Engagée',
+                ]);
+            }
             return array_merge($cta, [
                 'type'       => 'revoir',
                 'label'      => 'Revoir',

--- a/wp-content/themes/chassesautresor/inc/enigme/engagements.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/engagements.php
@@ -46,8 +46,16 @@ defined('ABSPATH') || exit;
      */
     function marquer_enigme_comme_engagee(int $user_id, int $enigme_id): bool
     {
-        $ok1 = enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'en_cours', true);
+        $mode = get_field('enigme_mode_validation', $enigme_id);
+        $statut = ($mode === 'aucune') ? 'resolue' : 'en_cours';
+
+        $ok1 = enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, $statut, true);
         $ok2 = enregistrer_engagement_enigme($user_id, $enigme_id);
+
+        if ($mode === 'aucune' && $ok1 && $ok2) {
+            do_action('enigme_resolue', $user_id, $enigme_id);
+        }
+
         return $ok1 && $ok2;
     }
 

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -251,7 +251,8 @@ function enigme_get_chasse_progression(int $chasse_id, int $user_id): array
         if ($mode === 'aucune') {
             return utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
         }
-        return get_user_meta($user_id, "statut_enigme_{$id}", true) === 'terminée';
+        $statut = get_user_meta($user_id, "statut_enigme_{$id}", true);
+        return in_array($statut, ['resolue', 'terminee'], true);
     }));
 
     return [
@@ -287,7 +288,8 @@ function compter_enigmes_resolues($chasse_id, $user_id): int
         if ($mode === 'aucune') {
             return utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
         }
-        return get_user_meta($user_id, "statut_enigme_{$enigme_id}", true) === 'terminée';
+        $statut = get_user_meta($user_id, "statut_enigme_{$enigme_id}", true);
+        return in_array($statut, ['resolue', 'terminee'], true);
     }));
 }
 
@@ -337,7 +339,8 @@ function verifier_fin_de_chasse($user_id, $enigme_id)
     }
 
     $enigmes_resolues = array_filter($enigmes_validables, function ($associee_id) use ($user_id) {
-        return get_user_meta($user_id, "statut_enigme_{$associee_id}", true) === 'terminée';
+        $statut = get_user_meta($user_id, "statut_enigme_{$associee_id}", true);
+        return in_array($statut, ['resolue', 'terminee'], true);
     });
 
     if (count($enigmes_resolues) === count($enigmes_validables)) {

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -157,11 +157,9 @@ function enigme_pre_requis_remplis(int $enigme_id, int $user_id): bool
 
         if ($enigme_id_requise) {
             $statut = get_user_meta($user_id, "statut_enigme_{$enigme_id_requise}", true);
-            // Les statuts d'énigme sont stockés sans accent ("terminee")
-            // dans les autres parties du code. Utiliser la même valeur ici
-            // pour éviter un échec de vérification systématique des
-            // prérequis lorsque l'utilisateur a pourtant terminé l'énigme.
-            if ($statut !== 'terminee') {
+            // Les statuts d'énigme sont stockés sans accent.
+            // Considérer une énigme comme validée si elle est résolue ou terminée.
+            if (!in_array($statut, ['resolue', 'terminee'], true)) {
                 return false; // ❌ Prérequis non rempli
             }
         }


### PR DESCRIPTION
## Summary
- assure que la progression de chasse reconnaît les énigmes résolues
- valide les prérequis en acceptant les statuts "résolue" ou "terminée"

## Testing
- `source ./setup-env.sh`
- `/usr/bin/composer install`
- `/usr/bin/php vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689b0bdaa1788332aedb66fc63236654