### PR TITLE
Document cancelled request status

### DIFF
--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -1277,7 +1277,7 @@ Index :
 | reason    | varchar(255)    | motif de l'opération             |
 | origin_type | enum('admin','chasse','tentative','achat','conversion') NULL DEFAULT 'admin' | catégorie |
 | origin_id | bigint unsigned NULL | identifiant lié (chasse, énigme, commande...) |
-| request_status | enum('pending','approved','paid','refused') DEFAULT 'pending' | statut de la demande |
+| request_status | enum('pending','approved','paid','refused','cancelled') DEFAULT 'pending' | statut de la demande |
 | request_date | datetime DEFAULT CURRENT_TIMESTAMP | date de la demande |
 | settlement_date | datetime NULL | date de règlement |
 | cancelled_date | datetime NULL | date d'annulation/refus |


### PR DESCRIPTION
Ajout de la documentation du statut « cancelled » pour les demandes de points.

- Documente le nouveau statut `cancelled` pour la colonne `request_status`.
- Vérifie le bon fonctionnement des mises à jour de statut côté AJAX et dépôt après migration.

### Testing
- `mysql -uroot local -e "ALTER TABLE wp_user_points MODIFY COLUMN request_status ENUM('pending','approved','paid','refused','cancelled') NOT NULL DEFAULT 'pending';"`
- `mysql -uroot local -e "SHOW COLUMNS FROM wp_user_points LIKE 'request_status';"`
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a08af5de648332a234dcb3c22e01d1