### PR TITLE
Renommer l'onglet Soumission et retirer l'onglet Indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -67,6 +67,36 @@ function initEnigmeEdit() {
     'automatique': ['.champ-groupe-reponse-automatique', '.champ-cout-points', '.champ-nb-tentatives']
   });
 
+  // ==============================
+  // 📨 Onglet Tentatives – affichage selon mode de validation
+  // ==============================
+  const radiosValidation = document.querySelectorAll('input[name="acf[enigme_mode_validation]"]');
+  const tabTentatives = panneauEdition?.querySelector('.edition-tab[data-target="enigme-tab-soumission"]');
+  const contenuTentatives = document.getElementById('enigme-tab-soumission');
+
+  function toggleTentativesTab(mode) {
+    const afficher = mode !== 'aucune';
+    if (tabTentatives) {
+      tabTentatives.style.display = afficher ? '' : 'none';
+      if (!afficher && tabTentatives.classList.contains('active')) {
+        panneauEdition?.querySelector('.edition-tab[data-target="enigme-tab-param"]')?.click();
+      }
+    }
+    if (!afficher && contenuTentatives) {
+      contenuTentatives.style.display = 'none';
+      contenuTentatives.classList.remove('active');
+    }
+  }
+
+  const radioChecked = document.querySelector('input[name="acf[enigme_mode_validation]"]:checked');
+  toggleTentativesTab(radioChecked ? radioChecked.value : 'aucune');
+
+  radiosValidation.forEach((radio) => {
+    radio.addEventListener('change', (e) => {
+      toggleTentativesTab(e.target.value);
+    });
+  });
+
 
   // ==============================
   // 🧠 Explication – Mode de validation de l’énigme

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -54,7 +54,7 @@ if (
   exit;
 }
 
-// ✅ Ouvre automatiquement l'onglet Soumission s'il y a des tentatives en attente
+// ✅ Ouvre automatiquement l'onglet Tentatives s'il y a des tentatives en attente
 if (
   $edition_active &&
   utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -89,8 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
     <div class="edition-tabs">
       <button class="edition-tab active" data-target="enigme-tab-param">Paramètres</button>
       <button class="edition-tab" data-target="enigme-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="enigme-tab-soumission">Soumission</button>
-      <button class="edition-tab" data-target="enigme-tab-indices">Indices</button>
+      <button class="edition-tab" data-target="enigme-tab-soumission"<?= $mode_validation === 'aucune' ? ' style="display:none;"' : ''; ?>>Tentatives</button>
       <button class="edition-tab" data-target="enigme-tab-solution">Solution</button>
     </div>
 
@@ -417,7 +416,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 <div id="enigme-tab-soumission" class="edition-tab-content" style="display:none;">
   <i class="fa-solid fa-paper-plane tab-watermark" aria-hidden="true"></i>
   <div class="edition-panel-header">
-    <h2><i class="fa-solid fa-paper-plane"></i> Soumission <span class="total-tentatives">(<?= intval(compter_tentatives_enigme($enigme_id)); ?>)</span></h2>
+    <h2><i class="fa-solid fa-paper-plane"></i> Tentatives <span class="total-tentatives">(<?= intval(compter_tentatives_enigme($enigme_id)); ?>)</span></h2>
   </div>
 <?php
   if (!function_exists('recuperer_tentatives_enigme')) {
@@ -440,14 +439,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       'pages'      => $pages_tentatives,
     ]); ?>
   </div>
-</div>
-
-<div id="enigme-tab-indices" class="edition-tab-content" style="display:none;">
-  <i class="fa-regular fa-lightbulb tab-watermark" aria-hidden="true"></i>
-  <div class="edition-panel-header">
-    <h2><i class="fa-regular fa-lightbulb"></i> Indices</h2>
-  </div>
-  <p class="edition-placeholder">La section « Indices » sera bientôt disponible.</p>
 </div>
 
 <div id="enigme-tab-solution" class="edition-tab-content" style="display:none;">


### PR DESCRIPTION
## Résumé
- renomme l'onglet "Soumission" en "Tentatives" et conditionne son affichage au mode de validation
- supprime définitivement l'onglet "Indices" de l'édition d'énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c7f16647083329cb7255bf7444980