### PR TITLE
Refactorisation des statistiques des joueurs pour les chasses

### DIFF
--- a/tests/ChasseParticipantsStatsTest.php
+++ b/tests/ChasseParticipantsStatsTest.php
@@ -1,0 +1,67 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse/stats.php';
+
+if (!defined('ARRAY_A')) {
+    define('ARRAY_A', 'ARRAY_A');
+}
+
+if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
+    function recuperer_ids_enigmes_pour_chasse(int $chasse_id): array {
+        return [10, 11];
+    }
+} else {
+    $GLOBALS['enigme_ids'] = [10, 11];
+}
+if (!function_exists('get_the_title')) {
+    function get_the_title($id) {
+        return 'Enigme ' . $id;
+    }
+}
+if (!function_exists('get_permalink')) {
+    function get_permalink($id) {
+        return 'http://example.com/' . $id;
+    }
+}
+
+class ChasseParticipantsStatsTest extends TestCase {
+    public function test_chasse_lister_participants_returns_engagements_and_resolutions(): void {
+        global $wpdb;
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+            public string $users = 'wp_users';
+            private int $call = 0;
+            public function prepare($query, ...$args) { return $query; }
+            public function get_results($query, $output = ARRAY_A) {
+                $this->call++;
+                if ($this->call === 1) {
+                    return [
+                        ['user_id' => 1, 'username' => 'alice', 'date_inscription' => '2024-01-01 10:00:00'],
+                    ];
+                }
+                if ($this->call === 2) {
+                    return [
+                        ['user_id' => 1, 'enigme_id' => 10],
+                        ['user_id' => 1, 'enigme_id' => 11],
+                    ];
+                }
+                if ($this->call === 3) {
+                    return [
+                        ['user_id' => 1, 'enigme_id' => 10],
+                    ];
+                }
+                return [];
+            }
+        };
+
+        $res = chasse_lister_participants(5, 25, 0, 'inscription', 'ASC');
+        $this->assertCount(1, $res);
+        $first = $res[0];
+        $this->assertSame(2, $first['nb_engagees']);
+        $this->assertSame(1, $first['nb_resolues']);
+        $this->assertCount(2, $first['enigmes']);
+        $this->assertSame('Enigme 10', $first['enigmes'][0]['title']);
+        $this->assertSame('http://example.com/10', $first['enigmes'][0]['url']);
+    }
+}

