### PR TITLE
Amélioration du menu latéral Mon Compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -52,8 +52,11 @@
     transition: color 0.2s ease, background 0.2s ease;
 }
 
-.dashboard-nav-link:hover {
+.dashboard-nav-link:hover,
+.dashboard-nav-sublink:hover,
+.dashboard-nav-subitem:hover {
     color: hsl(var(--primary));
+    text-decoration: underline;
 }
 
 .dashboard-nav-link.active {
@@ -79,8 +82,14 @@
     transition: color 0.2s ease, background 0.2s ease;
 }
 
-.dashboard-nav-sublink:hover {
-    color: hsl(var(--primary));
+.dashboard-nav-subitem {
+    display: block;
+    padding: 4px 12px 4px 48px;
+    border-radius: 8px;
+    color: hsl(var(--muted-foreground));
+    text-decoration: none;
+    font-size: 0.75rem;
+    transition: color 0.2s ease, background 0.2s ease;
 }
 
 .dashboard-nav-heading {
@@ -90,6 +99,31 @@
     font-weight: 600;
     color: hsl(var(--muted-foreground));
     text-transform: uppercase;
+}
+
+.dashboard-nav-link.status-important,
+.dashboard-nav-sublink.status-important,
+.dashboard-nav-subitem.status-important {
+    color: hsl(var(--destructive));
+}
+
+.dashboard-nav-link.status-pending,
+.dashboard-nav-sublink.status-pending,
+.dashboard-nav-subitem.status-pending {
+    opacity: 0.7;
+}
+
+.dashboard-nav-link.status-banned,
+.dashboard-nav-sublink.status-banned,
+.dashboard-nav-subitem.status-banned {
+    opacity: 0.3;
+    pointer-events: none;
+}
+
+.dashboard-nav-link.status-muted,
+.dashboard-nav-sublink.status-muted,
+.dashboard-nav-subitem.status-muted {
+    opacity: 0.6;
 }
 
 .myaccount-main {

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -93,6 +93,7 @@ require_once $inc_path . 'organisateur-functions.php';
 require_once $inc_path . 'access-functions.php';
 require_once $inc_path . 'relations-functions.php';
 require_once $inc_path . 'layout-functions.php';
+require_once $inc_path . 'myaccount-functions.php';
 require_once $inc_path . 'utils/liens.php';
 require_once $inc_path . 'chasse/stats.php';
 

--- a/wp-content/themes/chassesautresor/inc/myaccount-functions.php
+++ b/wp-content/themes/chassesautresor/inc/myaccount-functions.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Helper functions for "Mon Compte" area.
+ *
+ * @package chassesautresor
+ */
+
+defined('ABSPATH') || exit;
+
+/**
+ * Retrieve organizer navigation data for the sidebar.
+ *
+ * @param int $user_id User ID.
+ * @return array|null Navigation data or null if no organizer.
+ */
+function myaccount_get_organizer_nav(int $user_id): ?array
+{
+    $organizer_id = get_organisateur_from_user($user_id);
+    if (!$organizer_id) {
+        return null;
+    }
+
+    $chasses = get_posts([
+        'post_type'   => 'chasse',
+        'post_status' => ['publish', 'pending'],
+        'numberposts' => -1,
+        'meta_query'  => [
+            'relation' => 'AND',
+            [
+                'key'     => 'chasse_cache_organisateur',
+                'value'   => '"' . $organizer_id . '"',
+                'compare' => 'LIKE',
+            ],
+            [
+                'key'     => 'chasse_cache_statut_validation',
+                'value'   => 'banni',
+                'compare' => '!=',
+            ],
+        ],
+    ]);
+
+    $data = [
+        'organizer' => [
+            'url'   => get_permalink($organizer_id),
+            'title' => get_the_title($organizer_id),
+        ],
+        'chasses' => [],
+    ];
+
+    foreach ($chasses as $chasse) {
+        $status_validation = get_field('chasse_cache_statut_validation', $chasse->ID);
+        $complet           = get_field('chasse_cache_complet', $chasse->ID);
+        $classes           = 'dashboard-nav-sublink';
+
+        if (!$complet || in_array($status_validation, ['creation', 'correction'], true)) {
+            $classes .= ' status-important';
+        } elseif ($status_validation === 'banni') {
+            $classes .= ' status-banned';
+        } elseif ($status_validation === 'en_attente') {
+            $classes .= ' status-pending';
+        } else {
+            $classes .= ' status-normal';
+        }
+
+        $chasse_item = [
+            'title'        => get_the_title($chasse->ID),
+            'url'          => $status_validation === 'banni' ? null : get_permalink($chasse->ID),
+            'classes'      => $classes,
+            'pending_icon' => $status_validation === 'en_attente',
+            'enigmes'      => [],
+        ];
+
+        $enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse->ID);
+        foreach ($enigme_ids as $enigme_id) {
+            $sub_classes = 'dashboard-nav-subitem ' . $classes;
+            $url         = get_permalink($enigme_id);
+
+            if (strpos($classes, 'status-normal') !== false) {
+                $etat_enigme = get_field('enigme_cache_etat_systeme', $enigme_id);
+                if (in_array($etat_enigme, ['bloquee_date', 'bloquee_pre_requis'], true)) {
+                    $sub_classes .= ' status-muted';
+                } elseif (in_array($etat_enigme, ['cache_invalide', 'invalide'], true)) {
+                    $sub_classes .= ' status-banned';
+                    $url         = null;
+                }
+            } else {
+                if (strpos($classes, 'status-banned') !== false) {
+                    $url = null;
+                }
+            }
+
+            $chasse_item['enigmes'][] = [
+                'title'   => get_the_title($enigme_id),
+                'url'     => $url,
+                'classes' => $sub_classes,
+            ];
+        }
+
+        $data['chasses'][] = $chasse_item;
+    }
+
+    return $data;
+}
+
+/**
+ * Render organizer navigation HTML for the sidebar.
+ *
+ * @param array $data Navigation data from myaccount_get_organizer_nav().
+ * @return string HTML output.
+ */
+function myaccount_render_organizer_nav(array $data): string
+{
+    ob_start();
+    ?>
+    <nav class="dashboard-nav organizer-nav">
+        <a href="<?php echo esc_url($data['organizer']['url']); ?>" class="dashboard-nav-link">
+            <i class="fas fa-landmark"></i>
+            <span><?php echo esc_html($data['organizer']['title']); ?></span>
+        </a>
+        <?php foreach ($data['chasses'] as $chasse) : ?>
+            <?php
+            $tag  = $chasse['url'] ? 'a' : 'span';
+            $attr = $chasse['url'] ? ' href="' . esc_url($chasse['url']) . '"' : '';
+            ?>
+            <<?php echo $tag . $attr; ?> class="<?php echo esc_attr($chasse['classes']); ?>">
+                <?php echo esc_html($chasse['title']); ?>
+                <?php if ($chasse['pending_icon']) : ?>
+                    <i class="fas fa-hourglass-half"></i>
+                <?php endif; ?>
+            </<?php echo $tag; ?>>
+            <?php foreach ($chasse['enigmes'] as $enigme) : ?>
+                <?php
+                $sub_tag  = $enigme['url'] ? 'a' : 'span';
+                $sub_attr = $enigme['url'] ? ' href="' . esc_url($enigme['url']) . '"' : '';
+                ?>
+                <<?php echo $sub_tag . $sub_attr; ?> class="<?php echo esc_attr($enigme['classes']); ?>">
+                    <?php echo esc_html($enigme['title']); ?>
+                </<?php echo $sub_tag; ?>>
+            <?php endforeach; ?>
+        <?php endforeach; ?>
+    </nav>
+    <?php
+    return ob_get_clean();
+}

--- a/wp-content/themes/chassesautresor/inc/myaccount-functions.php
+++ b/wp-content/themes/chassesautresor/inc/myaccount-functions.php
@@ -39,6 +39,8 @@ function myaccount_get_organizer_nav(int $user_id): ?array
         ],
     ]);
 
