### PR TITLE
Ameliore le tableau de statistiques des enigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1138,23 +1138,73 @@ body.panneau-ouvert::before {
   font-weight: bold;
 }
 
+/* ====== Cartes de statistiques ====== */
+
+.stats-cards {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin: 1rem 0;
+}
+
+.stats-cards .dashboard-card {
+  background-color: var(--color-editor-background);
+  border: 1px solid var(--color-editor-border);
+  border-radius: 8px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: center;
+  color: var(--color-editor-text);
+}
+
+.stats-cards .dashboard-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-editor-heading);
+}
+
+.stats-cards .dashboard-card-header i {
+  font-size: 1rem;
+}
+
+.stats-cards .stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
 /* ====== Tableaux de statistiques ====== */
 
 .stats-table {
   width: 100%;
   border-collapse: collapse;
-  border: 0 transparent;
 }
 
-.stats-table tr,
-.stats-table td {
-  border: 0 solid transparent;
-}
-
+.stats-table th,
 .stats-table td {
   text-align: left;
   padding: 8px;
-  font-weight: bold;
+}
+
+.stats-table th {
+  font-weight: 600;
+  color: var(--color-editor-heading);
+  border-bottom: 1px solid var(--color-editor-border);
+}
+
+.stats-table td {
+  color: var(--color-editor-text);
+}
+
+.stats-table tbody tr:nth-child(even) {
+  background-color: var(--color-editor-field-hover);
 }
 
 /* ====== Mode de fin ====== */

--- a/wp-content/themes/chassesautresor/assets/js/enigme-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-stats.js
@@ -1,0 +1,88 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('enigme-stats');
+  const select = document.getElementById('enigme-periode');
+  if (!container || !select) {
+    return;
+  }
+
+  const cards = {
+    joueurs: container.querySelector('[data-stat="joueurs"]'),
+    tentatives: container.querySelector('[data-stat="tentatives"]'),
+    points: container.querySelector('[data-stat="points"]'),
+    solutions: container.querySelector('[data-stat="solutions"]'),
+  };
+
+  function updateValues(stats) {
+    if (cards.joueurs) {
+      cards.joueurs.querySelector('.stat-value').textContent = stats.joueurs ?? 0;
+    }
+    if (cards.tentatives) {
+      cards.tentatives.querySelector('.stat-value').textContent = stats.tentatives ?? 0;
+    }
+    if (cards.points) {
+      cards.points.querySelector('.stat-value').textContent = stats.points ?? 0;
+    }
+    if (cards.solutions) {
+      cards.solutions.querySelector('.stat-value').textContent = stats.solutions ?? 0;
+    }
+  }
+
+  function fetchStats() {
+    const periode = select.value;
+
+    const data = new FormData();
+    data.append('action', 'enigme_recuperer_stats');
+    data.append('enigme_id', EnigmeStats.enigmeId);
+    data.append('periode', periode);
+
+    fetch(EnigmeStats.ajaxUrl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: data,
+    })
+      .then((response) => response.json())
+      .then((res) => {
+        if (!res.success) return;
+        updateValues(res.data);
+      })
+      .catch(() => {});
+  }
+
+  function updateVisibility() {
+    const mode = document.querySelector('input[name="acf[enigme_mode_validation]"]:checked')?.value || 'aucune';
+    const coutInput = document.getElementById('enigme-tentative-cout');
+    let cout = parseInt(coutInput?.value || '0', 10);
+    if (isNaN(cout)) cout = 0;
+    if (document.getElementById('cout-gratuit-enigme')?.checked) {
+      cout = 0;
+    }
+    if (cards.tentatives) {
+      cards.tentatives.classList.toggle('cache', mode === 'aucune');
+    }
+    if (cards.solutions) {
+      cards.solutions.classList.toggle('cache', mode === 'aucune');
+    }
+    if (cards.points) {
+      cards.points.classList.toggle('cache', mode === 'aucune' || cout <= 0);
+    }
+  }
+
+  updateVisibility();
+
+  const originalHook = window.onChampSimpleMisAJour;
+  window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
+    if (typeof originalHook === 'function') {
+      originalHook(champ, postId, valeur, cpt);
+    }
+    if (
+      cpt === 'enigme' &&
+      (champ === 'enigme_mode_validation' || champ.includes('enigme_tentative_cout_points'))
+    ) {
+      updateVisibility();
+      fetchStats();
+    }
+  };
+
+  select.addEventListener('change', fetchStats);
+});
+

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -32,7 +32,16 @@ function enqueue_script_enigme_edit()
   if (!utilisateur_peut_modifier_post($enigme_id)) return;
 
   // 📦 Modules JS partagés + scripts spécifiques
