### PR TITLE
Vérification de fin de chasse lors de l'engagement

### DIFF
--- a/tests/EnigmeEngagementActionTest.php
+++ b/tests/EnigmeEngagementActionTest.php
@@ -1,0 +1,44 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+$last_action = null;
+function do_action($tag, ...$args): void
+{
+    global $last_action;
+    $last_action = ['tag' => $tag, 'args' => $args];
+}
+
+function enigme_mettre_a_jour_statut_utilisateur(int $enigme_id, int $user_id, string $statut, bool $forcer = false): bool
+{
+    return true;
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/engagements.php';
+
+class EnigmeEngagementActionTest extends TestCase
+{
+    public function test_marquer_enigme_comme_engagee_triggers_action(): void
+    {
+        global $wpdb, $last_action;
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+            public function get_var($query)
+            {
+                return 0;
+            }
+            public function insert($table, $data, $format)
+            {
+                return 1;
+            }
+        };
+
+        $this->assertTrue(marquer_enigme_comme_engagee(5, 10));
+        $this->assertNotNull($last_action);
+        $this->assertSame('enigme_engagee', $last_action['tag']);
+        $this->assertSame([5, 10], $last_action['args']);
+    }
+}

--- a/tests/EnigmeEngagementActionTest.php
+++ b/tests/EnigmeEngagementActionTest.php
@@ -34,6 +34,17 @@ class EnigmeEngagementActionTest extends TestCase
             {
                 return 1;
             }
+            public function prepare($query, ...$args)
+            {
+                $params = $args[0] ?? [];
+                if (is_array($params) && count($args) === 1) {
+                    $args = $params;
+                }
+                if (!$args) {
+                    return $query;
+                }
+                return vsprintf($query, $args);
+            }
         };
 
         $this->assertTrue(marquer_enigme_comme_engagee(5, 10));

--- a/tests/FinDeChasseAutomatiqueTest.php
+++ b/tests/FinDeChasseAutomatiqueTest.php
@@ -1,0 +1,100 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+$test_fields = [];
+$updated_fields = [];
+$winner_log = [];
+$enigmes_associees = [];
+
+function get_field($field, $id) {
+    global $test_fields;
+    return $test_fields[$field . '_' . $id] ?? null;
+}
+
+function update_field($field, $value, $id) {
+    global $updated_fields;
+    $updated_fields[$field . '_' . $id] = $value;
+}
+
+if (!function_exists('enregistrer_gagnant_chasse')) {
+    function enregistrer_gagnant_chasse(int $user_id, int $chasse_id, string $date_win): void
+    {
+        global $winner_log;
+        $winner_log[] = [$user_id, $chasse_id, $date_win];
+    }
+}
+
+function recuperer_id_chasse_associee($enigme_id) {
+    return 777;
+}
+
+function recuperer_enigmes_associees($chasse_id): array {
+    global $enigmes_associees;
+    return $enigmes_associees;
+}
+
+function get_userdata($user_id) {
+    return (object) ['display_name' => 'Alice', 'user_login' => 'alice'];
+}
+
+function current_time($type) {
+    if ($type === 'mysql') {
+        return '2024-01-01 00:00:00';
+    }
+    return '2024-01-01';
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/gamify-functions.php';
+
+class FinDeChasseAutomatiqueTest extends TestCase
+{
+    public function test_enregistrement_gagnant_et_chasse_terminee(): void
+    {
+        global $wpdb, $test_fields, $updated_fields, $winner_log, $enigmes_associees;
+
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+            public bool $replace_called = false;
+            public function get_var($query)
+            {
+                return 1;
+            }
+            public function prepare($query, ...$args)
+            {
+                $params = $args[0] ?? [];
+                if (is_array($params) && count($args) === 1) {
+                    $args = $params;
+                }
+                if (!$args) {
+                    return $query;
+                }
+                return vsprintf($query, $args);
+            }
+            public function replace($table, $data, $format)
+            {
+                $this->replace_called = true;
+                return 1;
+            }
+        };
+
+        $test_fields = [
+            'chasse_mode_fin_777' => 'automatique',
+            'chasse_infos_nb_max_gagants_777' => 1,
+            'chasse_cache_gagnants_777' => '',
+            'enigme_mode_validation_1001' => 'automatique',
+            'enigme_mode_validation_1002' => 'aucune',
+        ];
+        $updated_fields = [];
+        $winner_log = [];
+        $enigmes_associees = [1001, 1002];
+
+        verifier_fin_de_chasse(5, 1002);
+
+        $this->assertTrue($wpdb->replace_called);
+        $this->assertSame('termine', $updated_fields['chasse_cache_statut_777']);
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/enigme/engagements.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/engagements.php
@@ -48,7 +48,13 @@ defined('ABSPATH') || exit;
     {
         $ok1 = enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'en_cours', true);
         $ok2 = enregistrer_engagement_enigme($user_id, $enigme_id);
-        return $ok1 && $ok2;
+
+        if ($ok1 && $ok2) {
+            do_action('enigme_engagee', $user_id, $enigme_id);
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -403,5 +403,9 @@ add_action('enigme_resolue', function($user_id, $enigme_id) {
     verifier_fin_de_chasse($user_id, $enigme_id); // 🎯 Vérifie et termine la chasse si besoin
 }, 10, 2);
 
+add_action('enigme_engagee', function($user_id, $enigme_id) {
+    verifier_fin_de_chasse($user_id, $enigme_id);
+}, 10, 2);
+
 
 

--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -88,11 +88,6 @@ if ($etat_systeme !== 'accessible' || !in_array($statut_utilisateur, $statuts_en
 // Déduction + enregistrement du statut
 marquer_enigme_comme_engagee($current_user_id, $enigme_id);
 
-// Vérifie la fin de chasse si l'énigme ne nécessite pas de validation
-if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
-    verifier_fin_de_chasse($current_user_id, $enigme_id);
-}
-
 // Redirection vers la page de l’énigme
 wp_redirect(get_permalink($enigme_id));
 exit;


### PR DESCRIPTION
## Résumé
- Assure le déclenchement de la vérification de fin de chasse à chaque engagement d’énigme.
- Ajoute un test unitaire pour l’action d’engagement.

## Changements notables
- Déclenche l’action `enigme_engagee` dans `marquer_enigme_comme_engagee`.
- Vérifie la fin de chasse sur les hooks `enigme_engagee` et `enigme_resolue`.
- Simplifie le traitement d’engagement en supprimant l’appel direct à la vérification.
- Ajoute un test unitaire garantissant l’émission de l’action d’engagement.

## Testing
- ⚠️ `php bin/composer.phar install` – Command "bin/composer.phar" is not defined.
- ⚠️ `vendor/bin/phpunit -c tests/phpunit.xml` – vendor/bin/phpunit: No such file or directory.

------
https://chatgpt.com/codex/tasks/task_e_689c0425cc148332b394965a8b986d4a