### PR TITLE
Fix period filter refresh in hunt stats

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
@@ -23,15 +23,18 @@ function initChasseStats() {
 
   select.addEventListener('change', () => {
     const periode = select.value;
-    const data = new FormData();
-    data.append('action', 'chasse_recuperer_stats');
-    data.append('chasse_id', ChasseStats.chasseId);
-    data.append('periode', periode);
+
+    const params = new URLSearchParams({
+      action: 'chasse_recuperer_stats',
+      chasse_id: ChasseStats.chasseId,
+      periode,
+    });
 
     fetch(ChasseStats.ajaxUrl, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       credentials: 'same-origin',
-      body: data,
+      body: params,
     })
       .then((response) => response.json())
       .then((res) => {


### PR DESCRIPTION
## Résumé
- Correction du rafraîchissement des cartes de statistiques lors du changement de période dans l'édition d'une chasse

## Changements notables
- Envoi des paramètres du filtre de période avec `URLSearchParams` et en-tête `application/x-www-form-urlencoded`

## Testing
- `source ./setup-env.sh` (aucune sortie)
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e0bd19ad483329e57180329261fa4