### PR TITLE
Utilise un switch pour le statut de paiement

### DIFF
--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -339,9 +339,19 @@ function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'en_
     echo '<tbody>';
 
     foreach ($paiements_filtres as $paiement) {
-        $statut_affiche  = ($paiement['request_status'] === 'paid')
-            ? '✅ ' . esc_html__('Réglé', 'chassesautresor')
-            : '🟡 ' . esc_html__('En attente', 'chassesautresor');
+        switch ($paiement['request_status']) {
+            case 'paid':
+                $statut_affiche = '✅ ' . __('Réglé', 'chassesautresor');
+                break;
+            case 'cancelled':
+                $statut_affiche = '❌ ' . __('Annulé', 'chassesautresor');
+                break;
+            case 'refused':
+                $statut_affiche = '🚫 ' . __('Refusé', 'chassesautresor');
+                break;
+            default:
+                $statut_affiche = '🟡 ' . __('En attente', 'chassesautresor');
+        }
         $points_utilises = esc_html(abs((int) $paiement['points']));
 
         echo '<tr>';


### PR DESCRIPTION
## Résumé
- Remplace la condition ternaire par un switch pour gérer les statuts des demandes de conversion

## Changements notables
- Affichage détaillé des statuts `paid`, `cancelled` et `refused`
- Valeur par défaut `En attente` pour les autres cas

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a08c0d53248332b42e120ff9858850