### PR TITLE
Masquer les statistiques pour les énigmes sans validation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -73,6 +73,8 @@ function initEnigmeEdit() {
   const radiosValidation = document.querySelectorAll('input[name="acf[enigme_mode_validation]"]');
   const tabTentatives = panneauEdition?.querySelector('.edition-tab[data-target="enigme-tab-soumission"]');
   const contenuTentatives = document.getElementById('enigme-tab-soumission');
+  const tabStats = panneauEdition?.querySelector('.edition-tab[data-target="enigme-tab-stats"]');
+  const contenuStats = document.getElementById('enigme-tab-stats');
 
   function toggleTentativesTab(mode) {
     const afficher = mode !== 'aucune';
@@ -88,12 +90,29 @@ function initEnigmeEdit() {
     }
   }
 
+  function toggleStatsTab(mode) {
+    const afficher = mode !== 'aucune';
+    if (tabStats) {
+      tabStats.style.display = afficher ? '' : 'none';
+      if (!afficher && tabStats.classList.contains('active')) {
+        panneauEdition?.querySelector('.edition-tab[data-target="enigme-tab-param"]')?.click();
+      }
+    }
+    if (!afficher && contenuStats) {
+      contenuStats.style.display = 'none';
+      contenuStats.classList.remove('active');
+    }
+  }
+
   const radioChecked = document.querySelector('input[name="acf[enigme_mode_validation]"]:checked');
-  toggleTentativesTab(radioChecked ? radioChecked.value : 'aucune');
+  const modeInitial = radioChecked ? radioChecked.value : 'aucune';
+  toggleTentativesTab(modeInitial);
+  toggleStatsTab(modeInitial);
 
   radiosValidation.forEach((radio) => {
     radio.addEventListener('change', (e) => {
       toggleTentativesTab(e.target.value);
+      toggleStatsTab(e.target.value);
     });
   });
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -88,7 +88,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
     <div class="edition-tabs">
       <button class="edition-tab active" data-target="enigme-tab-param">Paramètres</button>
-      <button class="edition-tab" data-target="enigme-tab-stats">Statistiques</button>
+      <button class="edition-tab"
+        data-target="enigme-tab-stats"
+        <?= $mode_validation === 'aucune' ? 'style="display:none;"' : ''; ?>
+      >Statistiques</button>
       <button class="edition-tab" data-target="enigme-tab-soumission"<?= $mode_validation === 'aucune' ? ' style="display:none;"' : ''; ?>>Tentatives</button>
       <button class="edition-tab" data-target="enigme-tab-solution">Solution</button>
     </div>


### PR DESCRIPTION
## Résumé
- Masque l'onglet Statistiques lorsque le mode de validation est "aucune"
- Ajout de la gestion dynamique de l'affichage des statistiques selon le mode

## Changements notables
- Masquage conditionnel de l'onglet Statistiques dans le panneau d'édition
- Basculage dynamique de l'onglet Statistiques via JavaScript

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_689c9b4b5460833286ebfb4cd8dde6c8