### PR TITLE
Charge conditionnelle de edition.css pour les éditeurs

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -44,7 +44,6 @@ add_action('wp_enqueue_scripts', function () {
         'gamification-style' => 'gamification.css',
         'cartes-style'       => 'cartes.css',
         'organisateurs'      => 'organisateurs.css',
-        'edition'            => 'edition.css',
         'mon compte'         => 'mon-compte.css',
         'commerce-style'     => 'commerce.css',
         'home'               => 'home.css',
@@ -53,6 +52,18 @@ add_action('wp_enqueue_scripts', function () {
     // 🚀 Chargement dynamique des styles avec gestion du cache
     foreach ($styles as $handle => $file) {
         wp_enqueue_style($handle, $theme_dir . $file, [], filemtime(get_stylesheet_directory() . "/assets/css/{$file}"));
+    }
+
+    if (
+        (is_singular() && current_user_can('edit_post', get_queried_object_id())) ||
+        (is_account_page() && is_user_logged_in())
+    ) {
+        wp_enqueue_style(
+            'edition',
+            $theme_dir . 'edition.css',
+            [],
+            filemtime(get_stylesheet_directory() . '/assets/css/edition.css')
+        );
     }
 
     $script_dir = get_stylesheet_directory_uri() . '/assets/js/';


### PR DESCRIPTION
## Résumé
- restreint l'inclusion de `edition.css` aux utilisateurs pouvant éditer ou aux pages de compte
- évite l'envoi du style d'édition aux visiteurs non organisateurs

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0742ae3588332a48b0c04bc67d40f