### PR TITLE
Fix points management redirect

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -127,10 +127,9 @@ function traiter_gestion_points() {
     // ✅ Redirection après soumission
     $redirect_url = add_query_arg(
         [
-            'section'          => 'outils',
-            'points_modifies'  => '1',
+            'points_modifies' => '1',
         ],
-        wc_get_account_endpoint_url('dashboard')
+        wc_get_account_endpoint_url('orders')
     );
 
     wp_redirect($redirect_url);


### PR DESCRIPTION
## Résumé
- Corrige la redirection après modification de points pour revenir sur l’onglet **Points**

## Changements notables
- Redirige l’administrateur vers l’onglet Points après mise à jour du solde utilisateur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a08dd54dc88332b92f5d614bebec2a