### PR TITLE
Ajout des graphiques de taux de participation et résolution

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1218,6 +1218,62 @@ body.panneau-ouvert::before {
   font-weight: 700;
 }
 
+/* ====== Histogrammes de statistiques ====== */
+
+.stats-cards .graph-card {
+  align-items: stretch;
+  text-align: left;
+}
+
+.stats-cards .graph-card h3 {
+  text-align: center;
+}
+
+.stats-bar-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.stats-bar-chart .bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stats-bar-chart .bar-label {
+  flex: 0 0 25%;
+  font-size: 0.8rem;
+  color: var(--color-editor-heading);
+  text-decoration: none;
+}
+
+.stats-bar-chart .bar-wrapper {
+  flex: 1;
+  background-color: var(--color-editor-background);
+  border: 1px solid var(--color-editor-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.stats-bar-chart .bar-fill {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 4px;
+  color: var(--color-editor-background);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.stats-bar-chart .bar-row:nth-child(1) .bar-fill { background-color: hsl(var(--chart-1)); }
+.stats-bar-chart .bar-row:nth-child(2) .bar-fill { background-color: hsl(var(--chart-2)); }
+.stats-bar-chart .bar-row:nth-child(3) .bar-fill { background-color: hsl(var(--chart-3)); }
+.stats-bar-chart .bar-row:nth-child(4) .bar-fill { background-color: hsl(var(--chart-4)); }
+.stats-bar-chart .bar-row:nth-child(5) .bar-fill { background-color: hsl(var(--chart-5)); }
+
 /* ====== Tableaux de statistiques ====== */
 
 .stats-table {

--- a/wp-content/themes/chassesautresor/template-parts/common/stat-histogram-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/stat-histogram-card.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Dashboard card displaying a horizontal bar chart.
+ *
+ * Expected variables:
+ * - $label (string) Card title.
+ * - $data  (array)  Each row: ['title' => string, 'url' => string, 'value' => float].
+ * - $max   (float)  Maximum value among rows.
+ * - $stat  (string) Data attribute identifier.
+ */
+
+defined('ABSPATH') || exit;
+
+$args  = $args ?? [];
+$label = $args['label'] ?? $label ?? '';
+$data  = $args['data'] ?? $data ?? [];
+$max   = $args['max'] ?? $max ?? 0;
+$stat  = $args['stat'] ?? $stat ?? '';
+?>
+<div class="dashboard-card graph-card" data-stat="<?= esc_attr($stat); ?>">
+  <h3><?= esc_html($label); ?></h3>
+  <?php if (!empty($data)) : ?>
+    <div class="stats-bar-chart">
+      <?php foreach ($data as $row) :
+          $width = $max > 0 ? (100 * $row['value']) / $max : 0;
+      ?>
+        <div class="bar-row">
+          <a href="<?= esc_url($row['url']); ?>" class="bar-label"><?= esc_html($row['title']); ?></a>
+          <div class="bar-wrapper">
+            <div class="bar-fill" style="width:<?= esc_attr($width); ?>%;">
+              <span class="bar-value"><?= esc_html(number_format($row['value'], 1, ',', ' ')); ?>%</span>
+            </div>
+          </div>
+        </div>
+      <?php endforeach; ?>
+    </div>
+  <?php else : ?>
+    <p><?php esc_html_e('Aucune donnée.', 'chassesautresor-com'); ?></p>
+  <?php endif; ?>
+</div>


### PR DESCRIPTION
Ajoute deux nouvelles cartes statistiques pour suivre la progression des joueurs.

- Calcul et tri des taux de participation et de résolution par énigme
- Affichage d'histogrammes horizontaux dans le panneau d'édition d'une chasse
- Styles CSS pour les nouveaux graphiques

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689de9f5a3ac8332be1f20b6b59c2d46