--- a/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
@@ -44,7 +44,7 @@ function initChasseStats() {
 
   const participantsWrapper = document.querySelector('#chasse-tab-stats .liste-participants');
   if (participantsWrapper) {
-    function charger(page = 1, orderby = participantsWrapper.dataset.orderby || 'chasse', order = participantsWrapper.dataset.order || 'asc') {
+    function charger(page = 1, orderby = participantsWrapper.dataset.orderby || 'inscription', order = participantsWrapper.dataset.order || 'asc') {
       fetch(ChasseStats.ajaxUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -92,7 +92,7 @@ function initChasseStats() {
       }
       if (btn.classList.contains('sort')) {
         e.preventDefault();
-        const orderby = btn.dataset.orderby || 'chasse';
+        const orderby = btn.dataset.orderby || 'inscription';
         let order = participantsWrapper.dataset.order || 'asc';
         if (participantsWrapper.dataset.orderby !== orderby) {
           order = 'asc';

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -424,8 +424,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
         $max_participation = !empty($participation_rates) ? max(array_column($participation_rates, 'value')) : 0;
         $max_resolution   = !empty($resolution_rates) ? max(array_column($resolution_rates, 'value')) : 0;
         $par_page_participants = 25;
-        $pages_participants    = (int) ceil($total_engagements / $par_page_participants);
-        $participants          = chasse_lister_participants($chasse_id, $par_page_participants, 0, 'chasse', 'ASC');
+        $total_participants    = chasse_compter_participants($chasse_id);
+        $pages_participants    = (int) ceil($total_participants / $par_page_participants);
+        $total_enigmes         = count($enigme_ids);
+        $participants          = chasse_lister_participants($chasse_id, $par_page_participants, 0, 'inscription', 'ASC');
       ?>
         <div class="edition-panel-body">
           <div class="stats-header" style="display:flex;align-items:center;justify-content:flex-end;gap:1rem;">
@@ -478,16 +480,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               'enigmes' => $enigmes_stats,
               'total'   => $total_engagements,
           ]); ?>
-          <div class="liste-participants" data-page="1" data-pages="<?= esc_attr($pages_participants); ?>" data-order="asc" data-orderby="chasse">
+          <div class="liste-participants" data-page="1" data-pages="<?= esc_attr($pages_participants); ?>" data-order="asc" data-orderby="inscription">
             <?php get_template_part('template-parts/chasse/partials/chasse-partial-participants', null, [
               'participants' => $participants,
               'page' => 1,
               'par_page' => $par_page_participants,
-              'total' => $total_engagements,
+              'total' => $total_participants,
               'pages' => $pages_participants,
-              'orderby' => 'chasse',
-              'order' => 'ASC',
-              'chasse_titre' => $titre,
+              'total_enigmes' => $total_enigmes,
             ]); ?>
           </div>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Displays hunt engagements (participants) table.
+ * Displays hunt participants table.
  *
  * Variables:
  * - $participants (array)
@@ -8,9 +8,7 @@
  * - $par_page (int)
  * - $total (int)
  * - $pages (int)
- * - $orderby (string)
- * - $order (string)
- * - $chasse_titre (string)
+ * - $total_enigmes (int)
  */
 
 defined('ABSPATH') || exit;
@@ -21,32 +19,37 @@ $page          = $args['page'] ?? $page ?? 1;
 $par_page      = $args['par_page'] ?? $par_page ?? 25;
 $total         = $args['total'] ?? $total ?? 0;
 $pages         = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
-$orderby       = $args['orderby'] ?? $orderby ?? 'chasse';
-$order         = $args['order'] ?? $order ?? 'ASC';
-$chasse_titre  = $args['chasse_titre'] ?? $chasse_titre ?? '';
-
-$icon_chasse = strtoupper($order) === 'ASC' ? 'fa-sort-up' : 'fa-sort-down';
+$total_enigmes = $args['total_enigmes'] ?? $total_enigmes ?? 0;
 ?>
-<h3>Participations</h3>
+<h3><?= esc_html__('Joueurs', 'chassesautresor-com'); ?></h3>
 <?php if (empty($participants)) : ?>
-<p>Aucune participation.</p>
+<p><?= esc_html__('Pas encore de joueur inscrit.', 'chassesautresor-com'); ?></p>
 <?php else : ?>
 <table class="stats-table compact">
   <thead>
     <tr>
-      <th scope="col">Rang</th>
-      <th scope="col">Joueur</th>
-      <th scope="col"><button class="sort" data-orderby="chasse" aria-label="Trier par date">Chasse <i class="fa-solid <?= esc_attr($icon_chasse); ?>"></i></button></th>
-      <th scope="col">Énigme</th>
+      <th scope="col"><?= esc_html__('Joueur', 'chassesautresor-com'); ?></th>
+      <th scope="col"><?= esc_html__('Inscription', 'chassesautresor-com'); ?></th>
+      <th scope="col"><?= esc_html__('Énigmes', 'chassesautresor-com'); ?></th>
+      <th scope="col"><?= esc_html__('Taux de participation', 'chassesautresor-com'); ?></th>
+      <th scope="col"><?= esc_html__('Taux de résolution', 'chassesautresor-com'); ?></th>
     </tr>
   </thead>
   <tbody>
-    <?php $rang = ($page - 1) * $par_page + 1; foreach ($participants as $p) : ?>
+    <?php foreach ($participants as $p) :
+        $links = [];
+        foreach ($p['enigmes'] as $e) {
+            $links[] = '<a href="' . esc_url($e['url']) . '">' . esc_html($e['title']) . '</a>';
+        }
+        $taux_participation = $total_enigmes > 0 ? (100 * $p['nb_engagees'] / $total_enigmes) : 0;
+        $taux_resolution    = $total_enigmes > 0 ? (100 * $p['nb_resolues'] / $total_enigmes) : 0;
+    ?>
     <tr>
-      <td><?= esc_html($rang++); ?></td>
       <td><?= esc_html($p['username']); ?></td>
-      <td><?= $p['date_chasse'] ? esc_html($chasse_titre . ' – ' . mysql2date('d/m/Y H:i', $p['date_chasse'])) : ''; ?></td>
-      <td><?= !$p['date_chasse'] && $p['date_enigme'] ? esc_html($p['enigme_titre'] . ' – ' . mysql2date('d/m/Y H:i', $p['date_enigme'])) : ''; ?></td>
+      <td><?= $p['date_inscription'] ? esc_html(mysql2date('d/m/Y H:i', $p['date_inscription'])) : ''; ?></td>
+      <td><?= implode(', ', $links); ?></td>
+      <td><?= esc_html(number_format_i18n($taux_participation, 0)); ?>%</td>
+      <td><?= esc_html(number_format_i18n($taux_resolution, 0)); ?>%</td>
     </tr>
     <?php endforeach; ?>
   </tbody>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
@@ -14,25 +14,61 @@
 defined('ABSPATH') || exit;
 
 $args = $args ?? [];
-$participants  = $args['participants'] ?? $participants ?? [];
-$page          = $args['page'] ?? $page ?? 1;
-$par_page      = $args['par_page'] ?? $par_page ?? 25;
-$total         = $args['total'] ?? $total ?? 0;
-$pages         = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
-$total_enigmes = $args['total_enigmes'] ?? $total_enigmes ?? 0;
+$participants   = $args['participants'] ?? $participants ?? [];
+$page           = $args['page'] ?? $page ?? 1;
+$par_page       = $args['par_page'] ?? $par_page ?? 25;
+$total          = $args['total'] ?? $total ?? 0;
+$pages          = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
+$total_enigmes  = $args['total_enigmes'] ?? $total_enigmes ?? 0;
+$orderby        = $args['orderby'] ?? $orderby ?? 'inscription';
+$order          = $args['order'] ?? $order ?? 'ASC';
+
+$icon_participation = 'fa-sort';
+if ($orderby === 'participation') {
+    $icon_participation = strtoupper($order) === 'ASC' ? 'fa-sort-up' : 'fa-sort-down';
+}
+$icon_resolution = 'fa-sort';
+if ($orderby === 'resolution') {
+    $icon_resolution = strtoupper($order) === 'ASC' ? 'fa-sort-up' : 'fa-sort-down';
+}
 ?>
 <h3><?= esc_html__('Joueurs', 'chassesautresor-com'); ?></h3>
 <?php if (empty($participants)) : ?>
 <p><?= esc_html__('Pas encore de joueur inscrit.', 'chassesautresor-com'); ?></p>
 <?php else : ?>
 <table class="stats-table compact">
+  <colgroup>
+    <col style="width:20%">
+    <col style="width:20%">
+    <col style="width:20%">
+    <col style="width:20%">
+    <col style="width:20%">
+  </colgroup>
   <thead>
     <tr>
       <th scope="col"><?= esc_html__('Joueur', 'chassesautresor-com'); ?></th>
       <th scope="col"><?= esc_html__('Inscription', 'chassesautresor-com'); ?></th>
       <th scope="col"><?= esc_html__('Énigmes', 'chassesautresor-com'); ?></th>
-      <th scope="col"><?= esc_html__('Taux de participation', 'chassesautresor-com'); ?></th>
-      <th scope="col"><?= esc_html__('Taux de résolution', 'chassesautresor-com'); ?></th>
+      <th scope="col">
+        <button
+          class="sort"
+          data-orderby="participation"
+          aria-label="<?= esc_attr__('Trier par taux de participation', 'chassesautresor-com'); ?>"
+        >
+          <?= esc_html__('Tx participation', 'chassesautresor-com'); ?>
+          <i class="fa-solid <?= esc_attr($icon_participation); ?>"></i>
+        </button>
+      </th>
+      <th scope="col">
+        <button
+          class="sort"
+          data-orderby="resolution"
+          aria-label="<?= esc_attr__('Trier par taux de résolution', 'chassesautresor-com'); ?>"
+        >
+          <?= esc_html__('Tx résolution', 'chassesautresor-com'); ?>
+          <i class="fa-solid <?= esc_attr($icon_resolution); ?>"></i>
+        </button>
+      </th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
## Résumé
- refonte du tableau des participations en liste de joueurs
- internationalisation et gestion de l'absence de participants
- agrégation des statistiques et mise à jour de l'interface

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689def7926788332943657330181f0d4