### PR TITLE
feat: cartes points pour organisateur sur commandes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -347,6 +347,10 @@
     margin-top: 20px;
 }
 
+.stats-cards {
+    margin: 1rem 0 2.5rem;
+}
+
 .dashboard-card {
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -13,15 +13,87 @@
 
 defined('ABSPATH') || exit;
 
-$points = function_exists('get_user_points') ? get_user_points() : 0;
+$current_user = wp_get_current_user();
+$roles        = (array) $current_user->roles;
+$is_organizer = in_array(ROLE_ORGANISATEUR, $roles, true) || in_array(ROLE_ORGANISATEUR_CREATION, $roles, true);
 
 do_action('woocommerce_before_account_orders', $has_orders);
 
-if ($points > 0) {
-    echo '<p class="myaccount-points">' . sprintf(esc_html__('Vous avez %d points', 'chassesautresor'), $points) . '</p>';
+if ($is_organizer) {
+    if (function_exists('charger_script_conversion')) {
+        charger_script_conversion(true);
+    }
+
+    $user_id        = (int) $current_user->ID;
+    $organisateur_id = function_exists('get_organisateur_from_user') ? get_organisateur_from_user($user_id) : null;
+    $user_points     = function_exists('get_user_points') ? get_user_points($user_id) : 0;
+    $access_message  = function_exists('verifier_acces_conversion') ? verifier_acces_conversion($user_id) : false;
+    $conversion_disabled = $access_message !== true;
+    $peut_editer     = $organisateur_id && function_exists('utilisateur_peut_editer_champs')
+        ? utilisateur_peut_editer_champs($organisateur_id)
+        : false;
+    $iban = $organisateur_id ? get_field('iban', $organisateur_id) : '';
+    $bic  = $organisateur_id ? get_field('bic', $organisateur_id) : '';
+    $coordonnees_vides = empty($iban) && empty($bic);
+    ?>
+    <div class="dashboard-grid stats-cards myaccount-points-cards">
+        <div class="dashboard-card" data-stat="points">
+            <i class="fa-solid fa-coins" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php echo esc_html($user_points); ?></p>
+        </div>
+        <div class="dashboard-card<?php echo $conversion_disabled ? ' disabled' : ''; ?>" data-stat="conversion">
+            <i class="fa-solid fa-right-left" aria-hidden="true"></i>
+            <h3>Conversion</h3>
+            <button type="button" id="open-conversion-modal" class="stat-value">
+                <?php esc_html_e('Convertir', 'chassesautresor-com'); ?>
+            </button>
+        </div>
+        <div class="dashboard-card" data-stat="bank-details">
+            <i class="fa-solid fa-building-columns" aria-hidden="true"></i>
+            <h3>
+                Coordonnées bancaires
+                <button
+                    type="button"
+                    class="mode-fin-aide stat-help"
+                    data-message="<?php echo esc_attr__('Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d\'argent.', 'chassesautresor-com'); ?>"
+                    aria-label="<?php esc_attr_e('Informations sur les coordonnées bancaires', 'chassesautresor-com'); ?>"
+                >
+                    <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
+                </button>
+            </h3>
+            <?php if ($peut_editer) : ?>
+                <?php
+                $bank_label = $coordonnees_vides ? __('Ajouter', 'chassesautresor-com') : __('Éditer', 'chassesautresor-com');
+                $bank_aria  = $coordonnees_vides ? __('Ajouter des coordonnées bancaires', 'chassesautresor-com') : __('Modifier les coordonnées bancaires', 'chassesautresor-com');
+                ?>
+                <a
+                    id="ouvrir-coordonnees"
+                    class="stat-value champ-modifier"
+                    href="#"
+                    aria-label="<?php echo esc_attr($bank_aria); ?>"
+                    data-champ="coordonnees_bancaires"
+                    data-cpt="organisateur"
+                    data-post-id="<?php echo esc_attr($organisateur_id); ?>"
+                    data-label-add="<?php esc_attr_e('Ajouter', 'chassesautresor-com'); ?>"
+                    data-label-edit="<?php esc_attr_e('Éditer', 'chassesautresor-com'); ?>"
+                    data-aria-add="<?php esc_attr_e('Ajouter des coordonnées bancaires', 'chassesautresor-com'); ?>"
+                    data-aria-edit="<?php esc_attr_e('Modifier les coordonnées bancaires', 'chassesautresor-com'); ?>"
+                ><?php echo esc_html($bank_label); ?></a>
+            <?php endif; ?>
+        </div>
+    </div>
+    <?php
+    get_template_part('template-parts/modals/modal-conversion');
 } else {
-    $shop_url = esc_url(home_url('/boutique'));
-    echo '<p class="myaccount-points"><a href="' . $shop_url . '">' . esc_html__('Ajouter des points', 'chassesautresor') . '</a></p>';
+    $points = function_exists('get_user_points') ? get_user_points() : 0;
+
+    if ($points > 0) {
+        echo '<p class="myaccount-points">' . sprintf(esc_html__('Vous avez %d points', 'chassesautresor'), $points) . '</p>';
+    } else {
+        $shop_url = esc_url(home_url('/boutique'));
+        echo '<p class="myaccount-points"><a href="' . $shop_url . '">' . esc_html__('Ajouter des points', 'chassesautresor') . '</a></p>';
+    }
 }
 
 if ($has_orders) : ?>


### PR DESCRIPTION
## Résumé
- affiche les cartes points, conversion et coordonnées bancaires pour les organisateurs sur la page commandes
- ajoute un style pour espacer la grille de cartes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a070dbff888332b17eaaf40c7a49f7