### PR TITLE
docs: update wp_user_points table for payment request history

### DIFF
--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -1274,7 +1274,12 @@ Index :
 | balance   | int unsigned    | solde après l'opération          |
 | points    | int             | variation (crédit ou débit)      |
 | reason    | varchar(255)    | motif de l'opération             |
-| created_at | datetime NULL DEFAULT CURRENT_TIMESTAMP | date d'enregistrement |
+| request_status | enum('pending','approved','paid','refused') DEFAULT 'pending' | statut de la demande |
+| request_date | datetime DEFAULT CURRENT_TIMESTAMP | date de la demande |
+| settlement_date | datetime NULL | date de règlement |
+| cancelled_date | datetime NULL | date d'annulation/refus |
+| cancellation_reason | varchar(255) NULL | motif du refus/annulation |
+| created_at | datetime DEFAULT CURRENT_TIMESTAMP | date d'enregistrement |
 
 Index :
 - `PRIMARY(id)`


### PR DESCRIPTION
## Summary
- document payment request fields in wp_user_points

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689effb2d10883328a0130f5338b7a97