### PR TITLE
Fix missing layout on admin myaccount pages

### DIFF
--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -15,6 +15,8 @@ $current_user     = wp_get_current_user();
 $display_name     = $current_user->ID ? $current_user->display_name : get_bloginfo('name');
 $show_nav         = is_user_logged_in();
 $current_path     = trim($_SERVER['REQUEST_URI'], '/');
+
+get_header();
 ?>
 <div class="myaccount-layout">
     <aside class="myaccount-sidebar">
@@ -169,4 +171,7 @@ $current_path     = trim($_SERVER['REQUEST_URI'], '/');
         </main>
     </div>
 </div>
+
+<?php
+get_footer();
 


### PR DESCRIPTION
## Résumé
- corrige l'affichage des sous-pages `/mon-compte` lors d'un accès direct

## Changements notables
- ajoute l'en-tête et le pied de page du thème au layout "Mon Compte"

## Testing
- `source ./setup-env.sh`
- `composer install` *(échec : Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined.)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(non trouvé)*
- `npm test` *(échec : jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ac4452483328b6717a6b51837b5