### PR TITLE
Empêche la suppression de la description longue

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -187,6 +187,39 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   });
 
+  // 🛡️ Vérifie la longueur minimale de la présentation
+  const descPanel = document.getElementById('panneau-description');
+  const descButton = descPanel?.querySelector('.bouton-enregistrer-description');
+  const descField = typeof acf !== 'undefined'
+    ? acf.getFields({ name: 'description_longue' })[0]
+    : null;
+  const minDescLength = 50;
+
+  const verifyDescription = () => {
+    if (!descButton || !descField) return;
+    const raw = descField.val() || '';
+    const text = raw.replace(/<[^>]*>/g, '').trim();
+    descButton.disabled = text.length < minDescLength;
+  };
+
+  if (descButton && descField) {
+    verifyDescription();
+    if (descField.editor) {
+      descField.editor.on('input keyup', verifyDescription);
+    }
+    const inputEl = descField.$input?.get(0);
+    inputEl?.addEventListener('input', verifyDescription);
+
+    descPanel.querySelector('form')?.addEventListener('submit', (e) => {
+      const raw = descField.val() || '';
+      const text = raw.replace(/<[^>]*>/g, '').trim();
+      if (text.length < minDescLength) {
+        e.preventDefault();
+        alert('La présentation doit contenir au moins 50 caractères.');
+      }
+    });
+  }
+
   // 🔑 Ouverture automatique via les paramètres d'URL
   const params = new URLSearchParams(window.location.search);
 

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -195,6 +195,8 @@ document.addEventListener('DOMContentLoaded', () => {
     : null;
   const minDescLength = 50;
 
+  let descTimeout;
+
   const verifyDescription = () => {
     if (!descButton || !descField) return;
     const raw = descField.val() || '';
@@ -202,13 +204,18 @@ document.addEventListener('DOMContentLoaded', () => {
     descButton.disabled = text.length < minDescLength;
   };
 
+  const scheduleVerify = () => {
+    clearTimeout(descTimeout);
+    descTimeout = setTimeout(verifyDescription, 400);
+  };
+
   if (descButton && descField) {
     verifyDescription();
     if (descField.editor) {
-      descField.editor.on('input keyup', verifyDescription);
+      descField.editor.on('input change keyup', scheduleVerify);
     }
     const inputEl = descField.$input?.get(0);
-    inputEl?.addEventListener('input', verifyDescription);
+    inputEl?.addEventListener('input', scheduleVerify);
 
     descPanel.querySelector('form')?.addEventListener('submit', (e) => {
       const raw = descField.val() || '';

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -502,3 +502,27 @@ function pre_remplir_utilisateur_associe($post_id)
   }
 }
 add_action('acf/save_post', 'pre_remplir_utilisateur_associe', 20);
+
+/**
+ * Valide la longueur minimale de la présentation d'un organisateur.
+ */
+add_filter('acf/validate_value/name=description_longue', function ($valid, $value, $field, $input) {
+    if (!$valid) {
+        return $valid;
+    }
+
+    if (get_post_type($_POST['post_ID'] ?? 0) !== 'organisateur') {
+        return $valid;
+    }
+
+    $texte = trim(strip_tags((string) $value));
+    if ($texte === '') {
+        return __('La présentation ne peut pas être vide.', 'chassesautresor-com');
+    }
+
+    if (mb_strlen($texte) < 50) {
+        return __('La présentation doit contenir au moins 50 caractères.', 'chassesautresor-com');
+    }
+
+    return $valid;
+}, 10, 4);

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -270,6 +270,13 @@ function ajax_modifier_champ_organisateur()
   }
 
   // ✅ Autres champs ACF simples
+  if ($champ_cible === 'description_longue') {
+    $texte = trim(strip_tags((string) $valeur));
+    if (mb_strlen($texte) < 50) {
+      wp_send_json_error('⚠️ description_trop_courte');
+    }
+  }
+
   $ok = update_field($champ_cible, is_numeric($valeur) ? (int) $valeur : $valeur, $post_id);
 
   // 🔍 Vérifie via get_post_meta en fallback

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -605,8 +605,8 @@ function organisateur_est_complet(int $organisateur_id): bool
     $logo_ok = !empty($logo);
 
     $description_field = get_field('description_longue', $organisateur_id);
-    $description = trim((string) $description_field);
-    $desc_ok = $description !== '';
+    $description = trim(strip_tags((string) $description_field));
+    $desc_ok = mb_strlen($description) >= 50;
 
     return $titre_ok && $logo_ok && $desc_ok;
 }


### PR DESCRIPTION
### Résumé
- Bloque la validation d’une présentation organisateur vide ou trop courte
- Ajoute un contrôle front-end empêchant l’enregistrement sous 50 caractères
- Marque un organisateur comme complet uniquement si la présentation atteint 50 caractères

### Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0011836c48332aaa9567932156e6b