### PR TITLE
Fix layout by removing stray div closing tags

### DIFF
--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -130,7 +130,6 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         echo render_form_validation_chasse($chasse_id);
         echo '</div>';
     }
-    echo '</div>';
 
     afficher_message_validation_chasse($chasse_id);
     ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -108,9 +108,6 @@ get_template_part('template-parts/organisateur/organisateur-partial-presentation
   'organisateur_id' => $organisateur_id
 ]);
 ?>
-</div>
-
-
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     document.body.dataset.organisateurId = "<?= esc_attr($organisateur_id); ?>";


### PR DESCRIPTION
## Summary
- supprime la balise `</div>` superflue dans le header d’organisateur
- retire la fermeture de conteneur erronée dans le template `single-chasse`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c47a6694c8332aee6813bc4d5e3d8