### PR TITLE
Ne pas ouvrir le panneau d’édition quand aucune énigme validable

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -62,13 +62,26 @@ function initChasseEdit() {
   const params = new URLSearchParams(window.location.search);
   const doitOuvrir = params.get('edition') === 'open';
   const tab = params.get('tab');
-  if (doitOuvrir) {
+  const skipAuto = document.body.classList.contains('scroll-to-enigmes');
+  if (doitOuvrir && !skipAuto) {
     document.body.classList.add('edition-active-chasse', 'panneau-ouvert', 'mode-edition');
     if (tab) {
       const btn = document.querySelector(`.edition-tab[data-target="chasse-tab-${tab}"]`);
       btn?.click();
     }
     DEBUG && console.log('🔧 Ouverture auto du panneau édition chasse via ?edition=open');
+  } else if (skipAuto && (doitOuvrir || tab)) {
+    params.delete('edition');
+    params.delete('tab');
+    const nouvelleUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}${window.location.hash}`;
+    window.history.replaceState({}, '', nouvelleUrl);
+  }
+
+  if (skipAuto) {
+    const cible = document.getElementById('carte-ajout-enigme');
+    if (cible) {
+      cible.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   }
 
   // ==============================

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -474,8 +474,19 @@ function injection_classe_edition_active(array $classes): array
         in_array($validation, ['creation', 'correction'], true) &&
         !get_field('chasse_cache_complet', $post->ID)
       ) {
-        $classes[] = 'edition-active-chasse';
-        $classes[] = 'mode-edition';
+        $mode_fin = get_field('chasse_mode_fin', $post->ID) ?: 'automatique';
+        $titre_ok = trim(get_the_title($post->ID)) !== '';
+        $image_ok = (bool) get_field('chasse_principale_image', $post->ID);
+        $desc_raw = get_field('chasse_principale_description', $post->ID);
+        $desc_ok = !empty(trim((string) $desc_raw));
+        $has_validatable = chasse_has_validatable_enigme($post->ID);
+
+        if ($mode_fin === 'automatique' && $titre_ok && $image_ok && $desc_ok && !$has_validatable) {
+          $classes[] = 'scroll-to-enigmes';
+        } else {
+          $classes[] = 'edition-active-chasse';
+          $classes[] = 'mode-edition';
+        }
       }
     }
   }


### PR DESCRIPTION
## Résumé
- évite l’ouverture automatique du panneau d’édition de chasse lorsqu’il manque une énigme validable
- fait défiler la page vers la carte d’ajout d’énigme pour guider l’utilisateur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689ff7f5a020833293131ac42ce5ba0a