### PR TITLE
Corrige le doublon d'alerte sur le taux d'engagement

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
-    document.querySelectorAll('.stat-help').forEach((btn) => {
+    document.querySelectorAll('.panneau-organisateur .stat-help').forEach((btn) => {
       btn.addEventListener('click', () => {
         const message = btn.dataset.message;
         if (message) {


### PR DESCRIPTION
## Résumé
- évite la double ouverture de l'alerte d'aide dans le panneau organisateur

## Changements notables
- limite l'écoute des clics d'aide au seul panneau organisateur

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a00e9c564883329710007b4dd5f5cb