### PR TITLE
feat: align enigme illustration editing UI

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -204,6 +204,12 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   display: block;
 }
 
+.champ-img .champ-modifier img.vignette-enigme {
+  display: inline-block;
+  max-width: 60px;
+  margin-right: 0.25rem;
+}
+
 .champ-img .champ-modifier .icone-modif {
   position: absolute;
   top: 0.2rem;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -139,26 +139,49 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
                   <?php
                   $has_images_utiles = enigme_a_une_image($enigme_id);
+                  $images_ids       = get_field('enigme_visuel_image', $enigme_id, false);
                   ?>
                   <li class="champ-enigme champ-img <?= $has_images_utiles ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
                     data-champ="enigme_visuel_image"
                     data-cpt="enigme"
                     data-post-id="<?= esc_attr($enigme_id); ?>"
                     data-rempli="<?= $has_images_utiles ? '1' : '0'; ?>">
-
-                    Image(s) <span class="champ-obligatoire">*</span>
-
-                    <?php if ($peut_editer) : ?>
-                      <button
-                        type="button"
-                        class="champ-modifier ouvrir-panneau-images"
-                        data-champ="enigme_visuel_image"
-                        data-cpt="enigme"
-                        data-post-id="<?= esc_attr($enigme_id); ?>">
-                        ✏️
+                    <div class="champ-affichage">
+                      <label>Illustrations <span class="champ-obligatoire">*</span></label>
+                      <?php if ($peut_editer) : ?>
+                        <button type="button"
+                          class="champ-modifier ouvrir-panneau-images"
+                          data-champ="enigme_visuel_image"
+                          data-cpt="enigme"
+                          data-post-id="<?= esc_attr($enigme_id); ?>">
+                          <?php if ($has_images_utiles && is_array($images_ids)) : ?>
+                            <?php foreach ($images_ids as $img_id) : ?>
+                              <?php $thumb_url = esc_url(add_query_arg([
+                                'id'     => $img_id,
+                                'taille' => 'thumbnail',
+                              ], site_url('/voir-image-enigme'))); ?>
+                              <img src="<?= $thumb_url; ?>" alt="" class="vignette-enigme" />
+                            <?php endforeach; ?>
+                          <?php else : ?>
+                            <span class="champ-ajout-image">ajouter</span>
+                          <?php endif; ?>
+                          <span class="icone-modif">✏️</span>
                         </button>
-                    <?php endif; ?>
-
+                      <?php else : ?>
+                        <?php if ($has_images_utiles && is_array($images_ids)) : ?>
+                          <?php foreach ($images_ids as $img_id) : ?>
+                            <?php $thumb_url = esc_url(add_query_arg([
+                              'id'     => $img_id,
+                              'taille' => 'thumbnail',
+                            ], site_url('/voir-image-enigme'))); ?>
+                            <img src="<?= $thumb_url; ?>" alt="" class="vignette-enigme" />
+                          <?php endforeach; ?>
+                        <?php else : ?>
+                          <span class="champ-ajout-image">ajouter</span>
+                        <?php endif; ?>
+                      <?php endif; ?>
+                    </div>
+                    <div class="champ-feedback"></div>
                   </li>
 
                   <li class="champ-enigme champ-wysiwyg<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_visuel_texte" data-cpt="enigme"


### PR DESCRIPTION
Affiche désormais les miniatures des illustrations d'une énigme dans son panneau d'édition.

- Remplace le libellé "Image(s)" par "Illustrations" et ajoute un lien d'ajout si vide
- Montre les vignettes de toutes les images et un bouton ✏️ pour les modifier
- Ajoute un style CSS pour afficher les vignettes en ligne

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a018ace390833285af4bd35875631d