### PR TITLE
Fix manual riddle engagement tracking

### DIFF
--- a/tests/EnigmeEngagementTest.php
+++ b/tests/EnigmeEngagementTest.php
@@ -1,0 +1,61 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('enigme_mettre_a_jour_statut_utilisateur')) {
+    function enigme_mettre_a_jour_statut_utilisateur($eid, $uid, $statut, $force = false) { return true; }
+}
+if (!function_exists('current_time')) {
+    function current_time($type) { return '2024-01-01 00:00:00'; }
+}
+if (!function_exists('do_action')) {
+    function do_action($hook, ...$args) {}
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/engagements.php';
+
+class EnigmeEngagementTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_ensure_enigme_engagement_registers_when_missing(): void
+    {
+        global $wpdb;
+        $wpdb = new WPDBStubInsert();
+        $res = ensure_enigme_engagement(1, 2);
+        $this->assertTrue($res);
+        $this->assertCount(1, $wpdb->inserted);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_ensure_enigme_engagement_skips_when_existing(): void
+    {
+        global $wpdb;
+        $wpdb = new WPDBStubNoInsert();
+        $res = ensure_enigme_engagement(1, 2);
+        $this->assertFalse($res);
+        $this->assertFalse($wpdb->inserted);
+    }
+}
+
+class WPDBStubInsert
+{
+    public string $prefix = 'wp_';
+    public array $inserted = [];
+    public function get_var($query) { return 0; }
+    public function prepare($query, ...$args) { return $query; }
+    public function insert($table, $data, $formats) { $this->inserted[] = $data; return true; }
+}
+
+class WPDBStubNoInsert
+{
+    public string $prefix = 'wp_';
+    public bool $inserted = false;
+    public function get_var($query) { return 1; }
+    public function prepare($query, ...$args) { return $query; }
+    public function insert($table, $data, $formats) { $this->inserted = true; return true; }
+}

--- a/wp-content/themes/chassesautresor/inc/enigme/engagements.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/engagements.php
@@ -76,3 +76,18 @@ defined('ABSPATH') || exit;
             $enigme_id
         ));
     }
+
+    /**
+     * Ensure a user is registered as engaged on a riddle.
+     *
+     * @param int $user_id   User identifier.
+     * @param int $enigme_id Riddle identifier.
+     * @return bool True if an engagement was recorded.
+     */
+    function ensure_enigme_engagement(int $user_id, int $enigme_id): bool
+    {
+        if (!utilisateur_est_engage_dans_enigme($user_id, $enigme_id)) {
+            return marquer_enigme_comme_engagee($user_id, $enigme_id);
+        }
+        return false;
+    }

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -146,6 +146,8 @@ function soumettre_reponse_manuelle()
         wp_send_json_error('points_insuffisants');
     }
 
+    ensure_enigme_engagement($user_id, $enigme_id);
+
     if ($cout > 0) {
         $reason = sprintf("Tentative de réponse pour l'énigme #%d", $enigme_id);
         deduire_points_utilisateur($user_id, $cout, $reason, 'tentative', $enigme_id);
@@ -202,6 +204,8 @@ function soumettre_reponse_automatique()
     if ($cout > get_user_points($user_id)) {
         wp_send_json_error('points_insuffisants');
     }
+
+    ensure_enigme_engagement($user_id, $enigme_id);
 
     $reponse_attendue = trim((string) get_field('enigme_reponse_bonne', $enigme_id));
     $respecter_casse  = (int) get_field('enigme_reponse_casse', $enigme_id) === 1;


### PR DESCRIPTION
## Résumé
- assure l’enregistrement de l’engagement lors d’une réponse d’énigme, même en validation manuelle

## Changements notables
- ajout d’un helper pour enregistrer l’engagement d’un joueur s’il est absent
- enregistrement automatique de l’engagement lors des réponses manuelles et automatiques
- couverture de tests pour la vérification de l’engagement

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a09205c690833288591985c19c1766