### PR TITLE
Améliore l'édition des variantes de réponse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1061,16 +1061,10 @@ body.panneau-ouvert::before {
 }
 
 .liste-variantes-resume .variante-texte {
-  background: none;
-  border: none;
   color: var(--color-editor-text);
-  text-decoration: underline;
-  cursor: pointer;
-  padding: 0;
 }
 
 .liste-variantes-resume .variante-message {
-  margin-top: 4px;
   color: var(--color-editor-text-muted);
 }
 

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1045,6 +1045,35 @@ body.panneau-ouvert::before {
   color:var(--color-text-fond-clair)
 }
 
+#bouton-ajouter-variante {
+  background-color: var(--color-editor-button);
+  color: #fff;
+}
+
+#bouton-ajouter-variante:hover {
+  background-color: var(--color-editor-button-hover);
+}
+
+.liste-variantes-resume {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.liste-variantes-resume .variante-texte {
+  background: none;
+  border: none;
+  color: var(--color-editor-text);
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.liste-variantes-resume .variante-message {
+  margin-top: 4px;
+  color: var(--color-editor-text-muted);
+}
+
 /* Alignement commun des headers dans les panneaux */
 .panneau-lateral__header {
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -148,8 +148,8 @@ window.mettreAJourResumeInfos = function () {
       }
 
       if (champ === 'enigme_reponse_variantes') {
-        const bouton = blocEdition?.querySelector('.champ-modifier');
-        estRempli = bouton && !bouton.textContent.includes('Créer');
+        const nbVar = blocEdition?.querySelectorAll('.liste-variantes-resume .variante-resume')?.length || 0;
+        estRempli = nbVar > 0;
       }
 
       if (champ === 'enigme_acces_condition') {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -147,6 +147,18 @@ function initEnigmeEdit() {
     });
   });
 
+  const explicationVariantes = wp.i18n.__(
+    "Les variantes sont des réponses alternatives qui ne sont pas considérées comme bonnes, mais affichent un message en retour " +
+      "(libre à vous d'y mettre de l'aide, un lien, un crypto ou ce que vous voulez)",
+    "chassesautresor-com"
+  );
+
+  document.querySelectorAll('.variantes-aide').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      alert(explicationVariantes);
+    });
+  });
+
 
   // ==============================
   // 🧰 Déclencheurs de résumé

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -677,20 +677,7 @@ function initPanneauVariantes() {
 
   if (!boutonOuvrir || !panneau || !formulaire || !postId || !wrapper || !boutonAjouter || !messageLimite) return;
 
-  function activerToggleMessage(liste) {
-    liste.addEventListener('click', (e) => {
-      const btn = e.target.closest('.variante-texte');
-      if (!btn) return;
-      const msg = btn.nextElementSibling;
-      if (msg) {
-        msg.style.display = msg.style.display === 'none' ? 'block' : 'none';
-      }
-    });
-  }
 
-  if (listeResume) {
-    activerToggleMessage(listeResume);
-  }
 
   // Ouvrir le panneau
   boutonOuvrir.addEventListener('click', () => {
@@ -841,7 +828,6 @@ function initPanneauVariantes() {
               listeResume = document.createElement('ul');
               listeResume.className = 'liste-variantes-resume';
               resumeBloc.insertBefore(listeResume, boutonEditerResume || lienAjouterResume || null);
-              activerToggleMessage(listeResume);
             }
 
             listeResume.innerHTML = '';
@@ -853,16 +839,15 @@ function initPanneauVariantes() {
                 nb++;
                 const li = document.createElement('li');
                 li.className = 'variante-resume';
-                const bt = document.createElement('button');
-                bt.type = 'button';
-                bt.className = 'variante-texte';
-                bt.textContent = t;
-                const div = document.createElement('div');
-                div.className = 'variante-message';
-                div.style.display = 'none';
-                div.textContent = m;
-                li.appendChild(bt);
-                li.appendChild(div);
+                const spanT = document.createElement('span');
+                spanT.className = 'variante-texte';
+                spanT.textContent = t;
+                const spanM = document.createElement('span');
+                spanM.className = 'variante-message';
+                spanM.textContent = m;
+                li.appendChild(spanT);
+                li.appendChild(document.createTextNode(' => '));
+                li.appendChild(spanM);
                 listeResume.appendChild(li);
               }
             }

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -671,16 +671,12 @@ function initPanneauVariantes() {
   const messageLimite = document.querySelector('.message-limite-variantes');
   const resumeBloc = document.querySelector('[data-champ="enigme_reponse_variantes"]');
   let listeResume = resumeBloc?.querySelector('.liste-variantes-resume');
-  const lienAjouterResume = resumeBloc?.querySelector('.champ-ajouter');
-  const boutonEditerResume = resumeBloc?.querySelector('.champ-modifier.ouvrir-panneau-variantes');
-  const boutonOuvrir = resumeBloc?.querySelector('.ouvrir-panneau-variantes');
+  let lienAjouterResume = resumeBloc?.querySelector('.champ-ajouter');
+  let boutonEditerResume = resumeBloc?.querySelector('.champ-modifier.ouvrir-panneau-variantes');
 
-  if (!boutonOuvrir || !panneau || !formulaire || !postId || !wrapper || !boutonAjouter || !messageLimite) return;
+  if (!panneau || !formulaire || !postId || !wrapper || !boutonAjouter || !messageLimite || !resumeBloc) return;
 
-
-
-  // Ouvrir le panneau
-  boutonOuvrir.addEventListener('click', () => {
+  function ouvrirPanneau() {
     document.querySelectorAll('.panneau-lateral.ouvert, .panneau-lateral-liens.ouvert').forEach(p => {
       p.classList.remove('ouvert');
       p.setAttribute('aria-hidden', 'true');
@@ -695,6 +691,13 @@ function initPanneauVariantes() {
     }
 
     mettreAJourEtatBouton();
+  }
+
+  resumeBloc.querySelectorAll('.ouvrir-panneau-variantes').forEach(el => {
+    el.addEventListener('click', e => {
+      e.preventDefault();
+      ouvrirPanneau();
+    });
   });
 
   // Fermer le panneau
@@ -742,10 +745,10 @@ function initPanneauVariantes() {
     const nouvelle = base.cloneNode(true);
 
     nouvelle.querySelector('.input-texte').value = '';
-    nouvelle.querySelector('.input-texte').placeholder = 'réponse déclenchant l\'affichage du message';
+    nouvelle.querySelector('.input-texte').placeholder = wp.i18n.__("réponse déclenchant l'affichage du message", 'chassesautresor-com');
 
     nouvelle.querySelector('.input-message').value = '';
-    nouvelle.querySelector('.input-message').placeholder = 'Message affiché au joueur';
+    nouvelle.querySelector('.input-message').placeholder = wp.i18n.__('Message affiché au joueur', 'chassesautresor-com');
     nouvelle.querySelector('input[type="checkbox"]').checked = false;
 
     wrapper.appendChild(nouvelle);
@@ -794,7 +797,7 @@ function initPanneauVariantes() {
     const feedback = formulaire.querySelector('.champ-feedback-variantes');
     if (feedback) {
       feedback.style.display = 'block';
-      feedback.textContent = 'Enregistrement...';
+      feedback.textContent = wp.i18n.__('Enregistrement...', 'chassesautresor-com');
       feedback.className = 'champ-feedback champ-loading';
     }
 
@@ -814,7 +817,7 @@ function initPanneauVariantes() {
     Promise.all(promises)
       .then(() => {
         if (feedback) {
-          feedback.textContent = '✔️ Variantes enregistrées';
+          feedback.textContent = wp.i18n.__('✔️ Variantes enregistrées', 'chassesautresor-com');
           feedback.className = 'champ-feedback champ-success';
         }
 
@@ -855,13 +858,50 @@ function initPanneauVariantes() {
             if (nb === 0) {
               resumeBloc.classList.add('champ-vide');
               resumeBloc.classList.remove('champ-rempli');
-              lienAjouterResume?.style.setProperty('display', 'inline-block');
               boutonEditerResume?.style.setProperty('display', 'none');
+
+              if (listeResume) {
+                listeResume.remove();
+                listeResume = null;
+              }
+
+              if (!lienAjouterResume) {
+                lienAjouterResume = document.createElement('a');
+                lienAjouterResume.href = '#';
+                lienAjouterResume.className = 'champ-ajouter ouvrir-panneau-variantes';
+                lienAjouterResume.dataset.cpt = 'enigme';
+                lienAjouterResume.dataset.postId = postId;
+                lienAjouterResume.setAttribute('aria-label', wp.i18n.__('Ajouter des variantes', 'chassesautresor-com'));
+                lienAjouterResume.innerHTML = `${wp.i18n.__('ajouter des variantes', 'chassesautresor-com')} <span class="icone-modif">✏️</span>`;
+                resumeBloc.appendChild(lienAjouterResume);
+                lienAjouterResume.addEventListener('click', e => {
+                  e.preventDefault();
+                  ouvrirPanneau();
+                });
+              }
+
+              lienAjouterResume.style.setProperty('display', 'inline-block');
             } else {
               resumeBloc.classList.add('champ-rempli');
               resumeBloc.classList.remove('champ-vide');
               lienAjouterResume?.style.setProperty('display', 'none');
-              boutonEditerResume?.style.setProperty('display', 'inline-block');
+
+              if (!boutonEditerResume) {
+                boutonEditerResume = document.createElement('button');
+                boutonEditerResume.type = 'button';
+                boutonEditerResume.className = 'champ-modifier ouvrir-panneau-variantes';
+                boutonEditerResume.dataset.cpt = 'enigme';
+                boutonEditerResume.dataset.postId = postId;
+                boutonEditerResume.setAttribute('aria-label', wp.i18n.__('Éditer les variantes', 'chassesautresor-com'));
+                boutonEditerResume.innerHTML = `${wp.i18n.__('éditer', 'chassesautresor-com')} <span class="icone-modif">✏️</span>`;
+                resumeBloc.appendChild(boutonEditerResume);
+                boutonEditerResume.addEventListener('click', e => {
+                  e.preventDefault();
+                  ouvrirPanneau();
+                });
+              }
+
+              boutonEditerResume.style.setProperty('display', 'inline-block');
             }
           }
 
@@ -870,7 +910,7 @@ function initPanneauVariantes() {
       })
       .catch(() => {
         if (feedback) {
-          feedback.textContent = '❌ Erreur réseau';
+          feedback.textContent = wp.i18n.__('❌ Erreur réseau', 'chassesautresor-com');
           feedback.className = 'champ-feedback champ-error';
         }
       });

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -663,15 +663,34 @@ if (document.readyState === 'loading') {
 // 🧩 Gestion du panneau variantes
 // ==============================
 function initPanneauVariantes() {
-  const boutonOuvrir = document.querySelector('.ouvrir-panneau-variantes');
   const panneau = document.getElementById('panneau-variantes-enigme');
   const formulaire = document.getElementById('formulaire-variantes-enigme');
   const postId = formulaire?.dataset.postId;
   const wrapper = formulaire?.querySelector('.liste-variantes-wrapper');
   const boutonAjouter = document.getElementById('bouton-ajouter-variante');
   const messageLimite = document.querySelector('.message-limite-variantes');
+  const resumeBloc = document.querySelector('[data-champ="enigme_reponse_variantes"]');
+  let listeResume = resumeBloc?.querySelector('.liste-variantes-resume');
+  const lienAjouterResume = resumeBloc?.querySelector('.champ-ajouter');
+  const boutonEditerResume = resumeBloc?.querySelector('.champ-modifier.ouvrir-panneau-variantes');
+  const boutonOuvrir = resumeBloc?.querySelector('.ouvrir-panneau-variantes');
 
   if (!boutonOuvrir || !panneau || !formulaire || !postId || !wrapper || !boutonAjouter || !messageLimite) return;
+
+  function activerToggleMessage(liste) {
+    liste.addEventListener('click', (e) => {
+      const btn = e.target.closest('.variante-texte');
+      if (!btn) return;
+      const msg = btn.nextElementSibling;
+      if (msg) {
+        msg.style.display = msg.style.display === 'none' ? 'block' : 'none';
+      }
+    });
+  }
+
+  if (listeResume) {
+    activerToggleMessage(listeResume);
+  }
 
   // Ouvrir le panneau
   boutonOuvrir.addEventListener('click', () => {
@@ -706,8 +725,9 @@ function initPanneauVariantes() {
 
   // Supprimer une ligne
   formulaire.addEventListener('click', (e) => {
-    if (!e.target.classList.contains('bouton-supprimer-ligne')) return;
-    const ligne = e.target.closest('.ligne-variante');
+    const btnSupprimer = e.target.closest('.bouton-supprimer-ligne');
+    if (!btnSupprimer) return;
+    const ligne = btnSupprimer.closest('.ligne-variante');
     const lignes = wrapper.querySelectorAll('.ligne-variante');
 
     if (!ligne) return;
@@ -735,9 +755,10 @@ function initPanneauVariantes() {
     const nouvelle = base.cloneNode(true);
 
     nouvelle.querySelector('.input-texte').value = '';
-    nouvelle.querySelector('.input-texte').placeholder = 'réponse déclenchante';
+    nouvelle.querySelector('.input-texte').placeholder = 'réponse déclenchant l\'affichage du message';
 
     nouvelle.querySelector('.input-message').value = '';
+    nouvelle.querySelector('.input-message').placeholder = 'Message affiché au joueur';
     nouvelle.querySelector('input[type="checkbox"]').checked = false;
 
     wrapper.appendChild(nouvelle);
@@ -815,15 +836,48 @@ function initPanneauVariantes() {
           document.body.classList.remove('panneau-ouvert');
           panneau.setAttribute('aria-hidden', 'true');
 
-          const resume = document.querySelector('[data-champ="enigme_reponse_variantes"] .champ-modifier');
-          if (resume) {
+          if (resumeBloc) {
+            if (!listeResume) {
+              listeResume = document.createElement('ul');
+              listeResume.className = 'liste-variantes-resume';
+              resumeBloc.insertBefore(listeResume, boutonEditerResume || lienAjouterResume || null);
+              activerToggleMessage(listeResume);
+            }
+
+            listeResume.innerHTML = '';
             let nb = 0;
             for (let i = 1; i <= 4; i++) {
               const t = updates.find(u => u[0] === 'texte_' + i)?.[1] || '';
               const m = updates.find(u => u[0] === 'message_' + i)?.[1] || '';
-              if (t && m) nb++;
+              if (t && m) {
+                nb++;
+                const li = document.createElement('li');
+                li.className = 'variante-resume';
+                const bt = document.createElement('button');
+                bt.type = 'button';
+                bt.className = 'variante-texte';
+                bt.textContent = t;
+                const div = document.createElement('div');
+                div.className = 'variante-message';
+                div.style.display = 'none';
+                div.textContent = m;
+                li.appendChild(bt);
+                li.appendChild(div);
+                listeResume.appendChild(li);
+              }
             }
-            resume.textContent = nb === 0 ? '➕ Créer des variantes' : (nb === 1 ? '1 variante ✏️' : `${nb} variantes ✏️`);
+
+            if (nb === 0) {
+              resumeBloc.classList.add('champ-vide');
+              resumeBloc.classList.remove('champ-rempli');
+              lienAjouterResume?.style.setProperty('display', 'inline-block');
+              boutonEditerResume?.style.setProperty('display', 'none');
+            } else {
+              resumeBloc.classList.add('champ-rempli');
+              resumeBloc.classList.remove('champ-vide');
+              lienAjouterResume?.style.setProperty('display', 'none');
+              boutonEditerResume?.style.setProperty('display', 'inline-block');
+            }
           }
 
           if (feedback) feedback.textContent = '';

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -294,7 +294,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               </div>
 
             <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique cache<?= $has_variantes ? ' champ-rempli' : ' champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-              <label><?= esc_html__('Variantes', 'chassesautresor-com'); ?> :</label>
+              <label>
+                <?= esc_html__('Variantes', 'chassesautresor-com'); ?>
+                <button
+                  type="button"
+                  class="bouton-aide-points variantes-aide"
+                  aria-label="<?= esc_attr__('Explication des variantes', 'chassesautresor-com'); ?>"
+                >
+                  <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+                </button>
+              </label>
 
               <?php if ($has_variantes) : ?>
                 <ul class="liste-variantes-resume">

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -300,8 +300,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <ul class="liste-variantes-resume">
                   <?php foreach ($variantes_list as $var) : ?>
                     <li class="variante-resume">
-                      <button type="button" class="variante-texte"><?= esc_html($var['texte']); ?></button>
-                      <div class="variante-message" style="display:none;"><?= esc_html($var['message']); ?></div>
+                      <span class="variante-texte"><?= esc_html($var['texte']); ?></span> => <span class="variante-message"><?= esc_html($var['message']); ?></span>
                     </li>
                   <?php endforeach; ?>
                 </ul>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -40,13 +40,18 @@ $chasse = get_field('enigme_chasse_associee', $enigme_id);
 $chasse_id = is_array($chasse) ? $chasse[0] : null;
 $chasse_title = $chasse_id ? get_the_title($chasse_id) : '';
 
-$nb_variantes = 0;
+$nb_variantes   = 0;
+$variantes_list = [];
 for ($i = 1; $i <= 4; $i++) {
-  $texte   = trim((string) get_field("texte_{$i}", $enigme_id));
-  $message = trim((string) get_field("message_{$i}", $enigme_id));
-  if ($texte && $message) {
-    $nb_variantes++;
-  }
+    $texte   = trim((string) get_field("texte_{$i}", $enigme_id));
+    $message = trim((string) get_field("message_{$i}", $enigme_id));
+    if ($texte && $message) {
+        $nb_variantes++;
+        $variantes_list[] = [
+            'texte'   => $texte,
+            'message' => $message,
+        ];
+    }
 }
 $has_variantes = ($nb_variantes > 0);
 
@@ -288,22 +293,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <div class="champ-feedback"></div>
               </div>
 
-            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique cache<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-              <label>Variantes :</label>
-              <?php
-              $bouton = $has_variantes
-                ? ($nb_variantes === 1 ? '1 variante ✏️' : $nb_variantes . ' variantes ✏️')
-                : '➕ Créer des variantes';
-              $texte = $has_variantes
-                ? ($nb_variantes === 1 ? '1 variante' : $nb_variantes . ' variantes')
-                : '';
-              ?>
-              <?php if ($peut_editer) : ?>
-                <button type="button" class="champ-modifier ouvrir-panneau-variantes" aria-label="<?= $has_variantes ? 'Éditer les variantes' : 'Créer des variantes'; ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                  <?= esc_html($bouton); ?>
-                </button>
-              <?php elseif ($has_variantes) : ?>
-                <span><?= esc_html($texte); ?></span>
+            <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique cache<?= $has_variantes ? ' champ-rempli' : ' champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+              <label><?= esc_html__('Variantes', 'chassesautresor-com'); ?> :</label>
+
+              <?php if ($has_variantes) : ?>
+                <ul class="liste-variantes-resume">
+                  <?php foreach ($variantes_list as $var) : ?>
+                    <li class="variante-resume">
+                      <button type="button" class="variante-texte"><?= esc_html($var['texte']); ?></button>
+                      <div class="variante-message" style="display:none;"><?= esc_html($var['message']); ?></div>
+                    </li>
+                  <?php endforeach; ?>
+                </ul>
+                <?php if ($peut_editer) : ?>
+                  <button type="button" class="champ-modifier ouvrir-panneau-variantes" aria-label="<?= esc_attr__('Éditer les variantes', 'chassesautresor-com'); ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                    <?= esc_html__('éditer', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                  </button>
+                <?php endif; ?>
+              <?php elseif ($peut_editer) : ?>
+                <a href="#" class="champ-ajouter ouvrir-panneau-variantes" aria-label="<?= esc_attr__('Ajouter des variantes', 'chassesautresor-com'); ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                  <?= esc_html__('ajouter des variantes', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                </a>
               <?php endif; ?>
             </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-variantes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-variantes.php
@@ -47,8 +47,8 @@ for ($i = 1; $i <= 4; $i++) {
         ?>
 
           <div class="ligne-variante" data-index="<?= $i; ?>">
-            <input type="text" name="<?= $inputTexte; ?>" class="champ-input input-texte" maxlength="75" placeholder="Texte de la variante" value="<?= esc_attr($texte); ?>">
-            <input type="text" name="<?= $inputMessage; ?>" class="champ-input input-message" maxlength="100" placeholder="Message affiché au joueur" value="<?= esc_attr($message); ?>">
+            <input type="text" name="<?= $inputTexte; ?>" class="champ-input input-texte" maxlength="75" placeholder="<?= esc_attr__('réponse déclenchant l\'affichage du message', 'chassesautresor-com'); ?>" value="<?= esc_attr($texte); ?>">
+            <input type="text" name="<?= $inputMessage; ?>" class="champ-input input-message" maxlength="100" placeholder="<?= esc_attr__('Message affiché au joueur', 'chassesautresor-com'); ?>" value="<?= esc_attr($message); ?>">
 
             <label class="label-casse">
               <input type="checkbox" name="<?= $inputCasse; ?>" <?= $casse ? 'checked' : ''; ?>>
@@ -64,7 +64,7 @@ for ($i = 1; $i <= 4; $i++) {
 
       <div class="ajout-variante-controls" style="margin-top: 20px; display: flex; flex-direction: column; gap: 8px;">
         <button type="button" id="bouton-ajouter-variante" class="bouton-enregistrer-description secondaire" style="align-self: start;">
-          ➕ Ajouter une variante
+          ➕ <?= esc_html__('Ajouter une variante', 'chassesautresor-com'); ?>
         </button>
         <p class="message-limite-variantes txt-small" style="display: none; color: var(--color-editor-error); font-size: 0.9em;">
           4 variantes maximum


### PR DESCRIPTION
## Résumé
- refonte de l'affichage des variantes d'énigme
- ergonomie du panneau latéral de variantes améliorée
- style du bouton d'ajout de variante rendu visible

## Changements notables
- liste détaillée des variantes avec messages associés
- placeholders et suppression de lignes corrigés dans le panneau
- rafraîchissement du résumé après enregistrement

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a01e77976c8332b93a3fba3f1821ac