### PR TITLE
Corrige l'affichage des points dans la topbar

### DIFF
--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -142,7 +142,7 @@ function afficher_points_utilisateur_callback() {
 
     // 🏷️ Récupération des données utilisateur
     $user_id = get_current_user_id();
-    $points = intval(get_user_meta($user_id, 'points_utilisateur', true)) ?: 0;
+    $points = get_user_points($user_id);
     $icone_points_url = esc_url(get_stylesheet_directory_uri() . '/assets/images/points-small.png');
     $boutique_url = esc_url(home_url('/boutique'));
 


### PR DESCRIPTION
## Résumé
- Corrige la récupération du solde de points dans la topbar en utilisant le nouveau dépôt

## Changements notables
- Remplace `get_user_meta` par `get_user_points` pour afficher le solde utilisateur

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689efc0d35b48332940a691a66d5b288