### PR TITLE
Restreindre le chargement des scripts ACF aux éditeurs autorisés

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -123,8 +123,15 @@ require_once $inc_path . 'edition/edition-securite.php';
  * @hook wp_head
  */
 add_action('wp_head', 'forcer_acf_form_head_chasse', 0);
-function forcer_acf_form_head_chasse() {
-    if (is_singular('chasse') && function_exists('acf_form_head')) {
+function forcer_acf_form_head_chasse()
+{
+    if (!is_singular('chasse') || !function_exists('acf_form_head')) {
+        return;
+    }
+
+    $post_id = get_queried_object_id();
+
+    if (current_user_can('edit_post', $post_id)) {
         acf_form_head();
     }
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -40,7 +40,11 @@ defined('ABSPATH') || exit;
 add_action('wp_enqueue_scripts', 'forcer_chargement_acf_scripts_chasse');
 function forcer_chargement_acf_scripts_chasse()
 {
-  if (is_singular('chasse')) {
+  if (!is_singular('chasse') || !function_exists('acf_enqueue_scripts')) {
+    return;
+  }
+
+  if (current_user_can('edit_post', get_the_ID())) {
     acf_enqueue_scripts();
   }
 }


### PR DESCRIPTION
Restreint le chargement des scripts ACF aux utilisateurs pouvant éditer les contenus.

- Ajout d'un contrôle de permission avant l'appel à `acf_form_head()` pour les fiches chasse.
- Enfilement conditionnel des scripts ACF selon la capacité d'édition.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a071ac47ac8332b0f210d86afc5c31