### PR TITLE
feat: smooth scroll to enigma list

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -899,7 +899,11 @@ function actualiser_cta_validation_chasse(): void
     ob_start();
     if (!empty($incompletes)) {
         echo '<div class="cta-chasse">';
-        echo '<p>⚠️ Certaines énigmes doivent être complétées :</p>';
+        $warning = esc_html__(
+            'Certaines énigmes doivent être complétées :',
+            'chassesautresor-com'
+        );
+        echo '<p>⚠️ ' . $warning . '</p>';
         echo '<ul class="liste-enigmes-incompletes">';
         foreach ($incompletes as $data) {
             echo '<li><a href="' . esc_url($data['lien']) . '">' . esc_html($data['titre']) . '</a></li>';

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -112,7 +112,11 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     if ($est_orga_associe && ($has_incomplete_enigme || $needs_validatable_message)) {
         echo '<div class="cta-chasse">';
         if ($has_incomplete_enigme) {
-            echo '<p>⚠️ Certaines énigmes doivent être complétées :</p>';
+            $warning = esc_html__(
+                'Certaines énigmes doivent être complétées :',
+                'chassesautresor-com'
+            );
+            echo '<p>⚠️ ' . $warning . '</p>';
             echo '<ul class="liste-enigmes-incompletes">';
             foreach ($enigmes_incompletes as $eid) {
                 $titre = get_the_title($eid);
@@ -120,6 +124,12 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
                 echo '<li><a href="' . esc_url($lien) . '">' . esc_html($titre) . '</a></li>';
             }
             echo '</ul>';
+            echo '<script>';
+            echo 'document.addEventListener("DOMContentLoaded", function () {';
+            echo 'var t = document.getElementById("liste-enigmes");';
+            echo 'if (t) { t.scrollIntoView({ behavior: "smooth" }); }';
+            echo '});';
+            echo '</script>';
         }
         if ($needs_validatable_message) {
             $msg = __(
@@ -231,7 +241,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
           ]);
         endif; ?>
       </div>
-      <div class="chasse-enigmes-liste">
+      <div id="liste-enigmes" class="chasse-enigmes-liste">
         <?php
         get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [
           'chasse_id'       => $chasse_id,


### PR DESCRIPTION
## Résumé
- internationalise l’alerte des énigmes incomplètes
- ajoute un défilement fluide vers la liste des énigmes lorsque des énigmes restent à compléter

## Changements notables
- utilise les fonctions de traduction WordPress pour le message d’alerte
- ajoute un script de défilement fluide et un identifiant sur la liste des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_689ffb60f7988332ad7576e2ae639fcd