### PR TITLE
Empêcher le doublon de validation d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -242,14 +242,20 @@ function soumettre_reponse_automatique()
         }
     }
 
+    $lock_key = "enigme_lock_{$enigme_id}_{$user_id}";
+    if (!wp_cache_add($lock_key, 1, 'enigme', 15)) {
+        wp_send_json_error('doublon');
+    }
+
     try {
         $uid = traiter_tentative($user_id, $enigme_id, $reponse, $resultat, true, false, false);
     } catch (Throwable $e) {
+        wp_cache_delete($lock_key, 'enigme');
         error_log('Erreur tentative : ' . $e->getMessage());
         wp_send_json_error('erreur_interne');
     }
 
-
+    wp_cache_delete($lock_key, 'enigme');
 
     $compteur = compter_tentatives_du_jour($user_id, $enigme_id);
     $solde = get_user_points($user_id);

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -369,6 +369,23 @@ function traiter_tentative(
     bool $envoyer_mail = true
 ): string
 {
+    global $wpdb;
+    $table = $wpdb->prefix . 'enigme_tentatives';
+
+    if ($resultat === 'bon') {
+        $existe = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND enigme_id = %d AND resultat = 'bon'",
+                $user_id,
+                $enigme_id
+            )
+        );
+
+        if ($existe > 0) {
+            return '';
+        }
+    }
+
     $cout = (int) get_field('enigme_tentative_cout_points', $enigme_id);
     if ($cout > 0) {
         deduire_points_utilisateur($user_id, $cout);


### PR DESCRIPTION
## Résumé
- Empêche l'enregistrement simultané de plusieurs bonnes réponses
- Vérifie qu'aucune bonne réponse préalable n'existe avant d'inscrire une tentative

## Détails
- Ajout d'un verrou cache sur la soumission automatique pour bloquer les doubles clics
- Contrôle préalable des tentatives validées pour éviter les duplications

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689dfb179b988332a84f3b12af55ed8d