### PR TITLE
Masquer les messages importants vides

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -122,6 +122,10 @@
     border-radius: 0.5rem;
 }
 
+.msg-important:empty {
+    display: none;
+}
+
 .myaccount-points {
     margin-bottom: 1rem;
     font-weight: 500;

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -156,9 +156,7 @@ get_header();
             <!-- TODO: header content -->
         </header>
         <main class="myaccount-content">
-            <section class="msg-important">
-                <?php echo myaccount_get_important_messages(); ?>
-            </section>
+            <section class="msg-important"><?php echo trim(myaccount_get_important_messages()); ?></section>
             <?php
             if ($content_template && file_exists($content_template)) {
                 include $content_template;


### PR DESCRIPTION
### Résumé
Masque les sections `msg-important` vides dans l’espace "Mon Compte".

### Changements
- Ajout d’une règle CSS pour ne pas afficher les sections vides
- Ajustement du template afin de générer une section sans espaces

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d76c306ec8332bad9c8fca7f2187e