### PR TITLE
Alignement à droite des entêtes triables des tableaux de statistiques

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1270,6 +1270,9 @@ body.panneau-ouvert::before {
   display: flex;
   align-items: center;
   gap: 4px;
+  justify-content: flex-end;
+  width: 100%;
+  text-align: right;
 }
 
 .stats-table th button.sort i {


### PR DESCRIPTION
### Résumé
Corrige l'alignement des colonnes triables dans les tableaux de statistiques pour respecter l'alignement à droite.

### Changements notables
- Aligne les boutons de tri des en-têtes de tableau à droite

### Testing
- `source ./setup-env.sh && composer install && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d93ac4e7083328b8cab1ad1e5dec8