### PR TITLE
feat: improve image editing previews

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -185,20 +185,43 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
 }
 
 .champ-img .champ-affichage {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
 }
 
 .champ-img .champ-modifier {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  position: relative;
+  display: inline-block;
   margin: 0;
   padding: 0;
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.champ-img .champ-modifier img {
+  display: block;
+}
+
+.champ-img .champ-modifier .icone-modif {
+  position: absolute;
+  top: 0.2rem;
+  right: 0.2rem;
+  font-size: 0.9rem;
+  color: var(--color-secondary);
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.25rem;
+  transition: transform 0.2s;
+}
+
+.champ-img .champ-modifier:hover .icone-modif {
+  transform: scale(1.1);
+}
+
+.champ-img.champ-vide .champ-modifier .icone-modif {
+  display: none;
 }
 
 .edition-panel .champ-img img {

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -201,7 +201,7 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   cursor: pointer;
 }
 
-.champ-img img {
+.edition-panel .champ-img img {
   max-width: 80px;
   height: auto;
   border-radius: 0.25rem;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -176,6 +176,14 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   transform: translateY(0);
 }
 
+.champ-img.champ-vide img {
+  display: none;
+}
+
+.champ-img:not(.champ-vide) .champ-ajout-image {
+  display: none;
+}
+
 .media-modal.wp-core-ui button.media-modal-close:hover {
   color: white !important;
 }

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -184,6 +184,29 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   display: none;
 }
 
+.champ-img .champ-affichage {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.champ-img .champ-modifier {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.champ-img img {
+  max-width: 80px;
+  height: auto;
+  border-radius: 0.25rem;
+}
+
 .media-modal.wp-core-ui button.media-modal-close:hover {
   color: white !important;
 }
@@ -790,8 +813,7 @@ li.champ-titre {
 }
 
 li.ligne-logo .champ-modifier {
-  margin-top: 0.5rem;
-  margin-left: -0.5rem;
+  margin: 0;
 }
 
 li.ligne-email i.fa-envelope {

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -187,7 +187,7 @@ function initChampDeclencheur(bouton) {
   if (!champ || !postId || !cpt) return;
 
   bouton.addEventListener('click', () => {
-    const bloc = document.querySelector(
+    const bloc = bouton.closest(
       `.champ-${cpt}[data-champ="${champ}"][data-post-id="${postId}"]`
     );
 

--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -96,6 +96,7 @@ function mettreAJourVisuelCPT(cpt, postId, nouvelleUrl) {
   document.querySelectorAll(`img.visuel-cpt[data-cpt="${cpt}"][data-post-id="${postId}"]`)
     .forEach(img => {
       img.src = nouvelleUrl;
+      img.srcset = nouvelleUrl;
     });
 }
 

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -34,10 +34,12 @@ function initChampImage(bloc) {
     frame.on('select', () => {
       const selection = frame.state().get('selection').first();
       const id = selection?.id;
-      const url = selection?.attributes?.url;
-      if (!id || !url) return;
+      const fullUrl = selection?.attributes?.url;
+      const thumbUrl = selection?.attributes?.sizes?.thumbnail?.url || fullUrl;
+      if (!id || !fullUrl) return;
 
-      image.src = url;
+      image.src = thumbUrl;
+      image.srcset = thumbUrl;
       input.value = id;
 
       if (feedback) {
@@ -69,7 +71,7 @@ function initChampImage(bloc) {
               window.mettreAJourResumeInfos();
             }
             if (typeof window.mettreAJourVisuelCPT === 'function') {
-              mettreAJourVisuelCPT(cpt, postId, url);
+              mettreAJourVisuelCPT(cpt, postId, fullUrl);
             }
           } else {
             if (feedback) {

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -35,11 +35,13 @@ function initChampImage(bloc) {
       const selection = frame.state().get('selection').first();
       const id = selection?.id;
       const fullUrl = selection?.attributes?.url;
-      const thumbUrl = selection?.attributes?.sizes?.thumbnail?.url || fullUrl;
+      const mediumUrl = selection?.attributes?.sizes?.medium?.url || fullUrl;
+      const thumbUrl = selection?.attributes?.sizes?.thumbnail?.url || mediumUrl;
       if (!id || !fullUrl) return;
 
       image.src = thumbUrl;
       image.srcset = thumbUrl;
+      bloc.classList.remove('champ-vide');
       input.value = id;
 
       if (feedback) {
@@ -62,7 +64,6 @@ function initChampImage(bloc) {
         .then(r => r.json())
         .then(res => {
           if (res.success) {
-            bloc.classList.remove('champ-vide');
             if (feedback) {
               feedback.textContent = '';
               feedback.className = 'champ-feedback champ-success';
@@ -71,7 +72,7 @@ function initChampImage(bloc) {
               window.mettreAJourResumeInfos();
             }
             if (typeof window.mettreAJourVisuelCPT === 'function') {
-              mettreAJourVisuelCPT(cpt, postId, fullUrl);
+              mettreAJourVisuelCPT(cpt, postId, mediumUrl);
             }
           } else {
             if (feedback) {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -19,7 +19,9 @@ $peut_editer_cout  = champ_est_editable('caracteristiques.chasse_infos_cout_poin
 
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
 
-$image = $infos_chasse['image_raw'];
+$image      = $infos_chasse['image_raw'];
+$image_id   = $infos_chasse['image_id'] ?? null;
+$image_url  = $infos_chasse['image_url'] ?? null;
 $description = $infos_chasse['description'];
 $titre = get_the_title($chasse_id);
 $liens = $infos_chasse['liens'];
@@ -108,19 +110,33 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 </li>
                 
                 <!-- Image -->
-                <li class="champ-chasse champ-img <?= empty($image) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                <li class="champ-chasse champ-img <?= empty($image_id) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
                   data-champ="chasse_principale_image"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
-                  Une image principale
-                  <?php if ($peut_editer) : ?>
-                    <button type="button"
-                      class="champ-modifier"
-                      data-champ="chasse_principale_image"
-                      data-cpt="chasse"
-                      data-post-id="<?= esc_attr($chasse_id); ?>"
-                      aria-label="Modifier l’image">✏️</button>
-                  <?php endif; ?>
+                  Image chasse
+                  <div class="champ-affichage">
+                    <?php if ($peut_editer) : ?>
+                      <button type="button"
+                        class="champ-modifier"
+                        data-champ="chasse_principale_image"
+                        data-cpt="chasse"
+                        data-post-id="<?= esc_attr($chasse_id); ?>"
+                        aria-label="Modifier l’image">
+                        <img src="<?= esc_url($image_url ?: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='); ?>" alt="Image de la chasse" />
+                        <span class="champ-ajout-image">ajouter une image</span>
+                        <span class="icone-modif">✏️</span>
+                      </button>
+                    <?php else : ?>
+                      <?php if ($image_url) : ?>
+                        <img src="<?= esc_url($image_url); ?>" alt="Image de la chasse" />
+                      <?php else : ?>
+                        <span class="champ-ajout-image">ajouter une image</span>
+                      <?php endif; ?>
+                    <?php endif; ?>
+                  </div>
+                  <input type="hidden" class="champ-input" value="<?= esc_attr($image_id ?? '') ?>">
+                  <div class="champ-feedback"></div>
                 </li>
 
                 <!-- Description -->

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -19,9 +19,8 @@ $peut_editer_cout  = champ_est_editable('caracteristiques.chasse_infos_cout_poin
 
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
 
-$image      = $infos_chasse['image_raw'];
 $image_id   = $infos_chasse['image_id'] ?? null;
-$image_url  = $infos_chasse['image_url'] ?? null;
+$image_url  = $image_id ? wp_get_attachment_image_src($image_id, 'thumbnail')[0] : null;
 $description = $infos_chasse['description'];
 $titre = get_the_title($chasse_id);
 $liens = $infos_chasse['liens'];
@@ -114,8 +113,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-champ="chasse_principale_image"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
-                  Image chasse
                   <div class="champ-affichage">
+                    <label>Image chasse</label>
                     <?php if ($peut_editer) : ?>
                       <button type="button"
                         class="champ-modifier"

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -119,8 +119,8 @@ $is_complete = (
                 </li>
 
                 <li class="champ-organisateur champ-img champ-logo ligne-logo <?= empty($logo_id) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="<?= esc_attr($organisateur_id); ?>">
-                  Logo organisateur
                   <div class="champ-affichage">
+                    <label>Logo organisateur</label>
                     <?php if ($peut_editer) : ?>
                       <button type="button"
                         class="champ-modifier"

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -20,6 +20,8 @@ $user_points    = function_exists('get_user_points') ? get_user_points((int) $cu
 // Post
 $titre        = get_post_field('post_title', $organisateur_id);
 $logo         = get_field('profil_public_logo_organisateur', $organisateur_id);
+$logo_id      = is_array($logo) ? ($logo['ID'] ?? null) : $logo;
+$logo_url     = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail')[0] : null;
 $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);
 $site         = get_field('lien_site_web', $organisateur_id);
@@ -116,19 +118,28 @@ $is_complete = (
                   <div class="champ-feedback"></div>
                 </li>
 
-                <li class="champ-organisateur champ-logo ligne-logo <?= !empty($logo) ? 'champ-rempli' : 'champ-vide'; ?>" data-champ="profil_public_logo_organisateur">
-                  Un logo
-                  <?php if ($peut_editer) : ?>
-                    <button type="button"
-                      class="champ-modifier"
-                      aria-label="Modifier le logo"
-                      data-champ="profil_public_logo_organisateur"
-                      data-cpt="organisateur"
-                      data-post-id="<?php echo esc_attr($organisateur_id); ?>">
-                      ✏️
-                    </button>
-
-                  <?php endif; ?>
+                <li class="champ-organisateur champ-img champ-logo ligne-logo <?= empty($logo_id) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="<?= esc_attr($organisateur_id); ?>">
+                  Logo organisateur
+                  <div class="champ-affichage">
+                    <?php if ($peut_editer) : ?>
+                      <button type="button"
+                        class="champ-modifier"
+                        aria-label="Modifier le logo"
+                        data-champ="profil_public_logo_organisateur"
+                        data-cpt="organisateur"
+                        data-post-id="<?= esc_attr($organisateur_id); ?>">
+                        <img src="<?= esc_url($logo_url ?: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='); ?>" alt="Logo de l’organisateur" />
+                        <span class="champ-ajout-image">ajouter une image</span>
+                        <span class="icone-modif">✏️</span>
+                      </button>
+                    <?php else : ?>
+                      <?php if ($logo_url) : ?>
+                        <img src="<?= esc_url($logo_url); ?>" alt="Logo de l’organisateur" />
+                      <?php else : ?>
+                        <span class="champ-ajout-image">ajouter une image</span>
+                      <?php endif; ?>
+                    <?php endif; ?>
+                  </div>
                   <input type="hidden" class="champ-input" value="<?= esc_attr($logo_id ?? '') ?>">
                   <div class="champ-feedback"></div>
                 </li>


### PR DESCRIPTION
## Summary
- permet l’ajout et la prévisualisation des images de chasse
- permet l’ajout et la prévisualisation du logo organisateur
- masque automatiquement le texte d’ajout lorsque l’image est sélectionnée

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689f669dd1148332ab5c78ca8b38e5ac