### PR TITLE
Enregistrement des gagnants de chasses

### DIFF
--- a/wp-content/themes/chassesautresor/templates/myaccount/content-statistiques.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-statistiques.php
@@ -11,8 +11,11 @@ if (!current_user_can('administrator')) {
     wp_redirect(home_url('/mon-compte/'));
     exit;
 }
+
+$user_id = get_current_user_id();
+$wins = compter_chasses_gagnees($user_id);
 ?>
 <section>
     <h1 class="mb-4 text-xl font-semibold"><?php esc_html_e('Statistiques', 'chassesautresor'); ?></h1>
-    <p><?php esc_html_e('Contenu des statistiques utilisateur.', 'chassesautresor'); ?></p>
+    <p><?php echo esc_html(sprintf(__('Chasses gagnées : %d', 'chassesautresor'), $wins)); ?></p>
 </section>

--- a/wp-content/themes/chassesautresor/tests/fixtures/templates/myaccount/content-statistiques.php
+++ b/wp-content/themes/chassesautresor/tests/fixtures/templates/myaccount/content-statistiques.php
@@ -1,1 +1,1 @@
-<?php echo '<section><h1>Statistiques</h1></section>'; ?>
+<?php echo '<section><h1>Statistiques</h1><p>Chasses gagnées : 0</p></section>'; ?>


### PR DESCRIPTION
## Résumé
Ajout d'une table dédiée aux gagnants de chasse et intégration de fonctions pour enregistrer et afficher ces succès.

## Changements notables
- Création de la table `chasse_winners` et des utilitaires d'enregistrement/compte.
- Mise à jour de la gestion de fin de chasse pour consigner les gagnants.
- Affichage du nombre de chasses gagnées dans les statistiques du compte.

## Testing
- `source ./setup-env.sh` *(aucune sortie)*
- `composer install` *(erreur : Command "/workspace/chassesautresor-local/bin/composer.phar" is not defined.)*
- `vendor/bin/phpunit -c tests/phpunit.xml` *(erreur : vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b877c70d4833289834ec446b96921