### PR TITLE
Supprime les bordures des colonnes fusionnées du tableau des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1325,6 +1325,24 @@ body.panneau-ouvert::before {
   border-bottom: none;
 }
 
+/* Tables with grouped headers: remove inner borders */
+.stats-table-grouped thead th,
+.stats-table-grouped tbody td {
+  border-left: 1px solid var(--color-editor-border);
+}
+
+.stats-table-grouped thead tr:first-child th:first-child,
+.stats-table-grouped tbody td:first-child {
+  border-left: none;
+}
+
+.stats-table-grouped thead tr:nth-child(2) th:nth-child(2),
+.stats-table-grouped thead tr:nth-child(2) th:nth-child(4),
+.stats-table-grouped tbody td:nth-child(3),
+.stats-table-grouped tbody td:nth-child(7) {
+  border-left: none;
+}
+
 .stats-table th button.sort {
   background: none;
   border: none;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -17,7 +17,7 @@ $total   = $args['total'] ?? $total ?? 0;
 <?php if (empty($enigmes)) : ?>
 <p>Aucune énigme.</p>
 <?php else : ?>
-<table class="stats-table compact">
+<table class="stats-table compact stats-table-grouped">
   <thead>
     <tr>
       <th scope="col" rowspan="2">Titre</th>


### PR DESCRIPTION
## Résumé
- corrige l'affichage des statistiques des énigmes en retirant les bordures entre colonnes fusionnées
- ajoute une classe dédiée et le style CSS associé

## Changements notables
- ajoute `stats-table-grouped` pour la table des énigmes
- définit des règles CSS supprimant les séparations internes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_689dfbf9d5f08332823e907515e46b30