### PR TITLE
Affichage dynamique des statistiques d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -263,14 +263,25 @@ function initEnigmeEdit() {
   });
   initChampNbTentatives();
   initChampRadioAjax('acf[enigme_mode_validation]');
+  mettreAJourCartesStats();
   const enigmeId = panneauEdition?.dataset.postId;
 
-  if (enigmeId) {
-    document.querySelectorAll('input[name="acf[enigme_mode_validation]"]').forEach(radio => {
-      radio.addEventListener('change', () => {
+  document.querySelectorAll('input[name="acf[enigme_mode_validation]"]').forEach(radio => {
+    radio.addEventListener('change', () => {
+      if (enigmeId) {
         forcerRecalculStatutEnigme(enigmeId);
-      });
+      }
+      mettreAJourCartesStats();
     });
+  });
+
+  const coutInput = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] .champ-input');
+  const coutCheckbox = document.getElementById('cout-gratuit-enigme');
+  if (coutInput) {
+    ['input', 'change'].forEach(evt => coutInput.addEventListener(evt, mettreAJourCartesStats));
+  }
+  if (coutCheckbox) {
+    coutCheckbox.addEventListener('change', mettreAJourCartesStats);
   }
 
   initChampPreRequis();
@@ -1126,6 +1137,28 @@ if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initEnregistrementPreRequis);
 } else {
   initEnregistrementPreRequis();
+}
+
+function mettreAJourCartesStats() {
+  const mode = document.querySelector('input[name="acf[enigme_mode_validation]"]:checked')?.value || 'aucune';
+  const coutInput = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] .champ-input');
+  const cout = coutInput ? parseInt(coutInput.value || '0', 10) : 0;
+  const cardTentatives = document.querySelector('#enigme-stats [data-stat="tentatives"]');
+  const cardPoints = document.querySelector('#enigme-stats [data-stat="points"]');
+  const cardSolutions = document.querySelector('#enigme-stats [data-stat="solutions"]');
+  const nbSolutions = cardSolutions
+    ? parseInt(cardSolutions.querySelector('.stat-value')?.textContent || '0', 10)
+    : 0;
+
+  if (cardTentatives) {
+    cardTentatives.style.display = mode === 'aucune' ? 'none' : '';
+  }
+  if (cardPoints) {
+    cardPoints.style.display = (mode === 'aucune' || cout <= 0) ? 'none' : '';
+  }
+  if (cardSolutions) {
+    cardSolutions.style.display = (mode === 'aucune' || nbSolutions <= 0) ? 'none' : '';
+  }
 }
 
 function appliquerEtatGratuitEnLive() {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -369,7 +369,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       if (!function_exists('enigme_compter_joueurs_engages')) {
           require_once get_stylesheet_directory() . '/inc/enigme/stats.php';
       }
-      $periode = 'total';
+      $periode        = 'total';
+      $nb_joueurs     = enigme_compter_joueurs_engages($enigme_id, $periode);
+      $nb_tentatives  = enigme_compter_tentatives($enigme_id, $mode_validation, $periode);
+      $nb_points      = enigme_compter_points_depenses($enigme_id, $mode_validation, $periode);
+      $nb_solutions   = enigme_compter_bonnes_solutions($enigme_id, $mode_validation, $periode);
       ?>
       <div class="edition-panel-body">
         <div class="stats-header" style="display:flex;align-items:center;">
@@ -390,42 +394,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               <h3>Nombre de joueurs engagés</h3>
             </div>
             <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html(enigme_compter_joueurs_engages($enigme_id, $periode)); ?></p>
+              <p class="stat-value"><?= esc_html($nb_joueurs); ?></p>
             </div>
           </div>
-          <?php if ($mode_validation !== 'aucune') : ?>
-          <div class="dashboard-card" data-stat="tentatives">
+          <div class="dashboard-card" data-stat="tentatives"
+            style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
             <div class="dashboard-card-header">
               <i class="fa-solid fa-arrow-rotate-right"></i>
               <h3>Nombre de tentatives</h3>
             </div>
             <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html(enigme_compter_tentatives($enigme_id, $mode_validation, $periode)); ?></p>
+              <p class="stat-value"><?= esc_html($nb_tentatives); ?></p>
             </div>
           </div>
-          <?php endif; ?>
-          <?php if ((int) $cout > 0) : ?>
-          <div class="dashboard-card" data-stat="points">
+          <div class="dashboard-card" data-stat="points"
+            style="<?= ($mode_validation === 'aucune' || (int) $cout <= 0) ? 'display:none;' : ''; ?>">
             <div class="dashboard-card-header">
               <i class="fa-solid fa-coins"></i>
-              <h3>Nombre de points dépensés</h3>
+              <h3>Nombre de points</h3>
             </div>
             <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html(enigme_compter_points_depenses($enigme_id, $mode_validation, $periode)); ?></p>
+              <p class="stat-value"><?= esc_html($nb_points); ?></p>
             </div>
           </div>
-          <?php endif; ?>
-          <?php if ($mode_validation !== 'aucune') : ?>
-          <div class="dashboard-card" data-stat="solutions">
+          <div class="dashboard-card" data-stat="solutions"
+            style="<?= ($mode_validation === 'aucune' || $nb_solutions <= 0) ? 'display:none;' : ''; ?>">
             <div class="dashboard-card-header">
               <i class="fa-solid fa-check"></i>
               <h3>Nombre de bonnes solutions</h3>
             </div>
             <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html(enigme_compter_bonnes_solutions($enigme_id, $mode_validation, $periode)); ?></p>
+              <p class="stat-value"><?= esc_html($nb_solutions); ?></p>
             </div>
           </div>
-          <?php endif; ?>
         </div>
         <?php if ($mode_validation !== 'aucune') :
             $resolveurs = enigme_lister_resolveurs($enigme_id);


### PR DESCRIPTION
## Résumé
- Ajuste les conditions d'affichage des cartes de statistiques des énigmes
- Met à jour dynamiquement les cartes lorsque le mode de validation ou le coût change

## Détails
- Nombre de points affiché seulement si la validation est active et que le coût est supérieur à zéro
- Masque la carte des bonnes solutions quand aucune n'est trouvée

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c8f5243ec8332ac5cf3c5b8c505e3