### PR TITLE
Store euro amount for conversion requests

### DIFF
--- a/wp-content/themes/chassesautresor/inc/PointsRepository.php
+++ b/wp-content/themes/chassesautresor/inc/PointsRepository.php
@@ -66,11 +66,16 @@ class PointsRepository
 
     /**
      * Record a conversion request with pending status and return the inserted row ID.
+     *
+     * @param int   $userId    User identifier.
+     * @param int   $points    Point variation (negative for conversions).
+     * @param float $amountEur Equivalent amount in euros.
      */
-    public function logConversionRequest(int $userId, int $points): int
+    public function logConversionRequest(int $userId, int $points, float $amountEur): int
     {
         $current = $this->getBalance($userId);
         $newBalance = max(0, $current + $points);
+        $amountEur = round($amountEur, 2);
 
         $this->wpdb->insert(
             $this->table,
@@ -78,11 +83,12 @@ class PointsRepository
                 'user_id'        => $userId,
                 'balance'        => $newBalance,
                 'points'         => $points,
+                'amount_eur'     => $amountEur,
                 'reason'         => 'conversion',
                 'request_status' => 'pending',
                 'request_date'   => current_time('mysql'),
             ],
-            ['%d', '%d', '%d', '%s', '%s', '%s']
+            ['%d', '%d', '%d', '%f', '%s', '%s', '%s']
         );
 
         return (int) $this->wpdb->insert_id;

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -581,7 +581,7 @@ function traiter_demande_paiement() {
 
     global $wpdb;
     $repo   = new PointsRepository($wpdb);
-    $log_id = $repo->logConversionRequest($user_id, -$points_a_convertir);
+    $log_id = $repo->logConversionRequest($user_id, -$points_a_convertir, $montant_euros);
 
     $nouvelle_demande = [
         'paiement_date_demande'   => current_time('mysql'),

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -1273,6 +1273,7 @@ Index :
 | user_id   | bigint unsigned | identifiant du joueur            |
 | balance   | int unsigned    | solde après l'opération          |
 | points    | int             | variation (crédit ou débit)      |
+| amount_eur | decimal(10,2) NULL | montant équivalent en euros |
 | reason    | varchar(255)    | motif de l'opération             |
 | request_status | enum('pending','approved','paid','refused') DEFAULT 'pending' | statut de la demande |
 | request_date | datetime DEFAULT CURRENT_TIMESTAMP | date de la demande |


### PR DESCRIPTION
## Résumé
- Enregistre le montant en euros lors des demandes de conversion
- Documente la colonne `amount_eur` dans la table `wp_user_points`

## Changements notables
- Ajout de l'argument `amount_eur` dans `PointsRepository::logConversionRequest`
- Passage du montant en euros depuis le traitement des formulaires de conversion
- Mise à jour de la notice décrivant la table `wp_user_points`

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689f039d6f6483328b8c6bef834b4212