### PR TITLE
Gestion fin de chasse lors d'un engagement

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/engagements.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/engagements.php
@@ -48,6 +48,17 @@ defined('ABSPATH') || exit;
     {
         $ok1 = enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'en_cours', true);
         $ok2 = enregistrer_engagement_enigme($user_id, $enigme_id);
+
+        if ($ok1 && $ok2) {
+            /**
+             * Fires after a user engages an enigme.
+             *
+             * @param int $user_id   User ID.
+             * @param int $enigme_id Enigme ID.
+             */
+            do_action('enigme_engagee', $user_id, $enigme_id);
+        }
+
         return $ok1 && $ok2;
     }
 

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -403,5 +403,11 @@ add_action('enigme_resolue', function($user_id, $enigme_id) {
     verifier_fin_de_chasse($user_id, $enigme_id); // 🎯 Vérifie et termine la chasse si besoin
 }, 10, 2);
 
+add_action('enigme_engagee', function($user_id, $enigme_id) {
+    if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
+        verifier_fin_de_chasse($user_id, $enigme_id);
+    }
+}, 10, 2);
+
 
 

--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -88,11 +88,6 @@ if ($etat_systeme !== 'accessible' || !in_array($statut_utilisateur, $statuts_en
 // Déduction + enregistrement du statut
 marquer_enigme_comme_engagee($current_user_id, $enigme_id);
 
-// Vérifie la fin de chasse si l'énigme ne nécessite pas de validation
-if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
-    verifier_fin_de_chasse($current_user_id, $enigme_id);
-}
-
 // Redirection vers la page de l’énigme
 wp_redirect(get_permalink($enigme_id));
 exit;


### PR DESCRIPTION
## Résumé
- vérifie automatiquement la fin de chasse après engagement d'une énigme sans validation
- centralise la vérification via un hook `enigme_engagee`
- simplifie le traitement d'engagement front-end

## Changements notables
- déclenchement d'un hook après engagement d'une énigme
- appel conditionnel à `verifier_fin_de_chasse` lors de l'engagement
- nettoyage du template d'engagement

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c1ef6765c8332938b2b9d1aeb38f0