### PR TITLE
Ajout d’un formulaire de conversion de points

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/modals/modal-conversion.php
+++ b/wp-content/themes/chassesautresor/template-parts/modals/modal-conversion.php
@@ -1,13 +1,37 @@
 <?php
 defined('ABSPATH') || exit;
 
+$access_message = verifier_acces_conversion(get_current_user_id());
 ?>
 <div id="conversion-modal" class="points-modal">
     <div class="points-modal-content">
         <span class="close-modal">&times;</span>
         <h2>💰 Taux de conversion</h2>
         <p>1 000 points = <?php echo esc_html(get_taux_conversion_actuel()); ?> €</p>
-        <p>La conversion des points en € n'est possible qu'à partir de 500 points afin d'éviter les mico-paiements qui génèrent des frais fixes</p>
-        <p>Ce taux est fixé par chassesautresor.com et peut être modifié : vous serez toujours prévenu préalablement avant toute éventuelle modification</p>
+        <p>
+            La conversion des points en € n'est possible qu'à partir de 500 points
+            afin d'éviter les mico-paiements qui génèrent des frais fixes
+        </p>
+        <p>
+            Ce taux est fixé par chassesautresor.com et peut être modifié :
+            vous serez toujours prévenu préalablement avant toute éventuelle
+            modification
+        </p>
+        <?php if (is_string($access_message) && $access_message !== '') : ?>
+            <p><?php echo esc_html($access_message); ?></p>
+        <?php else : ?>
+            <form action="" method="POST">
+                <label for="points-a-convertir">Points à convertir</label>
+                <input type="number"
+                    name="points_a_convertir"
+                    id="points-a-convertir"
+                    min="500"
+                    max="<?php echo esc_attr(get_user_points()); ?>"
+                    data-taux="<?php echo esc_attr(get_taux_conversion_actuel()); ?>">
+                <input type="hidden" name="demander_paiement" value="1">
+                <?php wp_nonce_field('demande_paiement_action', 'demande_paiement_nonce'); ?>
+                <button type="submit"><?php esc_html_e('Envoyer', 'chassesautresor-com'); ?></button>
+            </form>
+        <?php endif; ?>
     </div>
 </div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -39,6 +39,11 @@ $liens_publics = is_array($liens_publics) ? array_filter($liens_publics, functio
 }) : [];
 
 
+if (function_exists('charger_script_conversion')) {
+    charger_script_conversion();
+}
+
+
 $peut_editer_titre = champ_est_editable('post_title', $organisateur_id);
 
 $is_complete = (
@@ -212,6 +217,17 @@ $is_complete = (
       </div>
         <div class="edition-panel-body">
           <div class="dashboard-grid stats-cards">
+            <div class="dashboard-card" data-stat="conversion">
+              <i class="fa-solid fa-right-left" aria-hidden="true"></i>
+              <h3>Conversion</h3>
+              <button
+                type="button"
+                id="open-conversion-modal"
+                class="stat-value"
+              >
+                <?php esc_html_e('Convertir', 'chassesautresor-com'); ?>
+              </button>
+            </div>
             <div class="dashboard-card" data-stat="bank-details">
               <i class="fa-solid fa-building-columns" aria-hidden="true"></i>
               <h3>
@@ -330,4 +346,6 @@ $is_complete = (
   <?php get_template_part('template-parts/organisateur/panneaux/organisateur-edition-coordonnees', null, [
     'organisateur_id' => $organisateur_id
   ]); ?>
+
+  <?php get_template_part('template-parts/modals/modal-conversion'); ?>
 <?php endif; ?>

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-dashboard-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-dashboard-organisateur.php
@@ -7,6 +7,10 @@
 
 defined('ABSPATH') || exit;
 
+if (function_exists('charger_script_conversion')) {
+    charger_script_conversion();
+}
+
 $current_user = wp_get_current_user();
 $user_id      = $current_user->ID;
 $organizer_id = get_organisateur_from_user($user_id);
@@ -27,9 +31,17 @@ if (function_exists('woocommerce_account_content')) {
     woocommerce_account_content();
 }
 
+if (isset($_GET['paiement_envoye']) && $_GET['paiement_envoye'] === '1') {
+    echo '<div class="notice notice-success">' .
+        esc_html__('Votre demande de conversion a bien été envoyée.', 'chassesautresor-com') .
+        '</div>';
+}
+
 if ($pending_table !== '') {
     echo '<div class="mb-6">';
-    echo '<h2 class="text-lg font-semibold mb-2">' . esc_html__('Demande de conversion en attente', 'chassesautresor') . '</h2>';
+    echo '<h2 class="text-lg font-semibold mb-2">' .
+        esc_html__('Demande de conversion en attente', 'chassesautresor') .
+        '</h2>';
     echo $pending_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     echo '</div>';
 }
@@ -41,3 +53,5 @@ $args = array(
 );
 
 get_template_part('template-parts/myaccount/dashboard-organisateur', null, $args);
+
+get_template_part('template-parts/modals/modal-conversion');


### PR DESCRIPTION
## Résumé
- ajout d’une carte de conversion avec formulaire dédié
- confirmation après l’envoi d’une demande de conversion

## Détails
- carte « Conversion » dans l’onglet Points et chargement du modal
- formulaire de demande avec vérification d’accès
- affichage d’un message après redirection `?paiement_envoye=1`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689eb88053e48332a804cb152f9d9f0b