### PR TITLE
Fixe le menu d'onglets dans l'entête des panneaux d'édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -554,10 +554,8 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
   z-index: 10000;
 }
 
+
 .edition-panel > .edition-panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: 0.5rem 0;
   border-bottom: 1px solid var(--color-editor-border);
   margin-bottom: 1rem;
@@ -565,6 +563,13 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
   top: 0;
   background-color: var(--color-editor-background);
   z-index: 10;
+}
+
+.edition-panel-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
 }
 
 .edition-panel .panneau-fermer {
@@ -1035,8 +1040,6 @@ body.panneau-ouvert::before {
 .edition-tabs {
   display: flex;
   gap: 0.5rem;
-  border-bottom: 1px solid var(--color-editor-border);
-  margin-bottom: 1rem;
 }
 
 .edition-tab {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -53,14 +53,15 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     <div id="erreur-global" style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
     <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-sliders"></i> <?= esc_html__('Panneau d\'édition chasse', 'chassesautresor-com'); ?></h2>
-        <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
-    </div>
-
-    <div class="edition-tabs">
-      <button class="edition-tab active" data-target="chasse-tab-param">Paramètres</button>
-      <button class="edition-tab" data-target="chasse-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="chasse-tab-animation">Animation</button>
+        <div class="edition-panel-header-top">
+            <h2><i class="fa-solid fa-sliders"></i> <?= esc_html__('Panneau d\'édition chasse', 'chassesautresor-com'); ?></h2>
+            <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
+        </div>
+        <div class="edition-tabs">
+          <button class="edition-tab active" data-target="chasse-tab-param">Paramètres</button>
+          <button class="edition-tab" data-target="chasse-tab-stats">Statistiques</button>
+          <button class="edition-tab" data-target="chasse-tab-animation">Animation</button>
+        </div>
     </div>
 
     <div id="chasse-tab-param" class="edition-tab-content active">

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -72,25 +72,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
     <div class="edition-panel-header">
-      <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+      <div class="edition-panel-header-top">
+        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
 
-      <!-- ✅ Ajout du champ Style ici -->
-      <div class="champ-enigme champ-style" data-champ="enigme_style_affichage" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="margin-top: 8px;">
-        <label for="select-style-affichage" style="font-weight: normal; font-size: 0.9em;">Style d'affichage :</label>
-        <select id="select-style-affichage" class="champ-input" style="margin-left: 10px;">
-          <option value="defaut" <?= $style === 'defaut' ? 'selected' : ''; ?>>Défaut</option>
-          <option value="pirate" <?= $style === 'pirate' ? 'selected' : ''; ?>>Pirate</option>
-          <option value="vintage" <?= $style === 'vintage' ? 'selected' : ''; ?>>Vintage</option>
-        </select>
+        <!-- ✅ Ajout du champ Style ici -->
+        <div class="champ-enigme champ-style" data-champ="enigme_style_affichage" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="margin-top: 8px;">
+          <label for="select-style-affichage" style="font-weight: normal; font-size: 0.9em;">Style d'affichage :</label>
+          <select id="select-style-affichage" class="champ-input" style="margin-left: 10px;">
+            <option value="defaut" <?= $style === 'defaut' ? 'selected' : ''; ?>>Défaut</option>
+            <option value="pirate" <?= $style === 'pirate' ? 'selected' : ''; ?>>Pirate</option>
+            <option value="vintage" <?= $style === 'vintage' ? 'selected' : ''; ?>>Vintage</option>
+          </select>
+        </div>
+        <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
       </div>
-      <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
-    </div>
-
-    <div class="edition-tabs">
-      <button class="edition-tab active" data-target="enigme-tab-param">Paramètres</button>
-      <button class="edition-tab" data-target="enigme-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="enigme-tab-soumission"<?= $mode_validation === 'aucune' ? ' style="display:none;"' : ''; ?>>Tentatives</button>
-      <button class="edition-tab" data-target="enigme-tab-solution">Solution</button>
+      <div class="edition-tabs">
+        <button class="edition-tab active" data-target="enigme-tab-param">Paramètres</button>
+        <button class="edition-tab" data-target="enigme-tab-stats">Statistiques</button>
+        <button class="edition-tab" data-target="enigme-tab-soumission"<?= $mode_validation === 'aucune' ? ' style="display:none;"' : ''; ?>>Tentatives</button>
+        <button class="edition-tab" data-target="enigme-tab-solution">Solution</button>
+      </div>
     </div>
 
 <div id="enigme-tab-param" class="edition-tab-content active">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -55,16 +55,15 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
   <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal<?php echo $edition_active ? ' edition-active' : ''; ?>" aria-hidden="<?php echo $edition_active ? 'false' : 'true'; ?>">
 
     <div class="edition-panel-header">
-      <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
-      <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres organisateur">
-        ✖
-      </button>
-    </div>
-
-    <div class="edition-tabs">
-      <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
-      <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="organisateur-tab-revenus">Revenus</button>
+      <div class="edition-panel-header-top">
+        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+        <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres organisateur">✖</button>
+      </div>
+      <div class="edition-tabs">
+        <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
+        <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
+        <button class="edition-tab" data-target="organisateur-tab-revenus">Revenus</button>
+      </div>
     </div>
 
     <div id="organisateur-tab-param" class="edition-tab-content active">


### PR DESCRIPTION
### Résumé
- Intègre le menu d'onglets dans l'entête fixe des panneaux d'édition.

### Changements notables
- Ajout d'un conteneur `edition-panel-header-top` pour aligner titre, sélecteurs et bouton de fermeture.
- Déplacement de `edition-tabs` dans l'entête pour qu'il reste collé lors du défilement.
- Ajustements CSS pour l'entête et les onglets d'édition.

### Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e3771015483329a3100eca08cb8d9