### PR TITLE
Conditionner l’avertissement de fin automatique aux champs requis

### DIFF
--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -76,9 +76,15 @@ $has_incomplete_enigme = !empty($enigmes_incompletes);
 
 $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
 $statut = $infos_chasse['statut'];
+$title_filled = trim(get_the_title($chasse_id)) !== '';
+$image_filled = !empty($image_id);
+$description_filled = !empty(trim($description));
+$required_fields_filled = $title_filled && $image_filled && $description_filled;
+
 $needs_validatable_message = $statut === 'revision'
     && $mode_fin === 'automatique'
-    && !chasse_has_validatable_enigme($chasse_id);
+    && !chasse_has_validatable_enigme($chasse_id)
+    && $required_fields_filled;
 
 $statut_validation = $infos_chasse['statut_validation'];
 $nb_joueurs = $infos_chasse['nb_joueurs'];


### PR DESCRIPTION
## Résumé
- ajuste l’alerte de fin automatique pour qu’elle n’apparaisse qu’après remplissage du titre, de l’image et de la description

## Changements notables
- vérification des champs obligatoires avant d’afficher l’avertissement de fin automatique

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d903459fc8332909ab193af4bab1f