### PR TITLE
Renommer les intitulés des cartes de statistiques d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -391,25 +391,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         <div class="dashboard-grid stats-cards" id="enigme-stats">
           <div class="dashboard-card" data-stat="joueurs">
             <i class="fa-solid fa-users"></i>
-            <h3>Nombre de joueurs engagés</h3>
+              <h3>Participants</h3>
             <p class="stat-value"><?= esc_html($nb_joueurs); ?></p>
           </div>
           <div class="dashboard-card" data-stat="tentatives"
             style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
             <i class="fa-solid fa-arrow-rotate-right"></i>
-            <h3>Nombre de tentatives</h3>
+              <h3>Tentatives</h3>
             <p class="stat-value"><?= esc_html($nb_tentatives); ?></p>
           </div>
           <div class="dashboard-card" data-stat="points"
             style="<?= ($mode_validation === 'aucune' || (int) $cout <= 0) ? 'display:none;' : ''; ?>">
             <i class="fa-solid fa-coins"></i>
-            <h3>Nombre de points</h3>
+              <h3>Points collectés</h3>
             <p class="stat-value"><?= esc_html($nb_points); ?></p>
           </div>
           <div class="dashboard-card" data-stat="solutions"
             style="<?= $mode_validation === 'aucune' ? 'display:none;' : ''; ?>">
             <i class="fa-solid fa-check"></i>
-            <h3>Nombre de bonnes solutions</h3>
+              <h3>Bonnes réponses</h3>
             <p class="stat-value"><?= esc_html($nb_solutions); ?></p>
           </div>
         </div>


### PR DESCRIPTION
Renomme les cartes de statistiques dans le panneau d'édition d'énigme.

- Remplace « Nombre de joueurs engagés » par « Participants »
- Remplace « Nombre de tentatives » par « Tentatives »
- Remplace « Nombre de points » par « Points collectés »
- Remplace « Nombre de bonnes solutions » par « Bonnes réponses »

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689d9f281d18833280d023de03d2d82e