### PR TITLE
Apply edition mode theme to account pages

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -266,6 +266,11 @@ span.champ-obligatoire {
   --color-editor-placeholder:      #9AA0A6;   /* 💬 Placeholder ou aide contextuelle */
 
   --editor-label-width:            170px;     /* 📏 Largeur minimale des labels dans les panneaux */
+
+  /* 🎯 Overrides global palette for edition mode */
+  --color-background:              var(--color-editor-background);
+  --color-text-primary:            var(--color-editor-text);
+  --color-text-secondary:          var(--color-editor-text-muted);
 }
 
 

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -30,29 +30,46 @@ add_action('wp_enqueue_scripts', function () {
 
     // 🎨 Chargement des styles du thème parent (Astra) et enfant
     wp_enqueue_style('astra-style', get_template_directory_uri() . '/style.css');
-    wp_enqueue_style('mon-theme-enfant-style', get_stylesheet_directory_uri() . '/style.css', ['astra-style'], filemtime(get_stylesheet_directory() . '/style.css'));
+    wp_enqueue_style(
+        'mon-theme-enfant-style',
+        get_stylesheet_directory_uri() . '/style.css',
+        ['astra-style'],
+        filemtime(get_stylesheet_directory() . '/style.css')
+    );
+
+    $is_myaccount = strpos($_SERVER['REQUEST_URI'] ?? '', '/mon-compte/') === 0;
 
     // 📂 Liste des fichiers CSS organisés
     $styles = [
-        'grid'               => 'grid.css',
-        'layout'             => 'layout.css',
-        'components'         => 'components.css',
-        'modal-bienvenue'    => 'modal-bienvenue.css',
-        'general-style'      => 'general.css',
-        'chasse-style'       => 'chasse.css',
-        'enigme-style'       => 'enigme.css',
-        'gamification-style' => 'gamification.css',
-        'cartes-style'       => 'cartes.css',
-        'organisateurs'      => 'organisateurs.css',
-        'edition'            => 'edition.css',
-        'mon compte'         => 'mon-compte.css',
-        'commerce-style'     => 'commerce.css',
-        'home'               => 'home.css',
+        'general-style' => 'general.css',
+        'edition'       => 'edition.css',
     ];
+
+    if ($is_myaccount) {
+        $styles['mon compte'] = 'mon-compte.css';
+    } else {
+        $styles = array_merge(
+            $styles,
+            [
+                'grid'               => 'grid.css',
+                'layout'             => 'layout.css',
+                'components'         => 'components.css',
+                'modal-bienvenue'    => 'modal-bienvenue.css',
+                'chasse-style'       => 'chasse.css',
+                'enigme-style'       => 'enigme.css',
+                'gamification-style' => 'gamification.css',
+                'cartes-style'       => 'cartes.css',
+                'organisateurs'      => 'organisateurs.css',
+                'commerce-style'     => 'commerce.css',
+                'home'               => 'home.css',
+            ]
+        );
+    }
 
     // 🚀 Chargement dynamique des styles avec gestion du cache
     foreach ($styles as $handle => $file) {
-        wp_enqueue_style($handle, $theme_dir . $file, [], filemtime(get_stylesheet_directory() . "/assets/css/{$file}"));
+        $path = get_stylesheet_directory() . "/assets/css/{$file}";
+        wp_enqueue_style($handle, $theme_dir . $file, [], filemtime($path));
     }
 
     $script_dir = get_stylesheet_directory_uri() . '/assets/js/';

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -424,14 +424,18 @@ add_filter('body_class', 'injection_classe_edition_active');
 function injection_classe_edition_active(array $classes): array
 {
 
-  if (!is_user_logged_in()) return $classes;
-
   if (strpos($_SERVER['REQUEST_URI'] ?? '', '/mon-compte/') === 0) {
     $classes[] = 'mode-edition';
   }
 
+  if (!is_user_logged_in()) {
+    return $classes;
+  }
+
   global $post;
-  if (!$post || !isset($post->post_type)) return $classes;
+  if (!$post || !isset($post->post_type)) {
+    return $classes;
+  }
 
   $user_id = get_current_user_id();
   $roles = wp_get_current_user()->roles;


### PR DESCRIPTION
## Summary
- uniformiser le style *mode édition* sur toutes les pages `/mon-compte`
- charger uniquement les feuilles de style dédiées au mode édition pour ces pages
- activer la classe `mode-edition` même pour les visiteurs

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a037775ef48332831faf71cc0bc50f