### PR TITLE
Ajout du tableau des participants dans les stats d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1207,6 +1207,26 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-field-hover);
 }
 
+.stats-table.compact th,
+.stats-table.compact td {
+  padding: 4px;
+  font-size: 0.85em;
+}
+
+.stats-table th button.sort {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.stats-table th button.sort i {
+  margin-left: 4px;
+}
+
 /* ====== Mode de fin ====== */
 .champ-mode-fin {
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1207,6 +1207,10 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-field-hover);
 }
 
+.stats-table-wrapper {
+  margin-bottom: 1.5rem;
+}
+
 .stats-table.compact th,
 .stats-table.compact td {
   padding: 4px;

--- a/wp-content/themes/chassesautresor/assets/js/enigme-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-stats.js
@@ -46,5 +46,69 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .catch(() => {});
   });
+
+  const participantsWrapper = document.querySelector('#enigme-tab-stats .liste-participants');
+  if (participantsWrapper) {
+    const postId = EnigmeStats.enigmeId;
+
+    function charger(page = 1, orderby = participantsWrapper.dataset.orderby || 'date', order = participantsWrapper.dataset.order || 'asc') {
+      fetch(EnigmeStats.ajaxUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          action: 'enigme_lister_participants',
+          enigme_id: postId,
+          page,
+          orderby,
+          order,
+        }),
+      })
+        .then((r) => r.json())
+        .then((res) => {
+          if (!res.success) return;
+          participantsWrapper.innerHTML = res.data.html;
+          participantsWrapper.dataset.page = res.data.page;
+          participantsWrapper.dataset.pages = res.data.pages;
+          participantsWrapper.dataset.order = order;
+          participantsWrapper.dataset.orderby = orderby;
+        });
+    }
+
+    participantsWrapper.addEventListener('click', (e) => {
+      const btn = e.target.closest('button');
+      if (!btn) return;
+      if (btn.classList.contains('pager-first')) {
+        e.preventDefault();
+        charger(1);
+      }
+      if (btn.classList.contains('pager-prev')) {
+        e.preventDefault();
+        const page = parseInt(participantsWrapper.dataset.page || '1', 10);
+        if (page > 1) charger(page - 1);
+      }
+      if (btn.classList.contains('pager-next')) {
+        e.preventDefault();
+        const page = parseInt(participantsWrapper.dataset.page || '1', 10);
+        const pages = parseInt(participantsWrapper.dataset.pages || '1', 10);
+        if (page < pages) charger(page + 1);
+      }
+      if (btn.classList.contains('pager-last')) {
+        e.preventDefault();
+        const pages = parseInt(participantsWrapper.dataset.pages || '1', 10);
+        charger(pages);
+      }
+      if (btn.classList.contains('sort')) {
+        e.preventDefault();
+        const orderby = btn.dataset.orderby || 'date';
+        let order = participantsWrapper.dataset.order || 'asc';
+        if (participantsWrapper.dataset.orderby !== orderby) {
+          order = 'asc';
+        } else {
+          order = order === 'asc' ? 'desc' : 'asc';
+        }
+        charger(1, orderby, order);
+      }
+    });
+  }
 });
 

--- a/wp-content/themes/chassesautresor/inc/enigme/stats.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/stats.php
@@ -124,6 +124,48 @@ function enigme_lister_resolveurs(int $enigme_id): array
     return $solvers;
 }
 
