### PR TITLE
Supprime le placeholder des liens vides de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -548,7 +548,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <div class="champ-donnees"
                       data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
                     <div class="champ-affichage champ-affichage-liens">
-                      <?= render_liens_publics($liens, 'chasse'); ?>
+                      <?= render_liens_publics($liens, 'chasse', ['placeholder' => false]); ?>
                     </div>
                     <div class="champ-feedback"></div>
                   </div>


### PR DESCRIPTION
Résumé
- Supprime l'affichage du placeholder des liens lorsqu'aucun lien n'est défini pour une chasse.

Changements notables
- Cache les icônes grises "liens-placeholder" dans la carte *Sites et réseaux de la chasse*.
- La carte n'affiche plus que l'icône et le bouton « Ajouter » lorsque la liste est vide.

Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e59cab5288332abf6def7b4e6c5a5