### PR TITLE
Empêcher l'ouverture automatique du panneau organisateur sur d'autres CPT

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -151,7 +151,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // 🔑 Ouverture automatique via les paramètres d'URL
   const params = new URLSearchParams(window.location.search);
 
-  if (params.get('edition') === 'open' && !params.has('tab')) {
+  const postType = params.get('post_type');
+  if (
+    params.get('edition') === 'open' &&
+    !params.has('tab') &&
+    (!postType || postType === 'organisateur')
+  ) {
     const toggle = document.getElementById('toggle-mode-edition');
     toggle?.click();
 


### PR DESCRIPTION
Ajoute un contrôle du type de post pour éviter que le panneau d'édition organisateur s'ouvre en parallèle lors de l'édition d'une énigme ou d'autres CPT.

- n'ouvre le panneau organisateur via `?edition=open` que pour le post type approprié
- conserve l'ouverture automatique pour les pages organisateur

## Testing
- `/usr/bin/composer install`
- `/usr/bin/php ./vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689b875e22d48332b224468731f6d23b