### PR TITLE
Ajout lien demande conversion

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -322,7 +322,24 @@ function myaccount_get_important_messages(): string
         if (is_array($paiements)) {
             foreach ($paiements as $paiement) {
                 if (!empty($paiement['statut']) && $paiement['statut'] === 'en attente') {
-                    $messages[] = __('Vous avez une demande de conversion en attente de règlement.', 'chassesautresor');
+                    $organisateur_url = add_query_arg(
+                        [
+                            'edition' => 'open',
+                            'onglet'  => 'revenus',
+                        ],
+                        get_permalink($organisateur_id)
+                    );
+
+                    $link = sprintf(
+                        '<a href="%s">%s</a>',
+                        esc_url($organisateur_url),
+                        esc_html__('demande de conversion', 'chassesautresor')
+                    );
+
+                    $messages[] = sprintf(
+                        __('Vous avez une %s en attente de règlement.', 'chassesautresor'),
+                        $link
+                    );
                     break;
                 }
             }

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -1,0 +1,93 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('est_organisateur')) {
+    function est_organisateur()
+    {
+        return true;
+    }
+}
+
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id()
+    {
+        return 1;
+    }
+}
+
+if (!function_exists('get_organisateur_from_user')) {
+    function get_organisateur_from_user($user_id)
+    {
+        return 99;
+    }
+}
+
+if (!function_exists('recuperer_enigmes_tentatives_en_attente')) {
+    function recuperer_enigmes_tentatives_en_attente($organisateur_id)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('get_user_meta')) {
+    function get_user_meta($user_id, $key, $single)
+    {
+        return [
+            [
+                'statut' => 'en attente',
+            ],
+        ];
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($post_id)
+    {
+        return 'https://example.com/organisateur';
+    }
+}
+
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($args, $url = '')
+    {
+        $query = http_build_query($args);
+        $sep = strpos($url, '?') === false ? '?' : '&';
+        return $url . $sep . $query;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url)
+    {
+        return $url;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+require_once __DIR__ . '/../inc/user-functions.php';
+
+class MyAccountMessagesTest extends TestCase
+{
+    public function test_conversion_request_message_contains_link(): void
+    {
+        $output = myaccount_get_important_messages();
+
+        $this->assertStringContainsString('<a', $output);
+        $this->assertStringContainsString('?edition=open&onglet=revenus', $output);
+        $this->assertStringContainsString('demande de conversion', $output);
+    }
+}


### PR DESCRIPTION
## Résumé
- Ajout d'un lien vers l'onglet Points du panneau organisateur lorsque une demande de conversion est en attente
- Ajout d'un test unitaire garantissant la présence du lien de conversion

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a06d8adf108332a6fdbe9c5bb9a011