### PR TITLE
Refactorisation du panneau paramètres des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -253,6 +253,17 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
+.champ-groupe-reponse-automatique {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.champ-groupe-reponse-automatique.cache {
+  display: none;
+}
+
 #champ-bonne-reponse {
   width: auto;
   flex: 1 0 200px;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -624,6 +624,10 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
   width: 180px;
 }
 
+.edition-panel-section .resume-reglages input.champ-nb-tentatives {
+  width: 80px;
+}
+
 .edition-panel-section .resume-technique .champ-select-heure,
 .edition-panel-section .resume-reglages .champ-select-heure {
   width: auto;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -253,6 +253,11 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
+#champ-bonne-reponse {
+  width: auto;
+  flex: 1 0 200px;
+}
+
 .champ-edition input.champ-input::placeholder {
   color: var(--color-editor-placeholder);
 }

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1181,6 +1181,11 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
+#champ-enigme-date.cache,
+#champ-enigme-pre-requis.cache {
+  display: none;
+}
+
 .fin-chasse-actions {
   margin-left: auto;
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1160,10 +1160,24 @@ body.panneau-ouvert::before {
   display: flex;
   flex-direction: row;
   gap: 1rem;
+  align-items: center;
 }
 
 .champ-mode-options label {
   display: flex;
+  align-items: center;
+}
+
+#champ-enigme-date {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#champ-enigme-pre-requis {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
   align-items: center;
 }
 

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -789,6 +789,14 @@ li.ligne-email .champ-organisateur .champ-affichage {
   margin-bottom: 0.9rem;
 }
 
+.edition-panel-section .resume-reglages .resume-infos > .champ-enigme {
+  margin-bottom: 0.9rem;
+}
+
+.edition-panel-section .resume-reglages .resume-infos > .champ-enigme:last-child {
+  margin-bottom: 0;
+}
+
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
 @media (max-width: 768px) {

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -306,7 +306,10 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
   ligne.classList.toggle('champ-vide', !estRempli);
   const estObligatoire =
     ligne.closest('.resume-bloc')?.classList.contains('resume-obligatoire') &&
-    !(type === 'chasse' && champ === 'chasse_infos_recompense_valeur');
+    !(
+      (type === 'chasse' && champ === 'chasse_infos_recompense_valeur') ||
+      (type === 'enigme' && ['enigme_visuel_legende', 'enigme_visuel_texte'].includes(champ))
+    );
   ligne.classList.toggle('champ-attention', estObligatoire && !estRempli);
 
   // Nettoyer anciennes icônes

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -72,12 +72,16 @@ function initEnigmeEdit() {
   // 🧠 Explication – Mode de validation de l’énigme
   // ==============================
   const explicationValidation = {
-    manuelle:
-      "Le joueur devra rédiger une réponse libre. Vous recevrez sa proposition par email, " +
-      "et pourrez la valider ou la refuser à partir de ce message.",
-    automatique:
-      "Le joueur devra saisir une réponse exacte. Celle-ci sera automatiquement vérifiée " +
-      "selon les critères définis (réponse attendue, casse, variantes)."
+    manuelle: wp.i18n.__(
+      "Validation manuelle : Le joueur rédige une réponse libre. Vous validez ou invalidez manuellement " +
+        "sa tentative depuis votre espace personnel. Un email et un message d'alerte vous avertit de chaque nouvelle soumission.",
+      "chassesautresor-com"
+    ),
+    automatique: wp.i18n.__(
+      "Validation automatique : Le joueur devra saisir une réponse exacte. Celle-ci sera automatiquement vérifiée " +
+        "selon les critères définis (réponse attendue, casse, variantes).",
+      "chassesautresor-com"
+    ),
   };
 
   document.querySelectorAll('.validation-aide').forEach((btn) => {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -94,6 +94,17 @@ function initEnigmeEdit() {
     });
   });
 
+  const explicationTentatives = wp.i18n.__(
+    "Nombre maximum de tentatives quotidiennes d'un joueur\nMode payant : tentatives illimitées.\nMode gratuit : maximum 24 tentatives par jour.",
+    "chassesautresor-com"
+  );
+
+  document.querySelectorAll('.tentatives-aide').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      alert(explicationTentatives);
+    });
+  });
+
 
   // ==============================
   // 🧰 Déclencheurs de résumé
