### PR TITLE
Handle case-insensitive validation mode for CTA

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -64,6 +64,25 @@ function enigme_get_liste_prerequis_possibles(int $enigme_id): array
 }
 
 
+/**
+ * Normalise la valeur du mode de validation d'une énigme.
+ */
+function enigme_normaliser_mode_validation($mode): string
+{
+    if (is_array($mode)) {
+        $mode = $mode['value'] ?? '';
+    }
+
+    $mode = strtolower(trim((string) $mode));
+
+    if ($mode === '' || strpos($mode, 'aucune') === 0 || $mode === 'none') {
+        return 'aucune';
+    }
+
+    return $mode;
+}
+
+
 
 /**
  * Retourne les données d’affichage du bouton d’engagement d’une énigme.
@@ -105,7 +124,9 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
     $etat_systeme = enigme_get_etat_systeme($enigme_id);
     $statut_utilisateur = enigme_get_statut_utilisateur($enigme_id, $user_id);
     $points = intval(get_field('enigme_tentative_cout_points', $enigme_id));
-    $mode_validation = strtolower(trim((string) get_field('enigme_mode_validation', $enigme_id)));
+    $mode_validation = enigme_normaliser_mode_validation(
+        get_field('enigme_mode_validation', $enigme_id)
+    );
     $chasse_terminee = $chasse_id && get_field('chasse_cache_statut', $chasse_id) === 'termine';
     if ($chasse_terminee && $etat_systeme !== 'bloquee_pre_requis') {
         $etat_systeme = 'accessible';


### PR DESCRIPTION
## Summary
- normaliser la récupération du mode de validation d'une énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c34e1d48c83329fd84feac1108845