### PR TITLE
Renommer la carte des liens de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -534,7 +534,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     data-cpt="chasse"
                     data-post-id="<?= esc_attr($chasse_id); ?>">
                     <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
-                    <h3>Sites et réseaux</h3>
+                    <h3>Sites et réseaux de la chasse</h3>
                     <?php if ($peut_modifier) : ?>
                       <button type="button"
                         class="stat-value champ-modifier ouvrir-panneau-liens"


### PR DESCRIPTION
## Résumé
- Renomme la carte des liens de chasse pour préciser sa portée

## Changements notables
- Libellé de la carte mis à jour en "Sites et réseaux de la chasse"

## Test
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_689e4fbb861c833283a0ee79f2b51db6