### PR TITLE
Clarifie l'intitulé du mode de fin

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -170,7 +170,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-no-edit="1"
                   data-no-icon="1"
                 >
-                  <label for="chasse_mode_fin"><?= esc_html__('Mode', 'chassesautresor-com'); ?></label>
+                  <label for="chasse_mode_fin"><?= esc_html__('Mode de fin', 'chassesautresor-com'); ?></label>
                   <div class="champ-mode-options">
                     <label>
                       <input


### PR DESCRIPTION
## Résumé
- Renomme le champ Mode en Mode de fin dans l’édition de chasse

## Changements notables
- Mise à jour de l’étiquette du mode de fin dans le panneau d’édition de chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5a999c208332a2236c6c55fb4804