### PR TITLE
Corrige l'icône d'édition des illustrations vides

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -251,7 +251,12 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
 }
 
 .champ-img.champ-vide .champ-modifier .icone-modif {
-  display: none;
+  position: static;
+  display: inline;
+  width: auto;
+  height: auto;
+  margin-left: 0.25rem;
+  background: none;
 }
 
 .edition-panel .champ-img img {


### PR DESCRIPTION
## Résumé
- corrige la position de l'icône ✏️ pour les champs Illustrations vides

## Changements notables
- affiche le stylo après le lien "ajouter" quand aucune image n'est présente

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0bbb3ed408332acd082aa991c66cd