### PR TITLE
style: harmoniser la hauteur des lignes de paramètres

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -68,6 +68,26 @@
   /* padding-left: 1.3rem; */
 }
 
+/* Hauteur et alignement par défaut des lignes de paramètres */
+.resume-infos > li {
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.resume-infos > li > .champ-affichage {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  flex: 1;
+}
+
+.resume-infos > li > .champ-edition,
+.resume-infos > li > .champ-feedback {
+  width: 100%;
+}
+
 .cache {
   display: none;
 }


### PR DESCRIPTION
## Résumé
- Ajuste la hauteur par défaut des lignes de paramètres pour une meilleure lisibilité.

## Changements notables
- Définit une hauteur minimale de 40px et aligne verticalement le contenu des lignes du panneau d'édition.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0196791a88332adaab2b4a3ff65f4