### PR TITLE
Ajuste le message de fin de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -75,9 +75,11 @@ foreach ($enigmes_associees as $eid) {
 $has_incomplete_enigme = !empty($enigmes_incompletes);
 
 $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
-$needs_validatable_message = $mode_fin === 'automatique' && !chasse_has_validatable_enigme($chasse_id);
-
 $statut = $infos_chasse['statut'];
+$needs_validatable_message = $statut === 'revision'
+    && $mode_fin === 'automatique'
+    && !chasse_has_validatable_enigme($chasse_id);
+
 $statut_validation = $infos_chasse['statut_validation'];
 $nb_joueurs = $infos_chasse['nb_joueurs'];
 


### PR DESCRIPTION
## Résumé
- restreint l'affichage du message invitant à ajouter une énigme validable aux chasses encore en révision

## Changements notables
- le message de fin automatique ne s'affiche plus pour les chasses terminées

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c821eeef08332b54ea39a70dfd30b