### PR TITLE
Optimise la récupération des chasses d'un organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1322,14 +1322,14 @@ function recuperer_organisateurs_en_creation() {
             continue;
         }
 
-        $chasse     = $chasses[0];
-        $nb_enigmes = count(recuperer_enigmes_associees($chasse->ID));
+        $chasse_id  = (int) $chasses[0];
+        $nb_enigmes = count(recuperer_enigmes_associees($chasse_id));
 
         $entries[] = [
             'date_creation'      => $date_creation,
             'organisateur_titre' => get_the_title($organisateur_id),
-            'chasse_id'          => $chasse->ID,
-            'chasse_titre'       => get_the_title($chasse->ID),
+            'chasse_id'          => $chasse_id,
+            'chasse_titre'       => get_the_title($chasse_id),
             'nb_enigmes'         => $nb_enigmes,
         ];
     }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -788,12 +788,13 @@ function trouver_chasse_a_valider(int $user_id): ?int
         return null;
     }
 
-    $query = get_chasses_de_organisateur($organisateur_id);
+    $query   = get_chasses_de_organisateur($organisateur_id);
     $chasses = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
 
-    foreach ($chasses as $post) {
-        if (peut_valider_chasse($post->ID, $user_id)) {
-            return $post->ID;
+    foreach ($chasses as $chasse_id) {
+        $chasse_id = (int) $chasse_id;
+        if (peut_valider_chasse($chasse_id, $user_id)) {
+            return $chasse_id;
         }
     }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -323,8 +323,8 @@ function rediriger_selon_etat_organisateur()
   $has_chasse_non_attente = false;
   $query = get_chasses_de_organisateur($organisateur_id);
   if ($query && $query->have_posts()) {
-    foreach ($query->posts as $chasse) {
-      $statut_validation = get_field('chasse_cache_statut_validation', $chasse->ID);
+    foreach ($query->posts as $chasse_id) {
+      $statut_validation = get_field('chasse_cache_statut_validation', (int) $chasse_id);
       if ($statut_validation !== 'en_attente') {
         $has_chasse_non_attente = true;
         break;

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -314,8 +314,8 @@ function recuperer_enigmes_tentatives_en_attente(int $organisateur_id): array
 
     $result = [];
 
-    foreach ($query->posts as $chasse) {
-        $enigmes = recuperer_enigmes_associees($chasse->ID);
+    foreach ($query->posts as $chasse_id) {
+        $enigmes = recuperer_enigmes_associees((int) $chasse_id);
         foreach ($enigmes as $enigme_id) {
             $mode = enigme_normaliser_mode_validation(
                 get_field('enigme_mode_validation', $enigme_id)

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -418,14 +418,14 @@ function generer_liste_chasses_hierarchique($organisateur_id) {
 
     if ($nombre_chasses > 0) {
         $out .= '<ul>';
-        foreach ($query->posts as $post) {
-            $chasse_id = $post->ID;
+        foreach ($query->posts as $chasse_id) {
+            $chasse_id    = (int) $chasse_id;
             $chasse_titre = get_the_title($chasse_id);
-            $nb_enigmes = count(recuperer_enigmes_associees($chasse_id));
-            $out .= '<li>';
-            $out .= 'Chasse : <a href="' . esc_url(get_permalink($chasse_id)) . '">' . esc_html($chasse_titre) . '</a> ';
-            $out .= '(' . sprintf(_n('%d énigme', '%d énigmes', $nb_enigmes, 'text-domain'), $nb_enigmes) . ')';
-            $out .= '</li>';
+            $nb_enigmes   = count(recuperer_enigmes_associees($chasse_id));
+            $out         .= '<li>';
+            $out         .= 'Chasse : <a href="' . esc_url(get_permalink($chasse_id)) . '">' . esc_html($chasse_titre) . '</a> ';
+            $out         .= '(' . sprintf(_n('%d énigme', '%d énigmes', $nb_enigmes, 'text-domain'), $nb_enigmes) . ')';
+            $out         .= '</li>';
         }
         $out .= '</ul>';
     }
@@ -486,13 +486,13 @@ function get_cta_devenir_organisateur(?int $user_id = null): array
         ];
     }
 
-    $organisateur_id = get_organisateur_from_user($user_id);
+    $organisateur_id   = get_organisateur_from_user($user_id);
     $has_pending_chasse = false;
     if ($organisateur_id) {
         $query = get_chasses_de_organisateur($organisateur_id);
         if ($query && $query->have_posts()) {
-            foreach ($query->posts as $chasse) {
-                $statut_validation = get_field('chasse_cache_statut_validation', $chasse->ID);
+            foreach ($query->posts as $chasse_id) {
+                $statut_validation = get_field('chasse_cache_statut_validation', (int) $chasse_id);
                 if ($statut_validation === 'en_attente') {
                     $has_pending_chasse = true;
                     break;

--- a/wp-content/themes/chassesautresor/inc/organisateur/stats.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur/stats.php
@@ -17,7 +17,7 @@ function organisateur_compter_joueurs_uniques(int $organisateur_id): int
         return 0;
     }
 
-    $ids = array_map('intval', wp_list_pluck($query->posts, 'ID'));
+    $ids = array_map('intval', $query->posts);
     if (empty($ids)) {
         return 0;
     }
@@ -45,8 +45,8 @@ function organisateur_compter_points_collectes(int $organisateur_id): int
     }
 
     $total = 0;
-    foreach ($query->posts as $post) {
-        $total += chasse_compter_points_collectes($post->ID);
+    foreach ($query->posts as $chasse_id) {
+        $total += chasse_compter_points_collectes((int) $chasse_id);
     }
 
     return $total;

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -60,15 +60,15 @@ get_header();
             $statut_organisateur === 'pending' &&
             !organisateur_a_des_chasses($organisateur_id);
 
-        $query       = get_chasses_de_organisateur($organisateur_id);
-        $chasses     = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
-        $user_id     = get_current_user_id();
-        $chasses     = array_values(array_filter(
-            $chasses,
-            static fn($post) => chasse_est_visible_pour_utilisateur($post->ID, $user_id)
+        $query        = get_chasses_de_organisateur($organisateur_id);
+        $chasse_ids   = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
+        $user_id      = get_current_user_id();
+        $chasse_ids   = array_values(array_filter(
+            $chasse_ids,
+            static fn($chasse_id) => chasse_est_visible_pour_utilisateur((int) $chasse_id, $user_id)
         ));
-        $peut_ajouter   = utilisateur_peut_ajouter_chasse($organisateur_id);
-        $has_chasses    = !empty($chasses);
+        $peut_ajouter = utilisateur_peut_ajouter_chasse($organisateur_id);
+        $has_chasses  = !empty($chasse_ids);
         $cache_complet  = (bool) get_field('organisateur_cache_complet', $organisateur_id);
         $highlight_pulse =
             !$has_chasses &&

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -12,13 +12,13 @@ $grid_class   = $args['grid_class'] ?? 'grille-liste';
 $before_items = $args['before_items'] ?? '';
 $after_items  = $args['after_items'] ?? '';
 
-$query = get_chasses_de_organisateur($organisateur_id);
-$posts = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
+$query      = get_chasses_de_organisateur($organisateur_id);
+$chasse_ids = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
 
 // 🔒 Filtrer les chasses visibles selon leur statut et l'utilisateur courant
-$user_id = get_current_user_id();
-$posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
-  return chasse_est_visible_pour_utilisateur($post->ID, $user_id);
+$user_id    = get_current_user_id();
+$chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use ($user_id) {
+  return chasse_est_visible_pour_utilisateur((int) $chasse_id, $user_id);
 }));
 
 ?>
@@ -29,22 +29,22 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
 <?php endif; ?>
 <div class="<?php echo esc_attr($grid_class); ?>">
 <?php echo $before_items; ?>
-  <?php foreach ($posts as $post) : ?>
+  <?php foreach ($chasse_ids as $chasse_id) : ?>
     <?php
-    $chasse_id = $post->ID;
-    $est_orga = est_organisateur();
-    $wp_status = get_post_status($chasse_id);
-    $voir_bordure = $est_orga &&
+    $chasse_id      = (int) $chasse_id;
+    $est_orga       = est_organisateur();
+    $wp_status      = get_post_status($chasse_id);
+    $voir_bordure   = $est_orga &&
       utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id) &&
       $wp_status !== 'publish';
     $classe_completion = '';
     if ($voir_bordure) {
       verifier_ou_mettre_a_jour_cache_complet($chasse_id);
-      $complet = (bool) get_field('chasse_cache_complet', $chasse_id);
+      $complet          = (bool) get_field('chasse_cache_complet', $chasse_id);
       $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
     }
     get_template_part('template-parts/chasse/chasse-card', null, [
-      'chasse_id' => $chasse_id,
+      'chasse_id'        => $chasse_id,
       'completion_class' => $classe_completion,
     ]);
     ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -29,8 +29,8 @@ $points          = organisateur_compter_points_collectes($organisateur_id);
   <?php
   $chasses = get_chasses_de_organisateur($organisateur_id);
   if ($chasses && !empty($chasses->posts)) {
-      foreach ($chasses->posts as $chasse) {
-          $chasse_id        = $chasse->ID;
+      foreach ($chasses->posts as $chasse_id) {
+          $chasse_id        = (int) $chasse_id;
           $participants     = chasse_compter_participants($chasse_id);
           $total_tentatives = 0;
           $total_resolutions = 0;


### PR DESCRIPTION
## Résumé
- Optimise la requête de récupération des chasses d’un organisateur
- Adapte les fonctions et gabarits aux tableaux d’ID

## Changements notables
- Ajout d’un cache statique et de paramètres de performance dans `get_chasses_de_organisateur`
- Mise à jour des statistiques organisateur pour exploiter directement les ID de chasse
- Adaptation des gabarits et utilitaires front à la nouvelle structure

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0729dce1c8332814f31a16cad0481