### PR TITLE
Refactor solution publication into dashboard cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -68,6 +68,16 @@
   /* padding-left: 1.3rem; */
 }
 
+/* Aligne l'icône de complétion et le contenu sur une seule ligne */
+.resume-infos li {
+  display: flex;
+  align-items: center;
+}
+
+.resume-infos li > .champ-affichage {
+  flex: 1;
+}
+
 .cache {
   display: none;
 }
@@ -178,6 +188,27 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
 
 .media-modal.wp-core-ui button.media-modal-close:hover {
   color: white !important;
+}
+
+/* Positionne le stylo dans le coin de la vignette */
+.resume-infos .champ-img .champ-modifier {
+  position: relative;
+  display: inline-block;
+}
+
+.resume-infos .champ-img .champ-modifier img {
+  display: block;
+}
+
+.resume-infos .champ-img .champ-modifier .icone-modif {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: var(--color-secondary);
+  padding: 0.2rem 0.3rem;
+  border-radius: 0.3rem;
+  pointer-events: none;
 }
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1279,10 +1279,17 @@ body.panneau-ouvert::before {
 
 .dashboard-card.solution-option {
   cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s, opacity 0.2s;
 }
 
 .dashboard-card.solution-option.active {
   border-color: var(--color-editor-button);
+  background-color: rgba(26, 115, 232, 0.1);
+  opacity: 1;
+}
+
+.dashboard-card.solution-option:not(.active) {
+  opacity: 0.6;
 }
 
 .dashboard-card h3 {

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1277,6 +1277,14 @@ body.panneau-ouvert::before {
   height: 2rem;
 }
 
+.dashboard-card.solution-option {
+  cursor: pointer;
+}
+
+.dashboard-card.solution-option.active {
+  border-color: var(--color-editor-button);
+}
+
 .dashboard-card h3 {
   margin: 0;
   font-size: 0.9rem;

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -59,6 +59,15 @@ function initEnigmeEdit() {
     }
   });
 
+  document.querySelectorAll('.stat-help').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const message = btn.dataset.message;
+      if (message) {
+        alert(message);
+      }
+    });
+  });
+
 
   // ==============================
   // 🧩 Affichage conditionnel – Champs radio
@@ -964,9 +973,7 @@ function initSolutionInline() {
   const postId = bloc.dataset.postId;
   const cpt = bloc.dataset.cpt || 'enigme';
 
-  const radios = bloc.querySelectorAll('input[name="acf[enigme_solution_mode]"]');
-  const zoneFichier = bloc.querySelector('.champ-solution-fichier');
-  const zoneTexte = bloc.querySelector('.champ-solution-texte');
+  const cards = bloc.querySelectorAll('.solution-option');
   const boutonTexte = bloc.querySelector('#ouvrir-panneau-solution');
 
   const inputDelai = bloc.querySelector('#solution-delai');
@@ -974,40 +981,36 @@ function initSolutionInline() {
   const inputFichier = bloc.querySelector('#solution-pdf-upload');
   const feedbackFichier = bloc.querySelector('.champ-feedback');
 
-  radios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      const val = radio.value;
-      modifierChampSimple('enigme_solution_mode', val, postId, cpt);
+  cards.forEach(card => {
+    card.addEventListener('click', (e) => {
+      e.preventDefault();
+      const mode = card.dataset.mode;
+      bloc.querySelectorAll('input[name="acf[enigme_solution_mode]"]').forEach(r => {
+        r.checked = false;
+      });
+      card.querySelector('input[name="acf[enigme_solution_mode]"]').checked = true;
 
-      if (val === 'pdf') {
-        zoneFichier.style.display = '';
-        zoneTexte.style.display = 'none';
+      cards.forEach(c => c.classList.remove('active'));
+      card.classList.add('active');
 
-        // Déclenche automatiquement la sélection de fichier PDF
+      modifierChampSimple('enigme_solution_mode', mode, postId, cpt);
+
+      if (mode === 'pdf') {
         setTimeout(() => {
           inputFichier?.click();
-        }, 100); // petit délai pour laisser le DOM s'afficher
+        }, 100);
       }
 
-      if (val === 'texte') {
-        zoneFichier.style.display = 'none';
-        zoneTexte.style.display = ''; // on montre l'encart avec le bouton
+      if (mode === 'texte') {
         setTimeout(() => {
-          boutonTexte?.click(); // on simule le clic pour ouvrir le panneau latéral
-        }, 100); // petit délai pour laisser le DOM se stabiliser
+          boutonTexte?.click();
+        }, 100);
       }
     });
   });
 
