### PR TITLE
feat: dynamic link icons in edit cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -218,6 +218,18 @@ body .header-img-modifiable .icone-modif {
   align-items: center;
 }
 
+.dashboard-card.champ-liens .icone-defaut {
+  display: none;
+}
+
+.dashboard-card.champ-liens.champ-vide .champ-affichage-liens {
+  display: none;
+}
+
+.dashboard-card.champ-liens.champ-vide .icone-defaut {
+  display: block;
+}
+
 .dashboard-card.champ-liens .liste-liens-publics {
   display: flex;
   gap: 0.5rem;

--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -120,7 +120,8 @@ function initLiensPublics(bloc, { panneauId, formId, action, reload = false }) {
 
   if (!champ || !postId || !bouton || !panneau || !formulaire) return;
 
-  bouton.addEventListener('click', () => {
+  bouton.addEventListener('click', (e) => {
+    e.preventDefault();
     if (typeof window.openPanel === 'function') {
       window.openPanel(panneauId);
     } else {

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -37,6 +37,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // ✅ Ce bouton existe ET il est contenu dans le panneau organisateur
     if (!btn || !btn.closest('.panneau-organisateur')) return;
 
+    e.preventDefault();
+
     if (typeof window.openPanel === 'function') {
       window.openPanel('panneau-liens-publics');
     }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -540,13 +540,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     </div>
                     <h3>Sites et réseaux de la chasse</h3>
                     <?php if ($peut_modifier) : ?>
-                      <button type="button"
+                      <a href="#"
                         class="stat-value champ-modifier ouvrir-panneau-liens"
                         data-champ="chasse_principale_liens"
                         data-cpt="chasse"
                         data-post-id="<?= esc_attr($chasse_id); ?>">
                         <?= empty($liens) ? 'Ajouter' : 'Éditer'; ?>
-                      </button>
+                      </a>
                     <?php endif; ?>
                     <div class="champ-donnees"
                       data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -534,7 +534,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     data-champ="chasse_principale_liens"
                     data-cpt="chasse"
                     data-post-id="<?= esc_attr($chasse_id); ?>">
-                    <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
+                    <i class="fa-solid fa-share-nodes icone-defaut" aria-hidden="true"></i>
+                    <div class="champ-affichage champ-affichage-liens">
+                      <?= render_liens_publics($liens, 'chasse', ['placeholder' => false]); ?>
+                    </div>
                     <h3>Sites et réseaux de la chasse</h3>
                     <?php if ($peut_modifier) : ?>
                       <button type="button"
@@ -547,9 +550,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <?php endif; ?>
                     <div class="champ-donnees"
                       data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
-                    <div class="champ-affichage champ-affichage-liens">
-                      <?= render_liens_publics($liens, 'chasse', ['placeholder' => false]); ?>
-                    </div>
                     <div class="champ-feedback"></div>
                   </div>
                   <?php

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -278,13 +278,13 @@ $is_complete = (
                     </div>
                     <h3>Sites et réseaux de l'organisation</h3>
                     <?php if ($peut_modifier) : ?>
-                      <button type="button"
+                      <a href="#"
                         class="stat-value champ-modifier ouvrir-panneau-liens"
                         data-champ="liens_publics"
                         data-cpt="organisateur"
                         data-post-id="<?= esc_attr($organisateur_id); ?>">
                         <?= empty($liens_publics) ? 'Ajouter' : 'Éditer'; ?>
-                      </button>
+                      </a>
                     <?php endif; ?>
                     <div class="champ-donnees"
                       data-valeurs='<?= json_encode($liens_publics, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -272,7 +272,10 @@ $is_complete = (
                     data-champ="liens_publics"
                     data-cpt="organisateur"
                     data-post-id="<?= esc_attr($organisateur_id); ?>">
-                    <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
+                    <i class="fa-solid fa-share-nodes icone-defaut" aria-hidden="true"></i>
+                    <div class="champ-affichage champ-affichage-liens">
+                      <?= render_liens_publics($liens_publics, 'organisateur', ['placeholder' => false]); ?>
+                    </div>
                     <h3>Sites et réseaux de l'organisation</h3>
                     <?php if ($peut_modifier) : ?>
                       <button type="button"
@@ -285,9 +288,6 @@ $is_complete = (
                     <?php endif; ?>
                     <div class="champ-donnees"
                       data-valeurs='<?= json_encode($liens_publics, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
-                    <div class="champ-affichage champ-affichage-liens">
-                      <?= render_liens_publics($liens_publics, 'organisateur', ['placeholder' => false]); ?>
-                    </div>
                     <div class="champ-feedback"></div>
                   </div>
                   <?php


### PR DESCRIPTION
Permet l'affichage dynamique des icônes des liens dans les cartes d'édition pour les chasses et les organisateurs.

- Remplace l'icône statique de partage par les icônes des liens configurés.
- Masque automatiquement l'icône par défaut lorsqu'au moins un lien est présent.
- Centralise le style pour l'affichage conditionnel des icônes dans les cartes d'édition.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689eba9b0e4c8332bb0467f81c7b7128