### PR TITLE
feat: refactor visibility section into communication cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1207,6 +1207,11 @@ body.panneau-ouvert::before {
   filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
 }
 
+.dashboard-card img {
+  width: 2rem;
+  height: 2rem;
+}
+
 .dashboard-card h3 {
   margin: 0;
   font-size: 0.9rem;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -527,24 +527,22 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
               <div class="resume-bloc resume-visibilite">
                 <h3>Communiquez</h3>
-                <div class="edition-stats-cards">
-                  <div class="edition-stats-card champ-chasse champ-liens <?= empty($liens) ? 'champ-vide' : 'champ-rempli'; ?>"
+                <div class="dashboard-grid stats-cards">
+                  <div class="dashboard-card champ-chasse champ-liens <?= empty($liens) ? 'champ-vide' : 'champ-rempli'; ?>"
                     data-champ="chasse_principale_liens"
                     data-cpt="chasse"
                     data-post-id="<?= esc_attr($chasse_id); ?>">
                     <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
-                    <div class="edition-stats-card-content">
-                      <span class="edition-stats-card-title">Sites et réseaux</span>
-                      <?php if ($peut_modifier) : ?>
-                        <button type="button"
-                          class="edition-stats-card-number champ-modifier ouvrir-panneau-liens"
-                          data-champ="chasse_principale_liens"
-                          data-cpt="chasse"
-                          data-post-id="<?= esc_attr($chasse_id); ?>">
-                          <?= empty($liens) ? 'Ajouter' : 'Éditer'; ?>
-                        </button>
-                      <?php endif; ?>
-                    </div>
+                    <h3>Sites et réseaux</h3>
+                    <?php if ($peut_modifier) : ?>
+                      <button type="button"
+                        class="stat-value champ-modifier ouvrir-panneau-liens"
+                        data-champ="chasse_principale_liens"
+                        data-cpt="chasse"
+                        data-post-id="<?= esc_attr($chasse_id); ?>">
+                        <?= empty($liens) ? 'Ajouter' : 'Éditer'; ?>
+                      </button>
+                    <?php endif; ?>
                     <div class="champ-feedback"></div>
                   </div>
                   <?php
@@ -563,13 +561,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                           . rawurlencode($url)
                           . '&format=' . $format;
                   ?>
-                  <div class="edition-stats-card champ-qr-code">
-                    <img src="<?= esc_url($url_qr_code); ?>" alt="QR code de la chasse">
-                    <div class="edition-stats-card-content">
-                      <span class="edition-stats-card-title">QR code de votre chasse</span>
-                      <a class="edition-stats-card-number" href="<?= esc_url($url_qr_code); ?>"
-                        download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>">Télécharger</a>
-                    </div>
+                  <div class="dashboard-card champ-qr-code">
+                    <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="QR code de la chasse">
+                    <h3>QR code de votre chasse</h3>
+                    <a class="stat-value" href="<?= esc_url($url_qr_code); ?>"
+                      download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>">Télécharger</a>
                   </div>
                   <?php endif; ?>
                 </div>


### PR DESCRIPTION
## Résumé
- refonte de la section Visibilité en Communiquez avec des cartes d'édition
- ajout des cartes Sites et réseaux et QR code

## Changements notables
- la carte Sites et réseaux propose un CTA dynamique et se met en évidence si vide
- la carte QR code affiche l'image de votre chasse avec un lien de téléchargement

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e0b615810833280d0bb3f5af1f295