### PR TITLE
Corriger l'accès refusé lors de l'enregistrement des liens de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -333,8 +333,9 @@ function modifier_champ_chasse()
 
     $demande_terminer = ($champ === 'champs_caches.chasse_cache_statut' && $valeur === 'termine');
     $champ_fin = in_array($champ, ['champs_caches.chasse_cache_gagnants', 'champs_caches.chasse_cache_date_decouverte'], true);
+    $champ_libre = ($champ === 'chasse_principale_liens');
 
-    if (!$demande_terminer && !$champ_fin && !utilisateur_peut_editer_champs($post_id)) {
+    if (!$demande_terminer && !$champ_fin && !$champ_libre && !utilisateur_peut_editer_champs($post_id)) {
         wp_send_json_error('⚠️ acces_refuse');
     }
 


### PR DESCRIPTION
## Résumé
- Autorise l'enregistrement des liens d'une chasse même si elle n'est plus en révision

## Changements notables
- Bypass de la vérification `utilisateur_peut_editer_champs` pour `chasse_principale_liens`

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e240182c0833285ef4828e23cced3