### PR TITLE
Ajoute un fond circulaire aux icônes d’édition d’images

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -211,8 +211,12 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   font-size: 0.9rem;
   color: var(--color-secondary);
   background-color: rgba(0, 0, 0, 0.6);
-  padding: 0.1rem 0.2rem;
-  border-radius: 0.25rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
   transition: transform 0.2s;
 }
 


### PR DESCRIPTION
## Résumé
- Ajoute une pastille circulaire derrière l’icône d’édition des images pour la rendre plus visible

## Changements notables
- Style de l’icône ✏️ revu pour afficher un petit fond arrondi

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a000b796888332ba53753ff1048834