### PR TITLE
Modernise le design des cartes de statistiques d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1194,23 +1194,23 @@ body.panneau-ouvert::before {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 12px;
   text-align: center;
   color: var(--color-editor-text);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
 }
 
-.stats-cards .dashboard-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-size: 0.875rem;
+.stats-cards .dashboard-card i {
+  font-size: 2rem;
+  color: var(--color-editor-heading);
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
+}
+
+.stats-cards .dashboard-card h3 {
+  margin: 0;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--color-editor-heading);
-}
-
-.stats-cards .dashboard-card-header i {
-  font-size: 1rem;
 }
 
 .stats-cards .stat-value {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -389,43 +389,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         </div>
         <div class="dashboard-grid stats-cards" id="enigme-stats">
           <div class="dashboard-card" data-stat="joueurs">
-            <div class="dashboard-card-header">
-              <i class="fa-solid fa-users"></i>
-              <h3>Nombre de joueurs engagés</h3>
-            </div>
-            <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html($nb_joueurs); ?></p>
-            </div>
+            <i class="fa-solid fa-users"></i>
+            <h3>Nombre de joueurs engagés</h3>
+            <p class="stat-value"><?= esc_html($nb_joueurs); ?></p>
           </div>
           <div class="dashboard-card" data-stat="tentatives"
             style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
-            <div class="dashboard-card-header">
-              <i class="fa-solid fa-arrow-rotate-right"></i>
-              <h3>Nombre de tentatives</h3>
-            </div>
-            <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html($nb_tentatives); ?></p>
-            </div>
+            <i class="fa-solid fa-arrow-rotate-right"></i>
+            <h3>Nombre de tentatives</h3>
+            <p class="stat-value"><?= esc_html($nb_tentatives); ?></p>
           </div>
           <div class="dashboard-card" data-stat="points"
             style="<?= ($mode_validation === 'aucune' || (int) $cout <= 0) ? 'display:none;' : ''; ?>">
-            <div class="dashboard-card-header">
-              <i class="fa-solid fa-coins"></i>
-              <h3>Nombre de points</h3>
-            </div>
-            <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html($nb_points); ?></p>
-            </div>
+            <i class="fa-solid fa-coins"></i>
+            <h3>Nombre de points</h3>
+            <p class="stat-value"><?= esc_html($nb_points); ?></p>
           </div>
           <div class="dashboard-card" data-stat="solutions"
             style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
-            <div class="dashboard-card-header">
-              <i class="fa-solid fa-check"></i>
-              <h3>Nombre de bonnes solutions</h3>
-            </div>
-            <div class="dashboard-card-content">
-              <p class="stat-value"><?= esc_html($nb_solutions); ?></p>
-            </div>
+            <i class="fa-solid fa-check"></i>
+            <h3>Nombre de bonnes solutions</h3>
+            <p class="stat-value"><?= esc_html($nb_solutions); ?></p>
           </div>
         </div>
         <?php


### PR DESCRIPTION
## Résumé
- Modernise l'apparence des cartes de statistiques dans l'édition d'une énigme

## Changements
- Réorganise chaque carte avec icône agrandie, titre et valeur empilés verticalement
- Applique une ombre légère et un style plus discret aux cartes de statistiques

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d959798808332ae9dcf693c547d59