### PR TITLE
feat: ajout boutons admin correction/bannir dans panneau chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1295,3 +1295,25 @@ body.panneau-ouvert::before {
 .mode-fin-aide i {
   pointer-events: none;
 }
+
+/* ========== ⚠️ ADMINISTRATION ACTIONS ========== */
+.edition-panel-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+.edition-panel-footer .btn-admin-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-editor-text);
+}
+
+.edition-panel-footer .btn-admin-danger:hover {
+  opacity: 1;
+}

--- a/wp-content/themes/chassesautresor/assets/css/organisateurs.css
+++ b/wp-content/themes/chassesautresor/assets/css/organisateurs.css
@@ -605,7 +605,7 @@ section#presentation .presentation-fermer {
 /* ========== ✍️ MODAL DEMANDE DE CORRECTION ========== */
 .modal-correction-chasse {
   position: fixed;
-  z-index: 9999;
+  z-index: 11000;
   inset: 0;
   background: rgba(0, 0, 0, 0.65);
   display: flex;

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1620,8 +1620,15 @@ function traiter_validation_chasse_admin() {
 
         $message = isset($_POST['validation_admin_message'])
             ? sanitize_textarea_field(wp_unslash($_POST['validation_admin_message']))
-
             : '';
+
+        foreach ($enigmes as $eid) {
+            wp_update_post([
+                'ID'          => $eid,
+                'post_status' => 'pending',
+            ]);
+            update_field('enigme_cache_etat_systeme', 'bloquee_chasse', $eid);
+        }
 
         envoyer_mail_demande_correction($organisateur_id, $chasse_id, $message);
 

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1618,6 +1618,13 @@ function traiter_validation_chasse_admin() {
         update_field('champs_caches', $cache, $chasse_id);
         update_field('chasse_cache_statut_validation', 'correction', $chasse_id);
 
+        wp_update_post([
+            'ID'          => $chasse_id,
+            'post_status' => 'pending',
+        ]);
+
+        mettre_a_jour_statuts_chasse($chasse_id);
+
         $message = isset($_POST['validation_admin_message'])
             ? sanitize_textarea_field(wp_unslash($_POST['validation_admin_message']))
             : '';

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -523,7 +523,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
           <?php wp_nonce_field('validation_admin_' . $chasse_id, 'validation_admin_nonce'); ?>
           <input type="hidden" name="action" value="traiter_validation_chasse">
           <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
-          <button type="submit" name="validation_admin_action" value="correction" class="btn-admin-danger btn-correction" onclick="return confirm('Confirmer la demande de correction&nbsp;?');">
+          <button type="button" class="btn-admin-danger btn-correction">
             <i class="fa-solid fa-triangle-exclamation"></i> Correction
           </button>
           <button type="submit" name="validation_admin_action" value="bannir" class="btn-admin-danger" onclick="return confirm('Bannir cette chasse&nbsp;?');">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -517,7 +517,21 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       </div>
     </div>
 
-    <div class="edition-panel-footer"></div>
+    <div class="edition-panel-footer">
+      <?php if (current_user_can('administrator')) : ?>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="admin-validation-actions">
+          <?php wp_nonce_field('validation_admin_' . $chasse_id, 'validation_admin_nonce'); ?>
+          <input type="hidden" name="action" value="traiter_validation_chasse">
+          <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
+          <button type="submit" name="validation_admin_action" value="correction" class="btn-admin-danger" onclick="return confirm('Confirmer la demande de correction&nbsp;?');">
+            <i class="fa-solid fa-triangle-exclamation"></i> Correction
+          </button>
+          <button type="submit" name="validation_admin_action" value="bannir" class="btn-admin-danger" onclick="return confirm('Bannir cette chasse&nbsp;?');">
+            <i class="fa-solid fa-triangle-exclamation"></i> Bannir
+          </button>
+        </form>
+      <?php endif; ?>
+    </div>
   </section>
 <?php endif; ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -519,11 +519,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
     <div class="edition-panel-footer">
       <?php if (current_user_can('administrator')) : ?>
-        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="admin-validation-actions">
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="admin-validation-actions form-traitement-validation-chasse">
           <?php wp_nonce_field('validation_admin_' . $chasse_id, 'validation_admin_nonce'); ?>
           <input type="hidden" name="action" value="traiter_validation_chasse">
           <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
-          <button type="submit" name="validation_admin_action" value="correction" class="btn-admin-danger" onclick="return confirm('Confirmer la demande de correction&nbsp;?');">
+          <button type="submit" name="validation_admin_action" value="correction" class="btn-admin-danger btn-correction" onclick="return confirm('Confirmer la demande de correction&nbsp;?');">
             <i class="fa-solid fa-triangle-exclamation"></i> Correction
           </button>
           <button type="submit" name="validation_admin_action" value="bannir" class="btn-admin-danger" onclick="return confirm('Bannir cette chasse&nbsp;?');">


### PR DESCRIPTION
## Résumé
Ajout de deux boutons d'administration dans le panneau d'édition d'une chasse pour corriger ou bannir rapidement.

## Changements notables
- Ajout de boutons **Correction** et **Bannir** visibles pour les administrateurs
- Confirmation par fenêtre d'alerte avant l'action
- Stylisation du pied de panneau pour alignement à droite des actions

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689c9187eea48332bc649942cd1f923c