### PR TITLE
feat: rafraîchissement dynamique de la récompense

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -190,6 +190,76 @@ function initChasseEdit() {
   const panneauRecompense = document.getElementById('panneau-recompense-chasse');
   const boutonSupprimerRecompense = document.getElementById('bouton-supprimer-recompense');
 
+  function majAffichageRecompense(titre, texte, valeur) {
+    const ligne = document.querySelector('.champ-chasse[data-champ="chasse_infos_recompense_valeur"]');
+    if (!ligne) return;
+    const champTexte = ligne.querySelector('.champ-texte');
+    if (!champTexte) return;
+    const peutEditer = !ligne.classList.contains('champ-desactive');
+    champTexte.innerHTML = '';
+
+    const complet = titre && texte && valeur && valeur > 0;
+    ligne.classList.toggle('champ-rempli', complet);
+    ligne.classList.toggle('champ-vide', !complet);
+
+    if (!complet) {
+      if (peutEditer) {
+        const lien = document.createElement('a');
+        lien.href = '#';
+        lien.className = 'champ-ajouter ouvrir-panneau-recompense';
+        lien.dataset.champ = 'chasse_infos_recompense_valeur';
+        lien.dataset.cpt = 'chasse';
+        lien.dataset.postId = ligne.dataset.postId || '';
+        lien.innerHTML = 'ajouter <span class="icone-modif">✏️</span>';
+        champTexte.appendChild(lien);
+      }
+      if (typeof window.mettreAJourResumeInfos === 'function') {
+        window.mettreAJourResumeInfos();
+      }
+      return;
+    }
+
+    const span = document.createElement('span');
+    span.className = 'champ-texte-contenu';
+
+    const valeurSpan = document.createElement('span');
+    valeurSpan.className = 'recompense-valeur';
+    valeurSpan.textContent = valeur.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' €';
+
+    const titreSpan = document.createElement('span');
+    titreSpan.className = 'recompense-titre';
+    titreSpan.textContent = titre;
+
+    span.appendChild(valeurSpan);
+    span.appendChild(document.createTextNode(' '));
+    span.appendChild(titreSpan);
+
+    if (peutEditer) {
+      span.appendChild(document.createTextNode(' '));
+      const bouton = document.createElement('button');
+      bouton.type = 'button';
+      bouton.className = 'champ-modifier ouvrir-panneau-recompense';
+      bouton.dataset.champ = 'chasse_infos_recompense_valeur';
+      bouton.dataset.cpt = 'chasse';
+      bouton.dataset.postId = ligne.dataset.postId || '';
+      bouton.setAttribute('aria-label', 'Modifier la récompense');
+      bouton.textContent = '✏️';
+      span.appendChild(bouton);
+      if (typeof initZoneClicEdition === 'function') initZoneClicEdition(bouton);
+    }
+
+    span.appendChild(document.createTextNode(' '));
+    const descSpan = document.createElement('span');
+    descSpan.className = 'recompense-description';
+    descSpan.textContent = texte;
+    span.appendChild(descSpan);
+    champTexte.appendChild(span);
+
+    if (typeof window.mettreAJourResumeInfos === 'function') {
+      window.mettreAJourResumeInfos();
+    }
+  }
+
   if (boutonSupprimerRecompense) {
     boutonSupprimerRecompense.addEventListener('click', () => {
       const panneauEdition = document.querySelector('.edition-panel-chasse');
@@ -218,13 +288,16 @@ function initChasseEdit() {
             })
           });
         })
-        ).then(() => {
-          const url = new URL(window.location.href);
-          url.searchParams.set('edition', 'open');
-          url.searchParams.set('tab', 'param');
-          window.location.href = url.toString();
-        });
+      ).then(() => {
+        majAffichageRecompense('', '', 0);
+        inputTitreRecompense.value = '';
+        inputTexteRecompense.value = '';
+        inputValeurRecompense.value = '';
+        if (typeof window.closePanel === 'function') {
+          window.closePanel('panneau-recompense-chasse');
+        }
       });
+    });
 
   }
 
