### PR TITLE
Affiche un titre plus discret pour la liste des participants

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1220,6 +1220,13 @@ body.panneau-ouvert::before {
 
 /* ====== Tableaux de statistiques ====== */
 
+.liste-participants .participants-count {
+  margin: 0 0 0.5rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-editor-heading);
+}
+
 .stats-table {
   width: 100%;
   border-collapse: collapse;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -466,7 +466,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         $pages_participants = (int) ceil($nb_participants / $par_page_participants);
         $participants = enigme_lister_participants($enigme_id, $mode_validation, $par_page_participants, 0, 'date', 'ASC');
         ?>
-        <h3><?= esc_html($nb_participants); ?> participants</h3>
         <div class="liste-participants" data-page="1" data-pages="<?= esc_attr($pages_participants); ?>" data-order="asc" data-orderby="date">
           <?php get_template_part('template-parts/enigme/partials/enigme-partial-participants', null, [
             'participants' => $participants,

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
@@ -32,6 +32,7 @@ if ($orderby === 'tentatives') {
     $icon_tentatives = strtoupper($order) === 'ASC' ? 'fa-sort-up' : 'fa-sort-down';
 }
 ?>
+<p class="participants-count"><?= esc_html($total); ?> participants</p>
 <?php if (empty($participants)) : ?>
 <p>Aucun participant engagé.</p>
 <?php else : ?>


### PR DESCRIPTION
## Résumé
- Ajuste l'affichage du compteur de participants
- Déplace le titre dans le conteneur de liste et réduit son style

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d8effb1f08332a779e638b341f5b3