### PR TITLE
Ajout de l'origine des transactions de points

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -107,18 +107,20 @@ function traiter_gestion_points() {
 
     // Modification des points selon l’action choisie
     if ($type_modification === "ajouter") {
-        $nouveau_solde = $solde_actuel + $nombre_points;
+        $delta  = $nombre_points;
+        $reason = sprintf('Ajout manuel de %d points', $nombre_points);
     } elseif ($type_modification === "retirer") {
         if ($nombre_points > $solde_actuel) {
             wp_die( __( '❌ Impossible de retirer plus de points que l’utilisateur en possède.', 'chassesautresor-com' ) );
         }
-        $nouveau_solde = $solde_actuel - $nombre_points;
+        $delta  = -$nombre_points;
+        $reason = sprintf('Retrait manuel de %d points', $nombre_points);
     } else {
         wp_die( __( '❌ Action invalide.', 'chassesautresor-com' ) );
     }
 
     // Mettre à jour les points de l'utilisateur
-    update_user_points($user_id, $nouveau_solde);
+    update_user_points($user_id, $delta, $reason, 'admin');
 
     error_log("✅ Points modifiés : $nombre_points $type_modification pour l'utilisateur $utilisateur");
 
@@ -503,7 +505,9 @@ function regler_paiement_admin() {
 
         $points = intval($paiement['paiement_points_utilises'] ?? 0);
         if ($points > 0) {
-            update_user_points($user_id, $points, 'refund');
+            $logId = intval($paiement['points_log_id'] ?? 0);
+            $reason = sprintf('Remboursement de la demande #%d', $logId);
+            update_user_points($user_id, $points, $reason, 'conversion', $logId);
         }
     }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -147,7 +147,8 @@ function soumettre_reponse_manuelle()
     }
 
     if ($cout > 0) {
-        deduire_points_utilisateur($user_id, $cout);
+        $reason = sprintf("Tentative de réponse pour l'énigme #%d", $enigme_id);
+        deduire_points_utilisateur($user_id, $cout, $reason, 'tentative', $enigme_id);
     }
 
     $uid = inserer_tentative($user_id, $enigme_id, $reponse);

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -391,7 +391,8 @@ function traiter_tentative(
 
     $cout = (int) get_field('enigme_tentative_cout_points', $enigme_id);
     if ($cout > 0) {
-        deduire_points_utilisateur($user_id, $cout);
+        $reason = sprintf("Tentative de réponse pour l'énigme #%d", $enigme_id);
+        deduire_points_utilisateur($user_id, $cout, $reason, 'tentative', $enigme_id);
     }
 
     $uid = '';

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -58,16 +58,24 @@ function get_user_points($user_id = null): int {
  *
  * @param int    $user_id       ID de l'utilisateur.
  * @param int    $points_change Nombre de points à ajouter ou retirer.
- * @param string $reason        Raison de la modification.
+ * @param string $reason        Motif lisible par l'utilisateur.
+ * @param string $origin_type   Catégorie de l'opération.
+ * @param int|null $origin_id   Identifiant de l'élément lié.
  */
-function update_user_points(int $user_id, int $points_change, string $reason = ''): void {
+function update_user_points(
+    int $user_id,
+    int $points_change,
+    string $reason = '',
+    string $origin_type = 'admin',
+    ?int $origin_id = null
+): void {
     if (!$user_id) {
         return;
     }
 
     global $wpdb;
     $repo = new PointsRepository($wpdb);
-    $repo->addPoints($user_id, $points_change, $reason);
+    $repo->addPoints($user_id, $points_change, $reason, $origin_type, $origin_id);
 
     // 🔄 Rafraîchit la session utilisateur si connecté
     if (is_user_logged_in()) {
@@ -102,7 +110,8 @@ function attribuer_points_apres_achat($order_id) {
         $slug = $product->get_slug();
         if (isset($packs_points[$slug])) {
             $points_to_add = $packs_points[$slug] * $item->get_quantity();
-            update_user_points($user_id, $points_to_add, 'purchase');
+            $reason = sprintf('Achat de %d points (commande #%d)', $points_to_add, $order_id);
+            update_user_points($user_id, $points_to_add, $reason, 'achat', $order_id);
             $points_ajoutes += $points_to_add;
             $order->add_order_note("✅ {$points_to_add} points ajoutés.");
         }
@@ -212,28 +221,44 @@ function utilisateur_a_assez_de_points(int $user_id, int $montant): bool {
 /**
  * ➖ Déduit un montant de points à un utilisateur.
  *
- * @param int    $user_id
- * @param int    $montant Nombre de points à retirer (doit être positif).
- * @param string $reason  Raison de la déduction.
+ * @param int      $user_id
+ * @param int      $montant     Nombre de points à retirer (doit être positif).
+ * @param string   $reason      Motif de la déduction.
+ * @param string   $origin_type Catégorie de l'opération.
+ * @param int|null $origin_id   Identifiant lié.
  * @return void
  */
-function deduire_points_utilisateur(int $user_id, int $montant, string $reason = ''): void {
+function deduire_points_utilisateur(
+    int $user_id,
+    int $montant,
+    string $reason = '',
+    string $origin_type = 'admin',
+    ?int $origin_id = null
+): void {
     if ($user_id && $montant > 0) {
-        update_user_points($user_id, -$montant, $reason);
+        update_user_points($user_id, -$montant, $reason, $origin_type, $origin_id);
     }
 }
 
 /**
  * ➕ Ajoute un montant de points à un utilisateur.
  *
- * @param int    $user_id
- * @param int    $montant Nombre de points à ajouter (doit être positif).
- * @param string $reason  Raison de l'ajout.
+ * @param int      $user_id
+ * @param int      $montant     Nombre de points à ajouter (doit être positif).
+ * @param string   $reason      Motif de l'ajout.
+ * @param string   $origin_type Catégorie de l'opération.
+ * @param int|null $origin_id   Identifiant lié.
  * @return void
  */
-function ajouter_points_utilisateur(int $user_id, int $montant, string $reason = ''): void {
+function ajouter_points_utilisateur(
+    int $user_id,
+    int $montant,
+    string $reason = '',
+    string $origin_type = 'admin',
+    ?int $origin_id = null
+): void {
     if ($user_id && $montant > 0) {
-        update_user_points($user_id, $montant, $reason);
+        update_user_points($user_id, $montant, $reason, $origin_type, $origin_id);
     }
 }
 

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -1275,6 +1275,8 @@ Index :
 | points    | int             | variation (crédit ou débit)      |
 | amount_eur | decimal(10,2) NULL | montant équivalent en euros |
 | reason    | varchar(255)    | motif de l'opération             |
+| origin_type | enum('admin','chasse','tentative','achat','conversion') NULL DEFAULT 'admin' | catégorie |
+| origin_id | bigint unsigned NULL | identifiant lié (chasse, énigme, commande...) |
 | request_status | enum('pending','approved','paid','refused') DEFAULT 'pending' | statut de la demande |
 | request_date | datetime DEFAULT CURRENT_TIMESTAMP | date de la demande |
 | settlement_date | datetime NULL | date de règlement |
@@ -1286,6 +1288,9 @@ Index :
 - `PRIMARY(id)`
 - `INDEX(user_id)`
 - `INDEX(created_at)`
+
+`origin_type` indique la source de la variation de points :
+`admin`, `chasse`, `tentative`, `achat` ou `conversion`.
 
 
 Les variantes sont comparées en tenant compte de leur option `respecter_casse_n`. Si la saisie correspond, le résultat enregistré est `variante` et le message défini est renvoyé via AJAX à chaque soumission, même identique.

--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -46,7 +46,8 @@ if ($chasse_id) {
     enregistrer_engagement_chasse($current_user_id, $chasse_id);
 
     if ($cout_points > 0) {
-        deduire_points_utilisateur($current_user_id, $cout_points);
+        $reason = sprintf('Déblocage de la chasse #%d', $chasse_id);
+        deduire_points_utilisateur($current_user_id, $cout_points, $reason, 'chasse', $chasse_id);
     }
 
     wp_safe_redirect(get_permalink($chasse_id));


### PR DESCRIPTION
## Résumé
- Enregistre l'origine et un motif pour chaque opération sur `wp_user_points`
- Ajoute des raisons dynamiques pour les achats, engagements, tentatives et remboursements
- Met à jour la documentation de la table des points

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a055a596388332b61011bc2d76a89a