### PR TITLE
feat(solution): update card status when filled

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -184,6 +184,30 @@ window.mettreAJourResumeInfos = function () {
         const val = document.querySelector('#solution-heure')?.value?.trim();
         estRempli = !!val;
       }
+
+      if (champ === 'enigme_solution_fichier') {
+        const lien = document.querySelector('.champ-solution-fichier p a');
+        const nom = lien?.textContent?.trim();
+        const btn = ligne.querySelector('.champ-modifier');
+        const labelNode = ligne.childNodes[0];
+        estRempli = !!nom;
+        if (labelNode && labelNode.nodeType === 3) {
+          labelNode.textContent = nom || 'Document PDF';
+        }
+        if (btn) {
+          btn.textContent = estRempli ? 'Modifier' : 'Choisir un fichier';
+        }
+      }
+
+      if (champ === 'enigme_solution_explication') {
+        const textarea = document.querySelector('#panneau-solution-enigme textarea');
+        const texte = textarea?.value?.trim();
+        const btn = ligne.querySelector('.champ-modifier');
+        estRempli = !!texte;
+        if (btn) {
+          btn.textContent = estRempli ? 'éditer' : 'Rédiger';
+        }
+      }
       mettreAJourLigneResume(ligne, champ, estRempli, 'enigme');
     });
     // ✅ Marquage spécial si bonne réponse manquante
@@ -274,7 +298,9 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
       'enigme_style_affichage',
       'enigme_solution_mode',
       'enigme_solution_delai',
-      'enigme_solution_heure'
+      'enigme_solution_heure',
+      'enigme_solution_fichier',
+      'enigme_solution_explication'
     ];
 
     if (champ === 'post_title' && typeof window.mettreAJourTitreHeader === 'function') {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -957,6 +957,9 @@ function initSolutionInline() {
         if (res.success) {
           feedbackFichier.textContent = '✅ Fichier enregistré';
           feedbackFichier.className = 'champ-feedback champ-success';
+          if (typeof window.mettreAJourResumeInfos === 'function') {
+            window.mettreAJourResumeInfos();
+          }
         } else {
           feedbackFichier.textContent = '❌ Erreur : ' + (res.data || 'inconnue');
           feedbackFichier.className = 'champ-feedback champ-error';
@@ -973,6 +976,12 @@ function initSolutionInline() {
 // ==============================
 // ✏️ Panneau solution (texte)
 // ==============================
+document.querySelector('#panneau-solution-enigme textarea')?.addEventListener('input', () => {
+  if (typeof window.mettreAJourResumeInfos === 'function') {
+    window.mettreAJourResumeInfos();
+  }
+});
+
 document.addEventListener('click', (e) => {
   const btn = e.target.closest('#ouvrir-panneau-solution'); // ou '.ouvrir-panneau-solution' si classe
   if (!btn) return;


### PR DESCRIPTION
## Summary
- mark solution cards complete when PDF or text provided
- adjust card labels and actions depending on content

## Testing
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68a0253094b08332878c71e66823b060