### PR TITLE
Affichage de la notification de validation en attente pour les organisateurs

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -310,7 +310,30 @@ function myaccount_get_important_messages(): string
         $pendingOwn = $repo->getConversionRequests($current_user_id, 'pending');
         if (!empty($pendingOwn)) {
             $messages[] = __('Vous avez une demande de conversion en attente de règlement.', 'chassesautresor');
+        }
 
+        if ($organisateur_id) {
+            $pendingChasses = get_posts([
+                'post_type'   => 'chasse',
+                'post_status' => ['publish', 'pending'],
+                'numberposts' => -1,
+                'fields'      => 'ids',
+                'meta_query'  => [
+                    [
+                        'key'     => 'chasse_cache_organisateur',
+                        'value'   => '"' . $organisateur_id . '"',
+                        'compare' => 'LIKE',
+                    ],
+                    [
+                        'key'   => 'chasse_cache_statut_validation',
+                        'value' => 'en_attente',
+                    ],
+                ],
+            ]);
+
+            if (!empty($pendingChasses)) {
+                $messages[] = __('Demande de validation en cours de traitement.', 'chassesautresor');
+            }
         }
     }
 

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -2,6 +2,13 @@
 
 use PHPUnit\Framework\TestCase;
 
+if (!function_exists('current_user_can')) {
+    function current_user_can($cap)
+    {
+        return $cap === 'administrator';
+    }
+}
+
 if (!function_exists('est_organisateur')) {
     function est_organisateur()
     {
@@ -78,6 +85,27 @@ if (!function_exists('__')) {
     }
 }
 
+if (!class_exists('PointsRepository')) {
+    class PointsRepository
+    {
+        public function __construct($wpdb)
+        {
+        }
+
+        public function getConversionRequests($userId, $status)
+        {
+            return [['id' => 1]];
+        }
+    }
+}
+
+if (!function_exists('get_posts')) {
+    function get_posts($args = [])
+    {
+        return [101];
+    }
+}
+
 require_once __DIR__ . '/../inc/user-functions.php';
 
 class MyAccountMessagesTest extends TestCase
@@ -89,5 +117,12 @@ class MyAccountMessagesTest extends TestCase
         $this->assertStringContainsString('<a', $output);
         $this->assertStringContainsString('?edition=open&onglet=revenus', $output);
         $this->assertStringContainsString('demande de conversion', $output);
+    }
+
+    public function test_pending_validation_message_is_displayed(): void
+    {
+        $output = myaccount_get_important_messages();
+
+        $this->assertStringContainsString('Demande de validation en cours de traitement', $output);
     }
 }


### PR DESCRIPTION
## Résumé
- Ajout du message "Demande de validation en cours de traitement" pour les organisateurs ayant une chasse en attente de validation.
- Couverture par un test unitaire dédié.

## Changements
- Affichage de la notification de validation en attente dans `myaccount_get_important_messages`.
- Ajout de stubs et d'un test vérifiant la présence de ce message.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd7b94b88332948eaaae910b4707