### PR TITLE
feat(points): add history table

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1661,6 +1661,11 @@ body.panneau-ouvert::before {
   white-space: nowrap;
 }
 
+.etiquette.grandes {
+  padding: 4px 8px;
+  font-size: 0.95em;
+}
+
 /* ====== Mode de fin ====== */
 .champ-mode-fin {
   display: flex;

--- a/wp-content/themes/chassesautresor/inc/PointsRepository.php
+++ b/wp-content/themes/chassesautresor/inc/PointsRepository.php
@@ -80,6 +80,29 @@ class PointsRepository
     }
 
     /**
+     * Retrieve points operations for a user.
+     *
+     * @param int $userId User identifier.
+     * @param int $limit  Maximum number of rows to return.
+     *
+     * @return array[]
+     */
+    public function getHistory(int $userId, int $limit = 50): array
+    {
+        $sql = $this->wpdb->prepare(
+            "SELECT id, request_date, origin_type, reason, points, balance\n" .
+            "FROM {$this->table}\n" .
+            "WHERE user_id = %d\n" .
+            "ORDER BY id DESC\n" .
+            "LIMIT %d",
+            $userId,
+            $limit
+        );
+
+        return $this->wpdb->get_results($sql, ARRAY_A);
+    }
+
+    /**
      * Record a conversion request with pending status and return the inserted row ID.
      *
      * @param int   $userId    User identifier.

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -113,37 +113,39 @@ if ($current_user->ID && !empty($history)) {
     ];
     ?>
     <h2><?php esc_html_e('Historique', 'chassesautresor-com'); ?></h2>
-    <table class="points-history">
-        <thead>
-            <tr>
-                <th scope="col"><?php esc_html_e('Id', 'chassesautresor-com'); ?></th>
-                <th scope="col"><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
-                <th scope="col" data-format="etiquette"><?php esc_html_e('Origine', 'chassesautresor-com'); ?></th>
-                <th scope="col"><?php esc_html_e('Motif', 'chassesautresor-com'); ?></th>
-                <th scope="col" data-format="etiquette"><?php esc_html_e('Variation', 'chassesautresor-com'); ?></th>
-                <th scope="col" data-format="etiquette"><?php esc_html_e('Solde', 'chassesautresor-com'); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($history as $row) : ?>
-            <?php
-                $origin = $origin_labels[$row['origin_type']] ?? $row['origin_type'];
-                $date   = $row['request_date']
-                    ? wp_date(get_option('date_format'), strtotime($row['request_date']))
-                    : '';
-                $delta  = sprintf('%+d', (int) $row['points']);
-            ?>
-            <tr>
-                <td><?php echo esc_html($row['id']); ?></td>
-                <td><?php echo esc_html($date); ?></td>
-                <td><span class="etiquette"><?php echo esc_html($origin); ?></span></td>
-                <td><?php echo esc_html($row['reason']); ?></td>
-                <td><span class="etiquette grandes"><?php echo esc_html($delta); ?></span></td>
-                <td><span class="etiquette grandes"><?php echo esc_html((int) $row['balance']); ?></span></td>
-            </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
+    <div class="stats-table-wrapper">
+        <table class="stats-table points-history">
+            <thead>
+                <tr>
+                    <th scope="col"><?php esc_html_e('Id', 'chassesautresor-com'); ?></th>
+                    <th scope="col"><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
+                    <th scope="col" data-format="etiquette"><?php esc_html_e('Origine', 'chassesautresor-com'); ?></th>
+                    <th scope="col"><?php esc_html_e('Motif', 'chassesautresor-com'); ?></th>
+                    <th scope="col" data-format="etiquette"><?php esc_html_e('Variation', 'chassesautresor-com'); ?></th>
+                    <th scope="col" data-format="etiquette"><?php esc_html_e('Solde', 'chassesautresor-com'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($history as $row) : ?>
+                <?php
+                    $origin = $origin_labels[$row['origin_type']] ?? $row['origin_type'];
+                    $date   = $row['request_date']
+                        ? wp_date(get_option('date_format'), strtotime($row['request_date']))
+                        : '';
+                    $delta  = sprintf('%+d', (int) $row['points']);
+                ?>
+                <tr>
+                    <td><?php echo esc_html($row['id']); ?></td>
+                    <td><?php echo esc_html($date); ?></td>
+                    <td><span class="etiquette"><?php echo esc_html($origin); ?></span></td>
+                    <td><?php echo esc_html($row['reason']); ?></td>
+                    <td><span class="etiquette grandes"><?php echo esc_html($delta); ?></span></td>
+                    <td><span class="etiquette grandes"><?php echo esc_html((int) $row['balance']); ?></span></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
     <?php
 }
 

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -103,7 +103,7 @@ if ($is_organizer) {
     }
 }
 
-if ($current_user->ID) {
+if ($current_user->ID && !empty($history)) {
     $origin_labels = [
         'admin'      => __('Admin', 'chassesautresor-com'),
         'chasse'     => __('Chasse', 'chassesautresor-com'),
@@ -116,20 +116,15 @@ if ($current_user->ID) {
     <table class="points-history">
         <thead>
             <tr>
-                <th><?php esc_html_e('Id', 'chassesautresor-com'); ?></th>
-                <th><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
-                <th><?php esc_html_e('Origine', 'chassesautresor-com'); ?></th>
-                <th><?php esc_html_e('Motif', 'chassesautresor-com'); ?></th>
-                <th><?php esc_html_e('Variation', 'chassesautresor-com'); ?></th>
-                <th><?php esc_html_e('Solde', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Id', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
+                <th scope="col" data-format="etiquette"><?php esc_html_e('Origine', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Motif', 'chassesautresor-com'); ?></th>
+                <th scope="col" data-format="etiquette"><?php esc_html_e('Variation', 'chassesautresor-com'); ?></th>
+                <th scope="col" data-format="etiquette"><?php esc_html_e('Solde', 'chassesautresor-com'); ?></th>
             </tr>
         </thead>
         <tbody>
-            <?php if (empty($history)) : ?>
-            <tr>
-                <td colspan="6"><?php esc_html_e('Aucune opération', 'chassesautresor-com'); ?></td>
-            </tr>
-            <?php else : ?>
             <?php foreach ($history as $row) : ?>
             <?php
                 $origin = $origin_labels[$row['origin_type']] ?? $row['origin_type'];
@@ -147,7 +142,6 @@ if ($current_user->ID) {
                 <td><span class="etiquette grandes"><?php echo esc_html((int) $row['balance']); ?></span></td>
             </tr>
             <?php endforeach; ?>
-            <?php endif; ?>
         </tbody>
     </table>
     <?php


### PR DESCRIPTION
## Résumé
- ajout d’un tableau d’historique des points dans l’onglet Mon Compte
- création d’une variante d’étiquette grande pour l’affichage des valeurs
- exposer les opérations de points via une nouvelle méthode du dépôt

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0761658e48332b6b686cf15f807e7