+    $pending_enigmes = recuperer_enigmes_tentatives_en_attente($organizer_id);
+
     $data = [
         'organizer' => [
             'url'   => get_permalink($organizer_id),
@@ -76,12 +78,16 @@ function myaccount_get_organizer_nav(int $user_id): ?array
             $url         = get_permalink($enigme_id);
 
             if (strpos($classes, 'status-normal') !== false) {
-                $etat_enigme = get_field('enigme_cache_etat_systeme', $enigme_id);
-                if (in_array($etat_enigme, ['bloquee_date', 'bloquee_pre_requis'], true)) {
-                    $sub_classes .= ' status-muted';
-                } elseif (in_array($etat_enigme, ['cache_invalide', 'invalide'], true)) {
-                    $sub_classes .= ' status-banned';
-                    $url         = null;
+                if (in_array($enigme_id, $pending_enigmes, true)) {
+                    $sub_classes .= ' status-important';
+                } else {
+                    $etat_enigme = get_field('enigme_cache_etat_systeme', $enigme_id);
+                    if (in_array($etat_enigme, ['bloquee_date', 'bloquee_pre_requis'], true)) {
+                        $sub_classes .= ' status-muted';
+                    } elseif (in_array($etat_enigme, ['cache_invalide', 'invalide'], true)) {
+                        $sub_classes .= ' status-banned';
+                        $url         = null;
+                    }
                 }
             } else {
                 if (strpos($classes, 'status-banned') !== false) {

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -113,76 +113,10 @@ get_header();
         </nav>
         <?php endif; ?>
         <?php
-        $organizer_id = get_organisateur_from_user($current_user->ID);
-        if ($organizer_id) {
-            $chasses = get_posts([
-                'post_type'   => 'chasse',
-                'post_status' => ['publish', 'pending'],
-                'numberposts' => -1,
-                'meta_query'  => [
-                    'relation' => 'AND',
-                    [
-                        'key'     => 'chasse_cache_organisateur',
-                        'value'   => '"' . $organizer_id . '"',
-                        'compare' => 'LIKE',
-                    ],
-                    [
-                        'key'     => 'chasse_cache_statut_validation',
-                        'value'   => 'banni',
-                        'compare' => '!=',
-                    ],
-                ],
-            ]);
-            ?>
-            <nav class="dashboard-nav organizer-nav">
-                <a href="<?php echo esc_url(get_permalink($organizer_id)); ?>" class="dashboard-nav-link">
-                    <i class="fas fa-landmark"></i>
-                    <span><?php echo esc_html(get_the_title($organizer_id)); ?></span>
-                </a>
-                <?php foreach ($chasses as $chasse) :
-                    $status_validation = get_field('chasse_cache_statut_validation', $chasse->ID);
-                    $complet           = get_field('chasse_cache_complet', $chasse->ID);
-                    $classes           = 'dashboard-nav-sublink';
-
-                    if (!$complet || in_array($status_validation, ['creation', 'correction'], true)) {
-                        $classes .= ' status-important';
-                    } elseif ($status_validation === 'banni') {
-                        $classes .= ' status-banned';
-                    } elseif ($status_validation === 'en_attente') {
-                        $classes .= ' status-pending';
-                    } else {
-                        $classes .= ' status-normal';
-                    }
-
-                    $tag  = strpos($classes, 'status-banned') !== false ? 'span' : 'a';
-                    $attr = $tag === 'a' ? ' href="' . esc_url(get_permalink($chasse->ID)) . '"' : '';
-                    echo '<' . $tag . $attr . ' class="' . esc_attr($classes) . '">';
-                    echo esc_html(get_the_title($chasse->ID));
-                    if ($status_validation === 'en_attente') {
-                        echo ' <i class="fas fa-hourglass-half"></i>';
-                    }
-                    echo '</' . $tag . '>';
-
-                    $enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse->ID);
-                    foreach ($enigme_ids as $enigme_id) {
-                        $sub_classes = 'dashboard-nav-subitem ' . $classes;
-                        if (strpos($classes, 'status-normal') !== false) {
-                            $etat_enigme = get_field('enigme_cache_etat_systeme', $enigme_id);
-                            if (in_array($etat_enigme, ['bloquee_date', 'bloquee_pre_requis'], true)) {
-                                $sub_classes .= ' status-muted';
-                            } elseif (in_array($etat_enigme, ['cache_invalide', 'invalide'], true)) {
-                                $sub_classes .= ' status-banned';
-                            }
-                        }
-                        $sub_tag  = strpos($sub_classes, 'status-banned') !== false ? 'span' : 'a';
-                        $sub_attr = $sub_tag === 'a' ? ' href="' . esc_url(get_permalink($enigme_id)) . '"' : '';
-                        echo '<' . $sub_tag . $sub_attr . ' class="' . esc_attr($sub_classes) . '">';
-                        echo esc_html(get_the_title($enigme_id));
-                        echo '</' . $sub_tag . '>';
-                    }
-                <?php endforeach; ?>
-            </nav>
-        <?php }
+        $organizer_nav = myaccount_get_organizer_nav($current_user->ID);
+        if ($organizer_nav) {
+            echo myaccount_render_organizer_nav($organizer_nav);
+        }
         ?>
         <?php endif; ?>
     </aside>


### PR DESCRIPTION
### Résumé
- ajout des énigmes liées sous chaque chasse et retrait du texte de statut
- stylisation dynamique des liens selon leur état avec indentation supplémentaire

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d86b24ba4833295a7d8d23453af08