-  // 🔄 Affichage initial selon valeur radio
   const checked = bloc.querySelector('input[name="acf[enigme_solution_mode]"]:checked');
-  if (checked?.value === 'pdf') {
-    zoneFichier.style.display = '';
-    zoneTexte.style.display = 'none';
-  } else if (checked?.value === 'texte') {
-    zoneFichier.style.display = 'none';
-    zoneTexte.style.display = '';
-  }
+  checked?.closest('.solution-option')?.classList.add('active');
 
   // ⏳ Modification du délai (jours)
   inputDelai?.addEventListener('input', () => {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -974,7 +974,6 @@ function initSolutionInline() {
   const cpt = bloc.dataset.cpt || 'enigme';
 
   const cards = bloc.querySelectorAll('.solution-option');
-  const boutonTexte = bloc.querySelector('#ouvrir-panneau-solution');
 
   const inputDelai = bloc.querySelector('#solution-delai');
   const selectHeure = bloc.querySelector('#solution-heure');
@@ -1002,9 +1001,7 @@ function initSolutionInline() {
       }
 
       if (mode === 'texte') {
-        setTimeout(() => {
-          boutonTexte?.click();
-        }, 100);
+        setTimeout(ouvrirPanneauSolution, 100);
       }
     });
   });
@@ -1068,10 +1065,7 @@ function initSolutionInline() {
 // ==============================
 // ✏️ Panneau solution (texte)
 // ==============================
-document.addEventListener('click', (e) => {
-  const btn = e.target.closest('#ouvrir-panneau-solution'); // ou '.ouvrir-panneau-solution' si classe
-  if (!btn) return;
-
+function ouvrirPanneauSolution() {
   const panneau = document.getElementById('panneau-solution-enigme');
   if (!panneau) return;
 
@@ -1083,17 +1077,24 @@ document.addEventListener('click', (e) => {
   panneau.classList.add('ouvert');
   document.body.classList.add('panneau-ouvert');
   panneau.setAttribute('aria-hidden', 'false');
-});
+}
 
+document.addEventListener('click', (e) => {
+  if (e.target.closest('#ouvrir-panneau-solution')) {
+    ouvrirPanneauSolution();
+  }
+});
 
 // ==============================
 // ✖️ Fermeture panneau solution (wysiwyg)
 // ==============================
-document.querySelector('#panneau-solution-enigme .panneau-fermer')?.addEventListener('click', () => {
-  const panneau = document.getElementById('panneau-solution-enigme');
-  panneau.classList.remove('ouvert');
-  document.body.classList.remove('panneau-ouvert');
-  panneau.setAttribute('aria-hidden', 'true');
+document.addEventListener('click', (e) => {
+  if (e.target.closest('#panneau-solution-enigme .panneau-fermer')) {
+    const panneau = document.getElementById('panneau-solution-enigme');
+    panneau.classList.remove('ouvert');
+    document.body.classList.remove('panneau-ouvert');
+    panneau.setAttribute('aria-hidden', 'true');
+  }
 });
 
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -299,6 +299,10 @@ function initEnigmeEdit() {
   initChampPreRequis();
   initChampSolution();
   initSolutionInline();
+  const paramsMaj = new URLSearchParams(window.location.search);
+  if (paramsMaj.get('maj') === 'solution') {
+    ouvrirPanneauSolution();
+  }
   initChampConditionnel('acf[enigme_acces_condition]', {
     'immediat': [], // pas d'affichage spécifique pour l'accès immédiat
     'date_programmee': ['#champ-enigme-date'],
@@ -1080,9 +1084,25 @@ function ouvrirPanneauSolution() {
 }
 
 document.addEventListener('click', (e) => {
-  if (e.target.closest('#ouvrir-panneau-solution')) {
-    ouvrirPanneauSolution();
+  const trigger = e.target.closest('#ouvrir-panneau-solution');
+  if (!trigger) return;
+
+  const bloc = document.querySelector('.champ-solution-mode');
+  const postId = bloc?.dataset.postId;
+  const cpt = bloc?.dataset.cpt || 'enigme';
+  const radioTexte = bloc?.querySelector('input[name="acf[enigme_solution_mode]"][value="texte"]');
+
+  if (bloc && radioTexte && !radioTexte.checked) {
+    bloc.querySelectorAll('input[name="acf[enigme_solution_mode]"]').forEach(r => { r.checked = false; });
+    radioTexte.checked = true;
+    bloc.querySelectorAll('.solution-option').forEach(c => c.classList.remove('active'));
+    radioTexte.closest('.solution-option')?.classList.add('active');
+    if (postId) {
+      modifierChampSimple('enigme_solution_mode', 'texte', postId, cpt);
+    }
   }
+
+  ouvrirPanneauSolution();
 });
 
 // ==============================

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -511,73 +511,70 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             <fieldset class="groupe-champ champ-groupe-solution">
               <legend>Publication de la solution</legend>
 
-              <div class="champ-enigme champ-solution champ-solution-mode" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+              <?php
+              $solution_mode = get_field('enigme_solution_mode', $enigme_id) ?? 'pdf';
+              $fichier      = get_field('enigme_solution_fichier', $enigme_id);
+              $fichier_url  = is_array($fichier) ? $fichier['url'] : '';
+              $delai        = get_field('enigme_solution_delai', $enigme_id) ?? 7;
+              $heure        = get_field('enigme_solution_heure', $enigme_id) ?? '18:00';
+              $aide_delai   = "Les solutions ne peuvent être publiées que si une chasse est déclarée terminée. Elles restent stockées dans un coffre fort numérique jusqu'à ce que vous décidiez de les en sortir.";
+              ?>
 
-                <?php
-                $solution_mode = get_field('enigme_solution_mode', $enigme_id) ?? 'pdf';
-                $fichier = get_field('enigme_solution_fichier', $enigme_id);
-                $fichier_url = is_array($fichier) ? $fichier['url'] : '';
-                $delai = get_field('enigme_solution_delai', $enigme_id) ?? 7;
-                $heure = get_field('enigme_solution_heure', $enigme_id) ?? '18:00';
-                ?>
+              <div class="champ-enigme champ-solution">
+                <div class="champ-solution-mode" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                  <div class="dashboard-grid solution-cards">
+                    <div class="dashboard-card solution-option<?= $solution_mode === 'pdf' ? ' active' : ''; ?>" data-mode="pdf">
+                      <i class="fa-solid fa-file-pdf" aria-hidden="true"></i>
+                      <h3>Document PDF</h3>
+                      <a href="#" class="stat-value">Choisir un fichier</a>
+                      <input type="radio" name="acf[enigme_solution_mode]" value="pdf" <?= $solution_mode === 'pdf' ? 'checked' : ''; ?> hidden>
+                    </div>
 
-                <!-- ✅ Ligne groupée : radio + fichier + bouton texte -->
-                <div style="display: flex; flex-wrap: wrap; align-items: flex-start; gap: 1rem;">
+                    <div class="dashboard-card solution-option<?= $solution_mode === 'texte' ? ' active' : ''; ?>" data-mode="texte">
+                      <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+                      <h3>Rédaction libre</h3>
+                      <button type="button" id="ouvrir-panneau-solution" class="stat-value">Rédiger</button>
+                      <input type="radio" name="acf[enigme_solution_mode]" value="texte" <?= $solution_mode === 'texte' ? 'checked' : ''; ?> hidden>
+                    </div>
 
-                  <!-- Radios -->
-                  <div class="champ-solution-mode" style="display: flex; flex-direction: column; min-width: 160px;">
-                    <label>
-                      <input type="radio" name="acf[enigme_solution_mode]" value="pdf" <?= $solution_mode === 'pdf' ? 'checked' : ''; ?>>
-                      Télécharger un PDF
-                    </label>
-
-                    <label style="margin-top: 5px;">
-                      <input type="radio" name="acf[enigme_solution_mode]" value="texte" <?= $solution_mode === 'texte' ? 'checked' : ''; ?>>
-                      Rédiger la solution
-                    </label>
+                    <div class="dashboard-card solution-delai">
+                      <i class="fa-regular fa-clock" aria-hidden="true"></i>
+                      <h3>
+                        Délai
+                        <button
+                          type="button"
+                          class="mode-fin-aide stat-help"
+                          data-message="<?= esc_attr($aide_delai); ?>"
+                          aria-label="<?= esc_attr__('Informations sur la publication de la solution', 'chassesautresor-com'); ?>"
+                        >
+                          <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
+                        </button>
+                      </h3>
+                      <p class="stat-value">
+                        <input
+                          type="number"
+                          min="0"
+                          max="60"
+                          step="1"
+                          value="<?= esc_attr($delai); ?>"
+                          id="solution-delai"
+                          class="champ-input champ-delai-inline"
+                        >
+                        jours à
+                        <select id="solution-heure" class="champ-select-heure">
+                          <?php foreach (range(0, 23) as $h) :
+                            $formatted = str_pad($h, 2, '0', STR_PAD_LEFT) . ':00'; ?>
+                            <option value="<?= $formatted; ?>" <?= $formatted === $heure ? 'selected' : ''; ?>><?= $formatted; ?></option>
+                          <?php endforeach; ?>
+                        </select>
+                        heure
+                      </p>
+                    </div>
                   </div>
 
-                  <!-- Upload fichier PDF -->
-                  <div class="champ-solution-fichier" style="<?= $solution_mode === 'pdf' ? '' : 'display:none;' ?> min-width: 200px;">
-                    <?php if ($fichier_url) : ?>
-                      <p style="margin-bottom: 4px;">Fichier actuel : <a href="<?= esc_url($fichier_url); ?>" target="_blank"><?= basename($fichier_url); ?></a></p>
-                    <?php endif; ?>
-                    <input type="file" id="solution-pdf-upload" accept="application/pdf">
-                    <div class="champ-feedback" style="margin-top: 5px;"></div>
-                  </div>
-
-                  <!-- Bouton WYSIWYG -->
-                  <div class="champ-solution-texte" style="<?= $solution_mode === 'texte' ? '' : 'display:none;' ?>">
-                    <button type="button" id="ouvrir-panneau-solution" class="bouton-ouvrir-wysiwyg">
-                      ✏️ Ouvrir l’éditeur de solution
-                    </button>
-                  </div>
-
+                  <input type="file" id="solution-pdf-upload" accept="application/pdf" style="display:none;">
+                  <div class="champ-feedback" style="margin-top: 5px;"></div>
                 </div>
-
-                <!-- ✅ Ligne publication -->
-                <div class="champ-solution-timing" style="margin-top: 15px;">
-                  <label for="solution-delai" style="margin-right: 8px;">Publication :</label>
-
-                  <input type="number"
-                    min="0"
-                    max="60"
-                    step="1"
-                    value="<?= esc_attr($delai); ?>"
-                    id="solution-delai"
-                    class="champ-input champ-delai-inline">
-
-                  <span>jours après la fin de la chasse, à</span>
-
-                  <select id="solution-heure" class="champ-select-heure">
-                    <?php foreach (range(0, 23) as $h) :
-                      $formatted = str_pad($h, 2, '0', STR_PAD_LEFT) . ':00'; ?>
-                      <option value="<?= $formatted; ?>" <?= $formatted === $heure ? 'selected' : ''; ?>><?= $formatted; ?></option>
-                    <?php endforeach; ?>
-                  </select>
-                  <span>heure.</span>
-                </div>
-
               </div>
             </fieldset>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-solution.php
@@ -15,17 +15,21 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
 
     <div class="champ-wrapper">
       <?php
+      $mode_field = acf_get_field('enigme_solution_mode');
+      $mode_key   = $mode_field['key'] ?? '';
+
       acf_form([
-        'post_id' => $enigme_id,
-        'form' => true,
-        'field_groups' => false,
-        'fields' => [
+        'post_id'         => $enigme_id,
+        'form'            => true,
+        'field_groups'    => false,
+        'fields'          => [
           'enigme_solution_explication',
         ],
-        'submit_value' => '💾 Enregistrer la solution',
-        'return' => get_permalink($enigme_id) . '?maj=solution',
-        'uploader' => 'basic',
+        'submit_value'    => '💾 Enregistrer la solution',
+        'return'          => get_permalink($enigme_id) . '?maj=solution',
+        'uploader'        => 'basic',
         'label_placement' => 'top',
+        'html_after_fields' => $mode_key ? '<input type="hidden" name="acf[' . esc_attr($mode_key) . ']" value="texte" />' : '',
       ]);
       ?>
     </div>


### PR DESCRIPTION
## Summary
- refonte de l'onglet solution avec trois cartes : PDF, rédaction et délai
- ajout de la logique JS pour la sélection des cartes
- mise en surbrillance CSS de la carte active

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689f6bb986f48332bb109d0f27b5c2da