### PR TITLE
feat: add orders page title

### DIFF
--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -137,7 +137,9 @@ echo render_points_history_table((int) $current_user->ID);
 
 if ($has_orders) : ?>
 
-<table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">
+<div class="stats-table-wrapper">
+    <h3><?php esc_html_e('Vos achats de points', 'chassesautresor-com'); ?></h3>
+    <table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">
 <thead>
 <tr>
 <?php foreach (wc_get_account_orders_columns() as $column_id => $column_name) : ?>
@@ -194,7 +196,8 @@ $is_order_number = 'order-number' === $column_id;
 </tbody>
 </table>
 
-<?php do_action('woocommerce_after_account_orders', $has_orders); ?>
+    <?php do_action('woocommerce_after_account_orders', $has_orders); ?>
+</div>
 
 <?php else : ?>
 <div class="woocommerce-message woocommerce-message--info woocommerce-MyAccount-orders--no-orders">


### PR DESCRIPTION
## Résumé
- affiche un titre pour les achats de points dans l'espace commandes

## Changements notables
- enveloppe le tableau WooCommerce avec `stats-table-wrapper`
- ajoute le titre "Vos achats de points" avant la liste des commandes

## Tests
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a08f0b4b5c8332b49a1b9a5996a121