### PR TITLE
Fix dynamic label update for puzzle title field

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -143,7 +143,7 @@ function initChampTexte(bloc) {
 
     modifierChampSimple(champ, valeur, postId, cpt).then(success => {
       if (success) {
-        const affichageTexte = affichage.querySelector('.champ-valeur, h1, h2, p, span');
+        const affichageTexte = affichage.querySelector('.champ-valeur, h1, h2, p, span:not(.champ-obligatoire)');
 
         if (champ === 'email_contact') {
           const fallbackEmail = window.organisateurData?.defaultEmail || '…';


### PR DESCRIPTION
## Résumé
- Empêche la copie du titre dans le label lors de l'édition dynamique d'une énigme

## Changements notables
- Affine le sélecteur de mise à jour du texte pour ignorer l'icône de champ obligatoire

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test` *(jest-haste-map: Haste module naming collision: jquery)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f48206c833287a4872777512d1a