### PR TITLE
Remove default WooCommerce dashboard message

### DIFF
--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/dashboard.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/dashboard.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * My Account Dashboard
+ *
+ * Custom template without default WooCommerce greeting or description.
+ *
+ * @package WooCommerce\\Templates
+ * @version 4.4.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+do_action('woocommerce_account_dashboard');
+
+do_action('woocommerce_before_my_account');
+
+do_action('woocommerce_after_my_account');
+


### PR DESCRIPTION
Supprime le message de bienvenue par défaut du tableau de bord WooCommerce.

- Ajout d'un modèle `dashboard.php` personnalisé sans message prédéfini
- Maintien des hooks du tableau de bord pour l'extension WooCommerce

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a036f4a42c8332aad6705fd91f0ff9