### PR TITLE
Supprime la carte Chasses du tableau de bord organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/myaccount/dashboard-organisateur.php
+++ b/wp-content/themes/chassesautresor/template-parts/myaccount/dashboard-organisateur.php
@@ -7,67 +7,20 @@
 
 defined('ABSPATH') || exit;
 
-$organizer_id    = $args['organizer_id'] ?? null;
-$organizer_title = $args['organizer_title'] ?? '';
-$orders_output   = $args['orders_output'] ?? '';
+$orders_output = $args['orders_output'] ?? '';
 ?>
 
 <div class="dashboard-grid">
-    <div class="dashboard-card">
+    <?php if (!empty($orders_output)) : ?>
+    <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>" class="dashboard-card">
         <div class="dashboard-card-header">
-            <i class="fas fa-map"></i>
-            <h4><?php esc_html_e('Chasses', 'chassesautresor'); ?></h4>
+            <i class="fas fa-shopping-cart"></i>
+            <h4><?php esc_html_e('Mes Commandes', 'chassesautresor'); ?></h4>
         </div>
         <div class="dashboard-card-content">
-                <?php
-                if ($organizer_id) {
-                    $query_total    = get_chasses_de_organisateur($organizer_id);
-                    $total_chasses  = $query_total->found_posts;
-                    $recent_chasses = array_slice($query_total->posts, 0, 5);
-                    if ($total_chasses) {
-                        echo '<table class="stats-table"><thead><tr><th>' . esc_html__('Titre', 'chassesautresor') . '</th><th>' . esc_html__('Énigmes', 'chassesautresor') . '</th><th>' . esc_html__('Joueurs', 'chassesautresor') . '</th></tr></thead><tbody>';
-                        foreach ($recent_chasses as $post) {
-                            $cid     = $post->ID;
-                            $enigmes = count(recuperer_enigmes_associees($cid));
-                            echo '<tr>';
-                            echo '<td><a href="' . esc_url(get_permalink($cid)) . '">' . esc_html(get_the_title($cid)) . '</a></td>';
-                            echo '<td>' . intval($enigmes) . '</td>';
-                            echo '<td>xx</td>';
-                            echo '</tr>';
-                        }
-                        echo '</tbody></table>';
-                        if ($total_chasses > 5) {
-                            echo '<p>' . sprintf(esc_html__('%d chasses au total', 'chassesautresor'), intval($total_chasses)) . '</p>';
-                        }
-                    } else {
-                        $can_add = utilisateur_peut_ajouter_chasse($organizer_id);
-                        if ($can_add) {
-                            get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, array(
-                                'organisateur_id' => $organizer_id,
-                                'has_chasses'     => false,
-                            ));
-                        } else {
-                            echo '<p><a href="' . esc_url(get_permalink($organizer_id)) . '">' . esc_html__('Complétez votre profil organisateur', 'chassesautresor') . '</a></p>';
-                        }
-                    }
-                } else {
-                    echo '<p>' . esc_html__('Aucune chasse trouvée.', 'chassesautresor') . '</p>';
-                }
-                ?>
-            </div>
+            <?php echo $orders_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         </div>
-
-        <?php if (!empty($orders_output)) : ?>
-        <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>" class="dashboard-card">
-            <div class="dashboard-card-header">
-                <i class="fas fa-shopping-cart"></i>
-                <h4><?php esc_html_e('Mes Commandes', 'chassesautresor'); ?></h4>
-            </div>
-            <div class="dashboard-card-content">
-                <?php echo $orders_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-            </div>
-        </a>
-        <?php endif; ?>
-    </div>
+    </a>
+    <?php endif; ?>
 </div>
 

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-dashboard-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-dashboard-organisateur.php
@@ -13,13 +13,6 @@ if (function_exists('charger_script_conversion')) {
 
 $current_user = wp_get_current_user();
 $user_id      = $current_user->ID;
-$organizer_id = get_organisateur_from_user($user_id);
-
-if ($organizer_id) {
-    $organizer_title = get_the_title($organizer_id);
-} else {
-    $organizer_title = __('Organisateur', 'chassesautresor');
-}
 
 $orders_output = afficher_commandes_utilisateur($user_id, 3);
 
@@ -49,9 +42,7 @@ if ($pending_table !== '') {
 }
 
 $args = array(
-    'organizer_id'    => $organizer_id,
-    'organizer_title' => $organizer_title,
-    'orders_output'   => $orders_output,
+    'orders_output' => $orders_output,
 );
 
 get_template_part('template-parts/myaccount/dashboard-organisateur', null, $args);


### PR DESCRIPTION
## Résumé
- Retire la carte « Chasses » du tableau de bord des organisateurs
- Nettoie les paramètres liés à cette carte désormais inutilisée

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a03a323ac88332aa7aab0bdeb14265