-  enqueue_core_edit_scripts(['organisateur-edit', 'enigme-edit']);
+  enqueue_core_edit_scripts(['organisateur-edit', 'enigme-edit', 'enigme-stats']);
+
+  wp_localize_script(
+    'enigme-stats',
+    'EnigmeStats',
+    [
+      'ajaxUrl'   => admin_url('admin-ajax.php'),
+      'enigmeId'  => $enigme_id,
+    ]
+  );
 
   // Localisation JS si besoin (ex : valeurs par défaut)
   wp_localize_script('champ-init', 'CHP_ENIGME_DEFAUT', [

--- a/wp-content/themes/chassesautresor/inc/enigme/stats.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/stats.php
@@ -84,3 +84,96 @@ function enigme_compter_bonnes_solutions(int $enigme_id, string $mode = 'automat
     $sql = $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE $where", ...$params);
     return (int) $wpdb->get_var($sql);
 }
+
+function enigme_lister_resolveurs(int $enigme_id): array
+{
+    global $wpdb;
+    $table   = $wpdb->prefix . 'enigme_tentatives';
+    $results = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT user_id, MIN(date_tentative) AS resolution_date
+             FROM $table
+             WHERE enigme_id = %d AND resultat = 'bon'
+             GROUP BY user_id
+             ORDER BY resolution_date ASC",
+            $enigme_id
+        ),
+        ARRAY_A
+    );
+
+    $solvers = [];
+    foreach ($results as $row) {
+        $attempts = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table
+                 WHERE enigme_id = %d AND user_id = %d AND date_tentative <= %s",
+                $enigme_id,
+                $row['user_id'],
+                $row['resolution_date']
+            )
+        );
+
+        $solvers[] = [
+            'user_id'   => (int) $row['user_id'],
+            'username'  => get_the_author_meta('user_login', (int) $row['user_id']),
+            'date'      => $row['resolution_date'],
+            'tentatives' => (int) $attempts,
+        ];
+    }
+
+    return $solvers;
+}
+
+/**
+ * AJAX handler retrieving statistics for a riddle.
+ *
+ * Expects the following POST parameters:
+ * - `enigme_id` (int, required) The ID of the riddle to inspect.
+ * - `periode` (string, optional) One of `jour`, `semaine`, `mois` or `total`.
+ *   Defaults to `total`.
+ *
+ * Sends a JSON success response containing at least:
+ * - `joueurs` (int) Number of engaged players for the selected period.
+ * - `tentatives` (int) Number of attempts. Present only when the validation
+ *   mode is not `aucune`.
+ * - `solutions` (int) Number of correct answers. Present only when the
+ *   validation mode is not `aucune`.
+ * - `points` (int) Total points spent. Present only when the validation mode
+ *   is not `aucune` and the cost per attempt is greater than zero.
+ *
+ * @return void
+ */
+function ajax_enigme_recuperer_stats()
+{
+    $enigme_id = isset($_POST['enigme_id']) ? (int) $_POST['enigme_id'] : 0;
+    if ($enigme_id <= 0) {
+        wp_send_json_error('missing_enigme', 400);
+    }
+
+    if (!utilisateur_peut_voir_panneau($enigme_id)) {
+        wp_send_json_error('forbidden', 403);
+    }
+
+    $periode = isset($_POST['periode']) ? sanitize_text_field($_POST['periode']) : 'total';
+    $periode = in_array($periode, ['jour', 'semaine', 'mois', 'total'], true) ? $periode : 'total';
+
+    $mode = get_field('enigme_mode_validation', $enigme_id) ?? 'automatique';
+    $cout = (int) get_field('enigme_tentative_cout_points', $enigme_id);
+
+    $stats = [
+        'joueurs' => enigme_compter_joueurs_engages($enigme_id, $periode),
+    ];
+
+    if ($mode !== 'aucune') {
+        $stats['tentatives'] = enigme_compter_tentatives($enigme_id, $mode, $periode);
+        $stats['solutions'] = enigme_compter_bonnes_solutions($enigme_id, $mode, $periode);
+
+        if ($cout > 0) {
+            $stats['points'] = enigme_compter_points_depenses($enigme_id, $mode, $periode);
+        }
+    }
+
+    wp_send_json_success($stats);
+}
+add_action('wp_ajax_enigme_recuperer_stats', 'ajax_enigme_recuperer_stats');
+


### PR DESCRIPTION
## Résumé
- Cache ou affiche les cartes de statistiques selon le mode de validation et le coût
- Rafraîchit dynamiquement les cartes lorsque les paramètres de validation changent

## Changements
- Masque la carte des points si l’énigme est sans validation ou gratuite
- Actualise les cartes de statistiques lors de la modification du mode de validation ou du coût
- Précise dans la réponse AJAX que les points ne sont retournés qu’en cas de validation et de coût positif

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c5ed174d0833280437927d9955b61