### PR TITLE
feat: add organizer stats cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1466,6 +1466,43 @@ body.panneau-ouvert::before {
   font-size: 0.875rem;
 }
 
+/* ========== 📊 EDITION STATISTIQUES ========== */
+.edition-stats-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.edition-stats-card {
+  flex: 1 1 160px;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1rem;
+  background: var(--color-editor-background);
+  border: 1px solid var(--color-editor-border);
+  border-radius: 0.5rem;
+}
+
+.edition-stats-card i {
+  font-size: 1.5rem;
+  color: var(--color-editor-accent);
+}
+
+.edition-stats-card-title {
+  display: block;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: var(--color-editor-text-muted);
+}
+
+.edition-stats-card-number {
+  font-size: 1.4rem;
+  font-weight: bold;
+  color: var(--color-editor-heading);
+}
+
 /* ========== ⚠️ ADMINISTRATION ACTIONS ========== */
 .edition-panel-footer {
   display: flex;

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -96,6 +96,7 @@ require_once $inc_path . 'layout-functions.php';
 require_once $inc_path . 'myaccount-functions.php';
 require_once $inc_path . 'utils/liens.php';
 require_once $inc_path . 'chasse/stats.php';
+require_once $inc_path . 'organisateur/stats.php';
 
 require_once $inc_path . 'edition/edition-core.php';
 require_once $inc_path . 'edition/edition-organisateur.php';

--- a/wp-content/themes/chassesautresor/inc/organisateur/stats.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur/stats.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Statistics helpers for organizers.
+ */
+
+defined('ABSPATH') || exit;
+
+require_once __DIR__ . '/../chasse/stats.php';
+
+/**
+ * Count distinct players engaged in all hunts of an organizer.
+ */
+function organisateur_compter_joueurs_uniques(int $organisateur_id): int
+{
+    $query = get_chasses_de_organisateur($organisateur_id);
+    if (!$query || empty($query->posts)) {
+        return 0;
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'engagements';
+    $ids   = [];
+
+    foreach ($query->posts as $post) {
+        $sql = $wpdb->prepare(
+            "SELECT DISTINCT user_id FROM {$table} WHERE chasse_id = %d AND enigme_id IS NULL",
+            $post->ID
+        );
+        $rows = $wpdb->get_col($sql);
+        if ($rows) {
+            $ids = array_merge($ids, array_map('intval', $rows));
+        }
+    }
+
+    $ids = array_filter(array_unique($ids), static function ($id) {
+        return $id > 0;
+    });
+
+    return count($ids);
+}
+
+/**
+ * Sum collected points for all hunts of an organizer.
+ */
+function organisateur_compter_points_collectes(int $organisateur_id): int
+{
+    $query = get_chasses_de_organisateur($organisateur_id);
+    if (!$query || empty($query->posts)) {
+        return 0;
+    }
+
+    $total = 0;
+    foreach ($query->posts as $post) {
+        $total += chasse_compter_points_collectes($post->ID);
+    }
+
+    return $total;
+}

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -223,7 +223,11 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
       <div class="edition-panel-header">
         <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
       </div>
-      <p class="edition-placeholder">La section « Statistiques » sera bientôt disponible.</p>
+      <?php get_template_part(
+          'template-parts/organisateur/panneaux/organisateur-edition-statistiques',
+          null,
+          ['organisateur_id' => $organisateur_id]
+      ); ?>
     </div>
 
     <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Organizer statistics panel.
+ */
+
+defined('ABSPATH') || exit;
+
+$organisateur_id = $args['organisateur_id'] ?? 0;
+$joueurs = organisateur_compter_joueurs_uniques($organisateur_id);
+$points  = organisateur_compter_points_collectes($organisateur_id);
+?>
+<div class="edition-panel-body">
+  <div class="edition-stats-cards">
+    <div class="edition-stats-card">
+      <i class="fa-solid fa-users" aria-hidden="true"></i>
+      <div class="edition-stats-card-content">
+        <span class="edition-stats-card-title">Joueurs</span>
+        <span class="edition-stats-card-number"><?php echo esc_html($joueurs); ?></span>
+      </div>
+    </div>
+    <div class="edition-stats-card">
+      <i class="fa-solid fa-coins" aria-hidden="true"></i>
+      <div class="edition-stats-card-content">
+        <span class="edition-stats-card-title">Points collectés</span>
+        <span class="edition-stats-card-number"><?php echo esc_html($points); ?></span>
+      </div>
+    </div>
+  </div>
+  <p class="edition-placeholder">Aucune statistique détaillée pour le moment.</p>
+</div>


### PR DESCRIPTION
## Résumé
- ajoute des helpers de statistiques pour les organisateurs
- affiche deux cartes (joueurs, points) dans l'onglet Statistiques de l'édition
- applique un style CSS réutilisable pour les cartes

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e060217308332b9ed3022bd3434ff