### PR TITLE
Améliore le récapitulatif des statistiques de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1301,6 +1301,31 @@ body.panneau-ouvert::before {
   font-size: 0.9rem;
 }
 
+/* ====== Résumé chasse ====== */
+
+.chasse-stats-header {
+  margin: 2rem 0 1rem;
+}
+
+.chasse-stats-header h3 {
+  margin: 0 0 0.5rem;
+}
+
+.chasse-stats-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stat-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  background-color: var(--color-editor-background);
+  border: 1px solid var(--color-editor-border);
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
 /* ====== Tableaux de statistiques ====== */
 
 .stats-table {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -499,6 +499,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <?php endif;
           endif;
           get_template_part('template-parts/chasse/partials/chasse-partial-enigmes', null, [
+              'title'   => 'Énigmes',
               'enigmes' => $enigmes_stats,
               'total'   => $total_engagements,
           ]); ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -12,10 +12,11 @@ defined('ABSPATH') || exit;
 $args    = $args ?? [];
 $enigmes = $args['enigmes'] ?? $enigmes ?? [];
 $total   = $args['total'] ?? $total ?? 0;
-$title   = $args['title'] ?? 'Énigmes';
-?>
-<h3><?= esc_html($title); ?></h3>
-<?php if (empty($enigmes)) : ?>
+$title   = $args['title'] ?? '';
+if ($title !== '') {
+    echo '<h3>' . esc_html($title) . '</h3>';
+}
+if (empty($enigmes)) : ?>
 <p>Aucune énigme.</p>
 <?php else : ?>
 <table class="stats-table compact">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -30,25 +30,40 @@ $points          = organisateur_compter_points_collectes($organisateur_id);
   $chasses = get_chasses_de_organisateur($organisateur_id);
   if ($chasses && !empty($chasses->posts)) {
       foreach ($chasses->posts as $chasse) {
-          $chasse_id     = $chasse->ID;
-          $participants  = chasse_compter_participants($chasse_id);
-          $enigmes_stats = [];
+          $chasse_id        = $chasse->ID;
+          $participants     = chasse_compter_participants($chasse_id);
+          $total_tentatives = 0;
+          $total_resolutions = 0;
+          $enigmes_stats    = [];
           foreach (recuperer_ids_enigmes_pour_chasse($chasse_id) as $enigme_id) {
-              $engagements     = enigme_compter_joueurs_engages($enigme_id);
+              $engagements = enigme_compter_joueurs_engages($enigme_id);
+              $tentatives  = enigme_compter_tentatives($enigme_id, 'automatique');
+              $resolutions = enigme_compter_bonnes_solutions($enigme_id, 'automatique');
               $enigmes_stats[] = [
                   'id'          => $enigme_id,
                   'titre'       => get_the_title($enigme_id),
                   'engagements' => $engagements,
-                  'tentatives'  => enigme_compter_tentatives($enigme_id, 'automatique'),
+                  'tentatives'  => $tentatives,
                   'points'      => enigme_compter_points_depenses($enigme_id, 'automatique'),
-                  'resolutions' => enigme_compter_bonnes_solutions($enigme_id, 'automatique'),
+                  'resolutions' => $resolutions,
               ];
+              $total_tentatives += $tentatives;
+              $total_resolutions += $resolutions;
           }
+          ?>
+          <div class="chasse-stats-header">
+            <h3><?php echo esc_html(get_the_title($chasse_id)); ?></h3>
+            <div class="chasse-stats-summary">
+              <span class="stat-badge"><?php echo esc_html($participants . ' participants'); ?></span>
+              <span class="stat-badge"><?php echo esc_html($total_tentatives . ' tentatives'); ?></span>
+              <span class="stat-badge"><?php echo esc_html($total_resolutions . ' bonnes réponses'); ?></span>
+            </div>
+          </div>
+          <?php
           get_template_part(
               'template-parts/chasse/partials/chasse-partial-enigmes',
               null,
               [
-                  'title'   => sprintf('%s - Énigmes - %d participants', get_the_title($chasse_id), $participants),
                   'enigmes' => $enigmes_stats,
                   'total'   => $participants,
               ]


### PR DESCRIPTION
## Résumé
- affiche un résumé participants/tentatives/bonnes réponses pour chaque chasse
- retire le titre du tableau des énigmes au profit de cette entête
- ajoute le style des badges de statistiques

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e527db3148332887bccae7f13a361