### PR TITLE
Ensure organizer panel reopens after description save

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -60,10 +60,11 @@ function initChasseEdit() {
   // 🧭 Déclencheur automatique
   // ==============================
   const params = new URLSearchParams(window.location.search);
-  const doitOuvrir = params.get('edition') === 'open';
-  const tab = params.get('tab');
-  const skipAuto = document.body.classList.contains('scroll-to-enigmes');
-  if (doitOuvrir && !skipAuto) {
+    const doitOuvrir = params.get('edition') === 'open';
+    const tab = params.get('tab');
+    const panel = params.get('panel');
+    const skipAuto = document.body.classList.contains('scroll-to-enigmes');
+    if (doitOuvrir && !skipAuto && panel !== 'organisateur') {
     document.body.classList.add('edition-active-chasse', 'panneau-ouvert', 'mode-edition');
     if (tab) {
       const btn = document.querySelector(`.edition-tab[data-target="chasse-tab-${tab}"]`);

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -191,10 +191,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
 
   const postType = params.get('post_type');
+  const panel = params.get('panel');
   if (
     params.get('edition') === 'open' &&
     !params.has('tab') &&
-    (!postType || postType === 'organisateur')
+    (panel === 'organisateur' || (!panel && (!postType || postType === 'organisateur')))
   ) {
     const toggle = document.getElementById('toggle-mode-edition');
     toggle?.click();

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-description.php
@@ -27,7 +27,10 @@ $organisateur_id = $args['organisateur_id'] ?? null;
             // ?edition=open. L'ancre #presentation permet de scroller
             // directement sur la section description.
             'return' => add_query_arg(
-                ['edition' => 'open'],
+                [
+                    'edition' => 'open',
+                    'panel'   => 'organisateur',
+                ],
                 remove_query_arg(['acf'], get_permalink())
             ) . '#presentation',
 


### PR DESCRIPTION
## Résumé
- Corrige l'ouverture du mauvais panneau après l'édition de la présentation d'un organisateur depuis une chasse

## Changements notables
- Ajout du paramètre `panel=organisateur` dans la redirection après sauvegarde de la présentation
- Gestion de ce paramètre côté JS pour éviter l'ouverture du panneau chasse et déclencher celui de l'organisateur

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a00c4ea88083328856d3e3ad85c79d