### PR TITLE
Affichage des tentatives manuelles à traiter

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -265,6 +265,25 @@ function myaccount_get_important_messages(): string
         }
     }
 
+    if (est_organisateur()) {
+        $organisateur_id = get_organisateur_from_user(get_current_user_id());
+        if ($organisateur_id) {
+            $enigmes = recuperer_enigmes_tentatives_en_attente($organisateur_id);
+            if (!empty($enigmes)) {
+                $links = array_map(
+                    function ($id) {
+                        $url   = esc_url(get_permalink($id));
+                        $title = esc_html(get_the_title($id));
+                        return '<a href="' . $url . '">' . $title . '</a>';
+                    },
+                    $enigmes
+                );
+
+                $messages[] = __('Tentatives à traiter :', 'chassesautresor') . ' ' . implode(', ', $links);
+            }
+        }
+    }
+
     if (empty($messages)) {
         return '';
     }


### PR DESCRIPTION
## Résumé
- affiche un message listant les énigmes avec tentatives manuelles en attente pour les organisateurs
- ajoute une fonction utilitaire pour récupérer les énigmes concernées et restreint le comptage aux tentatives non traitées

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689ca61a13c48332a233a0a73a5f7024