### PR TITLE
Ajoute une validation serveur pour la présentation organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -189,6 +189,14 @@ function ajax_modifier_champ_organisateur()
   // 🔁 Corrige le nom du champ si groupé
   $champ_cible = $champ_correspondances[$champ] ?? $champ;
 
+  // 🛑 Validation métier : texte de présentation minimal
+  if ($champ_cible === 'description_longue') {
+    $texte = wp_strip_all_tags($valeur);
+    if (mb_strlen(trim($texte)) < 50) {
+      wp_send_json_error('votre texte doit comporter au moins 50 caractères');
+    }
+  }
+
   // ✏️ Titre natif WordPress
   if ($champ === 'post_title') {
     $ok = wp_update_post([


### PR DESCRIPTION
Ajout d'une validation serveur pour empêcher l'enregistrement d'une présentation organisateur trop courte.

- Bloque l'enregistrement lorsque la présentation compte moins de 50 caractères.
- Retourne un message d'erreur clair à l'utilisateur.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a00aa71b60833282e8fdbcb9f7edd4