@@ -443,32 +454,21 @@ function initChampNbTentatives() {
 
   let timerDebounce;
 
-  // ✅ Crée un message d'aide dynamique
-  let aide = bloc.querySelector('.champ-aide-tentatives');
-  if (!aide) {
-    aide = document.createElement('p');
-    aide.className = 'champ-aide champ-aide-tentatives';
-    aide.style.margin = '5px 0 0 10px';
-    aide.style.fontSize = '0.9em';
-    aide.style.color = '#ccc';
-    bloc.appendChild(aide);
-  }
-
-  // 🔄 Fonction centralisée
   function mettreAJourAideTentatives() {
     const coutInput = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] .champ-input');
     if (!coutInput) return;
 
     const cout = parseInt(coutInput.value.trim(), 10);
     const estGratuit = isNaN(cout) || cout === 0;
-    const valeur = parseInt(input.value.trim(), 10); // ✅ ligne manquante
+    const valeur = parseInt(input.value.trim(), 10);
 
-    aide.textContent = estGratuit
-      ? "Mode gratuit : maximum 24 tentatives par jour."
-      : "Mode payant : tentatives illimitées.";
-
-    if (estGratuit && valeur > 24) {
-      input.value = '24';
+    if (estGratuit) {
+      input.max = 24;
+      if (valeur > 24) {
+        input.value = '24';
+      }
+    } else {
+      input.removeAttribute('max');
     }
   }
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -69,27 +69,26 @@ function initEnigmeEdit() {
 
 
   // ==============================
-  // 🧠 Explication dynamique – Mode de validation de l’énigme
+  // 🧠 Explication – Mode de validation de l’énigme
   // ==============================
   const explicationValidation = {
-    'aucune': "Aucun formulaire de réponse ne sera affiché pour cette énigme.",
-    'manuelle': "Le joueur devra rédiger une réponse libre. Vous recevrez sa proposition par email, et pourrez la valider ou la refuser à partir de ce message.",
-    'automatique': "Le joueur devra saisir une réponse exacte. Celle-ci sera automatiquement vérifiée selon les critères définis (réponse attendue, casse, variantes)."
+    manuelle:
+      "Le joueur devra rédiger une réponse libre. Vous recevrez sa proposition par email, " +
+      "et pourrez la valider ou la refuser à partir de ce message.",
+    automatique:
+      "Le joueur devra saisir une réponse exacte. Celle-ci sera automatiquement vérifiée " +
+      "selon les critères définis (réponse attendue, casse, variantes)."
   };
 
-  const zoneExplication = document.querySelector('.champ-explication-validation');
-  if (zoneExplication) {
-    document.querySelectorAll('input[name="acf[enigme_mode_validation]"]').forEach((radio) => {
-      radio.addEventListener('change', () => {
-        const val = radio.value;
-        DEBUG && console.log(val)
-        zoneExplication.textContent = explicationValidation[val] || '';
-      });
-      if (radio.checked) {
-        zoneExplication.textContent = explicationValidation[radio.value] || '';
+  document.querySelectorAll('.validation-aide').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const mode = btn.dataset.mode;
+      const message = explicationValidation[mode];
+      if (message) {
+        alert(message);
       }
     });
-  }
+  });
 
 
   // ==============================

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -263,11 +263,36 @@ function initEnigmeEdit() {
       .then(res => {
         if (res.success) {
           DEBUG && console.log('🔄 Statut système de l’énigme recalculé');
+          mettreAJourCTAValidationChasse(postId);
         } else {
           console.warn('⚠️ Échec recalcul statut énigme :', res.data);
         }
       });
   }
+
+  function mettreAJourCTAValidationChasse(postId) {
+    const conteneur = document.getElementById('cta-validation-chasse');
+    if (!conteneur) return;
+
+    fetch(ajaxurl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        action: 'actualiser_cta_validation_chasse',
+        enigme_id: postId
+      })
+    })
+      .then(r => r.json())
+      .then(res => {
+        if (res.success) {
+          conteneur.innerHTML = res.data?.html || '';
+        } else {
+          console.warn('⚠️ CTA validation non mis à jour :', res.data);
+        }
+      })
+      .catch(err => console.error('❌ Erreur réseau CTA validation', err));
+  }
+  window.mettreAJourCTAValidationChasse = mettreAJourCTAValidationChasse;
 
 
   (() => {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -63,8 +63,8 @@ function initEnigmeEdit() {
   // ==============================
   initChampConditionnel('acf[enigme_mode_validation]', {
     'aucune': [],
-    'manuelle': ['.champ-groupe-tentatives'],
-    'automatique': ['.champ-groupe-reponse-automatique', '.champ-groupe-tentatives']
+    'manuelle': ['.champ-cout-points', '.champ-nb-tentatives'],
+    'automatique': ['.champ-groupe-reponse-automatique', '.champ-cout-points', '.champ-nb-tentatives']
   });
 
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -199,14 +199,16 @@ function initEnigmeEdit() {
         if (champ && postId) {
           clearTimeout(timerSauvegarde);
           timerSauvegarde = setTimeout(() => {
-            modifierChampSimple(champ, input.value.trim(), postId, cptChamp);
+            modifierChampSimple(champ, input.value.trim(), postId, cptChamp)
+              .then(() => {
+                const enigmeId = panneauEdition?.dataset.postId;
+                if (enigmeId) {
+                  forcerRecalculStatutEnigme(enigmeId);
+                }
+              });
           }, 400);
         }
       });
-      const enigmeId = panneauEdition?.dataset.postId;
-      if (enigmeId) {
-        forcerRecalculStatutEnigme(enigmeId);
-      }
     }
   }
 
