### PR TITLE
Ouvre automatiquement l'édition pour les énigmes incomplètes

### DIFF
--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -46,7 +46,7 @@ verifier_ou_mettre_a_jour_cache_complet($enigme_id);
 $enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);
 if (
   $edition_active &&
-  current_user_can(ROLE_ORGANISATEUR_CREATION) &&
+  utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&
   !$enigme_complete &&
   !isset($_GET['edition'])
 ) {


### PR DESCRIPTION
## Résumé
- autorise l'ouverture auto du panneau d'édition pour un organisateur associé quand l'énigme est incomplète

## Changements notables
- vérifie l'association à la chasse avant d'ouvrir l'édition

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c1ae6a5e083329d1bd845c5d98d23