### PR TITLE
Renommer l’onglet Revenus en Points

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -62,7 +62,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
       <div class="edition-tabs">
         <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
         <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
-        <button class="edition-tab" data-target="organisateur-tab-revenus">Revenus</button>
+        <button class="edition-tab" data-target="organisateur-tab-revenus">Points</button>
       </div>
     </div>
 
@@ -232,13 +232,13 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
     <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-coins tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-coins"></i> Revenus</h2>
+        <h2><i class="fa-solid fa-coins"></i> Points</h2>
       </div>
       <div class="edition-panel-body">
         <div class="edition-panel-section edition-panel-section-ligne">
           <h3 class="section-title">
             <i class="fa-solid fa-coins" aria-hidden="true"></i>
-            Revenus
+            Points
           </h3>
 
           <div class="section-content deux-col-wrapper">


### PR DESCRIPTION
## Résumé
Renomme l’onglet « Revenus » et son en-tête en « Points » dans l’édition organisateur.

## Changements notables
- libellé de l’onglet modifié en « Points »
- titre principal du contenu renommé
- section interne ajustée pour refléter le nouveau terme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e3bb708048332853c5d2ca882781b