### PR TITLE
Fix solution redirection to reopen solution tab

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -300,7 +300,7 @@ function initEnigmeEdit() {
   initChampSolution();
   initSolutionInline();
   const paramsMaj = new URLSearchParams(window.location.search);
-  if (paramsMaj.get('maj') === 'solution') {
+  if (paramsMaj.get('maj') === 'solution' && !paramsMaj.has('tab')) {
     ouvrirPanneauSolution();
   }
   initChampConditionnel('acf[enigme_acces_condition]', {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-solution.php
@@ -18,6 +18,15 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
       $mode_field = acf_get_field('enigme_solution_mode');
       $mode_key   = $mode_field['key'] ?? '';
 
+      $return_url = add_query_arg(
+        [
+          'maj'     => 'solution',
+          'edition' => 'open',
+          'tab'     => 'solution',
+        ],
+        get_permalink($enigme_id)
+      );
+
       acf_form([
         'post_id'         => $enigme_id,
         'form'            => true,
@@ -26,7 +35,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
           'enigme_solution_explication',
         ],
         'submit_value'    => '💾 Enregistrer la solution',
-        'return'          => get_permalink($enigme_id) . '?maj=solution',
+        'return'          => $return_url,
         'uploader'        => 'basic',
         'label_placement' => 'top',
         'html_after_fields' => $mode_key ? '<input type="hidden" name="acf[' . esc_attr($mode_key) . ']" value="texte" />' : '',


### PR DESCRIPTION
## Résumé
Corrige la redirection après l'enregistrement d'une solution d'énigme afin de revenir directement sur l'onglet "Solution".

## Changements
- Ajoute une URL de retour avec paramètres `maj`, `edition` et `tab` pour rouvrir l'onglet Solution

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a02210fd3c8332a352f94c9b51de68