### PR TITLE
Harmonise les liens d'action et la taille des icônes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1215,14 +1215,14 @@ body.panneau-ouvert::before {
 }
 
 .dashboard-card i {
-  font-size: 2rem;
+  font-size: 1.5rem;
   color: var(--color-editor-heading);
   filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
 }
 
 .dashboard-card img {
-  width: 2rem;
-  height: 2rem;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .dashboard-card h3 {
@@ -1235,6 +1235,13 @@ body.panneau-ouvert::before {
 .stat-value {
   font-size: 1.5rem;
   font-weight: 700;
+}
+
+.dashboard-card .stat-value.champ-modifier {
+  font-size: 1.5rem;
+  color: var(--color-editor-text);
+  opacity: 1;
+  transform: none;
 }
 
 .dashboard-card.graph-card {


### PR DESCRIPTION
## Résumé
- Ajuste la taille des liens "Ajouter/Éditer" pour qu'ils correspondent au style des liens de téléchargement
- Réduit la taille des icônes dans les cartes du tableau de bord

## Changements notables
- Harmonisation du style des actions des cartes d'animation
- Icônes de cartes plus petites pour un affichage plus équilibré

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689eb2c8db50833288e2df5512780237