### PR TITLE
Limite le bandeau de validation aux énigmes associées

### DIFF
--- a/tests/LayoutFunctionsTest.php
+++ b/tests/LayoutFunctionsTest.php
@@ -43,6 +43,61 @@ if (!function_exists('is_singular')) {
     }
 }
 
+if (!function_exists('get_the_ID')) {
+    function get_the_ID() {
+        global $current_post_id;
+        return $current_post_id;
+    }
+}
+
+if (!function_exists('recuperer_id_chasse_associee')) {
+    function recuperer_id_chasse_associee($post_id = null) {
+        return 123;
+    }
+}
+
+if (!function_exists('get_the_title')) {
+    function get_the_title($post_id) {
+        return 'Chasse Exemple';
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($post_id) {
+        return 'https://example.com/chasse';
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url) {
+        return $url;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+
+if (!function_exists('get_organisateur_from_user')) {
+    function get_organisateur_from_user($user_id) {
+        return 42;
+    }
+}
+
+if (!function_exists('get_chasses_de_organisateur')) {
+    function get_chasses_de_organisateur($organisateur_id) {
+        return [(object) ['ID' => 123]];
+    }
+}
+
+if (!function_exists('peut_valider_chasse')) {
+    function peut_valider_chasse($chasse_id, $user_id) {
+        return true;
+    }
+}
+
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/layout-functions.php';
 
 class LayoutFunctionsTest extends TestCase
@@ -76,5 +131,19 @@ class LayoutFunctionsTest extends TestCase
         $current_post_type = 'chasse';
 
         $this->assertSame('', $this->getBannerOutput());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_banner_displayed_on_enigme_page(): void
+    {
+        global $current_post_type, $current_post_id;
+        $current_post_type = 'enigme';
+        $current_post_id = 456;
+
+        $output = $this->getBannerOutput();
+        $this->assertStringContainsString('bandeau-info-chasse', $output);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -401,9 +401,12 @@ function afficher_bandeau_validation_chasse_global() {
         return;
     }
 
-    $enigme_chasse = get_field('chasse_associee', get_the_ID(), false);
-    $enigme_chasse = is_array($enigme_chasse) ? reset($enigme_chasse) : $enigme_chasse;
-    if ((int) $enigme_chasse !== (int) $chasse_id) {
+    if (!function_exists('recuperer_id_chasse_associee')) {
+        return;
+    }
+
+    $enigme_chasse_id = recuperer_id_chasse_associee(get_the_ID());
+    if ((int) $enigme_chasse_id !== (int) $chasse_id) {
         return;
     }
 


### PR DESCRIPTION
## Résumé
- restreint l'affichage du bandeau de validation aux pages d'énigmes rattachées à la chasse en édition

## Changements notables
- vérifie que la page est une énigme liée à la chasse en cours avant d'afficher le bandeau

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c4f2483d4833285b5e9a769168734