### PR TITLE
Harmonise l'entête des organisateurs et corrige les labels

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -135,6 +135,12 @@ p {
 label {
     color: var(--color-text-primary);
 }
+
+.edition-panel label,
+.edit-account label,
+.stats-filtres label {
+    color: var(--color-editor-text-muted);
+}
 .ast-plain-container.ast-no-sidebar #primary {
     margin-top: 0;
 }

--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -520,12 +520,6 @@
     font-size: 1.6rem;
 }
 
-/* ==========================================================
-📌 Page modifier compte Woocommerce
-========================================================== */
-.woocommerce-account .edit-account label {
-    color: var(--color-text-secondary);
-}
 /* Sections for account dashboard */
 .dashboard-section {
     margin-top: 40px;

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1471,21 +1471,6 @@ function afficher_tableau_organisateurs_pending(array $liste = null)
         return;
     }
 
-    $etats = [];
-    foreach ($liste as $entry) {
-        if (!empty($entry['statut'])) {
-            $etats[$entry['statut']] = true;
-        }
-    }
-
-    echo '<label for="filtre-etat">' . esc_html__('Filtrer par état :', 'chassesautresor') . '</label>';
-    echo '<select id="filtre-etat">';
-    echo '<option value="tous">' . esc_html__('Tous', 'chassesautresor') . '</option>';
-    foreach (array_keys($etats) as $etat) {
-        echo '<option value="' . esc_attr($etat) . '">' . esc_html($etat) . '</option>';
-    }
-    echo '</select>';
-
     $grouped = [];
     foreach ($liste as $entry) {
         $oid = $entry['organisateur_id'];

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-organisateurs.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-organisateurs.php
@@ -19,7 +19,26 @@ $organisateurs_liste = recuperer_organisateurs_pending();
     <?php if (empty($organisateurs_liste)) : ?>
         <p><?php esc_html_e('Aucun organisateur.', 'chassesautresor'); ?></p>
     <?php else : ?>
-        <span><?php echo count($organisateurs_liste); ?> <?php esc_html_e('résultat(s) trouvé(s)', 'chassesautresor'); ?></span>
+        <?php
+        $etats = [];
+        foreach ($organisateurs_liste as $entry) {
+            if (!empty($entry['statut'])) {
+                $etats[$entry['statut']] = true;
+            }
+        }
+        ?>
+        <div class="stats-header" style="display:flex;align-items:center;">
+            <span><?php echo count($organisateurs_liste); ?> <?php esc_html_e('organisateur', 'chassesautresor'); ?></span>
+            <div class="stats-filtres" style="margin-left:auto;">
+                <label for="filtre-etat"><?php esc_html_e('Filtrer par état :', 'chassesautresor'); ?></label>
+                <select id="filtre-etat">
+                    <option value="tous"><?php esc_html_e('Tous', 'chassesautresor'); ?></option>
+                    <?php foreach (array_keys($etats) as $etat) : ?>
+                        <option value="<?php echo esc_attr($etat); ?>"><?php echo esc_html($etat); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
         <?php afficher_tableau_organisateurs_pending($organisateurs_liste); ?>
     <?php endif; ?>
 


### PR DESCRIPTION
## Résumé
- Harmonisation de l'entête de la section organisateurs avec filtre en haut à droite
- Ajustement global des couleurs des labels sur les panneaux d'édition

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d7bf95a848332a73b9fb76e0f9098