### PR TITLE
Remove obsolete points purchase update call

### DIFF
--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -118,7 +118,6 @@ function attribuer_points_apres_achat($order_id) {
     }
 
     if ($points_ajoutes > 0) {
-        mettre_a_jour_points_achetes($points_ajoutes); // 🔄 Mise à jour des points acheté
         $order->update_meta_data('_points_deja_attribues', true); // ✅ Marque la commande comme traitée
         $order->save();
     }


### PR DESCRIPTION
### Résumé
- supprime l'appel à `mettre_a_jour_points_achetes` lors de l'attribution des points après achat
- l'attribution s'appuie uniquement sur `update_user_points`

### Modifications notables
- retrait de l'appel à la fonction non définie dans `gamify-functions.php`

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0800766a08332a193d1eea86672a8