### PR TITLE
Ajoute un padding horizontal aux tableaux en édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1089,7 +1089,7 @@ body.panneau-ouvert::before {
 
 .edition-panel th,
 .edition-panel td {
-  padding: 6px 8px;
+  padding: 6px 12px;
   text-align: right;
 }
 
@@ -1111,7 +1111,7 @@ body.panneau-ouvert::before {
 
 .table-tentatives th,
 .table-tentatives td {
-  padding: 6px 8px;
+  padding: 6px 12px;
   border-bottom: 1px solid var(--color-editor-border);
   color: var(--color-editor-text);
 }
@@ -1292,7 +1292,7 @@ body.panneau-ouvert::before {
 .stats-table th,
 .stats-table td {
   text-align: right;
-  padding: 8px;
+  padding: 8px 12px;
 }
 
 .stats-table th {
@@ -1315,7 +1315,7 @@ body.panneau-ouvert::before {
 
 .stats-table.compact th,
 .stats-table.compact td {
-  padding: 4px;
+  padding: 4px 8px;
   font-size: 0.85em;
 }
 


### PR DESCRIPTION
Ajout d'un léger padding horizontal dans les cellules des tableaux en mode édition.

- Ajout d'un padding horizontal par défaut pour les cellules des tableaux de l'éditeur
- Harmonisation de l'espacement des tableaux de tentatives et de statistiques, y compris la version compacte

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689dfc6ae50083329feb56cb23ddc69d