### PR TITLE
Masquer le titre des résolveurs sans joueurs

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -433,8 +433,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         $nb_resolveurs = count($resolveurs);
         ?>
         <div id="enigme-resolveurs" style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
-          <h3>Résolue par (<?= esc_html($nb_resolveurs); ?>) joueurs</h3>
           <?php if ($nb_resolveurs > 0) : ?>
+          <h3>Résolue par (<?= esc_html($nb_resolveurs); ?>) joueurs</h3>
           <div class="stats-table-wrapper">
             <table class="stats-table" id="enigme-resolveurs-table">
               <thead>


### PR DESCRIPTION
## Résumé
- supprime l'entête "Résolue par (0) joueurs" lorsqu'aucun joueur n'a résolu l'énigme

## Changements notables
- affiche le tableau des résolveurs uniquement si la liste n'est pas vide
- garde le message "Aucun joueur n'a résolu l'énigme" lorsque c'est le cas

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689cb89648e88332aa4694e16eb97351