@@ -217,6 +219,14 @@ function initEnigmeEdit() {
   initChampNbTentatives();
   initChampRadioAjax('acf[enigme_mode_validation]');
   const enigmeId = panneauEdition?.dataset.postId;
+
+  if (enigmeId) {
+    document.querySelectorAll('input[name="acf[enigme_mode_validation]"]').forEach(radio => {
+      radio.addEventListener('change', () => {
+        forcerRecalculStatutEnigme(enigmeId);
+      });
+    });
+  }
 
   initChampPreRequis();
   initChampSolution();

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -97,6 +97,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     ?>
 
     <?php
+    echo '<div id="cta-validation-chasse">';
     if ($est_orga_associe && $has_incomplete_enigme) {
         echo '<div class="cta-chasse">';
         echo '<p>⚠️ Certaines énigmes doivent être complétées :</p>';
@@ -117,6 +118,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         echo render_form_validation_chasse($chasse_id);
         echo '</div>';
     }
+    echo '</div>';
 
     afficher_message_validation_chasse($chasse_id);
     ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -199,14 +199,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <div class="resume-infos">
 
             <!-- Mode de validation -->
-            <div class="champ-enigme champ-mode-validation<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_mode_validation" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-              <fieldset>
-                <legend>Validation de l’énigme</legend>
-                <label><input type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Aucune validation</label>
-                <label><input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Validation manuelle</label>
-                <label><input type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Validation automatique</label>
-                <div class="champ-explication champ-explication-validation" aria-live="polite"></div>
-              </fieldset>
+            <div class="champ-enigme champ-mode-validation champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_mode_validation" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" data-no-icon="1">
+              <label for="enigme_mode_validation"><?= esc_html__('Validation', 'chassesautresor-com'); ?></label>
+              <div class="champ-mode-options">
+                <label>
+                  <input id="enigme_mode_validation" type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Aucune', 'chassesautresor-com'); ?>
+                </label>
+                <label>
+                  <input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
+                </label>
+                <label>
+                  <input type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
+                </label>
+              </div>
+              <div class="champ-explication champ-explication-validation" aria-live="polite"></div>
             </div>
 
             <!-- Accès à l'énigme -->

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -233,7 +233,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </div>
             </div>
 
-            <div class="champ-enigme champ-bonne-reponse champ-groupe-reponse-automatique <?= empty($reponse) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_bonne" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap;">
+            <div class="champ-enigme champ-bonne-reponse champ-groupe-reponse-automatique cache<?= empty($reponse) ? ' champ-vide' : ' champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_bonne" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
                 <label for="champ-bonne-reponse">Réponse</label>
                 <input type="text" id="champ-bonne-reponse" name="champ-bonne-reponse" class="champ-input champ-texte-edit" value="<?= esc_attr($reponse); ?>" placeholder="Ex : soleil" <?= $peut_editer ? '' : 'disabled'; ?> />
                 <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display: inline-flex; align-items: center;">
@@ -243,7 +243,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <div class="champ-feedback"></div>
               </div>
 
-            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display: flex; align-items: center; gap: 10px;">
+            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique cache<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <label>Variantes :</label>
               <?php
               $bouton = $has_variantes

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -233,17 +233,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </div>
             </div>
 
-            <div class="champ-enigme champ-bonne-reponse champ-groupe-reponse-automatique <?= empty($reponse) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_bonne" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-              <label for="champ-bonne-reponse">Réponse</label>
-              <div class="champ-reponse-ligne">
+            <div class="champ-enigme champ-bonne-reponse champ-groupe-reponse-automatique <?= empty($reponse) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_bonne" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap;">
+                <label for="champ-bonne-reponse">Réponse</label>
                 <input type="text" id="champ-bonne-reponse" name="champ-bonne-reponse" class="champ-input champ-texte-edit" value="<?= esc_attr($reponse); ?>" placeholder="Ex : soleil" <?= $peut_editer ? '' : 'disabled'; ?> />
-                <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                  <label><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Respecter la casse</label>
+                <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display: inline-flex; align-items: center;">
+                  <label style="display: flex; align-items: center; gap: 4px;"><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Respecter la casse</label>
                   <div class="champ-feedback"></div>
                 </div>
+                <div class="champ-feedback"></div>
               </div>
-              <div class="champ-feedback"></div>
-            </div>
 
             <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <?php

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -243,16 +243,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <div class="champ-feedback"></div>
               </div>
 
-            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display: flex; align-items: center; gap: 10px;">
+              <label>Variantes :</label>
               <?php
-              $label = $has_variantes
+              $bouton = $has_variantes
                 ? ($nb_variantes === 1 ? '1 variante ✏️' : $nb_variantes . ' variantes ✏️')
                 : '➕ Créer des variantes';
+              $texte = $has_variantes
+                ? ($nb_variantes === 1 ? '1 variante' : $nb_variantes . ' variantes')
+                : '';
               ?>
               <?php if ($peut_editer) : ?>
                 <button type="button" class="champ-modifier ouvrir-panneau-variantes" aria-label="<?= $has_variantes ? 'Éditer les variantes' : 'Créer des variantes'; ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                  <?= esc_html($label); ?>
+                  <?= esc_html($bouton); ?>
                 </button>
+              <?php elseif ($has_variantes) : ?>
+                <span><?= esc_html($texte); ?></span>
               <?php endif; ?>
             </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -262,6 +262,43 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               <?php endif; ?>
             </div>
 
+            <!-- Tentatives -->
+            <fieldset class="groupe-champ champ-groupe-tentatives">
+              <legend>Gestion des tentatives</legend>
+
+              <div class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_cout_points" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 1rem;">
+                  <label for="enigme-tentative-cout">Coût tentative
+                    <button type="button" class="bouton-aide-points open-points-modal" aria-label="En savoir plus sur les points">
+                      <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+                    </button>
+                  </label>
+                  <input type="number" id="enigme-tentative-cout" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
+                  <span class="txt-small">points</span>
+                  <div class="champ-option-gratuit" style="margin-left: 5px;">
+                    <?php
+                    $cout_normalise = trim((string)$cout);
+                    $is_gratuit = $cout_normalise === '' || $cout_normalise === '0' || (int)$cout === 0;
+                    ?>
+                    <input type="checkbox" id="cout-gratuit-enigme" name="cout-gratuit-enigme" <?= $is_gratuit ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?> >
+                    <label for="cout-gratuit-enigme">Gratuit</label>
+                  </div>
+                </div>
+                <div class="champ-feedback"></div>
+              </div>
+
+              <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px;">
+                  <label for="enigme-nb-tentatives">Nb tentatives</label>
+                  <input type="number" id="enigme-nb-tentatives" class="champ-input" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
+                  <span class="txt-small">max par jour</span>
+                </div>
+                <p class="message-tentatives txt-small" style="margin-top: 4px;"></p>
+                <p class="champ-aide champ-aide-tentatives" style="margin:5px 0 0 10px; font-size:0.9em; color:#ccc;"></p>
+                <div class="champ-feedback"></div>
+              </div>
+            </fieldset>
+
             <!-- Accès à l'énigme -->
             <fieldset class="groupe-champ champ-groupe-acces">
               <legend>Condition d’accès</legend>
@@ -350,47 +387,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </div>
             </fieldset>
 
-            <!-- Tentatives -->
-            <fieldset class="groupe-champ champ-groupe-tentatives">
-              <legend>Gestion des tentatives</legend>
-
-              <div class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_cout_points" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                <div class="champ-edition" style="display: flex; align-items: flex-end; gap: 1rem; flex-wrap: wrap;">
-
-                  <!-- Coût en points -->
-                  <div style="display: flex; flex-direction: column;">
-                    <label>Coût <span class="txt-small">(points)</span>
-                      <button type="button" class="bouton-aide-points open-points-modal" aria-label="En savoir plus sur les points">
-                        <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                      </button>
-                    </label>
-                    <input type="number" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
-                  </div>
-
-                  <!-- Option gratuit -->
-                  <div class="champ-option-gratuit" style="margin-left: 5px;">
-                    <?php
-                    $cout_normalise = trim((string)$cout); // on nettoie
-                    $is_gratuit = $cout_normalise === '' || $cout_normalise === '0' || (int)$cout === 0;
-                    ?>
-                    <input type="checkbox" id="cout-gratuit-enigme" name="cout-gratuit-enigme"
-                      <?= $is_gratuit ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?> >
-
-                    <label for="cout-gratuit-enigme">Gratuit</label>
-                  </div>
-
-                  <!-- Nombre max de tentatives -->
-                  <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                    <label for="enigme-nb-tentatives">Nombre max de tentatives/jour</label>
-                    <input type="number" id="enigme-nb-tentatives" class="champ-input" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
-                    <p class="message-tentatives txt-small" style="margin-top: 4px;"></p>
-                    <div class="champ-feedback"></div>
-                  </div>
-
-                </div>
-                <div class="champ-feedback"></div>
-              </div>
-            </fieldset>
 
         </div>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -286,12 +286,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
             <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px;">
-                <label for="enigme-nb-tentatives">Nb tentatives</label>
+                <label for="enigme-nb-tentatives">Nb tentatives
+                  <button
+                    type="button"
+                    class="mode-fin-aide tentatives-aide"
+                    aria-label="<?= esc_attr__('Explication du nombre de tentatives', 'chassesautresor-com'); ?>"
+                  >
+                    <i class="fa-regular fa-circle-question"></i>
+                  </button>
+                </label>
                 <input type="number" id="enigme-nb-tentatives" class="champ-input champ-nb-tentatives" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
                 <span class="txt-small">max par jour</span>
               </div>
-              <p class="message-tentatives txt-small" style="margin-top: 4px;"></p>
-              <p class="champ-aide champ-aide-tentatives" style="margin:5px 0 0 10px; font-size:0.9em; color:#ccc;"></p>
               <div class="champ-feedback"></div>
             </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -99,111 +99,104 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       <div class="edition-panel-header">
         <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
       </div>
-      <div class="edition-panel-body edition-panel-section">
-      <div class="resume-blocs-grid deux-col-wrapper">
-        <div class="resume-bloc resume-obligatoire deux-col-bloc">
+      <div class="edition-panel-body">
+        <div class="edition-panel-section edition-panel-section-ligne">
+          <div class="section-content">
+            <div class="resume-blocs-grid">
+              <div class="resume-bloc resume-obligatoire">
 
-          <h3>Champs obligatoires</h3>
-          <ul class="resume-infos">
-            <li class="champ-enigme champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
-              data-champ="post_title"
-              data-cpt="enigme"
-              data-post-id="<?= esc_attr($enigme_id); ?>">
+                <h3>Informations</h3>
+                <ul class="resume-infos">
+                  <li class="champ-enigme champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
+                    data-champ="post_title"
+                    data-cpt="enigme"
+                    data-post-id="<?= esc_attr($enigme_id); ?>">
 
-              <div class="champ-affichage">
-                <label for="champ-titre-enigme">Titre de l’énigme</label>
-                <?php if ($peut_editer_titre) : ?>
-                  <button type="button"
-                    class="champ-modifier"
-                    aria-label="Modifier le titre">
-                    ✏️
-                  </button>
-                <?php endif; ?>
+                    <div class="champ-affichage">
+                      <label for="champ-titre-enigme">Titre de l’énigme</label>
+                      <?php if ($peut_editer_titre) : ?>
+                        <button type="button"
+                          class="champ-modifier"
+                          aria-label="Modifier le titre">
+                          ✏️
+                        </button>
+                      <?php endif; ?>
+                    </div>
+
+                    <div class="champ-edition" style="display: none;">
+                      <input type="text"
+                        class="champ-input"
+                        maxlength="80"
+                        value="<?= esc_attr($titre); ?>"
+                        id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?> >
+                      <button type="button" class="champ-enregistrer">✓</button>
+                      <button type="button" class="champ-annuler">✖</button>
+                    </div>
+
+                    <div class="champ-feedback"></div>
+                  </li>
+
+                  <?php
+                  $has_images_utiles = enigme_a_une_image($enigme_id);
+                  ?>
+                  <li class="champ-enigme champ-img <?= $has_images_utiles ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                    data-champ="enigme_visuel_image"
+                    data-cpt="enigme"
+                    data-post-id="<?= esc_attr($enigme_id); ?>"
+                    data-rempli="<?= $has_images_utiles ? '1' : '0'; ?>">
+
+                    Image(s)
+
+                    <?php if ($peut_editer) : ?>
+                      <button
+                        type="button"
+                        class="champ-modifier ouvrir-panneau-images"
+                        data-champ="enigme_visuel_image"
+                        data-cpt="enigme"
+                        data-post-id="<?= esc_attr($enigme_id); ?>">
+                        ✏️
+                        </button>
+                    <?php endif; ?>
+
+                  </li>
+
+                  <li class="champ-enigme champ-wysiwyg<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_texte" data-cpt="enigme"
+                    data-post-id="<?= esc_attr($enigme_id); ?>">
+                    Un texte principal
+                    <?php if ($peut_editer) : ?>
+                      <button type="button" class="champ-modifier ouvrir-panneau-description" data-champ="enigme_visuel_texte"
+                        data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                        ✏️
+                      </button>
+                    <?php endif; ?>
+                  </li>
+
+                  <li class="champ-enigme champ-texte<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_legende" data-cpt="enigme"
+                    data-post-id="<?= esc_attr($enigme_id); ?>">
+
+                    <div class="champ-affichage">
+                      Un sous-titre
+                      <?php if ($peut_editer) : ?>
+                        <button type="button" class="champ-modifier" aria-label="Modifier la légende">✏️</button>
+                      <?php endif; ?>
+                    </div>
+
+                    <div class="champ-edition" style="display: none;">
+                      <input type="text" class="champ-input" maxlength="100" value="<?= esc_attr($legende); ?>"
+                        placeholder="Ajouter une légende (max 100 caractères)" <?= $peut_editer ? '' : 'disabled'; ?>>
+                      <button type="button" class="champ-enregistrer">✓</button>
+                      <button type="button" class="champ-annuler">✖</button>
+                    </div>
+
+                    <div class="champ-feedback"></div>
+                  </li>
+                </ul>
               </div>
 
-              <div class="champ-edition" style="display: none;">
-                <input type="text"
-                  class="champ-input"
-                  maxlength="80"
-                  value="<?= esc_attr($titre); ?>"
-                  id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?> >
-                <button type="button" class="champ-enregistrer">✓</button>
-                <button type="button" class="champ-annuler">✖</button>
-              </div>
-
-              <div class="champ-feedback"></div>
-            </li>
-
-            <?php
-            $has_images_utiles = enigme_a_une_image($enigme_id);
-            ?>
-            <li class="champ-enigme champ-img <?= $has_images_utiles ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
-              data-champ="enigme_visuel_image"
-              data-cpt="enigme"
-              data-post-id="<?= esc_attr($enigme_id); ?>"
-              data-rempli="<?= $has_images_utiles ? '1' : '0'; ?>">
-
-              Image(s)
-
-              <?php if ($peut_editer) : ?>
-                <button
-                  type="button"
-                  class="champ-modifier ouvrir-panneau-images"
-                  data-champ="enigme_visuel_image"
-                  data-cpt="enigme"
-                  data-post-id="<?= esc_attr($enigme_id); ?>">
-                  ✏️
-                  </button>
-              <?php endif; ?>
-
-            </li>
-
-
-          </ul>
-        </div>
-
-        <!-- SECTION 2 : Champs recommandés -->
-        <div class="resume-bloc resume-facultatif deux-col-bloc">
-          <h3>Facultatif mais recommandé</h3>
-          <ul class="resume-infos">
-
-            <li class="champ-enigme champ-wysiwyg<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_texte" data-cpt="enigme"
-              data-post-id="<?= esc_attr($enigme_id); ?>">
-              Un texte principal
-              <?php if ($peut_editer) : ?>
-                <button type="button" class="champ-modifier ouvrir-panneau-description" data-champ="enigme_visuel_texte"
-                  data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                  ✏️
-                </button>
-              <?php endif; ?>
-            </li>
-
-            <li class="champ-enigme champ-texte<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_legende" data-cpt="enigme"
-              data-post-id="<?= esc_attr($enigme_id); ?>">
-
-              <div class="champ-affichage">
-                Un sous-titre
-                <?php if ($peut_editer) : ?>
-                  <button type="button" class="champ-modifier" aria-label="Modifier la légende">✏️</button>
-                <?php endif; ?>
-              </div>
-
-              <div class="champ-edition" style="display: none;">
-                <input type="text" class="champ-input" maxlength="100" value="<?= esc_attr($legende); ?>"
-                  placeholder="Ajouter une légende (max 100 caractères)" <?= $peut_editer ? '' : 'disabled'; ?>>
-                <button type="button" class="champ-enregistrer">✓</button>
-                <button type="button" class="champ-annuler">✖</button>
-              </div>
-
-              <div class="champ-feedback"></div>
-            </li>
-          </ul>
-        </div>
-
-        <!-- Caractéristiques -->
-        <div class="resume-bloc resume-technique">
-          <h3>Caractéristiques</h3>
-          <div class="resume-infos">
+              <!-- Règlages -->
+              <div class="resume-bloc resume-reglages">
+                <h3>Réglages</h3>
+                <div class="resume-infos">
 
             <!-- Mode de validation -->
             <div class="champ-enigme champ-mode-validation<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_mode_validation" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
@@ -398,10 +391,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             </fieldset>
 
         </div>
+        </div>
       </div>
-    </div>
+      </div>
+      </div>
 
-    </div> <!-- .edition-panel-body -->
+      </div> <!-- .edition-panel-body -->
     <?php if (utilisateur_peut_supprimer_enigme($enigme_id)) : ?>
       <div class="edition-panel-footer">
         <button type="button" id="bouton-supprimer-enigme" class="bouton-texte secondaire">❌ Suppression énigme</button>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -289,10 +289,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <label for="enigme-nb-tentatives">Nb tentatives
                   <button
                     type="button"
-                    class="mode-fin-aide tentatives-aide"
+                    class="bouton-aide-points tentatives-aide"
                     aria-label="<?= esc_attr__('Explication du nombre de tentatives', 'chassesautresor-com'); ?>"
                   >
-                    <i class="fa-regular fa-circle-question"></i>
+                    <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
                   </button>
                 </label>
                 <input type="number" id="enigme-nb-tentatives" class="champ-input champ-nb-tentatives" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
@@ -302,92 +302,49 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             </div>
 
             <!-- Accès à l'énigme -->
-            <fieldset class="groupe-champ champ-groupe-acces">
-              <legend>Condition d’accès</legend>
-
-              <?php
-              $condition = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
-              $enigmes_possibles = enigme_get_liste_prerequis_possibles($enigme_id);
-
-              $options = [
-                'immediat'        => 'Immédiat',
-                'date_programmee' => 'Date programmée',
-              ];
-
-              if (!empty($enigmes_possibles)) {
-                $options['pre_requis'] = 'Pré-requis';
-              }
-              ?>
-              <div class="champ-enigme champ-access<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                data-champ="enigme_acces_condition"
-                data-cpt="enigme"
-                data-post-id="<?= esc_attr($enigme_id); ?>">
-
-                <?php foreach ($options as $val => $label) : ?>
-                  <label style="display:inline-block; margin-right: 15px;">
-                    <input type="radio" name="acf[enigme_acces_condition]"
-                      value="<?= esc_attr($val); ?>"
-                      <?= $condition === $val ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                    <?= esc_html($label); ?>
+            <?php
+            $condition = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
+            $enigmes_possibles = enigme_get_liste_prerequis_possibles($enigme_id);
+            $prerequis_actuels = get_field('enigme_acces_pre_requis', $enigme_id, false) ?? [];
+            if (!is_array($prerequis_actuels)) {
+              $prerequis_actuels = [$prerequis_actuels];
+            }
+            ?>
+            <div class="champ-enigme champ-acces champ-mode-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_condition" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" data-no-icon="1">
+              <label for="enigme_acces_condition"><?= esc_html__('Accès', 'chassesautresor-com'); ?></label>
+              <div class="champ-mode-options">
+                <label>
+                  <input id="enigme_acces_condition" type="radio" name="acf[enigme_acces_condition]" value="immediat" <?= $condition === 'immediat' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Libre', 'chassesautresor-com'); ?>
+                </label>
+                <label>
+                  <input type="radio" name="acf[enigme_acces_condition]" value="date_programmee" <?= $condition === 'date_programmee' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Date programmée', 'chassesautresor-com'); ?>
+                </label>
+                <div id="champ-enigme-date" class="champ-enigme champ-date<?= $condition === 'date_programmee' ? '' : ' cache'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_date" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display:flex; align-items:center; gap:4px;">
+                  <input type="datetime-local" id="enigme-date-deblocage" name="enigme-date-deblocage" value="<?= esc_attr($date_deblocage); ?>" class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
+                  <div class="champ-feedback champ-date-feedback" style="display:none;"></div>
+                </div>
+                <?php if (!empty($enigmes_possibles)) : ?>
+                  <label>
+                    <input type="radio" name="acf[enigme_acces_condition]" value="pre_requis" <?= $condition === 'pre_requis' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                    <?= esc_html__('Pré-requis', 'chassesautresor-com'); ?>
                   </label>
-                <?php endforeach; ?>
-
-                <div class="champ-feedback"></div>
+                  <div id="champ-enigme-pre-requis" class="champ-enigme champ-pre-requis<?= $condition === 'pre_requis' ? '' : ' cache'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_pre_requis" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-vide="<?= empty($enigmes_possibles) ? '1' : '0'; ?>" style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center;">
+                    <?php if (empty($enigmes_possibles)) : ?>
+                      <em><?= esc_html__('Aucune autre énigme disponible comme prérequis.', 'chassesautresor-com'); ?></em>
+                    <?php else : ?>
+                      <?php foreach ($enigmes_possibles as $id => $titre) :
+                        $checked = in_array($id, $prerequis_actuels); ?>
+                        <label><input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> <?= esc_html($titre); ?></label>
+                      <?php endforeach; ?>
+                    <?php endif; ?>
+                    <div class="champ-feedback"></div>
+                  </div>
+                <?php endif; ?>
               </div>
-
-              <div class="champ-enigme champ-date cache<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_date" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" id="champ-enigme-date">
-                <label for="enigme-date-deblocage">Date et heure de déblocage</label>
-                <input type="datetime-local"
-                  id="enigme-date-deblocage"
-                  name="enigme-date-deblocage"
-                  value="<?= esc_attr($date_deblocage); ?>"
-                  class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
-                <div class="champ-feedback champ-date-feedback" style="display:none;"></div>
-              </div>
-
-              <div class="champ-enigme champ-pre-requis cache<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                data-champ="enigme_acces_pre_requis"
-                data-cpt="enigme"
-                data-post-id="<?= esc_attr($enigme_id); ?>"
-                id="champ-enigme-pre-requis"
-                data-vide="<?= empty($enigmes_possibles) ? '1' : '0'; ?>">
-
-                <label>Pré-requis</label>
-
-                <?php
-                $enigmes_possibles = enigme_get_liste_prerequis_possibles($enigme_id);
-                $prerequis_actuels = get_field('enigme_acces_pre_requis', $enigme_id, false) ?? [];
-                if (!is_array($prerequis_actuels)) {
-                  $prerequis_actuels = [$prerequis_actuels];
-                }
-
-                ?>
-                <ul class="liste-pre-requis">
-
-                  <small class="champ-aide">
-                    Seules les autres énigmes de cette chasse, avec une validation manuelle ou automatique, peuvent être sélectionnées.
-                  </small>
-
-                  <?php if (empty($enigmes_possibles)) : ?>
-                    <li><em>Aucune autre énigme disponible comme prérequis.</em></li>
-                  <?php else : ?>
-                    <?php foreach ($enigmes_possibles as $id => $titre) :
-                      $checked = in_array($id, $prerequis_actuels);
-                    ?>
-                      <li>
-                        <label>
-                          <input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                          <?= esc_html($titre); ?>
-                        </label>
-                      </li>
-                    <?php endforeach; ?>
-                  <?php endif; ?>
-                </ul>
-
-
-                <div class="champ-feedback"></div>
-              </div>
-            </fieldset>
+              <div class="champ-feedback"></div>
+            </div>
 
 
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -233,6 +233,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </div>
             </div>
 
+            <div class="champ-enigme champ-bonne-reponse champ-groupe-reponse-automatique <?= empty($reponse) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_bonne" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+              <label for="champ-bonne-reponse">Réponse</label>
+              <div class="champ-reponse-ligne">
+                <input type="text" id="champ-bonne-reponse" name="champ-bonne-reponse" class="champ-input champ-texte-edit" value="<?= esc_attr($reponse); ?>" placeholder="Ex : soleil" <?= $peut_editer ? '' : 'disabled'; ?> />
+                <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                  <label><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Respecter la casse</label>
+                  <div class="champ-feedback"></div>
+                </div>
+              </div>
+              <div class="champ-feedback"></div>
+            </div>
+
+            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+              <?php
+              $label = $has_variantes
+                ? ($nb_variantes === 1 ? '1 variante ✏️' : $nb_variantes . ' variantes ✏️')
+                : '➕ Créer des variantes';
+              ?>
+              <?php if ($peut_editer) : ?>
+                <button type="button" class="champ-modifier ouvrir-panneau-variantes" aria-label="<?= $has_variantes ? 'Éditer les variantes' : 'Créer des variantes'; ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                  <?= esc_html($label); ?>
+                </button>
+              <?php endif; ?>
+            </div>
+
             <!-- Accès à l'énigme -->
             <fieldset class="groupe-champ champ-groupe-acces">
               <legend>Condition d’accès</legend>
@@ -361,57 +386,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 </div>
                 <div class="champ-feedback"></div>
               </div>
-            </fieldset>
-
-            <!-- Réponse automatique -->
-            <fieldset class="groupe-champ champ-groupe-reponse-automatique">
-              <legend>Réponse attendue</legend>
-              <div class="champ-enigme champ-bonne-reponse <?= empty($reponse) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                data-champ="enigme_reponse_bonne"
-                data-cpt="enigme"
-                data-post-id="<?= esc_attr($enigme_id); ?>">
-
-                <label for="champ-bonne-reponse">Bonne réponse attendue</label>
-
-                <input type="text"
-                  id="champ-bonne-reponse"
-                  name="champ-bonne-reponse"
-                  class="champ-input champ-texte-edit"
-                  value="<?= esc_attr($reponse); ?>"
-                  placeholder="Ex : soleil" <?= $peut_editer ? '' : 'disabled'; ?> />
-
-                <div class="champ-feedback"></div>
-              </div>
-
-              <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                data-champ="enigme_reponse_casse"
-                data-cpt="enigme"
-                data-post-id="<?= esc_attr($enigme_id); ?>">
-                <label><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Respecter la casse</label>
-                <div class="champ-feedback"></div>
-              </div>
-
-              <div class="champ-enigme champ-variantes-resume<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                data-champ="enigme_reponse_variantes"
-                data-cpt="enigme"
-                data-post-id="<?= esc_attr($enigme_id); ?>">
-
-                <?php
-                $label = $has_variantes
-                  ? ($nb_variantes === 1 ? '1 variante ✏️' : $nb_variantes . ' variantes ✏️')
-                  : '➕ Créer des variantes';
-                ?>
-                <?php if ($peut_editer) : ?>
-                  <button type="button"
-                    class="champ-modifier ouvrir-panneau-variantes"
-                    aria-label="<?= $has_variantes ? 'Éditer les variantes' : 'Créer des variantes'; ?>"
-                    data-cpt="enigme"
-                    data-post-id="<?= esc_attr($enigme_id); ?>">
-                    <?= esc_html($label); ?>
-                  </button>
-                <?php endif; ?>
-              </div>
-
             </fieldset>
 
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -209,13 +209,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <label>
                   <input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                   <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
+                  <button
+                    type="button"
+                    class="mode-fin-aide validation-aide"
+                    data-mode="manuelle"
+                    aria-label="<?= esc_attr__('Explication du mode manuel', 'chassesautresor-com'); ?>"
+                  >
+                    <i class="fa-regular fa-circle-question"></i>
+                  </button>
                 </label>
                 <label>
                   <input type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                   <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
+                  <button
+                    type="button"
+                    class="mode-fin-aide validation-aide"
+                    data-mode="automatique"
+                    aria-label="<?= esc_attr__('Explication du mode automatique', 'chassesautresor-com'); ?>"
+                  >
+                    <i class="fa-regular fa-circle-question"></i>
+                  </button>
                 </label>
               </div>
-              <div class="champ-explication champ-explication-validation" aria-live="polite"></div>
             </div>
 
             <!-- Accès à l'énigme -->

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -203,8 +203,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               <label for="enigme_mode_validation"><?= esc_html__('Validation', 'chassesautresor-com'); ?></label>
               <div class="champ-mode-options">
                 <label>
-                  <input id="enigme_mode_validation" type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                  <?= esc_html__('Aucune', 'chassesautresor-com'); ?>
+                  <input id="enigme_mode_validation" type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
+                  <button
+                    type="button"
+                    class="mode-fin-aide validation-aide"
+                    data-mode="automatique"
+                    aria-label="<?= esc_attr__('Explication du mode automatique', 'chassesautresor-com'); ?>"
+                  >
+                    <i class="fa-regular fa-circle-question"></i>
+                  </button>
                 </label>
                 <label>
                   <input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
@@ -219,16 +227,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                   </button>
                 </label>
                 <label>
-                  <input type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                  <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
-                  <button
-                    type="button"
-                    class="mode-fin-aide validation-aide"
-                    data-mode="automatique"
-                    aria-label="<?= esc_attr__('Explication du mode automatique', 'chassesautresor-com'); ?>"
-                  >
-                    <i class="fa-regular fa-circle-question"></i>
-                  </button>
+                  <input type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                  <?= esc_html__('Aucune', 'chassesautresor-com'); ?>
                 </label>
               </div>
             </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -321,7 +321,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                   <input type="radio" name="acf[enigme_acces_condition]" value="date_programmee" <?= $condition === 'date_programmee' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                   <?= esc_html__('Date programmée', 'chassesautresor-com'); ?>
                 </label>
-                <div id="champ-enigme-date" class="champ-enigme champ-date<?= $condition === 'date_programmee' ? '' : ' cache'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_date" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="display:flex; align-items:center; gap:4px;">
+                <div id="champ-enigme-date" class="champ-enigme champ-date<?= $condition === 'date_programmee' ? '' : ' cache'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_date" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
                   <input type="datetime-local" id="enigme-date-deblocage" name="enigme-date-deblocage" value="<?= esc_attr($date_deblocage); ?>" class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
                   <div class="champ-feedback champ-date-feedback" style="display:none;"></div>
                 </div>
@@ -330,7 +330,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     <input type="radio" name="acf[enigme_acces_condition]" value="pre_requis" <?= $condition === 'pre_requis' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                     <?= esc_html__('Pré-requis', 'chassesautresor-com'); ?>
                   </label>
-                  <div id="champ-enigme-pre-requis" class="champ-enigme champ-pre-requis<?= $condition === 'pre_requis' ? '' : ' cache'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_pre_requis" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-vide="<?= empty($enigmes_possibles) ? '1' : '0'; ?>" style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center;">
+                  <div id="champ-enigme-pre-requis" class="champ-enigme champ-pre-requis<?= $condition === 'pre_requis' ? '' : ' cache'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_pre_requis" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-vide="<?= empty($enigmes_possibles) ? '1' : '0'; ?>">
                     <?php if (empty($enigmes_possibles)) : ?>
                       <em><?= esc_html__('Aucune autre énigme disponible comme prérequis.', 'chassesautresor-com'); ?></em>
                     <?php else : ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -263,41 +263,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             </div>
 
             <!-- Tentatives -->
-            <fieldset class="groupe-champ champ-groupe-tentatives">
-              <legend>Gestion des tentatives</legend>
-
-              <div class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_cout_points" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 1rem;">
-                  <label for="enigme-tentative-cout">Coût tentative
-                    <button type="button" class="bouton-aide-points open-points-modal" aria-label="En savoir plus sur les points">
-                      <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                    </button>
-                  </label>
-                  <input type="number" id="enigme-tentative-cout" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
-                  <span class="txt-small">points</span>
-                  <div class="champ-option-gratuit" style="margin-left: 5px;">
-                    <?php
-                    $cout_normalise = trim((string)$cout);
-                    $is_gratuit = $cout_normalise === '' || $cout_normalise === '0' || (int)$cout === 0;
-                    ?>
-                    <input type="checkbox" id="cout-gratuit-enigme" name="cout-gratuit-enigme" <?= $is_gratuit ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?> >
-                    <label for="cout-gratuit-enigme">Gratuit</label>
-                  </div>
+            <div class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_cout_points" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+              <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 1rem;">
+                <label for="enigme-tentative-cout">Coût tentative
+                  <button type="button" class="bouton-aide-points open-points-modal" aria-label="En savoir plus sur les points">
+                    <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+                  </button>
+                </label>
+                <input type="number" id="enigme-tentative-cout" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
+                <span class="txt-small">points</span>
+                <div class="champ-option-gratuit" style="margin-left: 5px;">
+                  <?php
+                  $cout_normalise = trim((string)$cout);
+                  $is_gratuit = $cout_normalise === '' || $cout_normalise === '0' || (int)$cout === 0;
+                  ?>
+                  <input type="checkbox" id="cout-gratuit-enigme" name="cout-gratuit-enigme" <?= $is_gratuit ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?> >
+                  <label for="cout-gratuit-enigme">Gratuit</label>
                 </div>
-                <div class="champ-feedback"></div>
               </div>
+              <div class="champ-feedback"></div>
+            </div>
 
-              <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px;">
-                  <label for="enigme-nb-tentatives">Nb tentatives</label>
-                  <input type="number" id="enigme-nb-tentatives" class="champ-input" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
-                  <span class="txt-small">max par jour</span>
-                </div>
-                <p class="message-tentatives txt-small" style="margin-top: 4px;"></p>
-                <p class="champ-aide champ-aide-tentatives" style="margin:5px 0 0 10px; font-size:0.9em; color:#ccc;"></p>
-                <div class="champ-feedback"></div>
+            <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+              <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px;">
+                <label for="enigme-nb-tentatives">Nb tentatives</label>
+                <input type="number" id="enigme-nb-tentatives" class="champ-input champ-nb-tentatives" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
+                <span class="txt-small">max par jour</span>
               </div>
-            </fieldset>
+              <p class="message-tentatives txt-small" style="margin-top: 4px;"></p>
+              <p class="champ-aide champ-aide-tentatives" style="margin:5px 0 0 10px; font-size:0.9em; color:#ccc;"></p>
+              <div class="champ-feedback"></div>
+            </div>
 
             <!-- Accès à l'énigme -->
             <fieldset class="groupe-champ champ-groupe-acces">


### PR DESCRIPTION
## Résumé
- Harmonisation de l'onglet *Paramètres* des énigmes avec celui des chasses
- Fusion des champs obligatoires et recommandés dans une section « Informations »
- Conteneur « Caractéristiques » renommé en « Réglages »

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c196491f08332b2fcbe4d3f65d4f9