@@ -309,20 +382,14 @@ function initChasseEdit() {
         .then(r => r.json())
         .then(res => {
           if (res.success) {
-            if (typeof window.mettreAJourResumeInfos === 'function') {
-              window.mettreAJourResumeInfos();
-            }
-
+            majAffichageRecompense(titre, texte, valeur);
             if (document.activeElement && panneauRecompense.contains(document.activeElement)) {
               document.activeElement.blur();
-              document.body.focus(); // 🔥 Correction ultime ici
+              document.body.focus();
             }
-
-            const url = new URL(window.location.href);
-            url.searchParams.set('edition', 'open');
-            url.searchParams.set('tab', 'param');
-            window.location.href = url.toString();
-
+            if (typeof window.closePanel === 'function') {
+              window.closePanel('panneau-recompense-chasse');
+            }
           } else {
             console.error('❌ Erreur valeur récompense', res.data);
           }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -26,6 +26,7 @@ $titre = get_the_title($chasse_id);
 $liens = $infos_chasse['liens'];
 $recompense = $infos_chasse['champs']['lot'];
 $valeur     = $infos_chasse['champs']['valeur_recompense'];
+$titre_recompense = $infos_chasse['champs']['titre_recompense'];
 $cout       = $infos_chasse['champs']['cout_points'];
 $date_debut = $infos_chasse['champs']['date_debut'];
 $date_fin   = $infos_chasse['champs']['date_fin'];
@@ -171,18 +172,41 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 </li>
 
                 <!-- Récompense -->
-                <li class="champ-chasse <?= empty($recompense) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
-                  Récompense
-                  <?php if ($peut_editer) : ?>
-                    <button
-                      type="button"
-                      class="champ-modifier ouvrir-panneau-recompense"
-                      data-champ="chasse_infos_recompense_valeur"
-                      data-cpt="chasse"
-                      data-post-id="<?= esc_attr($chasse_id); ?>"
-                      aria-label="Modifier la récompense"
-                    >✏️</button>
-                  <?php endif; ?>
+                <?php
+                $recompense_remplie = !empty($titre_recompense) && !empty($recompense) && (float) $valeur > 0;
+                ?>
+                <li class="champ-chasse champ-recompense <?= $recompense_remplie ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+                    data-champ="chasse_infos_recompense_valeur"
+                    data-cpt="chasse"
+                    data-post-id="<?= esc_attr($chasse_id); ?>">
+                    <label><?= esc_html__('Récompense', 'chassesautresor-com'); ?></label>
+                    <div class="champ-texte">
+                        <?php if (!$recompense_remplie) : ?>
+                            <?php if ($peut_editer) : ?>
+                                <a href="#"
+                                   class="champ-ajouter ouvrir-panneau-recompense"
+                                   data-champ="chasse_infos_recompense_valeur"
+                                   data-cpt="chasse"
+                                   data-post-id="<?= esc_attr($chasse_id); ?>">
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                </a>
+                            <?php endif; ?>
+                        <?php else : ?>
+                            <span class="champ-texte-contenu">
+                                <span class="recompense-valeur"><?= esc_html(number_format_i18n((float) $valeur, 2)); ?> €</span>
+                                <span class="recompense-titre"><?= esc_html($titre_recompense); ?></span>
+                                <?php if ($peut_editer) : ?>
+                                    <button type="button"
+                                        class="champ-modifier ouvrir-panneau-recompense"
+                                        data-champ="chasse_infos_recompense_valeur"
+                                        data-cpt="chasse"
+                                        data-post-id="<?= esc_attr($chasse_id); ?>"
+                                        aria-label="<?= esc_attr__('Modifier la récompense', 'chassesautresor-com'); ?>">✏️</button>
+                                <?php endif; ?>
+                                <span class="recompense-description"><?= esc_html(wp_trim_words(wp_strip_all_tags($recompense), 25)); ?></span>
+                            </span>
+                        <?php endif; ?>
+                    </div>
                 </li>
 
               </ul>


### PR DESCRIPTION
Affichage dynamique de la récompense dans le panneau d'édition de chasse.

- Rendu complet de la ligne « Récompense » avec valeur, titre, bouton d’édition et description.
- Fonction JS pour actualiser l’affichage lors de la sauvegarde ou suppression de la récompense.

### Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a00f6144a4833283e1b8b6d5c7afb8