### PR TITLE
Affiche toujours la carte des solutions

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1147,9 +1147,6 @@ function mettreAJourCartesStats() {
   const cardTentatives = document.querySelector('#enigme-stats [data-stat="tentatives"]');
   const cardPoints = document.querySelector('#enigme-stats [data-stat="points"]');
   const cardSolutions = document.querySelector('#enigme-stats [data-stat="solutions"]');
-  const nbSolutions = cardSolutions
-    ? parseInt(cardSolutions.querySelector('.stat-value')?.textContent || '0', 10)
-    : 0;
   const resolveursSection = document.getElementById('enigme-resolveurs');
 
   if (cardTentatives) {
@@ -1159,7 +1156,7 @@ function mettreAJourCartesStats() {
     cardPoints.style.display = (mode === 'aucune' || cout <= 0) ? 'none' : '';
   }
   if (cardSolutions) {
-    cardSolutions.style.display = (mode === 'aucune' || nbSolutions <= 0) ? 'none' : '';
+    cardSolutions.style.display = mode === 'aucune' ? 'none' : '';
   }
   if (resolveursSection) {
     resolveursSection.style.display = mode === 'aucune' ? 'none' : '';

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -431,10 +431,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         <?php
         $resolveurs = $mode_validation === 'aucune' ? [] : enigme_lister_resolveurs($enigme_id);
         $nb_resolveurs = count($resolveurs);
+        if ($nb_resolveurs > 0) :
         ?>
-        <div id="enigme-resolveurs" style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
+        <div id="enigme-resolveurs">
           <h3>Résolue par (<?= esc_html($nb_resolveurs); ?>) joueurs</h3>
-          <?php if ($nb_resolveurs > 0) : ?>
           <div class="stats-table-wrapper">
             <table class="stats-table" id="enigme-resolveurs-table">
               <thead>
@@ -457,8 +457,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </tbody>
             </table>
           </div>
-          <?php endif; ?>
         </div>
+        <?php endif; ?>
 
         <?php
         $nb_participants = enigme_compter_joueurs_engages($enigme_id);

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -418,7 +418,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             </div>
           </div>
           <div class="dashboard-card" data-stat="solutions"
-            style="<?= ($mode_validation === 'aucune' || $nb_solutions <= 0) ? 'display:none;' : ''; ?>">
+            style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
             <div class="dashboard-card-header">
               <i class="fa-solid fa-check"></i>
               <h3>Nombre de bonnes solutions</h3>
@@ -433,8 +433,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         $nb_resolveurs = count($resolveurs);
         ?>
         <div id="enigme-resolveurs" style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
-          <?php if ($nb_resolveurs > 0) : ?>
           <h3>Résolue par (<?= esc_html($nb_resolveurs); ?>) joueurs</h3>
+          <?php if ($nb_resolveurs > 0) : ?>
           <div class="stats-table-wrapper">
             <table class="stats-table" id="enigme-resolveurs-table">
               <thead>
@@ -457,8 +457,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </tbody>
             </table>
           </div>
-          <?php else : ?>
-          <p><?php esc_html_e("Aucun joueur n'a résolu l'énigme", 'chassesautresor-com'); ?></p>
           <?php endif; ?>
         </div>
 


### PR DESCRIPTION
## Résumé
- supprime le message "Aucun joueur n'a résolu l'énigme"
- affiche la carte "Nombre de bonnes solutions" même avec zéro résolveur

## Modifications
- retire la condition cachant la carte des bonnes solutions quand elle est vide
- simplifie l'affichage des résolveurs sans message lorsque la liste est vide
- ajuste le script d'édition pour garder la carte visible

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d73fa3bd08332824f8ce27a28d539