### PR TITLE
Add engagement rate card to hunt stats

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
@@ -9,6 +9,7 @@ function initChasseStats() {
     participants: container.querySelector('[data-stat="participants"] .stat-value'),
     tentatives: container.querySelector('[data-stat="tentatives"] .stat-value'),
     points: container.querySelector('[data-stat="points"] .stat-value'),
+    engagementRate: container.querySelector('[data-stat="engagement-rate"] .stat-value'),
   };
 
   select.addEventListener('change', () => {
@@ -37,6 +38,9 @@ function initChasseStats() {
         }
         if (cards.points && typeof stats.points !== 'undefined') {
           cards.points.textContent = stats.points;
+        }
+        if (cards.engagementRate && typeof stats.engagement_rate !== 'undefined') {
+          cards.engagementRate.textContent = `${stats.engagement_rate}%`;
         }
       })
       .catch(() => {});

--- a/wp-content/themes/chassesautresor/inc/chasse/stats.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/stats.php
@@ -64,6 +64,24 @@ function chasse_compter_engagements(int $chasse_id): int
 }
 
 /**
+ * Calculate engagement rate for a hunt.
+ */
+function chasse_calculer_taux_engagement(int $chasse_id, string $periode = 'total'): float
+{
+    $participants = chasse_compter_participants($chasse_id, $periode);
+    $enigme_ids   = recuperer_ids_enigmes_pour_chasse($chasse_id);
+    $total_enigmes = count($enigme_ids);
+    if ($participants === 0 || $total_enigmes === 0) {
+        return 0.0;
+    }
+    $total = 0;
+    foreach ($enigme_ids as $eid) {
+        $total += enigme_compter_joueurs_engages($eid, $periode);
+    }
+    return (100 * $total) / ($participants * $total_enigmes);
+}
+
+/**
  * List hunt participants with aggregated statistics.
  *
  * Each participant includes registration date, engaged riddles and counts of
@@ -216,6 +234,7 @@ function ajax_chasse_recuperer_stats()
         'participants' => chasse_compter_participants($chasse_id, $periode),
         'tentatives'   => chasse_compter_tentatives($chasse_id, $periode),
         'points'       => chasse_compter_points_collectes($chasse_id, $periode),
+        'engagement_rate' => (int) round(chasse_calculer_taux_engagement($chasse_id, $periode)),
     ];
 
     wp_send_json_success($stats);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -393,8 +393,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
         $enigmes_stats         = [];
         $progress_data         = [];
         $no_validation_enigmas = [];
+        $total_enigme_engagements = 0;
         foreach ($enigme_ids as $enigme_id) {
             $engagements = enigme_compter_joueurs_engages($enigme_id, $periode);
+            $total_enigme_engagements += $engagements;
             $resolutions = enigme_compter_bonnes_solutions($enigme_id, 'automatique', $periode);
             $enigmes_stats[] = [
                 'id'          => $enigme_id,
@@ -426,6 +428,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
         $total_participants    = chasse_compter_participants($chasse_id);
         $pages_participants    = (int) ceil($total_participants / $par_page_participants);
         $total_enigmes         = count($enigme_ids);
+        $taux_engagement       = 0;
+        if ($nb_participants > 0 && $total_enigmes > 0) {
+            $taux_engagement = (int) round((100 * $total_enigme_engagements) / ($nb_participants * $total_enigmes));
+        }
         $participants          = chasse_lister_participants($chasse_id, $par_page_participants, 0, 'inscription', 'ASC');
       ?>
         <div class="edition-panel-body">
@@ -460,6 +466,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 'label' => 'Points collectés',
                 'value' => $nb_points,
                 'stat'  => 'points',
+            ]);
+            get_template_part('template-parts/common/stat-card', null, [
+                'icon'  => 'fa-solid fa-percent',
+                'label' => 'Taux d\'engagement',
+                'value' => $taux_engagement . '%',
+                'stat'  => 'engagement-rate',
             ]);
             ?>
           </div>


### PR DESCRIPTION
Ajoute une carte affichant le taux d'engagement dans l'onglet Statistiques des chasses.

- Calcule le pourcentage moyen d'engagement des énigmes
- Affiche ce taux dans une nouvelle carte de statistiques
- Met à jour l'interface et l'API pour exposer cette donnée

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test` (avertissement "jest-haste-map" mais tests passés)


------
https://chatgpt.com/codex/tasks/task_e_689e03fa0c44833291aeaba4ff1dee1f