### PR TITLE
Format étiquettes pour les colonnes de statistiques

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1464,6 +1464,7 @@ body.panneau-ouvert::before {
 .stats-table th:first-child,
 .stats-table td:first-child {
   text-align: left;
+  font-weight: 600;
 }
 
 .stats-table th {

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -66,7 +66,7 @@ $points          = organisateur_compter_points_collectes($organisateur_id);
               [
                   'enigmes'       => $enigmes_stats,
                   'total'         => $participants,
-                  'cols_etiquette' => [2, 3, 6, 7],
+                  'cols_etiquette' => [2, 3, 4, 5, 6, 7],
               ]
           );
       }


### PR DESCRIPTION
### Résumé
- harmonise le format étiquettes pour toutes les colonnes des statistiques de chasse
- met en gras la première colonne des tableaux en mode édition

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689ff2ee2450833289c1d4f03dc82574