### PR TITLE
Ajout de la réinitialisation dynamique des solutions

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1420,6 +1420,7 @@ body.panneau-ouvert::before {
   text-align: center;
   color: var(--color-editor-text);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  position: relative;
 }
 
 .dashboard-card.disabled {
@@ -1464,6 +1465,23 @@ body.panneau-ouvert::before {
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--color-editor-heading);
+}
+
+.dashboard-card .solution-reset {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  background: none;
+  border: none;
+  color: var(--color-editor-text-muted);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.dashboard-card .solution-reset:hover {
+  color: var(--color-editor-text);
 }
 
 .stat-value {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -401,6 +401,37 @@ function enregistrer_fichier_solution_enigme()
 }
 
 /**
+ * Supprime le fichier PDF de solution via AJAX.
+ *
+ * @return void (JSON)
+ */
+add_action('wp_ajax_supprimer_fichier_solution_enigme', 'supprimer_fichier_solution_enigme');
+function supprimer_fichier_solution_enigme()
+{
+  if (!is_user_logged_in()) {
+    wp_send_json_error("Non autorisé.");
+  }
+
+  $post_id = intval($_POST['post_id'] ?? 0);
+  if (!$post_id || get_post_type($post_id) !== 'enigme') {
+    wp_send_json_error("ID de post invalide.");
+  }
+
+  if (!utilisateur_peut_modifier_post($post_id)) {
+    wp_send_json_error("Non autorisé.");
+  }
+
+  $fichier_id = get_field('enigme_solution_fichier', $post_id, false);
+  if ($fichier_id) {
+    wp_delete_attachment($fichier_id, true);
+  }
+
+  update_field('enigme_solution_fichier', null, $post_id);
+
+  wp_send_json_success();
+}
+
+/**
  * Redirige temporairement les fichiers uploadés vers /wp-content/protected/solutions/
  *
  * Ce filtre est utilisé uniquement lors de l’upload d’un fichier PDF de solution,

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -604,6 +604,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <p class="solution-publication-message"><?= esc_html($publication_message); ?></p>
                 <div class="dashboard-grid solution-cards">
                     <div class="dashboard-card solution-option<?= $solution_mode === 'pdf' ? ' active' : ''; ?>" data-mode="pdf">
+                      <button type="button" class="solution-reset" aria-label="Vider"<?= $fichier_nom ? '' : ' style="display:none;"'; ?>><i class="fa-solid fa-circle-xmark"></i></button>
                       <i class="fa-solid fa-file-pdf" aria-hidden="true"<?= $pdf_icon_attr; ?>></i>
                       <h3><?= esc_html($pdf_title); ?></h3>
                       <a href="#" class="stat-value"><?= esc_html($pdf_link_text); ?></a>
@@ -611,6 +612,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     </div>
 
                     <div class="dashboard-card solution-option<?= $solution_mode === 'texte' ? ' active' : ''; ?>" data-mode="texte">
+                      <button type="button" class="solution-reset" aria-label="Vider"<?= $explication !== '' ? '' : ' style="display:none;"'; ?>><i class="fa-solid fa-circle-xmark"></i></button>
                       <i class="fa-solid fa-pen-to-square" aria-hidden="true"<?= $texte_icon_attr; ?>></i>
                       <h3>Rédaction libre</h3>
                       <button type="button" id="ouvrir-panneau-solution" class="stat-value"><?= esc_html($texte_link_text); ?></button>


### PR DESCRIPTION
## Résumé
- ajoute une croix de vidage pour le PDF et la rédaction libre
- rafraîchit dynamiquement les informations après suppression
- gère la suppression serveur du fichier PDF

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test` *(collision de modules jquery)*

------
https://chatgpt.com/codex/tasks/task_e_68a087a005f88332864c30818f1e88da