### PR TITLE
Ajout des statistiques d'énigmes par chasse pour les organisateurs

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -4,7 +4,7 @@
  *
  * Variables:
  * - $enigmes (array)
- * - $total (int) Total engagements in the hunt.
+ * - $total (int) Total participants in the hunt.
  */
 
 defined('ABSPATH') || exit;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -12,8 +12,9 @@ defined('ABSPATH') || exit;
 $args    = $args ?? [];
 $enigmes = $args['enigmes'] ?? $enigmes ?? [];
 $total   = $args['total'] ?? $total ?? 0;
+$title   = $args['title'] ?? 'Énigmes';
 ?>
-<h3>Énigmes</h3>
+<h3><?= esc_html($title); ?></h3>
 <?php if (empty($enigmes)) : ?>
 <p>Aucune énigme.</p>
 <?php else : ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -26,5 +26,36 @@ $points  = organisateur_compter_points_collectes($organisateur_id);
       </div>
     </div>
   </div>
-  <p class="edition-placeholder">Aucune statistique détaillée pour le moment.</p>
+  <?php
+  $chasses = get_chasses_de_organisateur($organisateur_id);
+  if ($chasses && !empty($chasses->posts)) {
+      foreach ($chasses->posts as $chasse) {
+          $chasse_id         = $chasse->ID;
+          $total_engagements = chasse_compter_engagements($chasse_id);
+          $enigmes_stats     = [];
+          foreach (recuperer_ids_enigmes_pour_chasse($chasse_id) as $enigme_id) {
+              $engagements    = enigme_compter_joueurs_engages($enigme_id);
+              $enigmes_stats[] = [
+                  'id'          => $enigme_id,
+                  'titre'       => get_the_title($enigme_id),
+                  'engagements' => $engagements,
+                  'tentatives'  => enigme_compter_tentatives($enigme_id, 'automatique'),
+                  'points'      => enigme_compter_points_depenses($enigme_id, 'automatique'),
+                  'resolutions' => enigme_compter_bonnes_solutions($enigme_id, 'automatique'),
+              ];
+          }
+          get_template_part(
+              'template-parts/chasse/partials/chasse-partial-enigmes',
+              null,
+              [
+                  'title'   => get_the_title($chasse_id) . ' - Énigmes',
+                  'enigmes' => $enigmes_stats,
+                  'total'   => $total_engagements,
+              ]
+          );
+      }
+  } else {
+      echo '<p class="edition-placeholder">Aucune statistique détaillée pour le moment.</p>';
+  }
+  ?>
 </div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -30,11 +30,11 @@ $points  = organisateur_compter_points_collectes($organisateur_id);
   $chasses = get_chasses_de_organisateur($organisateur_id);
   if ($chasses && !empty($chasses->posts)) {
       foreach ($chasses->posts as $chasse) {
-          $chasse_id         = $chasse->ID;
-          $total_engagements = chasse_compter_engagements($chasse_id);
-          $enigmes_stats     = [];
+          $chasse_id     = $chasse->ID;
+          $participants  = chasse_compter_participants($chasse_id);
+          $enigmes_stats = [];
           foreach (recuperer_ids_enigmes_pour_chasse($chasse_id) as $enigme_id) {
-              $engagements    = enigme_compter_joueurs_engages($enigme_id);
+              $engagements     = enigme_compter_joueurs_engages($enigme_id);
               $enigmes_stats[] = [
                   'id'          => $enigme_id,
                   'titre'       => get_the_title($enigme_id),
@@ -48,9 +48,9 @@ $points  = organisateur_compter_points_collectes($organisateur_id);
               'template-parts/chasse/partials/chasse-partial-enigmes',
               null,
               [
-                  'title'   => get_the_title($chasse_id) . ' - Énigmes',
+                  'title'   => sprintf('%s - Énigmes - %d participants', get_the_title($chasse_id), $participants),
                   'enigmes' => $enigmes_stats,
-                  'total'   => $total_engagements,
+                  'total'   => $participants,
               ]
           );
       }


### PR DESCRIPTION
## Résumé
- affichage des tableaux d'énigmes pour chaque chasse liée à l'organisateur
- titre dynamique pour chaque tableau : "[titre de la chasse] - énigmes"

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e3d5e464c83329714ee8449eb6263