### PR TITLE
Retire les deux-points dans les labels Titre des panneaux d’édition

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -88,7 +88,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
                   <div class="champ-affichage">
-                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre :</label>
+                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre</label>
                     <span class="champ-valeur">
                       <?= $isTitreParDefaut ? 'renseigner le titre de la chasse' : esc_html($titre); ?>
                     </span>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -94,7 +94,7 @@ $is_complete = (
                     data-post-id="<?= esc_attr($organisateur_id); ?>">
 
                   <div class="champ-affichage">
-                    <label for="champ-titre-organisateur">Titre :</label>
+                    <label for="champ-titre-organisateur">Titre</label>
                     <span class="champ-valeur">
                       <?= empty($titre) ? "renseigner le titre de l’organisateur" : esc_html($titre); ?>
                     </span>


### PR DESCRIPTION
## Résumé
- Supprime le « : » des labels Titre sur les écrans d’édition de chasse et d’organisateur

## Changements notables
- Retrait du caractère « : » dans le label Titre de l’édition de chasse
- Retrait du caractère « : » dans le label Titre de l’édition de l’organisateur

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689fef51b9b88332af408642fd99edd9