### PR TITLE
Ameliore la lisibilite des labels du formulaire de compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -515,6 +515,13 @@
 .woocommerce h2 {
     font-size: 1.6rem;
 }
+
+/* ==========================================================
+📌 Page modifier compte Woocommerce
+========================================================== */
+.woocommerce-account .edit-account label {
+    color: var(--color-text-secondary);
+}
 /* Sections for account dashboard */
 .dashboard-section {
     margin-top: 40px;


### PR DESCRIPTION
## Résumé
- Corrige la couleur des labels du formulaire de modification de compte pour une meilleure lisibilité sur fond clair

## Changements notables
- Force les labels du formulaire de compte à utiliser `var(--color-text-secondary)`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d7591868483328713f51c33ee514a