### PR TITLE
Marque les champs obligatoires dans les panneaux d’édition

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -88,7 +88,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
                   <div class="champ-affichage">
-                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre</label>
+                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre <span class="champ-obligatoire">*</span></label>
                     <span class="champ-valeur">
                       <?= $isTitreParDefaut ? 'renseigner le titre de la chasse' : esc_html($titre); ?>
                     </span>
@@ -114,7 +114,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
                   <div class="champ-affichage">
-                    <label>Image chasse</label>
+                    <label>Image chasse <span class="champ-obligatoire">*</span></label>
                     <?php if ($peut_editer) : ?>
                       <button type="button"
                         class="champ-modifier"
@@ -143,7 +143,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-champ="chasse_principale_description"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
-                    <label><?= esc_html__('Description chasse', 'chassesautresor-com'); ?></label>
+                    <label><?= esc_html__('Description chasse', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
                     <div class="champ-texte">
                         <?php if (empty(trim($description))) : ?>
                             <?php if ($peut_editer) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -113,7 +113,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     data-post-id="<?= esc_attr($enigme_id); ?>">
 
                     <div class="champ-affichage">
-                      <label for="champ-titre-enigme">Titre :</label>
+                      <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span> :</label>
                       <span class="champ-valeur">
                         <?= $isTitreParDefaut ? 'renseigner le titre de l’énigme' : esc_html($titre); ?>
                       </span>
@@ -146,7 +146,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     data-post-id="<?= esc_attr($enigme_id); ?>"
                     data-rempli="<?= $has_images_utiles ? '1' : '0'; ?>">
 
-                    Image(s)
+                    Image(s) <span class="champ-obligatoire">*</span>
 
                     <?php if ($peut_editer) : ?>
                       <button

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -94,7 +94,7 @@ $is_complete = (
                     data-post-id="<?= esc_attr($organisateur_id); ?>">
 
                   <div class="champ-affichage">
-                    <label for="champ-titre-organisateur">Titre</label>
+                    <label for="champ-titre-organisateur">Titre <span class="champ-obligatoire">*</span></label>
                     <span class="champ-valeur">
                       <?= empty($titre) ? "renseigner le titre de l’organisateur" : esc_html($titre); ?>
                     </span>
@@ -120,7 +120,7 @@ $is_complete = (
 
                 <li class="champ-organisateur champ-img champ-logo ligne-logo <?= empty($logo_id) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="<?= esc_attr($organisateur_id); ?>">
                   <div class="champ-affichage">
-                    <label>Logo organisateur</label>
+                    <label>Logo organisateur <span class="champ-obligatoire">*</span></label>
                     <?php if ($peut_editer) : ?>
                       <button type="button"
                         class="champ-modifier"
@@ -145,7 +145,7 @@ $is_complete = (
                 </li>
                 <?php $class_description = empty($description) ? 'champ-vide' : 'champ-rempli'; ?>
                 <li class="champ-organisateur champ-description ligne-description <?= $class_description; ?>" data-champ="description_longue">
-                    <label><?= esc_html__('Présentation', 'chassesautresor-com'); ?></label>
+                    <label><?= esc_html__('Présentation', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
                     <div class="champ-texte">
                         <?php if (empty(trim($description))) : ?>
                             <?php if ($peut_editer) : ?>


### PR DESCRIPTION
### Résumé
- Ajoute un astérisque discret aux labels des champs obligatoires pour les chasses, énigmes et organisateurs.

### Changements
- Chasse : Titre, image et description affichent désormais l'astérisque obligatoire.
- Énigme : Titre et image(s) marqués comme requis.
- Organisateur : Titre, logo et présentation marqués comme requis.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0024f45188332b5687ad2421e329e