### PR TITLE
Correction du filtre de période des statistiques d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-stats.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initEnigmeStats() {
   const container = document.getElementById('enigme-stats');
   const select = document.getElementById('enigme-periode');
   if (!container || !select) {
@@ -110,5 +110,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-});
+}
+
+document.addEventListener('DOMContentLoaded', initEnigmeStats);
+initEnigmeStats();
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -376,14 +376,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       $nb_solutions   = enigme_compter_bonnes_solutions($enigme_id, $mode_validation, $periode);
       ?>
       <div class="edition-panel-body">
-        <div class="stats-header" style="display:flex;align-items:center;">
+        <div class="stats-header" style="display:flex;align-items:center;justify-content:flex-end;gap:1rem;">
+          <a href="?edition=open&amp;tab=stats" class="stats-reset"><i class="fa-solid fa-rotate-right"></i> Réinitialiser</a>
           <div class="stats-filtres">
             <label for="enigme-periode">Période&nbsp;:</label>
             <select id="enigme-periode">
-              <option value="total">Depuis le début</option>
+              <option value="total">Total (depuis le début)</option>
               <option value="jour">Aujourd’hui</option>
-              <option value="semaine">7&nbsp;derniers jours</option>
-              <option value="mois">30&nbsp;derniers jours</option>
+              <option value="semaine">Semaine (7&nbsp;derniers jours)</option>
+              <option value="mois">Mois (30&nbsp;derniers jours)</option>
             </select>
           </div>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -377,14 +377,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       ?>
       <div class="edition-panel-body">
         <div class="stats-header" style="display:flex;align-items:center;justify-content:flex-end;gap:1rem;">
-          <a href="?edition=open&amp;tab=stats" class="stats-reset"><i class="fa-solid fa-rotate-right"></i> Réinitialiser</a>
+          <a href="?edition=open&amp;tab=stats" class="stats-reset"><i class="fa-solid fa-rotate-right"></i> Actualiser</a>
           <div class="stats-filtres">
             <label for="enigme-periode">Période&nbsp;:</label>
             <select id="enigme-periode">
-              <option value="total">Total (depuis le début)</option>
+              <option value="total">Total</option>
               <option value="jour">Aujourd’hui</option>
-              <option value="semaine">Semaine (7&nbsp;derniers jours)</option>
-              <option value="mois">Mois (30&nbsp;derniers jours)</option>
+              <option value="semaine">Semaine</option>
+              <option value="mois">Mois</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
## Résumé
- rétablit le rafraîchissement dynamique des cartes de statistiques d'énigme
- ajoute un lien de réinitialisation et revoit les intitulés du filtre de période

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d91fcf36483328c2fc2fb6977d63e