### PR TITLE
feat: style des tableaux en mode édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1110,28 +1110,6 @@ body.panneau-ouvert::before {
   position: relative;
   z-index: 1;
 }
-
-/* ====== Styles génériques des tableaux d'édition ====== */
-.edition-panel table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.edition-panel th,
-.edition-panel td {
-  padding: 6px 12px;
-  text-align: right;
-}
-
-.edition-panel thead {
-  background-color: var(--color-editor-background);
-  color: var(--color-editor-heading);
-}
-
-.edition-panel tbody tr:nth-child(even) {
-  background-color: var(--color-editor-field-hover);
-}
-
 /* Table des tentatives de réponse */
 .table-tentatives {
   width: 100%;

--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -376,3 +376,37 @@ span.champ-obligatoire {
   align-items: center;
   gap: 1rem;
 }
+
+/* ====== Tableaux – Mode édition ====== */
+.mode-edition table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  caption-side: bottom;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+}
+
+.mode-edition table thead {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.mode-edition table th,
+.mode-edition table td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid hsl(var(--border));
+  white-space: nowrap;
+}
+
+.mode-edition table tbody tr:hover {
+  background-color: var(--color-editor-field-hover);
+}
+
+.mode-edition table tbody tr:last-child td {
+  border-bottom: none;
+}

--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -389,7 +389,6 @@
 .dashboard-card table {
     width: 100%;
     border-collapse: collapse;
-    border : 0 transparent;
 }
 
 .dashboard-card table tr,  .stats-table tr td{
@@ -399,7 +398,6 @@
 .dashboard-card table td {
     text-align: left;
     padding: 8px;
-    font-weight: bold;
 }
 /* images */
 .image-container {

--- a/wp-content/themes/chassesautresor/docs/mode-edition-charte.md
+++ b/wp-content/themes/chassesautresor/docs/mode-edition-charte.md
@@ -22,6 +22,15 @@ Le mode édition est actif lorsque la classe `mode-edition` est présente sur la
 - **Grille de cartes** : `.dashboard-grid` organisant les `.dashboard-card` adaptatives.
 - **Cartes et tableaux** : utilisation de bordures `1px` et rayons `8px`.
 
+### Tableaux
+
+Les tableaux affichés en mode édition adoptent par défaut un style inspiré de `shadcn/ui` :
+
+- bordure `1px` arrondie (`8px`) ;
+- en‑tête collant avec fond `--muted` ;
+- lignes séparées par une bordure fine et survolées en `--color-editor-field-hover` ;
+- cellules espacées (`0.5rem`) et texte aligné à gauche.
+
 ## Typographie
 
 Le mode édition utilise la police principale définie par `var(--font-main)`.


### PR DESCRIPTION
## Résumé
- harmonise les tableaux du mode édition avec le style shadcn/ui
- nettoie les styles obsolètes et documente la charte

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689f486a22ec83329ab0535370e087c2