### PR TITLE
Ajout d’une carte Coordonnées bancaires dans l’onglet Points

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1525,6 +1525,17 @@ body.panneau-ouvert::before {
   color: var(--color-editor-heading);
 }
 
+.edition-stats-card-link {
+  font-size: 1.1rem;
+  color: var(--color-editor-accent);
+  text-decoration: underline;
+}
+
+.edition-stats-card-link:hover,
+.edition-stats-card-link:focus {
+  text-decoration: none;
+}
+
 /* ========== ⚠️ ADMINISTRATION ACTIONS ========== */
 .edition-panel-footer {
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1526,6 +1526,8 @@ body.panneau-ouvert::before {
 }
 
 .edition-stats-card-link {
+  display: block;
+  margin-top: 0.25rem;
   font-size: 1.1rem;
   color: var(--color-editor-accent);
   text-decoration: underline;
@@ -1534,6 +1536,27 @@ body.panneau-ouvert::before {
 .edition-stats-card-link:hover,
 .edition-stats-card-link:focus {
   text-decoration: none;
+}
+
+.edition-stats-card--vertical {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.edition-stats-card--vertical .edition-stats-card-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.edition-stats-card-info {
+  margin-left: 0.25rem;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--color-editor-text-muted);
+  cursor: pointer;
 }
 
 /* ========== ⚠️ ADMINISTRATION ACTIONS ========== */

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -61,7 +61,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const validerIban = (iban) => /^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test(iban.replace(/\s/g, '').toUpperCase());
   const validerBic = (bic) => /^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$/.test(bic.toUpperCase());
 
-  boutonOuvrirCoord?.addEventListener('click', () => {
+  boutonOuvrirCoord?.addEventListener('click', (e) => {
+    e.preventDefault();
     if (typeof window.openPanel === 'function') {
       window.openPanel('panneau-coordonnees');
     } else {

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -231,10 +231,20 @@ $is_complete = (
       </div>
       <div class="edition-panel-body">
         <div class="edition-stats-cards">
-          <div class="edition-stats-card">
-            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+          <div class="edition-stats-card edition-stats-card--vertical">
+            <i class="fa-solid fa-building-columns" aria-hidden="true"></i>
             <div class="edition-stats-card-content">
-              <span class="edition-stats-card-title">Coordonnées bancaires&nbsp;?</span>
+              <span class="edition-stats-card-title">
+                Coordonnées bancaires
+                <button
+                  type="button"
+                  class="edition-stats-card-info icone-info"
+                  aria-label="Informations sur les coordonnées bancaires"
+                  onclick="alert('Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d\u2019argent.');"
+                >
+                  <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+                </button>
+              </span>
               <?php if ($peut_editer) : ?>
                 <a
                   id="ouvrir-coordonnees"

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -23,8 +23,6 @@ $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);
 $site         = get_field('lien_site_web', $organisateur_id);
 $email_contact = get_field('profil_public_email_contact', $organisateur_id);
-$iban         = get_field('coordonnees_bancaires_iban', $organisateur_id);
-$bic          = get_field('coordonnees_bancaires_bic', $organisateur_id);
 
 $liens_publics = get_field('liens_publics', $organisateur_id); // ← manquant !
 $liens_publics = is_array($liens_publics) ? array_filter($liens_publics, function ($entree) {
@@ -46,9 +44,6 @@ $is_complete = (
   !empty($description)
 );
 
-$iban_vide = empty($iban);
-$bic_vide  = empty($bic);
-$classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 ?>
 
 <?php if ($peut_modifier) : ?>
@@ -235,37 +230,22 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
         <h2><i class="fa-solid fa-coins"></i> Points</h2>
       </div>
       <div class="edition-panel-body">
-        <div class="edition-panel-section edition-panel-section-ligne">
-          <h3 class="section-title">
-            <i class="fa-solid fa-coins" aria-hidden="true"></i>
-            Points
-          </h3>
-
-          <div class="section-content deux-col-wrapper">
-            <div class="resume-bloc resume-facultatif deux-col-bloc">
-              <h3>Information bancaires</h3>
-
-              <ul class="resume-infos">
-                <li id="ligne-coordonnees" class="champ-organisateur champ-coordonnees ligne-coordonnees <?= !empty($iban) ? 'champ-rempli' : ''; ?>" data-champ="coordonnees_bancaires">
-                  Coordonnées bancaires
-                  <button type="button" class="icone-info" aria-label="Informations sur les coordonnées bancaires"
-                    onclick="alert('Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d\u2019argent.');">
-                    <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                  </button>
-                  <?php if ($peut_editer) : ?>
-                    <button type="button"
-                      id="ouvrir-coordonnees"
-                      class="champ-modifier"
-                      aria-label="Modifier les coordonnées bancaires"
-                      data-champ="coordonnees_bancaires"
-                      data-cpt="organisateur"
-                      data-post-id="<?php echo esc_attr($organisateur_id); ?>">
-                      ✏️
-                    </button>
-
-                  <?php endif; ?>
-                </li>
-              </ul>
+        <div class="edition-stats-cards">
+          <div class="edition-stats-card">
+            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+            <div class="edition-stats-card-content">
+              <span class="edition-stats-card-title">Coordonnées bancaires&nbsp;?</span>
+              <?php if ($peut_editer) : ?>
+                <a
+                  id="ouvrir-coordonnees"
+                  class="edition-stats-card-link"
+                  href="#"
+                  aria-label="Modifier les coordonnées bancaires"
+                  data-champ="coordonnees_bancaires"
+                  data-cpt="organisateur"
+                  data-post-id="<?php echo esc_attr($organisateur_id); ?>"
+                >Éditer</a>
+              <?php endif; ?>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Résumé
- Remplace la section Points par une carte dédiée aux coordonnées bancaires.

## Modifications
- Carte "Coordonnées bancaires ?" avec lien d’édition dans l’onglet Points.
- Nouveau style pour le lien de carte.
- Empêche la navigation sur le lien d’édition.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e4691f2cc8332a42b3469177d9f9a