+function enigme_lister_participants(
+    int $enigme_id,
+    string $mode = 'automatique',
+    int $limit = 25,
+    int $offset = 0,
+    string $orderby = 'date',
+    string $order = 'ASC'
+): array {
+    global $wpdb;
+
+    $order = strtoupper($order) === 'DESC' ? 'DESC' : 'ASC';
+    $order_by_sql = $orderby === 'tentatives' ? 'nb_tentatives' : 'date_engagement';
+
+    $table_eng = $wpdb->prefix . 'engagements';
+    $table_tent = $wpdb->prefix . 'enigme_tentatives';
+    $table_stat = $wpdb->prefix . 'enigme_statuts_utilisateur';
+
+    $sql = $wpdb->prepare(
+        "SELECT e.user_id, u.user_login AS username, e.date_engagement,
+                COALESCE(t.nb_tentatives, 0) AS nb_tentatives,
+                IF(s.statut IN ('resolue','terminee'), 1, 0) AS trouve
+         FROM {$table_eng} e
+         JOIN {$wpdb->users} u ON e.user_id = u.ID
+         LEFT JOIN (
+             SELECT user_id, COUNT(*) AS nb_tentatives
+             FROM {$table_tent}
+             WHERE enigme_id = %d
+             GROUP BY user_id
+         ) t ON t.user_id = e.user_id
+         LEFT JOIN {$table_stat} s ON s.user_id = e.user_id AND s.enigme_id = e.enigme_id
+         WHERE e.enigme_id = %d
+         ORDER BY {$order_by_sql} {$order}
+         LIMIT %d OFFSET %d",
+        $enigme_id,
+        $enigme_id,
+        $limit,
+        $offset
+    );
+
+    return $wpdb->get_results($sql, ARRAY_A);
+}
+
 /**
  * AJAX handler retrieving statistics for a riddle.
  *
@@ -176,4 +218,51 @@ function ajax_enigme_recuperer_stats()
     wp_send_json_success($stats);
 }
 add_action('wp_ajax_enigme_recuperer_stats', 'ajax_enigme_recuperer_stats');
+
+function ajax_enigme_lister_participants() {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $enigme_id = isset($_POST['enigme_id']) ? (int) $_POST['enigme_id'] : 0;
+    $page = max(1, (int) ($_POST['page'] ?? 1));
+    $orderby = isset($_POST['orderby']) ? sanitize_text_field($_POST['orderby']) : 'date';
+    $order = isset($_POST['order']) ? sanitize_text_field($_POST['order']) : 'ASC';
+
+    if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
+        wp_send_json_error('post_invalide');
+    }
+
+    if (!utilisateur_peut_modifier_post($enigme_id)) {
+        wp_send_json_error('acces_refuse');
+    }
+
+    $mode = get_field('enigme_mode_validation', $enigme_id) ?? 'aucune';
+    $par_page = 25;
+    $offset = ($page - 1) * $par_page;
+    $participants = enigme_lister_participants($enigme_id, $mode, $par_page, $offset, $orderby, $order);
+    $total = enigme_compter_joueurs_engages($enigme_id);
+    $pages = (int) ceil($total / $par_page);
+
+    ob_start();
+    get_template_part('template-parts/enigme/partials/enigme-partial-participants', null, [
+        'participants' => $participants,
+        'page' => $page,
+        'par_page' => $par_page,
+        'total' => $total,
+        'pages' => $pages,
+        'mode_validation' => $mode,
+        'orderby' => $orderby,
+        'order' => $order,
+    ]);
+    $html = ob_get_clean();
+
+    wp_send_json_success([
+        'html' => $html,
+        'total' => $total,
+        'page' => $page,
+        'pages' => $pages,
+    ]);
+}
+add_action('wp_ajax_enigme_lister_participants', 'ajax_enigme_lister_participants');
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -458,6 +458,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         <p><?php esc_html_e("Aucun joueur n'a résolu l'énigme", 'chassesautresor-com'); ?></p>
         <?php endif; ?>
         <?php endif; ?>
+
+        <?php
+        $nb_participants = enigme_compter_joueurs_engages($enigme_id);
+        $par_page_participants = 25;
+        $pages_participants = (int) ceil($nb_participants / $par_page_participants);
+        $participants = enigme_lister_participants($enigme_id, $mode_validation, $par_page_participants, 0, 'date', 'ASC');
+        ?>
+        <h3><?= esc_html($nb_participants); ?> participants</h3>
+        <div class="liste-participants" data-page="1" data-pages="<?= esc_attr($pages_participants); ?>" data-order="asc" data-orderby="date">
+          <?php get_template_part('template-parts/enigme/partials/enigme-partial-participants', null, [
+            'participants' => $participants,
+            'page' => 1,
+            'par_page' => $par_page_participants,
+            'total' => $nb_participants,
+            'pages' => $pages_participants,
+            'mode_validation' => $mode_validation,
+            'orderby' => 'date',
+            'order' => 'ASC',
+          ]); ?>
+        </div>
       </div>
     </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Affiche le tableau des participants engagés sur une énigme.
+ * Variables requises :
+ * - $participants (array)
+ * - $page (int)
+ * - $par_page (int)
+ * - $total (int)
+ * - $pages (int)
+ * - $mode_validation (string)
+ * - $orderby (string)
+ * - $order (string)
+ */
+defined('ABSPATH') || exit;
+
+$args = $args ?? [];
+$participants = $args['participants'] ?? $participants ?? [];
+$page = $args['page'] ?? $page ?? 1;
+$par_page = $args['par_page'] ?? $par_page ?? 25;
+$total = $args['total'] ?? $total ?? 0;
+$pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
+$mode_validation = $args['mode_validation'] ?? $mode_validation ?? 'aucune';
+$orderby = $args['orderby'] ?? $orderby ?? 'date';
+$order = $args['order'] ?? $order ?? 'ASC';
+
+$icon_date = 'fa-sort';
+if ($orderby === 'date') {
+    $icon_date = strtoupper($order) === 'ASC' ? 'fa-sort-up' : 'fa-sort-down';
+}
+$icon_tentatives = 'fa-sort';
+if ($orderby === 'tentatives') {
+    $icon_tentatives = strtoupper($order) === 'ASC' ? 'fa-sort-up' : 'fa-sort-down';
+}
+?>
+<?php if (empty($participants)) : ?>
+<p>Aucun participant engagé.</p>
+<?php else : ?>
+<table class="stats-table compact">
+  <thead>
+    <tr>
+      <th scope="col">Rang</th>
+      <th scope="col">Nom</th>
+      <th scope="col"><button class="sort" data-orderby="date" aria-label="Trier par date">Date <i class="fa-solid <?= esc_attr($icon_date); ?>"></i></button></th>
+      <?php if ($mode_validation !== 'aucune') : ?>
+      <th scope="col"><button class="sort" data-orderby="tentatives" aria-label="Trier par nombre d'essais">Nb essais <i class="fa-solid <?= esc_attr($icon_tentatives); ?>"></i></button></th>
+      <?php endif; ?>
+      <th scope="col">Trouvé</th>
+    </tr>
+  </thead>
+  <tbody>
+    <?php $rang = ($page - 1) * $par_page + 1; foreach ($participants as $p) : ?>
+    <tr>
+      <td><?= esc_html($rang++); ?></td>
+      <td><?= esc_html($p['username']); ?></td>
+      <td><?= esc_html(mysql2date('d/m/Y H:i', $p['date_engagement'])); ?></td>
+      <?php if ($mode_validation !== 'aucune') : ?>
+      <td><?= esc_html($p['nb_tentatives']); ?></td>
+      <?php endif; ?>
+      <td><?= $p['trouve'] ? '<i class="fa-solid fa-xmark"></i>' : ''; ?></td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+<div class="pager" style="margin-top:10px;">
+  <?php if ($page > 1) : ?>
+    <button class="pager-first" aria-label="Première page"><i class="fa-solid fa-angles-left"></i></button>
+    <button class="pager-prev" aria-label="Page précédente" style="margin-left:5px;"><i class="fa-solid fa-angle-left"></i></button>
+  <?php endif; ?>
+  <span class="pager-info" style="margin:0 8px;"><?= esc_html($page); ?> / <?= esc_html($pages); ?></span>
+  <?php if ($page < $pages) : ?>
+    <button class="pager-next" aria-label="Page suivante" style="margin-left:10px;"><i class="fa-solid fa-angle-right"></i></button>
+    <button class="pager-last" aria-label="Dernière page" style="margin-left:5px;"><i class="fa-solid fa-angles-right"></i></button>
+  <?php endif; ?>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
## Résumé
- Ajoute un tableau compact des participants avec tri dynamique et pagination
- Expose les données via un nouveau handler AJAX
- Met à jour les styles et scripts pour le tri par date et nombre d'essais

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c8fe83de08332be2b6170254f6ddb