### PR TITLE
Cache des statistiques avec invalidation automatique

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -752,6 +752,9 @@ function enregistrer_engagement_chasse(int $user_id, int $chasse_id): bool
         ],
         ['%d', '%d', '%s', '%s']
     );
+    if ($inserted) {
+        do_action('chasse_engagement_created', $chasse_id);
+    }
 
     return (bool) $inserted;
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/engagements.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/engagements.php
@@ -34,6 +34,9 @@ defined('ABSPATH') || exit;
             'enigme_id'       => $enigme_id,
             'date_engagement' => current_time('mysql'),
         ], ['%d', '%d', '%s']);
+        if ($result !== false) {
+            do_action('enigme_engagement_created', $enigme_id);
+        }
 
         return $result !== false;
     }

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -27,7 +27,7 @@ defined('ABSPATH') || exit;
         $table = $wpdb->prefix . 'enigme_tentatives';
         $uid = function_exists('wp_generate_uuid4') ? wp_generate_uuid4() : uniqid('tent_', true);
 
-        $wpdb->insert($table, [
+        $inserted = $wpdb->insert($table, [
             'tentative_uid'   => $uid,
             'user_id'         => $user_id,
             'enigme_id'       => $enigme_id,
@@ -37,6 +37,9 @@ defined('ABSPATH') || exit;
             'ip'              => $_SERVER['REMOTE_ADDR'] ?? null,
             'user_agent'      => $_SERVER['HTTP_USER_AGENT'] ?? null,
         ]);
+        if ($inserted !== false) {
+            do_action('enigme_tentative_created', $enigme_id);
+        }
 
         return $uid;
     }


### PR DESCRIPTION
Résumé rapide en français.

- Mise en cache des statistiques de chasses et d’énigmes via l’object cache ou les transients.
- Invalidation du cache lors de nouveaux engagements ou tentatives via des hooks WordPress.
- Ajout de hooks dans les fonctions d’enregistrement pour déclencher la purge des caches.

## Testing
- `source ./setup-env.sh`
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689e5b23fd9c833285594d1cb4fa79e0