### PR TITLE
Refactor organisers admin table

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/tri-organisateurs.js
+++ b/wp-content/themes/chassesautresor/assets/js/tri-organisateurs.js
@@ -1,21 +1,33 @@
-// Tri dynamique du tableau des organisateurs par colonne "\xC3\x89tat"
+// Gestion du tri par date et du filtre par état pour le tableau des organisateurs
+
 document.addEventListener('DOMContentLoaded', () => {
   const table = document.querySelector('.table-organisateurs');
   if (!table) return;
-  const header = table.querySelector('th[data-col="etat"]');
-  if (!header) return;
-  header.style.cursor = 'pointer';
-  let asc = true;
-  header.addEventListener('click', () => {
-    const tbody = table.querySelector('tbody');
-    if (!tbody) return;
-    const rows = Array.from(tbody.querySelectorAll('tr'));
-    rows.sort((a, b) => {
-      const va = a.querySelector('td[data-col="etat"]').textContent.trim();
-      const vb = b.querySelector('td[data-col="etat"]').textContent.trim();
-      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+  const tbody = table.querySelector('tbody');
+  const filter = document.getElementById('filtre-etat');
+  const header = table.querySelector('th[data-col="date"]');
+
+  if (filter) {
+    filter.addEventListener('change', () => {
+      const val = filter.value;
+      tbody.querySelectorAll('tr').forEach(row => {
+        const etat = row.dataset.etat || '';
+        row.style.display = val === 'tous' || val === '' || etat === val ? '' : 'none';
+      });
     });
-    rows.forEach(r => tbody.appendChild(r));
-    asc = !asc;
-  });
+  }
+
+  if (header) {
+    header.style.cursor = 'pointer';
+    let asc = false;
+    header.addEventListener('click', () => {
+      const rows = Array.from(tbody.querySelectorAll('tr')).sort((a, b) => {
+        const da = new Date(a.dataset.date);
+        const db = new Date(b.dataset.date);
+        return asc ? da - db : db - da;
+      });
+      rows.forEach(r => tbody.appendChild(r));
+      asc = !asc;
+    });
+  }
 });

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-organisateurs.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-organisateurs.php
@@ -16,12 +16,11 @@ $organisateurs_liste = recuperer_organisateurs_pending();
 ?>
 <section>
     <h1 class="mb-4 text-xl font-semibold"><?php esc_html_e('Organisateurs', 'chassesautresor'); ?></h1>
-    <h2 class="text-lg font-semibold mb-2"><?php esc_html_e('Organisateurs en attente', 'chassesautresor'); ?></h2>
     <?php if (empty($organisateurs_liste)) : ?>
-        <p><?php esc_html_e('Aucun organisateur en attente.', 'chassesautresor'); ?></p>
+        <p><?php esc_html_e('Aucun organisateur.', 'chassesautresor'); ?></p>
     <?php else : ?>
         <span><?php echo count($organisateurs_liste); ?> <?php esc_html_e('résultat(s) trouvé(s)', 'chassesautresor'); ?></span>
-        <?php afficher_tableau_organisateurs_pending(); ?>
+        <?php afficher_tableau_organisateurs_pending($organisateurs_liste); ?>
     <?php endif; ?>
 
     <h2 class="text-lg font-semibold mt-8 mb-2"><?php esc_html_e('Demandes de paiement', 'chassesautresor'); ?></h2>


### PR DESCRIPTION
## Summary
- refactor organiser retrieval to list all hunts by organiser
- add dynamic status filter and date sorting to organiser table
- refresh organiser admin template

## Testing
- `source ./setup-env.sh` *(fails: no output)*
- `./bin/composer install` *(fails: Command "./bin/composer.phar" is not defined.)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(fails: No such file or directory)*
- `npm install`
- `npm test` *(fails: 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689b804ff62083328fd6693f1ba82f3e