### PR TITLE
Centralise l'indentation des labels du mode édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -651,7 +651,7 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
 .edition-panel-section .resume-reglages label,
 .edition-panel-section .resume-obligatoire label {
   display: inline-block;
-  min-width: 150px;
+  min-width: var(--editor-label-width);
 }
 
 .resume-infos .champ-valeur {

--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -264,6 +264,8 @@ span.champ-obligatoire {
 
   --color-editor-field-hover:      #E8F0FE;   /* 💠 Fond des champs actifs / survolés */
   --color-editor-placeholder:      #9AA0A6;   /* 💬 Placeholder ou aide contextuelle */
+
+  --editor-label-width:            150px;     /* 📏 Largeur minimale des labels dans les panneaux */
 }
 
 

--- a/wp-content/themes/chassesautresor/docs/mode-edition-charte.md
+++ b/wp-content/themes/chassesautresor/docs/mode-edition-charte.md
@@ -22,6 +22,12 @@ Le mode édition est actif lorsque la classe `mode-edition` est présente sur la
 - **Grille de cartes** : `.dashboard-grid` organisant les `.dashboard-card` adaptatives.
 - **Cartes et tableaux** : utilisation de bordures `1px` et rayons `8px`.
 
+### Indentation des labels
+
+Les formulaires des panneaux d'édition alignent les zones de saisie grâce à une largeur minimale appliquée aux labels.
+Cette valeur est centralisée dans `assets/css/general.css` via la variable `--editor-label-width` (par défaut : `150px`).
+Modifier cette variable ajuste l'indentation de tous les champs du mode édition.
+
 ## Typographie
 
 Le mode édition utilise la police principale définie par `var(--font-main)`.


### PR DESCRIPTION
## Résumé
- centralisation de l'indentation des labels du mode édition via une variable CSS
- documentation de la règle d'indentation dans la charte du mode édition

## Changements notables
- ajout de `--editor-label-width` pour contrôler la largeur minimale des labels
- application de cette variable dans les panneaux d'édition
- mise à jour de la documentation du mode édition

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689f5df078dc833287be3d8efebd1321