### PR TITLE
Harmonise le style des cartes statistiques

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1488,42 +1488,6 @@ body.panneau-ouvert::before {
   font-size: 0.875rem;
 }
 
-/* ========== 📊 EDITION STATISTIQUES ========== */
-.edition-stats-cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.edition-stats-card {
-  flex: 1 1 160px;
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 1rem;
-  background: var(--color-editor-background);
-  border: 1px solid var(--color-editor-border);
-  border-radius: 0.5rem;
-}
-
-.edition-stats-card i {
-  font-size: 1.5rem;
-  color: var(--color-editor-accent);
-}
-
-.edition-stats-card-title {
-  display: block;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  color: var(--color-editor-text-muted);
-}
-
-.edition-stats-card-number {
-  font-size: 1.4rem;
-  font-weight: bold;
-  color: var(--color-editor-heading);
-}
 
 /* ========== ⚠️ ADMINISTRATION ACTIONS ========== */
 .edition-panel-footer {

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -6,25 +6,25 @@
 defined('ABSPATH') || exit;
 
 $organisateur_id = $args['organisateur_id'] ?? 0;
-$joueurs = organisateur_compter_joueurs_uniques($organisateur_id);
-$points  = organisateur_compter_points_collectes($organisateur_id);
+$joueurs         = organisateur_compter_joueurs_uniques($organisateur_id);
+$points          = organisateur_compter_points_collectes($organisateur_id);
 ?>
 <div class="edition-panel-body">
-  <div class="edition-stats-cards">
-    <div class="edition-stats-card">
-      <i class="fa-solid fa-users" aria-hidden="true"></i>
-      <div class="edition-stats-card-content">
-        <span class="edition-stats-card-title">Joueurs</span>
-        <span class="edition-stats-card-number"><?php echo esc_html($joueurs); ?></span>
-      </div>
-    </div>
-    <div class="edition-stats-card">
-      <i class="fa-solid fa-coins" aria-hidden="true"></i>
-      <div class="edition-stats-card-content">
-        <span class="edition-stats-card-title">Points collectés</span>
-        <span class="edition-stats-card-number"><?php echo esc_html($points); ?></span>
-      </div>
-    </div>
+  <div class="dashboard-grid stats-cards">
+    <?php
+    get_template_part('template-parts/common/stat-card', null, [
+        'icon'  => 'fa-solid fa-users',
+        'label' => 'Joueurs',
+        'value' => $joueurs,
+        'stat'  => 'joueurs',
+    ]);
+    get_template_part('template-parts/common/stat-card', null, [
+        'icon'  => 'fa-solid fa-coins',
+        'label' => 'Points collectés',
+        'value' => $points,
+        'stat'  => 'points',
+    ]);
+    ?>
   </div>
   <?php
   $chasses = get_chasses_de_organisateur($organisateur_id);


### PR DESCRIPTION
## Résumé
Unifie l'affichage des cartes de statistiques dans les panneaux d'édition.

## Changements
- Utilisation du composant `stat-card` pour les statistiques de l'organisateur
- Suppression des anciennes règles CSS dédiées

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e4b04282c8332b86b040dc7bac579