### PR TITLE
feat: show summary for description fields

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -855,6 +855,14 @@ li.ligne-logo .champ-modifier {
 .resume-infos li.champ-description .champ-texte,
 .resume-infos li.champ-wysiwyg .champ-texte {
   flex: 1;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.resume-infos li.champ-description .champ-texte-contenu,
+.resume-infos li.champ-wysiwyg .champ-texte-contenu {
+  flex: 1;
 }
 
 .resume-infos li.champ-description.champ-vide .champ-texte,

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -839,6 +839,36 @@ li.ligne-logo .champ-modifier {
   margin: 0;
 }
 
+/* WYSIWYG résumé blocks */
+.resume-infos li.champ-description,
+.resume-infos li.champ-wysiwyg {
+  display: flex;
+  align-items: flex-start;
+}
+
+.resume-infos li.champ-description label,
+.resume-infos li.champ-wysiwyg label {
+  min-width: var(--editor-label-width);
+}
+
+.resume-infos li.champ-description .champ-texte,
+.resume-infos li.champ-wysiwyg .champ-texte {
+  flex: 1;
+  position: relative;
+}
+
+.resume-infos li.champ-description .champ-texte .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.resume-infos li.champ-description.champ-vide .champ-texte,
+.resume-infos li.champ-wysiwyg.champ-vide .champ-texte {
+  color: var(--color-editor-text-muted);
+}
+
 li.ligne-email i.fa-envelope {
   opacity: 0.6;
   margin-top: 6px;

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -843,7 +843,7 @@ li.ligne-logo .champ-modifier {
 .resume-infos li.champ-description,
 .resume-infos li.champ-wysiwyg {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   gap: 0.5rem;
 }
 

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -844,6 +844,7 @@ li.ligne-logo .champ-modifier {
 .resume-infos li.champ-wysiwyg {
   display: flex;
   align-items: flex-start;
+  gap: 0.5rem;
 }
 
 .resume-infos li.champ-description label,
@@ -854,14 +855,6 @@ li.ligne-logo .champ-modifier {
 .resume-infos li.champ-description .champ-texte,
 .resume-infos li.champ-wysiwyg .champ-texte {
   flex: 1;
-  position: relative;
-}
-
-.resume-infos li.champ-description .champ-texte .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
-  position: absolute;
-  top: 0;
-  right: 0;
 }
 
 .resume-infos li.champ-description.champ-vide .champ-texte,

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -855,14 +855,17 @@ li.ligne-logo .champ-modifier {
 .resume-infos li.champ-description .champ-texte,
 .resume-infos li.champ-wysiwyg .champ-texte {
   flex: 1;
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
 }
 
 .resume-infos li.champ-description .champ-texte-contenu,
 .resume-infos li.champ-wysiwyg .champ-texte-contenu {
-  flex: 1;
+  display: inline;
+}
+
+.resume-infos li.champ-description .champ-texte-contenu .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte-contenu .champ-modifier {
+  transform: none;
+  margin-left: 0.3rem;
 }
 
 .resume-infos li.champ-description.champ-vide .champ-texte,

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -144,6 +144,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
                     <label><?= esc_html__('Description chasse', 'chassesautresor-com'); ?></label>
+                    <?php if ($peut_editer && !empty(trim($description))) : ?>
+                      <button type="button"
+                        class="champ-modifier ouvrir-panneau-description"
+                        data-cpt="chasse"
+                        data-champ="chasse_principale_description"
+                        data-post-id="<?= esc_attr($chasse_id); ?>"
+                        aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
+                    <?php endif; ?>
                     <div class="champ-texte">
                         <?php if (empty(trim($description))) : ?>
                             <?php if ($peut_editer) : ?>
@@ -156,14 +164,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
-                            <?php if ($peut_editer) : ?>
-                                <button type="button"
-                                  class="champ-modifier ouvrir-panneau-description"
-                                  data-cpt="chasse"
-                                  data-champ="chasse_principale_description"
-                                  data-post-id="<?= esc_attr($chasse_id); ?>"
-                                  aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
-                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                 </li>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -155,15 +155,17 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
-                            <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
-                            <?php if ($peut_editer) : ?>
-                              <button type="button"
-                                class="champ-modifier ouvrir-panneau-description"
-                                data-cpt="chasse"
-                                data-champ="chasse_principale_description"
-                                data-post-id="<?= esc_attr($chasse_id); ?>"
-                                aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
-                            <?php endif; ?>
+                            <span class="champ-texte-contenu">
+                                <?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?>
+                                <?php if ($peut_editer) : ?>
+                                    <button type="button"
+                                        class="champ-modifier ouvrir-panneau-description"
+                                        data-cpt="chasse"
+                                        data-champ="chasse_principale_description"
+                                        data-post-id="<?= esc_attr($chasse_id); ?>"
+                                        aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
+                                <?php endif; ?>
+                            </span>
                         <?php endif; ?>
                     </div>
                 </li>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -144,14 +144,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
                     <label><?= esc_html__('Description chasse', 'chassesautresor-com'); ?></label>
-                    <?php if ($peut_editer && !empty(trim($description))) : ?>
-                      <button type="button"
-                        class="champ-modifier ouvrir-panneau-description"
-                        data-cpt="chasse"
-                        data-champ="chasse_principale_description"
-                        data-post-id="<?= esc_attr($chasse_id); ?>"
-                        aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
-                    <?php endif; ?>
                     <div class="champ-texte">
                         <?php if (empty(trim($description))) : ?>
                             <?php if ($peut_editer) : ?>
@@ -164,6 +156,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
+                            <?php if ($peut_editer) : ?>
+                              <button type="button"
+                                class="champ-modifier ouvrir-panneau-description"
+                                data-cpt="chasse"
+                                data-champ="chasse_principale_description"
+                                data-post-id="<?= esc_attr($chasse_id); ?>"
+                                aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                 </li>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -143,15 +143,29 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-champ="chasse_principale_description"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
-                  Une description
-                  <?php if ($peut_editer) : ?>
-                    <button type="button"
-                      class="champ-modifier ouvrir-panneau-description"
-                      data-cpt="chasse"
-                      data-champ="chasse_principale_description"
-                      data-post-id="<?= esc_attr($chasse_id); ?>"
-                      aria-label="Modifier la description">✏️</button>
-                  <?php endif; ?>
+                    <label><?= esc_html__('Description chasse', 'chassesautresor-com'); ?></label>
+                    <div class="champ-texte">
+                        <?php if (empty(trim($description))) : ?>
+                            <?php if ($peut_editer) : ?>
+                                <a href="#" class="champ-ajouter ouvrir-panneau-description"
+                                   data-cpt="chasse"
+                                   data-champ="chasse_principale_description"
+                                   data-post-id="<?= esc_attr($chasse_id); ?>">
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                </a>
+                            <?php endif; ?>
+                        <?php else : ?>
+                            <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
+                            <?php if ($peut_editer) : ?>
+                                <button type="button"
+                                  class="champ-modifier ouvrir-panneau-description"
+                                  data-cpt="chasse"
+                                  data-champ="chasse_principale_description"
+                                  data-post-id="<?= esc_attr($chasse_id); ?>"
+                                  aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </div>
                 </li>
 
                 <!-- Récompense -->

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -163,13 +163,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
                   <li class="champ-enigme champ-wysiwyg<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_texte" data-cpt="enigme"
                     data-post-id="<?= esc_attr($enigme_id); ?>">
-                    Un texte principal
-                    <?php if ($peut_editer) : ?>
-                      <button type="button" class="champ-modifier ouvrir-panneau-description" data-champ="enigme_visuel_texte"
-                        data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                        ✏️
-                      </button>
-                    <?php endif; ?>
+                    <label><?= esc_html__('Texte énigme', 'chassesautresor-com'); ?></label>
+                    <div class="champ-texte">
+                        <?php if (empty(trim($texte))) : ?>
+                            <?php if ($peut_editer) : ?>
+                                <a href="#" class="champ-ajouter ouvrir-panneau-description"
+                                   data-champ="enigme_visuel_texte"
+                                   data-cpt="enigme"
+                                   data-post-id="<?= esc_attr($enigme_id); ?>">
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                </a>
+                            <?php endif; ?>
+                        <?php else : ?>
+                            <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?></span>
+                            <?php if ($peut_editer) : ?>
+                                <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                  data-champ="enigme_visuel_texte"
+                                  data-cpt="enigme"
+                                  data-post-id="<?= esc_attr($enigme_id); ?>"
+                                  aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </div>
                   </li>
 
                   <li class="champ-enigme champ-texte<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_legende" data-cpt="enigme"

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -164,13 +164,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                   <li class="champ-enigme champ-wysiwyg<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_texte" data-cpt="enigme"
                     data-post-id="<?= esc_attr($enigme_id); ?>">
                     <label><?= esc_html__('Texte énigme', 'chassesautresor-com'); ?></label>
-                    <?php if ($peut_editer && !empty(trim($texte))) : ?>
-                      <button type="button" class="champ-modifier ouvrir-panneau-description"
-                        data-champ="enigme_visuel_texte"
-                        data-cpt="enigme"
-                        data-post-id="<?= esc_attr($enigme_id); ?>"
-                        aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
-                    <?php endif; ?>
                     <div class="champ-texte">
                         <?php if (empty(trim($texte))) : ?>
                             <?php if ($peut_editer) : ?>
@@ -183,6 +176,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?></span>
+                            <?php if ($peut_editer) : ?>
+                              <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                data-champ="enigme_visuel_texte"
+                                data-cpt="enigme"
+                                data-post-id="<?= esc_attr($enigme_id); ?>"
+                                aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                   </li>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -164,6 +164,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                   <li class="champ-enigme champ-wysiwyg<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_texte" data-cpt="enigme"
                     data-post-id="<?= esc_attr($enigme_id); ?>">
                     <label><?= esc_html__('Texte énigme', 'chassesautresor-com'); ?></label>
+                    <?php if ($peut_editer && !empty(trim($texte))) : ?>
+                      <button type="button" class="champ-modifier ouvrir-panneau-description"
+                        data-champ="enigme_visuel_texte"
+                        data-cpt="enigme"
+                        data-post-id="<?= esc_attr($enigme_id); ?>"
+                        aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
+                    <?php endif; ?>
                     <div class="champ-texte">
                         <?php if (empty(trim($texte))) : ?>
                             <?php if ($peut_editer) : ?>
@@ -176,13 +183,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?></span>
-                            <?php if ($peut_editer) : ?>
-                                <button type="button" class="champ-modifier ouvrir-panneau-description"
-                                  data-champ="enigme_visuel_texte"
-                                  data-cpt="enigme"
-                                  data-post-id="<?= esc_attr($enigme_id); ?>"
-                                  aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
-                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                   </li>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -175,14 +175,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
-                            <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?></span>
-                            <?php if ($peut_editer) : ?>
-                              <button type="button" class="champ-modifier ouvrir-panneau-description"
-                                data-champ="enigme_visuel_texte"
-                                data-cpt="enigme"
-                                data-post-id="<?= esc_attr($enigme_id); ?>"
-                                aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
-                            <?php endif; ?>
+                            <span class="champ-texte-contenu">
+                                <?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?>
+                                <?php if ($peut_editer) : ?>
+                                    <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                        data-champ="enigme_visuel_texte"
+                                        data-cpt="enigme"
+                                        data-post-id="<?= esc_attr($enigme_id); ?>"
+                                        aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
+                                <?php endif; ?>
+                            </span>
                         <?php endif; ?>
                     </div>
                   </li>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -146,14 +146,6 @@ $is_complete = (
                 <?php $class_description = empty($description) ? 'champ-vide' : 'champ-rempli'; ?>
                 <li class="champ-organisateur champ-description ligne-description <?= $class_description; ?>" data-champ="description_longue">
                     <label><?= esc_html__('Présentation', 'chassesautresor-com'); ?></label>
-                    <?php if ($peut_editer && !empty(trim($description))) : ?>
-                      <button type="button"
-                        class="champ-modifier ouvrir-panneau-description"
-                        data-champ="description_longue"
-                        data-cpt="organisateur"
-                        data-post-id="<?= esc_attr($organisateur_id); ?>"
-                        aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
-                    <?php endif; ?>
                     <div class="champ-texte">
                         <?php if (empty(trim($description))) : ?>
                             <?php if ($peut_editer) : ?>
@@ -166,6 +158,14 @@ $is_complete = (
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
+                            <?php if ($peut_editer) : ?>
+                              <button type="button"
+                                class="champ-modifier ouvrir-panneau-description"
+                                data-champ="description_longue"
+                                data-cpt="organisateur"
+                                data-post-id="<?= esc_attr($organisateur_id); ?>"
+                                aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                 </li>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -145,15 +145,29 @@ $is_complete = (
                 </li>
                 <?php $class_description = empty($description) ? 'champ-vide' : 'champ-rempli'; ?>
                 <li class="champ-organisateur champ-description ligne-description <?= $class_description; ?>" data-champ="description_longue">
-                  Une présentation
-                  <?php if ($peut_editer) : ?>
-                    <button type="button"
-                      class="champ-modifier ouvrir-panneau-description"
-                      aria-label="Modifier la description longue">
-                      ✏️
-                    </button>
-
-                  <?php endif; ?>
+                    <label><?= esc_html__('Présentation', 'chassesautresor-com'); ?></label>
+                    <div class="champ-texte">
+                        <?php if (empty(trim($description))) : ?>
+                            <?php if ($peut_editer) : ?>
+                                <a href="#" class="champ-ajouter ouvrir-panneau-description"
+                                   data-champ="description_longue"
+                                   data-cpt="organisateur"
+                                   data-post-id="<?= esc_attr($organisateur_id); ?>">
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                </a>
+                            <?php endif; ?>
+                        <?php else : ?>
+                            <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
+                            <?php if ($peut_editer) : ?>
+                                <button type="button"
+                                  class="champ-modifier ouvrir-panneau-description"
+                                  data-champ="description_longue"
+                                  data-cpt="organisateur"
+                                  data-post-id="<?= esc_attr($organisateur_id); ?>"
+                                  aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </div>
                 </li>
               </ul>
               </div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -157,15 +157,17 @@ $is_complete = (
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
-                            <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
-                            <?php if ($peut_editer) : ?>
-                              <button type="button"
-                                class="champ-modifier ouvrir-panneau-description"
-                                data-champ="description_longue"
-                                data-cpt="organisateur"
-                                data-post-id="<?= esc_attr($organisateur_id); ?>"
-                                aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
-                            <?php endif; ?>
+                            <span class="champ-texte-contenu">
+                                <?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?>
+                                <?php if ($peut_editer) : ?>
+                                    <button type="button"
+                                        class="champ-modifier ouvrir-panneau-description"
+                                        data-champ="description_longue"
+                                        data-cpt="organisateur"
+                                        data-post-id="<?= esc_attr($organisateur_id); ?>"
+                                        aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
+                                <?php endif; ?>
+                            </span>
                         <?php endif; ?>
                     </div>
                 </li>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -146,6 +146,14 @@ $is_complete = (
                 <?php $class_description = empty($description) ? 'champ-vide' : 'champ-rempli'; ?>
                 <li class="champ-organisateur champ-description ligne-description <?= $class_description; ?>" data-champ="description_longue">
                     <label><?= esc_html__('Présentation', 'chassesautresor-com'); ?></label>
+                    <?php if ($peut_editer && !empty(trim($description))) : ?>
+                      <button type="button"
+                        class="champ-modifier ouvrir-panneau-description"
+                        data-champ="description_longue"
+                        data-cpt="organisateur"
+                        data-post-id="<?= esc_attr($organisateur_id); ?>"
+                        aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
+                    <?php endif; ?>
                     <div class="champ-texte">
                         <?php if (empty(trim($description))) : ?>
                             <?php if ($peut_editer) : ?>
@@ -158,14 +166,6 @@ $is_complete = (
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu"><?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?></span>
-                            <?php if ($peut_editer) : ?>
-                                <button type="button"
-                                  class="champ-modifier ouvrir-panneau-description"
-                                  data-champ="description_longue"
-                                  data-cpt="organisateur"
-                                  data-post-id="<?= esc_attr($organisateur_id); ?>"
-                                  aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
-                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                 </li>


### PR DESCRIPTION
## Résumé
- ajout du retour visuel pour les textes de description
- nouveaux libellés pour les champs de description des chasses, organisateurs et énigmes
- style des blocs de texte dans les résumés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689ff1e2869883328e6a2f512fa3e8f9