### PR TITLE
Améliore l'affichage et la validation de la conversion de points

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/gamification.css
+++ b/wp-content/themes/chassesautresor/assets/css/gamification.css
@@ -520,8 +520,18 @@ header .points-link:hover {
 
 .points-modal .conversion-equivalent {
     margin-top: 0.5rem;
+}
+
+.points-modal .conversion-equivalent .label {
     font-size: 0.875rem;
     color: var(--color-editor-text-muted);
+}
+
+.points-modal .conversion-equivalent .amount {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--color-editor-heading);
 }
 
 .points-modal .points-feedback {

--- a/wp-content/themes/chassesautresor/assets/js/conversion.js
+++ b/wp-content/themes/chassesautresor/assets/js/conversion.js
@@ -27,8 +27,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const initForm = () => {
         const inputPoints = document.getElementById("points-a-convertir");
         const montantEquivalent = document.getElementById("montant-equivalent");
+        const submitBtn = modal.querySelector(".modal-actions button[type='submit']");
 
-        if (inputPoints && montantEquivalent) {
+        if (inputPoints && montantEquivalent && submitBtn) {
             const tauxConversion = parseFloat(inputPoints.dataset.taux) || 85;
             const min = parseInt(inputPoints.min) || 0;
             const max = parseInt(inputPoints.max) || Infinity;
@@ -58,8 +59,18 @@ document.addEventListener("DOMContentLoaded", () => {
                 montantEquivalent.textContent = montant;
             };
 
+            const toggleButton = () => {
+                submitBtn.disabled = inputPoints.value.trim() === "";
+            };
+
             const validateAndClamp = () => {
-                let points = parseInt(inputPoints.value, 10);
+                const raw = inputPoints.value.trim();
+                if (raw === "") {
+                    updateEquivalent();
+                    toggleButton();
+                    return;
+                }
+                let points = parseInt(raw, 10);
                 if (isNaN(points) || points < min) {
                     points = min;
                     showMessage(`points minimum : ${min} points`);
@@ -69,10 +80,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 inputPoints.value = points;
                 updateEquivalent();
+                toggleButton();
             };
 
             inputPoints.addEventListener("input", () => {
                 updateEquivalent();
+                toggleButton();
                 clearTimeout(debounceTimer);
                 debounceTimer = setTimeout(validateAndClamp, 500);
             });
@@ -80,6 +93,7 @@ document.addEventListener("DOMContentLoaded", () => {
             inputPoints.addEventListener("blur", validateAndClamp);
 
             updateEquivalent();
+            toggleButton();
         }
     };
 

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -268,22 +268,19 @@ function render_conversion_modal_content($access_message = null): string
                     min="<?php echo esc_attr($points_minimum); ?>"
                     max="<?php echo esc_attr($user_points); ?>"
                     step="1"
-                    value="<?php echo esc_attr($points_minimum); ?>"
+                    value=""
                     data-taux="<?php echo esc_attr($taux_conversion); ?>"
                 >
                 <span class="points-unit"><?php esc_html_e('points', 'chassesautresor-com'); ?></span>
             </div>
             <p class="conversion-equivalent">
-                <?php esc_html_e('contre-valeur :', 'chassesautresor-com'); ?>
-                <span id="montant-equivalent">
-                    <?php echo esc_html(number_format(($points_minimum / 1000) * $taux_conversion, 2, '.', '')); ?>
-                </span>
-                €
+                <span class="label"><?php esc_html_e('contre valeur', 'chassesautresor-com'); ?></span>
+                <span class="amount"><span id="montant-equivalent">0.00</span> €</span>
             </p>
             <input type="hidden" name="demander_paiement" value="1">
             <?php wp_nonce_field('demande_paiement_action', 'demande_paiement_nonce'); ?>
             <div class="modal-actions">
-                <button type="submit"><?php esc_html_e('Convertir', 'chassesautresor-com'); ?></button>
+                <button type="submit" disabled><?php esc_html_e('Convertir', 'chassesautresor-com'); ?></button>
             </div>
         </form>
         <?php


### PR DESCRIPTION
## Résumé
- Ajuste l'affichage de la contre-valeur en euros dans la modale
- Vide l'entrée de points par défaut et désactive le bouton tant qu'elle est vide
- Vérifie dynamiquement la quantité saisie avant de permettre la conversion

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689f527a1a9c833287cea6217f3c2f43