### PR TITLE
Vérifie la complétude des chasses automatiques

### DIFF
--- a/tests/ChasseCompletenessTest.php
+++ b/tests/ChasseCompletenessTest.php
@@ -1,0 +1,55 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/statut-functions.php';
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($id)
+    {
+        return 'chasse';
+    }
+}
+
+if (!function_exists('titre_est_valide')) {
+    function titre_est_valide($id)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
+    function recuperer_ids_enigmes_pour_chasse($chasse_id)
+    {
+        global $enigme_ids;
+        return $enigme_ids ?? [];
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($field_name, $post_id)
+    {
+        global $post_fields;
+        return $post_fields[$post_id][$field_name] ?? null;
+    }
+}
+
+class ChasseCompletenessTest extends TestCase
+{
+    public function test_chasse_est_complet_returns_false_when_automatic_without_validable_enigme(): void
+    {
+        global $post_fields, $enigme_ids;
+        $chasse_id   = 100;
+        $enigme_ids  = [201, 202];
+        $post_fields = [
+            $chasse_id => [
+                'chasse_principale_description' => 'desc',
+                'chasse_principale_image'       => ['ID' => 123],
+                'chasse_mode_fin'               => 'automatique',
+            ],
+            201 => ['enigme_mode_validation' => 'aucune'],
+            202 => ['enigme_mode_validation' => 'aucune'],
+        ];
+
+        $this->assertFalse(chasse_est_complet($chasse_id));
+    }
+}

--- a/tests/ChasseCompletenessTest.php
+++ b/tests/ChasseCompletenessTest.php
@@ -50,6 +50,7 @@ class ChasseCompletenessTest extends TestCase
             202 => ['enigme_mode_validation' => 'aucune'],
         ];
 
+        $this->assertFalse(chasse_has_validatable_enigme($chasse_id));
         $this->assertFalse(chasse_est_complet($chasse_id));
     }
 }

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -618,6 +618,20 @@ function organisateur_mettre_a_jour_complet(int $organisateur_id): bool
     return $complet;
 }
 
+function chasse_has_validatable_enigme(int $chasse_id): bool
+{
+    $enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse_id);
+
+    foreach ($enigme_ids as $eid) {
+        $mode = get_field('enigme_mode_validation', $eid);
+        if ($mode !== 'aucune') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function chasse_est_complet(int $chasse_id): bool
 {
     if (get_post_type($chasse_id) !== 'chasse') {
@@ -626,19 +640,8 @@ function chasse_est_complet(int $chasse_id): bool
 
     $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
 
-    if ($mode_fin === 'automatique') {
-        $enigme_ids    = recuperer_ids_enigmes_pour_chasse($chasse_id);
-        $enigme_valide = false;
-        foreach ($enigme_ids as $eid) {
-            $mode = get_field('enigme_mode_validation', $eid);
-            if ($mode !== 'aucune') {
-                $enigme_valide = true;
-                break;
-            }
-        }
-        if (!$enigme_valide) {
-            return false;
-        }
+    if ($mode_fin === 'automatique' && !chasse_has_validatable_enigme($chasse_id)) {
+        return false;
     }
 
     $titre_ok = titre_est_valide($chasse_id);

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -624,13 +624,30 @@ function chasse_est_complet(int $chasse_id): bool
         return false;
     }
 
+    $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
+
+    if ($mode_fin === 'automatique') {
+        $enigme_ids    = recuperer_ids_enigmes_pour_chasse($chasse_id);
+        $enigme_valide = false;
+        foreach ($enigme_ids as $eid) {
+            $mode = get_field('enigme_mode_validation', $eid);
+            if ($mode !== 'aucune') {
+                $enigme_valide = true;
+                break;
+            }
+        }
+        if (!$enigme_valide) {
+            return false;
+        }
+    }
+
     $titre_ok = titre_est_valide($chasse_id);
 
     $desc_field = get_field('chasse_principale_description', $chasse_id);
-    $desc = trim((string) $desc_field);
-    $desc_ok = $desc !== '';
+    $desc       = trim((string) $desc_field);
+    $desc_ok    = $desc !== '';
 
-    $image = get_field('chasse_principale_image', $chasse_id);
+    $image    = get_field('chasse_principale_image', $chasse_id);
     $image_id = is_array($image) ? ($image['ID'] ?? 0) : (int) $image;
     $image_ok = !empty($image_id) && $image_id !== 3902;
 

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -74,6 +74,9 @@ foreach ($enigmes_associees as $eid) {
 }
 $has_incomplete_enigme = !empty($enigmes_incompletes);
 
+$mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
+$needs_validatable_message = $mode_fin === 'automatique' && !chasse_has_validatable_enigme($chasse_id);
+
 $statut = $infos_chasse['statut'];
 $statut_validation = $infos_chasse['statut_validation'];
 $nb_joueurs = $infos_chasse['nb_joueurs'];
@@ -97,16 +100,25 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     ?>
 
     <?php
-    if ($est_orga_associe && $has_incomplete_enigme) {
+    if ($est_orga_associe && ($has_incomplete_enigme || $needs_validatable_message)) {
         echo '<div class="cta-chasse">';
-        echo '<p>⚠️ Certaines énigmes doivent être complétées :</p>';
-        echo '<ul class="liste-enigmes-incompletes">';
-        foreach ($enigmes_incompletes as $eid) {
-            $titre = get_the_title($eid);
-            $lien  = add_query_arg('edition', 'open', get_permalink($eid));
-            echo '<li><a href="' . esc_url($lien) . '">' . esc_html($titre) . '</a></li>';
+        if ($has_incomplete_enigme) {
+            echo '<p>⚠️ Certaines énigmes doivent être complétées :</p>';
+            echo '<ul class="liste-enigmes-incompletes">';
+            foreach ($enigmes_incompletes as $eid) {
+                $titre = get_the_title($eid);
+                $lien  = add_query_arg('edition', 'open', get_permalink($eid));
+                echo '<li><a href="' . esc_url($lien) . '">' . esc_html($titre) . '</a></li>';
+            }
+            echo '</ul>';
         }
-        echo '</ul>';
+        if ($needs_validatable_message) {
+            $msg = __(
+                'Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique.',
+                'chassesautresor-com'
+            );
+            echo '<p>⚠️ ' . esc_html($msg) . '</p>';
+        }
         echo '</div>';
     } elseif ($can_validate) {
         echo '<div class="cta-chasse">';


### PR DESCRIPTION
## Résumé
- impose qu'une chasse en mode automatique possède au moins une énigme validable
- retourne `false` si aucune énigme n'est validable
- ajoute un test pour ce scénario

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c3d5ab6448332b1be96a9d3f0b780