### PR TITLE
Fix Convertir link visibility on My Account page

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -369,6 +369,15 @@
     background: hsl(var(--muted));
 }
 
+.dashboard-card .stat-value {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
 .dashboard-card-header {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Assure que le bouton "Convertir" dans l'onglet Points de la page Mon Compte reste lisible.

- Déclare un style dédié pour `.stat-value` afin de reprendre la couleur de texte du tableau de bord
- Supprime le fond et la bordure par défaut du bouton pour éviter un texte blanc sur fond blanc

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a093c56afc83329cd0411ad72cbe78