### PR TITLE
Affichage amélioré des prérequis d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1896,3 +1896,47 @@ body.panneau-ouvert::before {
 .edition-panel-footer .btn-admin-danger:hover {
   opacity: 1;
 }
+
+/* ========== 🧩 PRÉ-REQUIS – LISTE D'ÉNIGMES ========== */
+.champ-pre-requis .liste-pre-requis {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.champ-pre-requis .prerequis-item {
+    display: block;
+    cursor: pointer;
+}
+
+.champ-pre-requis .prerequis-item input {
+    display: none;
+}
+
+.champ-pre-requis .prerequis-mini {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+    border: 1px solid var(--color-editor-border);
+    border-radius: 4px;
+    padding: 0.5rem;
+    transition: background-color 0.2s, border-color 0.2s;
+}
+
+.champ-pre-requis .prerequis-mini img {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 4px;
+}
+
+.champ-pre-requis .prerequis-item input:checked + .prerequis-mini {
+    border-color: var(--color-editor-accent);
+    background-color: var(--color-editor-field-hover);
+}
+
+.champ-pre-requis .prerequis-mini:hover {
+    border-color: var(--color-editor-accent);
+}

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -387,10 +387,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     <?php if (empty($enigmes_possibles)) : ?>
                       <em><?= esc_html__('Aucune autre énigme disponible comme prérequis.', 'chassesautresor-com'); ?></em>
                     <?php else : ?>
-                      <?php foreach ($enigmes_possibles as $id => $titre) :
-                        $checked = in_array($id, $prerequis_actuels); ?>
-                        <label><input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> <?= esc_html($titre); ?></label>
-                      <?php endforeach; ?>
+                      <div class="liste-pre-requis">
+                        <?php foreach ($enigmes_possibles as $id => $titre) :
+                          $checked = in_array($id, $prerequis_actuels);
+                          $img = get_image_enigme($id, 'thumbnail'); ?>
+                          <label class="prerequis-item">
+                            <input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                            <span class="prerequis-mini">
+                              <?php if ($img) : ?>
+                                <img src="<?= esc_url($img); ?>" alt="" />
+                              <?php endif; ?>
+                              <span class="prerequis-titre"><?= esc_html($titre); ?></span>
+                            </span>
+                          </label>
+                        <?php endforeach; ?>
+                      </div>
                     <?php endif; ?>
                     <div class="champ-feedback"></div>
                   </div>


### PR DESCRIPTION
## Résumé
Améliore l'affichage des prérequis dans l'onglet paramètres des énigmes.

## Changements
- Transforme les prérequis en vignettes cliquables avec visuel et titre
- Mise en évidence visuelle des vignettes sélectionnées
- Ajout du style dédié dans `edition.css`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0bff8d5508332b832ea2a90d8b849