### PR TITLE
Affichage du titre dans les panneaux d'édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -648,9 +648,14 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
 }
 
 .edition-panel-section .resume-technique label,
-.edition-panel-section .resume-reglages label {
+.edition-panel-section .resume-reglages label,
+.edition-panel-section .resume-obligatoire label {
   display: inline-block;
   min-width: 150px;
+}
+
+.resume-infos .champ-valeur {
+  display: inline-block;
 }
 
 .edition-panel-section .resume-technique input.inline-date,

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -215,11 +215,15 @@ window.mettreAJourResumeInfos = function () {
 window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
   cpt = cpt?.toLowerCase?.() || cpt;
 
-  // ✅ ORGANISATEUR : mise à jour titre + image
-  if (cpt === 'organisateur') {
-    if (champ === 'post_title' && typeof window.mettreAJourTitreHeader === 'function') {
+  if (champ === 'post_title') {
+    mettreAJourResumeTitre(cpt, valeur);
+    if (typeof window.mettreAJourTitreHeader === 'function') {
       window.mettreAJourTitreHeader(cpt, valeur);
     }
+  }
+
+  // ✅ ORGANISATEUR : mise à jour image
+  if (cpt === 'organisateur') {
     if (champ === 'logo_organisateur') {
       const bloc = document.querySelector(`.champ-organisateur[data-champ="${champ}"][data-post-id="${postId}"]`);
       if (bloc && typeof bloc.__ouvrirMedia === 'function') bloc.__ouvrirMedia();
@@ -238,11 +242,8 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
     }
   }
 
-  // ✅ CHASSE : titre + image + statut
+  // ✅ CHASSE : image + statut
   if (cpt === 'chasse') {
-    if (champ === 'post_title' && typeof window.mettreAJourTitreHeader === 'function') {
-      window.mettreAJourTitreHeader(cpt, valeur);
-    }
     if (champ === 'chasse_principale_image') {
       const bloc = document.querySelector(`.champ-chasse[data-champ="${champ}"][data-post-id="${postId}"]`);
       if (bloc && typeof bloc.__ouvrirMedia === 'function') bloc.__ouvrirMedia();
@@ -257,6 +258,10 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
     ];
     if (champsStatut.includes(champ)) {
       rafraichirStatutChasse(postId);
+    }
+    const champsResume = ['post_title'];
+    if (champsResume.includes(champ) && typeof window.mettreAJourResumeInfos === 'function') {
+      window.mettreAJourResumeInfos();
     }
   }
 
@@ -280,10 +285,6 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
       'enigme_solution_heure'
     ];
 
-    if (champ === 'post_title' && typeof window.mettreAJourTitreHeader === 'function') {
-      window.mettreAJourTitreHeader(cpt, valeur);
-    }
-
     if (champ === 'enigme_visuel_legende') {
       const legende = document.querySelector('.enigme-soustitre');
       if (legende) legende.textContent = valeur;
@@ -295,6 +296,32 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
   }
 
 };
+
+function mettreAJourResumeTitre(cpt, valeur) {
+  const span = document.querySelector(`.edition-panel-${cpt} .resume-infos li[data-champ="post_title"] .champ-valeur`);
+  if (!span) return;
+
+  const titre = valeur?.trim() || '';
+  let placeholder = '';
+  let defaut = '';
+
+  switch (cpt) {
+    case 'chasse':
+      placeholder = 'renseigner le titre de la chasse';
+      defaut = window.CHP_CHASSE_DEFAUT?.titre || 'nouvelle chasse';
+      break;
+    case 'enigme':
+      placeholder = 'renseigner le titre de l’énigme';
+      defaut = 'en création';
+      break;
+    default:
+      placeholder = 'renseigner le titre de l’organisateur';
+      defaut = 'votre nom d’organisateur';
+  }
+
+  const estVide = !titre || titre.toLowerCase() === defaut.toLowerCase();
+  span.textContent = estVide ? placeholder : titre;
+}
 
 
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -87,11 +87,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
                   <div class="champ-affichage">
-                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre de la chasse</label>
+                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre :</label>
+                    <span class="champ-valeur">
+                      <?= $isTitreParDefaut ? 'renseigner le titre de la chasse' : esc_html($titre); ?>
+                    </span>
                     <?php if ($peut_editer_titre) : ?>
-                      <button type="button" class="champ-modifier" aria-label="Modifier le titre">
-                        ✏️
-                      </button>
+                      <button type="button" class="champ-modifier" aria-label="Modifier le titre">✏️</button>
                     <?php endif; ?>
                   </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -113,13 +113,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     data-post-id="<?= esc_attr($enigme_id); ?>">
 
                     <div class="champ-affichage">
-                      <label for="champ-titre-enigme">Titre de l’énigme</label>
+                      <label for="champ-titre-enigme">Titre :</label>
+                      <span class="champ-valeur">
+                        <?= $isTitreParDefaut ? 'renseigner le titre de l’énigme' : esc_html($titre); ?>
+                      </span>
                       <?php if ($peut_editer_titre) : ?>
                         <button type="button"
                           class="champ-modifier"
-                          aria-label="Modifier le titre">
-                          ✏️
-                        </button>
+                          aria-label="Modifier le titre">✏️</button>
                       <?php endif; ?>
                     </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -92,13 +92,14 @@ $is_complete = (
                     data-post-id="<?= esc_attr($organisateur_id); ?>">
 
                   <div class="champ-affichage">
-                    <label for="champ-titre-organisateur">Nom d’organisateur</label>
+                    <label for="champ-titre-organisateur">Titre :</label>
+                    <span class="champ-valeur">
+                      <?= empty($titre) ? "renseigner le titre de l’organisateur" : esc_html($titre); ?>
+                    </span>
                     <?php if ($peut_editer_titre) : ?>
                       <button type="button"
                         class="champ-modifier"
-                        aria-label="Modifier le nom d’organisateur">
-                        ✏️
-                      </button>
+                        aria-label="Modifier le nom d’organisateur">✏️</button>
                     <?php endif; ?>
                   </div>
 


### PR DESCRIPTION
## Résumé
- harmonise l'affichage du titre dans les panneaux d'édition
- met à jour dynamiquement le résumé après modification du titre
- applique une règle CSS pour aligner les labels

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f57260cfc8332a780ceb264612919