### PR TITLE
feat: améliorer affichage email de contact

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -820,7 +820,7 @@ body.edition-active .edition-panel {
   margin-right: 10px;
 }
 
-li.ligne-email .champ-organisateur.champ-vide,
+li.ligne-email.champ-organisateur.champ-vide,
 li.ligne-coordonnees.champ-organisateur.champ-vide,
 li.ligne-logo.champ-organisateur.champ-vide {
   border: 0;
@@ -830,7 +830,6 @@ li.ligne-logo.champ-organisateur.champ-vide {
   opacity: 1;
 }
 
-li.ligne-email,
 li.ligne-logo,
 li.champ-titre {
   display: flex;
@@ -877,13 +876,13 @@ li.ligne-logo .champ-modifier {
   color: var(--color-editor-text-muted);
 }
 
-li.ligne-email i.fa-envelope {
+li.ligne-email label i.fa-envelope {
   opacity: 0.6;
-  margin-top: 6px;
+  margin-right: 0.3rem;
 }
 
-li.ligne-email .champ-organisateur .champ-affichage {
-  justify-content: start;
+li.ligne-email .champ-affichage {
+  justify-content: flex-start;
   text-align: unset;
 }
 

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -831,11 +831,11 @@ li.ligne-logo.champ-organisateur.champ-vide {
 }
 
 li.ligne-logo,
-li.champ-titre {
+li.champ-titre,
+li.ligne-email {
   display: flex;
-  align-items: start;
+  align-items: center;
   gap: 0.5rem;
-  align-items: center ;
 }
 
 li.ligne-logo .champ-modifier {
@@ -876,7 +876,7 @@ li.ligne-logo .champ-modifier {
   color: var(--color-editor-text-muted);
 }
 
-li.ligne-email label i.fa-envelope {
+li.ligne-email > i.fa-envelope {
   opacity: 0.6;
   margin-right: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -88,9 +88,9 @@ function initChampTexte(bloc) {
 
     if (champ === 'email_contact') {
       const fallback = window.organisateurData?.defaultEmail || '…';
-      const affichageTexte = affichage.querySelector('p');
+      const affichageTexte = affichage.querySelector('.champ-valeur');
       if (affichageTexte && input.value.trim() === '') {
-        affichageTexte.innerHTML = '<strong>Email de contact :</strong> <em>' + fallback + '</em>';
+        affichageTexte.innerHTML = '<em>' + fallback + '</em>';
       }
     }
   });
@@ -143,13 +143,13 @@ function initChampTexte(bloc) {
 
     modifierChampSimple(champ, valeur, postId, cpt).then(success => {
       if (success) {
-        const affichageTexte = affichage.querySelector('h1, h2, p, span');
+        const affichageTexte = affichage.querySelector('.champ-valeur, h1, h2, p, span');
 
         if (champ === 'email_contact') {
           const fallbackEmail = window.organisateurData?.defaultEmail || '…';
-          const p = affichage.querySelector('p');
-          if (p) {
-            p.innerHTML = '<strong>Email de contact :</strong> ' + (valeur ? valeur : '<em>' + fallbackEmail + '</em>');
+          const spanValeur = affichage.querySelector('.champ-valeur');
+          if (spanValeur) {
+            spanValeur.innerHTML = valeur ? valeur : '<em>' + fallbackEmail + '</em>';
           }
         } else if (affichageTexte) {
           affichageTexte.textContent = valeur;

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -184,10 +184,11 @@ $is_complete = (
                   data-champ="email_contact"
                   data-cpt="organisateur"
                   data-post-id="<?= esc_attr($organisateur_id); ?>"
+                  data-no-icon
                 >
+                  <i class="fa-regular fa-envelope" aria-hidden="true"></i>
                   <div class="champ-affichage">
                     <label for="champ-email-contact">
-                      <i aria-hidden="true" class="fa-regular fa-envelope"></i>
                       Email de contact
                     </label>
                     <span class="champ-valeur">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -179,43 +179,53 @@ $is_complete = (
                 <h3>Réglages</h3>
                 <ul class="resume-infos">
 
-                <li class="ligne-email <?= !empty($email_contact) ? 'champ-rempli' : ''; ?>">
-                  <i aria-hidden="true" class="fa-regular fa-solid fa-envelope"></i>
-                  <div class="champ-organisateur champ-email-contact"
-                    data-champ="profil_public_email_contact"
-                    data-cpt="organisateur"
-                    data-post-id="<?= esc_attr($organisateur_id); ?>">
-
-                    <div class="champ-affichage">
-
-                      Email de contact :
+                <li
+                  class="champ-organisateur champ-email-contact ligne-email <?= empty($email_contact) ? 'champ-vide' : 'champ-rempli'; ?>"
+                  data-champ="email_contact"
+                  data-cpt="organisateur"
+                  data-post-id="<?= esc_attr($organisateur_id); ?>"
+                >
+                  <div class="champ-affichage">
+                    <label for="champ-email-contact">
+                      <i aria-hidden="true" class="fa-regular fa-envelope"></i>
+                      Email de contact
+                    </label>
+                    <span class="champ-valeur">
                       <?= esc_html($email_contact ?: get_the_author_meta('user_email', get_post_field('post_author', $organisateur_id))); ?>
-
-                      <button type="button" class="icone-info"
-                        aria-label="Informations sur l’adresse email de contact"
-                        onclick="alert('Quand aucune adresse n est renseignée, votre email utilisateur est utilisé par défaut.');">
-                        <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+                    </span>
+                    <button
+                      type="button"
+                      class="icone-info"
+                      aria-label="Informations sur l’adresse email de contact"
+                      onclick="alert('Quand aucune adresse n est renseignée, votre email utilisateur est utilisé par défaut.');"
+                    >
+                      <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+                    </button>
+                    <?php if ($peut_editer) : ?>
+                      <button
+                        type="button"
+                        class="champ-modifier"
+                        aria-label="Modifier l’adresse email de contact"
+                      >
+                        ✏️
                       </button>
-                      <?php if ($peut_editer) : ?>
-                        <button type="button"
-                          class="champ-modifier"
-                          aria-label="Modifier l’adresse email de contact">
-                          ✏️
-                        </button>
-                      <?php endif; ?>
-                    </div>
-
-                    <div class="champ-edition" style="display: none;">
-                      <input type="email" maxlength="255"
-                        value="<?= esc_attr($email_contact); ?>"
-                        class="champ-input"
-                        placeholder="exemple@domaine.com">
-                      <button type="button" class="champ-enregistrer">✓</button>
-                      <button type="button" class="champ-annuler">✖</button>
-                    </div>
-
-                    <div class="champ-feedback"></div>
+                    <?php endif; ?>
                   </div>
+
+                  <div class="champ-edition" style="display: none;">
+                    <input
+                      type="email"
+                      maxlength="255"
+                      value="<?= esc_attr($email_contact); ?>"
+                      class="champ-input"
+                      id="champ-email-contact"
+                      placeholder="exemple@domaine.com"
+                    >
+                    <button type="button" class="champ-enregistrer">✓</button>
+                    <button type="button" class="champ-annuler">✖</button>
+                  </div>
+
+                  <div class="champ-feedback"></div>
                 </li>
 
                 </ul>


### PR DESCRIPTION
## Summary
- harmonise l'affichage de l'email de contact dans l'édition organisateur
- met à jour les styles et le script d'initialisation associés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a005c55d1c8332a4a9a9b2b560c95c