### PR TITLE
Supprimer le deux-points du titre d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -113,7 +113,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     data-post-id="<?= esc_attr($enigme_id); ?>">
 
                     <div class="champ-affichage">
-                      <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span> :</label>
+                        <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span></label>
                       <span class="champ-valeur">
                         <?= $isTitreParDefaut ? 'renseigner le titre de l’énigme' : esc_html($titre); ?>
                       </span>


### PR DESCRIPTION
## Résumé
- Retire le signe `:` après l'étiquette "Titre *" dans le panneau d'édition d'une énigme.

## Modifications
- Ajustement du libellé du champ titre pour éviter l'affichage du deux-points final.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a004c6b9148332bcd43f2370fe08f4