### PR TITLE
feat: add points history table

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1661,6 +1661,11 @@ body.panneau-ouvert::before {
   white-space: nowrap;
 }
 
+.etiquette-grande {
+  padding: 4px 8px;
+  font-size: 1rem;
+}
+
 /* ====== Mode de fin ====== */
 .champ-mode-fin {
   display: flex;

--- a/wp-content/themes/chassesautresor/inc/PointsRepository.php
+++ b/wp-content/themes/chassesautresor/inc/PointsRepository.php
@@ -80,6 +80,22 @@ class PointsRepository
     }
 
     /**
+     * Retrieve points operations for a user ordered by newest first.
+     *
+     * @param int $userId User identifier.
+     * @return array[] List of operations.
+     */
+    public function getHistory(int $userId): array
+    {
+        $sql = $this->wpdb->prepare(
+            "SELECT id, request_date, origin_type, reason, points, balance FROM {$this->table} WHERE user_id = %d ORDER BY id DESC",
+            $userId
+        );
+
+        return $this->wpdb->get_results($sql, ARRAY_A);
+    }
+
+    /**
      * Record a conversion request with pending status and return the inserted row ID.
      *
      * @param int   $userId    User identifier.

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -440,5 +440,74 @@ add_action('enigme_resolue', function($user_id, $enigme_id) {
     verifier_fin_de_chasse($user_id, $enigme_id); // 🎯 Vérifie et termine la chasse si besoin
 }, 10, 2);
 
+/**
+ * Retrieve points history for a user.
+ *
+ * @param int|null $user_id User identifier or current user if null.
+ * @return array[]
+ */
+function get_user_points_history($user_id = null): array
+{
+    $user_id = $user_id ?: get_current_user_id();
+    if (!$user_id) {
+        return [];
+    }
+
+    global $wpdb;
+    $repo = new PointsRepository($wpdb);
+
+    return $repo->getHistory((int) $user_id);
+}
+
+/**
+ * Render points history table for a user.
+ *
+ * @param int $user_id User identifier.
+ * @return string HTML table or empty string.
+ */
+function render_points_history_table(int $user_id): string
+{
+    $operations = get_user_points_history($user_id);
+    if (empty($operations)) {
+        return '';
+    }
+
+    ob_start();
+    ?>
+    <div class="stats-table-wrapper">
+        <h3><?php esc_html_e('Historique', 'chassesautresor-com'); ?></h3>
+        <table class="stats-table">
+            <thead>
+            <tr>
+                <th scope="col"><?php esc_html_e('ID', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Origine', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Motif', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Variation', 'chassesautresor-com'); ?></th>
+                <th scope="col"><?php esc_html_e('Solde', 'chassesautresor-com'); ?></th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($operations as $op) :
+                $variation      = (int) $op['points'];
+                $variation_label = $variation > 0 ? '+' . $variation : (string) $variation;
+                $date = !empty($op['request_date']) ? mysql2date('d/m/Y', $op['request_date']) : '';
+                ?>
+                <tr>
+                    <td><?php echo esc_html($op['id']); ?></td>
+                    <td><?php echo esc_html($date); ?></td>
+                    <td><span class="etiquette"><?php echo esc_html($op['origin_type']); ?></span></td>
+                    <td><?php echo esc_html($op['reason']); ?></td>
+                    <td><span class="etiquette etiquette-grande"><?php echo esc_html($variation_label); ?></span></td>
+                    <td><span class="etiquette etiquette-grande"><?php echo esc_html($op['balance']); ?></span></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+
 
 

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -313,6 +313,7 @@ $is_complete = (
               <?php endif; ?>
             </div>
           </div>
+          <?php echo render_points_history_table((int) $current_user->ID); ?>
         </div> <!-- .edition-panel-body -->
     </div>
 

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -96,6 +96,8 @@ if ($is_organizer) {
     }
 }
 
+echo render_points_history_table((int) $current_user->ID);
+
 if ($has_orders) : ?>
 
 <table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">


### PR DESCRIPTION
## Résumé
- ajoute un tableau d'historique des points pour les utilisateurs
- duplique cet historique dans le panneau d'édition organisateur
- applique un nouveau style d'étiquette agrandie pour les variations et soldes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a07fd983f483328014bb1de6369ecb