### PR TITLE
Remove hero on Mon Compte pages

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -81,10 +81,10 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
     if ( is_cart() ) {
         get_template_part('template-parts/header-panier');
     }
-    elseif ( is_page() ) {
+    elseif ( is_page() && ! is_user_account_area() ) {
         $image_id  = get_post_thumbnail_id();
         $image_url = $image_id ? imagify_get_webp_url( wp_get_attachment_image_url( $image_id, 'full' ) ) : '';
-    
+
         get_header_fallback([
             'titre'       => get_the_title(),
             'sous_titre'  => '',

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -236,10 +236,22 @@ function get_svg_icon($icone) {
 // 🧩 HEADERS
 // ==================================================
 /**
+ * 🔹 is_user_account_area → Vérifie si l’URL courante appartient à l’espace "Mon Compte".
  * 🔹 get_header_fallback → Affiche un header alternatif (style hero) pour les pages hors CPT organisateur.
  * 🔹 ajouter_class_has_hero_si_header_fallback → Ajoute la classe CSS "has-hero" au body si le header fallback est actif.
  * 🔹 filtrer_content_sans_titre → Supprime le <h1> du contenu s’il est identique au titre principal (évite les doublons SEO).
  */
+
+/**
+ * Vérifie si la requête actuelle cible une URL de l’espace utilisateur "Mon Compte".
+ *
+ * @return bool
+ */
+function is_user_account_area(): bool {
+    $request = trim($_SERVER['REQUEST_URI'], '/');
+
+    return strpos($request, 'mon-compte') === 0;
+}
 
 
 /**
@@ -278,10 +290,11 @@ function get_header_fallback($args = []) {
  * @return array
  */
 function ajouter_class_has_hero_si_header_fallback( $classes ) {
-	if ( is_page() ) {
-		$classes[] = 'has-hero';
-	}
-	return $classes;
+    if ( is_page() && ! is_user_account_area() ) {
+        $classes[] = 'has-hero';
+    }
+
+    return $classes;
 }
 add_filter( 'body_class', 'ajouter_class_has_hero_si_header_fallback' );
 


### PR DESCRIPTION
## Résumé
Supprime l'affichage du bandeau hero sur les pages "Mon Compte".

## Changements
- Ajout d'un helper pour détecter l'espace Mon Compte.
- Exclusion du hero et de la classe `has-hero` pour ces pages.

## Testing
- `source ./setup-env.sh`
- `/usr/bin/composer install`
- `/usr/bin/php ./vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689b0548e5ac833283a19564f6a60889