### PR TITLE
Planifier la vérification des protections htaccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ wp i18n make-pot ./wp-content/themes/chassesautresor ./wp-content/themes/chasses
 
 Ajoutez ensuite vos fichiers `.mo` compilés dans ce même dossier pour charger les traductions en front‑end.
 
+Tâches cron
+-----------
+
+Lors de l'installation, planifiez l'événement `cat_htaccess_check` (toutes les 5 minutes)
+pour réactiver automatiquement les protections `.htaccess` désactivées temporairement.
+

--- a/wp-content/themes/chassesautresor/inc/edition/edition-securite.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-securite.php
@@ -266,8 +266,9 @@ add_action('acf/save_post', 'reactiver_htaccess_protection_enigme_apres_save', 9
 
 
 /**
+ * Vérifie les désactivations temporaires et réactive les protections expirées.
  *
- * @hook template_redirect
+ * @hook cat_htaccess_check
  */
 function verifier_expiration_desactivations_htaccess()
 {
@@ -309,6 +310,8 @@ function verifier_expiration_desactivations_htaccess()
   }
 }
 
+// 🔁 Vérification planifiée des désactivations temporaires
+add_action('cat_htaccess_check', 'verifier_expiration_desactivations_htaccess');
 
 /**
  * Si un fichier .htaccess.tmp est présent mais qu’aucun .htaccess n’existe,
@@ -496,6 +499,19 @@ function purger_htaccess_temp_enigmes()
     }
   }
 }
+
+
+/**
+ * Crée la tâche planifiée `cat_htaccess_check` si elle n’existe pas.
+ * Reliée à la fonction `verifier_expiration_desactivations_htaccess()`.
+ */
+function enregistrer_cron_verification_htaccess()
+{
+  if (!wp_next_scheduled('cat_htaccess_check')) {
+    wp_schedule_event(time(), 'every_5_minutes', 'cat_htaccess_check');
+  }
+}
+add_action('wp', 'enregistrer_cron_verification_htaccess');
 
 
 /**


### PR DESCRIPTION
## Résumé
- planification du contrôle d'expiration des désactivations `.htaccess`
- documentation de l'événement cron `cat_htaccess_check`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a07447ea488332837d2db7307ff75e