### PR TITLE
Champs de titre en saisie directe

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -374,6 +374,12 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
+@media (min-width: 768px) {
+  .edition-panel-body input.champ-texte-edit {
+    width: 260px;
+  }
+}
+
 
 .champ-groupe-reponse-automatique {
   display: flex;

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -77,6 +77,60 @@ function initChampTexte(bloc) {
     bloc.appendChild(feedback);
   }
 
+  // ✍️ Édition directe : aucun bouton d'édition/sauvegarde
+  if (!boutonSave && !boutonEdit) {
+    let timer;
+    input.addEventListener('input', () => {
+      clearTimeout(timer);
+      const valeur = input.value.trim();
+
+      timer = setTimeout(() => {
+        if (champ === 'email_contact') {
+          const isValide = valeur === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(valeur);
+          if (!isValide) {
+            feedback.textContent = '⛔ Adresse email invalide';
+            feedback.className = 'champ-feedback champ-error';
+            return;
+          }
+        }
+
+        if (champ === 'post_title' && !valeur) {
+          feedback.textContent = '❌ Le titre est obligatoire.';
+          feedback.className = 'champ-feedback champ-error';
+          return;
+        }
+
+        if (champ === 'enigme_visuel_legende') {
+          const legendeDOM =
+            document.querySelector('.enigme-soustitre') ||
+            document.querySelector('.enigme-legende');
+          if (legendeDOM) {
+            legendeDOM.textContent = valeur;
+            legendeDOM.classList.add('modifiee');
+          }
+        }
+
+        feedback.textContent = 'Enregistrement en cours...';
+        feedback.className = 'champ-feedback champ-loading';
+
+        modifierChampSimple(champ, valeur, postId, cpt).then(success => {
+          if (success) {
+            bloc.classList.toggle('champ-vide', !valeur);
+            feedback.textContent = '';
+            feedback.className = 'champ-feedback champ-success';
+            if (typeof window.mettreAJourResumeInfos === 'function') {
+              window.mettreAJourResumeInfos();
+            }
+          } else {
+            feedback.textContent = 'Erreur lors de l’enregistrement.';
+            feedback.className = 'champ-feedback champ-error';
+          }
+        });
+      }, 400);
+    });
+    return;
+  }
+
   // ✏️ Ouverture édition
   boutonEdit?.addEventListener('click', () => {
     if (affichage?.style) affichage.style.display = 'none';

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -290,6 +290,10 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
       if (legende) legende.textContent = valeur;
     }
 
+    if (champ === 'enigme_reponse_bonne' && typeof window.forcerRecalculStatutEnigme === 'function') {
+      window.forcerRecalculStatutEnigme(postId);
+    }
+
     if (champsResume.includes(champ) && typeof window.mettreAJourResumeInfos === 'function') {
       window.mettreAJourResumeInfos();
     }

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -360,7 +360,13 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
   const dejaBouton = ligne.querySelector('.champ-modifier');
   const pasDEdition = ligne.dataset.noEdit !== undefined;
 
-  if (!dejaBouton && !pasDEdition) {
+  if (pasDEdition) {
+    ligne.style.cursor = '';
+    dejaBouton?.remove();
+    return;
+  }
+
+  if (!dejaBouton) {
     const bouton = document.createElement('button');
     bouton.type = 'button';
     bouton.className = 'champ-modifier';

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -233,11 +233,6 @@ function initEnigmeEdit() {
   const bloc = document.querySelector('[data-champ="enigme_reponse_bonne"]');
   if (bloc) {
     const input = bloc.querySelector('.champ-input');
-    const champ = bloc.dataset.champ;
-    const postId = bloc.dataset.postId;
-    const cptChamp = bloc.dataset.cpt || 'enigme';
-    let timerSauvegarde;
-
     if (input) {
       let alerte = bloc.querySelector('.message-limite');
       if (!alerte) {
@@ -263,19 +258,6 @@ function initEnigmeEdit() {
         } else {
           alerte.textContent = '';
           alerte.style.display = 'none';
-        }
-
-        if (champ && postId) {
-          clearTimeout(timerSauvegarde);
-          timerSauvegarde = setTimeout(() => {
-            modifierChampSimple(champ, input.value.trim(), postId, cptChamp)
-              .then(() => {
-                const enigmeId = panneauEdition?.dataset.postId;
-                if (enigmeId) {
-                  forcerRecalculStatutEnigme(enigmeId);
-                }
-              });
-          }, 400);
         }
       });
     }
@@ -376,6 +358,7 @@ function initEnigmeEdit() {
       })
       .catch(err => console.error('❌ Erreur réseau CTA validation', err));
   }
+  window.forcerRecalculStatutEnigme = forcerRecalculStatutEnigme;
   window.mettreAJourCTAValidationChasse = mettreAJourCTAValidationChasse;
 
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -86,7 +86,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 <li class="champ-chasse champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
                   data-champ="post_title"
                   data-cpt="chasse"
-                  data-post-id="<?= esc_attr($chasse_id); ?>">
+                  data-post-id="<?= esc_attr($chasse_id); ?>"
+                  data-no-edit="1">
 
                   <label for="champ-titre-chasse">Titre <span class="champ-obligatoire">*</span></label>
                   <input type="text" class="champ-input champ-texte-edit" maxlength="70"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -112,7 +112,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         aria-label="Modifier l’image">
                         <img src="<?= esc_url($image_url ?: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='); ?>" alt="Image de la chasse" />
                         <span class="champ-ajout-image">ajouter une image</span>
-                        <span class="icone-modif">✏️</span>
                       </button>
                     <?php else : ?>
                       <?php if ($image_url) : ?>
@@ -139,19 +138,21 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                    data-cpt="chasse"
                                    data-champ="chasse_principale_description"
                                    data-post-id="<?= esc_attr($chasse_id); ?>">
-                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?>
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu">
                                 <?= esc_html(wp_trim_words(wp_strip_all_tags($description), 25)); ?>
                                 <?php if ($peut_editer) : ?>
-                                    <button type="button"
-                                        class="champ-modifier ouvrir-panneau-description"
-                                        data-cpt="chasse"
-                                        data-champ="chasse_principale_description"
-                                        data-post-id="<?= esc_attr($chasse_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">✏️</button>
+                                      <button type="button"
+                                          class="champ-modifier ouvrir-panneau-description"
+                                          data-cpt="chasse"
+                                          data-champ="chasse_principale_description"
+                                          data-post-id="<?= esc_attr($chasse_id); ?>"
+                                          aria-label="<?= esc_attr__('Modifier la description', 'chassesautresor-com'); ?>">
+                                          <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                      </button>
                                 <?php endif; ?>
                             </span>
                         <?php endif; ?>
@@ -176,7 +177,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                    data-champ="chasse_infos_recompense_valeur"
                                    data-cpt="chasse"
                                    data-post-id="<?= esc_attr($chasse_id); ?>">
-                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?>
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
@@ -198,7 +199,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         data-champ="chasse_infos_recompense_valeur"
                                         data-cpt="chasse"
                                         data-post-id="<?= esc_attr($chasse_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier la récompense', 'chassesautresor-com'); ?>">✏️</button>
+                                        aria-label="<?= esc_attr__('Modifier la récompense', 'chassesautresor-com'); ?>">
+                                        <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                    </button>
                                 <?php endif; ?>
                                 &nbsp;–&nbsp;
                                 <span class="recompense-description"><?= esc_html($desc_court); ?></span>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -88,24 +88,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
-                  <div class="champ-affichage">
-                    <label<?= $peut_editer_titre ? ' for="champ-titre-chasse"' : ''; ?>>Titre <span class="champ-obligatoire">*</span></label>
-                    <span class="champ-valeur">
-                      <?= $isTitreParDefaut ? 'renseigner le titre de la chasse' : esc_html($titre); ?>
-                    </span>
-                    <?php if ($peut_editer_titre) : ?>
-                      <button type="button" class="champ-modifier" aria-label="Modifier le titre">✏️</button>
-                    <?php endif; ?>
-                  </div>
-
-                  <div class="champ-edition" style="display: none;">
-                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>>
-                    <?php if ($peut_editer_titre) : ?>
-                      <button type="button" class="champ-enregistrer">✓</button>
-                      <button type="button" class="champ-annuler">✖</button>
-                    <?php endif; ?>
-                  </div>
-
+                  <label for="champ-titre-chasse">Titre <span class="champ-obligatoire">*</span></label>
+                  <input type="text" class="champ-input champ-texte-edit" maxlength="70"
+                    value="<?= esc_attr($titre); ?>"
+                    id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>
+                    placeholder="renseigner le titre de la chasse" />
                   <div class="champ-feedback"></div>
                 </li>
                 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -107,28 +107,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     data-cpt="enigme"
                     data-post-id="<?= esc_attr($enigme_id); ?>">
 
-                    <div class="champ-affichage">
-                        <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span></label>
-                      <span class="champ-valeur">
-                        <?= $isTitreParDefaut ? 'renseigner le titre de l’énigme' : esc_html($titre); ?>
-                      </span>
-                      <?php if ($peut_editer_titre) : ?>
-                        <button type="button"
-                          class="champ-modifier"
-                          aria-label="Modifier le titre">✏️</button>
-                      <?php endif; ?>
-                    </div>
-
-                    <div class="champ-edition" style="display: none;">
-                      <input type="text"
-                        class="champ-input"
-                        maxlength="80"
-                        value="<?= esc_attr($titre); ?>"
-                        id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?> >
-                      <button type="button" class="champ-enregistrer">✓</button>
-                      <button type="button" class="champ-annuler">✖</button>
-                    </div>
-
+                    <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span></label>
+                    <input type="text"
+                      class="champ-input champ-texte-edit"
+                      maxlength="80"
+                      value="<?= esc_attr($titre); ?>"
+                      id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?>
+                      placeholder="renseigner le titre de l’énigme" />
                     <div class="champ-feedback"></div>
                   </li>
 
@@ -211,23 +196,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     data-champ="enigme_visuel_legende" data-cpt="enigme"
                     data-post-id="<?= esc_attr($enigme_id); ?>">
 
-                    <div class="champ-affichage">
-                      <label for="champ-soustitre-enigme"><?= esc_html__('Sous-titre', 'chassesautresor-com'); ?></label>
-                      <span class="champ-valeur">
-                        <?= empty(trim($legende)) ? esc_html__('ajouter', 'chassesautresor-com') : esc_html($legende); ?>
-                      </span>
-                      <?php if ($peut_editer) : ?>
-                        <button type="button" class="champ-modifier" aria-label="<?= esc_attr__('Modifier le sous-titre', 'chassesautresor-com'); ?>">✏️</button>
-                      <?php endif; ?>
-                    </div>
-
-                    <div class="champ-edition" style="display: none;">
-                      <input type="text" class="champ-input" maxlength="100" value="<?= esc_attr($legende); ?>" id="champ-soustitre-enigme"
-                        placeholder="<?= esc_attr__('Ajouter un sous-titre (max 100 caractères)', 'chassesautresor-com'); ?>" <?= $peut_editer ? '' : 'disabled'; ?>>
-                      <button type="button" class="champ-enregistrer">✓</button>
-                      <button type="button" class="champ-annuler">✖</button>
-                    </div>
-
+                    <label for="champ-soustitre-enigme"><?= esc_html__('Sous-titre', 'chassesautresor-com'); ?></label>
+                    <input type="text" class="champ-input champ-texte-edit" maxlength="100" value="<?= esc_attr($legende); ?>" id="champ-soustitre-enigme"
+                      placeholder="<?= esc_attr__('Ajouter un sous-titre (max 100 caractères)', 'chassesautresor-com'); ?>" <?= $peut_editer ? '' : 'disabled'; ?> />
                     <div class="champ-feedback"></div>
                   </li>
                 </ul>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -105,7 +105,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                   <li class="champ-enigme champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
                     data-champ="post_title"
                     data-cpt="enigme"
-                    data-post-id="<?= esc_attr($enigme_id); ?>">
+                    data-post-id="<?= esc_attr($enigme_id); ?>"
+                    data-no-edit="1">
 
                     <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span></label>
                     <input type="text"
@@ -195,7 +196,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
                   <li class="champ-enigme champ-texte champ-soustitre<?= empty(trim($legende)) ? ' champ-vide' : ' champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
                     data-champ="enigme_visuel_legende" data-cpt="enigme"
-                    data-post-id="<?= esc_attr($enigme_id); ?>">
+                    data-post-id="<?= esc_attr($enigme_id); ?>"
+                    data-no-edit="1">
 
                     <label for="champ-soustitre-enigme"><?= esc_html__('Sous-titre', 'chassesautresor-com'); ?></label>
                     <input type="text" class="champ-input champ-texte-edit" maxlength="100" value="<?= esc_attr($legende); ?>" id="champ-soustitre-enigme"

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -145,7 +145,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                           <?php else : ?>
                             <span class="champ-ajout-image">ajouter</span>
                           <?php endif; ?>
-                          <span class="icone-modif">✏️</span>
                         </button>
                       <?php else : ?>
                         <?php if ($has_images_utiles && is_array($images_ids)) : ?>
@@ -174,18 +173,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                    data-champ="enigme_visuel_texte"
                                    data-cpt="enigme"
                                    data-post-id="<?= esc_attr($enigme_id); ?>">
-                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?>
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
                             <span class="champ-texte-contenu">
                                 <?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?>
                                 <?php if ($peut_editer) : ?>
-                                    <button type="button" class="champ-modifier ouvrir-panneau-description"
-                                        data-champ="enigme_visuel_texte"
-                                        data-cpt="enigme"
-                                        data-post-id="<?= esc_attr($enigme_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">✏️</button>
+                                      <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                          data-champ="enigme_visuel_texte"
+                                          data-cpt="enigme"
+                                          data-post-id="<?= esc_attr($enigme_id); ?>"
+                                          aria-label="<?= esc_attr__('Modifier le texte', 'chassesautresor-com'); ?>">
+                                          <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                      </button>
                                 <?php endif; ?>
                             </span>
                         <?php endif; ?>
@@ -276,12 +277,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 </ul>
                 <?php if ($peut_editer) : ?>
                   <button type="button" class="champ-modifier ouvrir-panneau-variantes" aria-label="<?= esc_attr__('Éditer les variantes', 'chassesautresor-com'); ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                    <?= esc_html__('éditer', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                    <?= esc_html__('éditer', 'chassesautresor-com'); ?>
                   </button>
                 <?php endif; ?>
               <?php elseif ($peut_editer) : ?>
                 <a href="#" class="champ-ajouter ouvrir-panneau-variantes" aria-label="<?= esc_attr__('Ajouter des variantes', 'chassesautresor-com'); ?>" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                  <?= esc_html__('ajouter des variantes', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                  <?= esc_html__('ajouter des variantes', 'chassesautresor-com'); ?>
                 </a>
               <?php endif; ?>
             </div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -93,30 +93,15 @@ $is_complete = (
                     data-cpt="organisateur"
                     data-post-id="<?= esc_attr($organisateur_id); ?>">
 
-                  <div class="champ-affichage">
                     <label for="champ-titre-organisateur">Titre <span class="champ-obligatoire">*</span></label>
-                    <span class="champ-valeur">
-                      <?= empty($titre) ? "renseigner le titre de l’organisateur" : esc_html($titre); ?>
-                    </span>
-                    <?php if ($peut_editer_titre) : ?>
-                      <button type="button"
-                        class="champ-modifier"
-                        aria-label="Modifier le nom d’organisateur">✏️</button>
-                    <?php endif; ?>
-                  </div>
-
-                  <div class="champ-edition" style="display: none;">
                     <input type="text"
-                      class="champ-input"
+                      class="champ-input champ-texte-edit"
                       maxlength="50"
                       value="<?= esc_attr($titre); ?>"
-                      id="champ-titre-organisateur" <?= $peut_editer_titre ? '' : 'disabled'; ?>>
-                    <button type="button" class="champ-enregistrer">✓</button>
-                    <button type="button" class="champ-annuler">✖</button>
-                  </div>
-
-                  <div class="champ-feedback"></div>
-                </li>
+                      id="champ-titre-organisateur" <?= $peut_editer_titre ? '' : 'disabled'; ?>
+                      placeholder="renseigner le titre de l’organisateur" />
+                    <div class="champ-feedback"></div>
+                  </li>
 
                 <li class="champ-organisateur champ-img champ-logo ligne-logo <?= empty($logo_id) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="<?= esc_attr($organisateur_id); ?>">
                   <div class="champ-affichage">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -115,7 +115,6 @@ $is_complete = (
                         data-post-id="<?= esc_attr($organisateur_id); ?>">
                         <img src="<?= esc_url($logo_url ?: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='); ?>" alt="Logo de l’organisateur" />
                         <span class="champ-ajout-image">ajouter une image</span>
-                        <span class="icone-modif">✏️</span>
                       </button>
                     <?php else : ?>
                       <?php if ($logo_url) : ?>
@@ -138,7 +137,7 @@ $is_complete = (
                                    data-champ="description_longue"
                                    data-cpt="organisateur"
                                    data-post-id="<?= esc_attr($organisateur_id); ?>">
-                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?> <span class="icone-modif">✏️</span>
+                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?>
                                 </a>
                             <?php endif; ?>
                         <?php else : ?>
@@ -150,7 +149,7 @@ $is_complete = (
                                         data-champ="description_longue"
                                         data-cpt="organisateur"
                                         data-post-id="<?= esc_attr($organisateur_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>">✏️</button>
+                                          aria-label="<?= esc_attr__('Modifier la présentation', 'chassesautresor-com'); ?>"><?= esc_html__('modifier', 'chassesautresor-com'); ?></button>
                                 <?php endif; ?>
                             </span>
                         <?php endif; ?>
@@ -188,13 +187,13 @@ $is_complete = (
                       <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
                     </button>
                     <?php if ($peut_editer) : ?>
-                      <button
-                        type="button"
-                        class="champ-modifier"
-                        aria-label="Modifier l’adresse email de contact"
-                      >
-                        ✏️
-                      </button>
+                        <button
+                          type="button"
+                          class="champ-modifier"
+                          aria-label="Modifier l’adresse email de contact"
+                        >
+                          <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                        </button>
                     <?php endif; ?>
                   </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -91,7 +91,8 @@ $is_complete = (
                   <li class="champ-organisateur champ-titre ligne-titre <?= empty($titre) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
                     data-champ="post_title"
                     data-cpt="organisateur"
-                    data-post-id="<?= esc_attr($organisateur_id); ?>">
+                    data-post-id="<?= esc_attr($organisateur_id); ?>"
+                    data-no-edit="1">
 
                     <label for="champ-titre-organisateur">Titre <span class="champ-obligatoire">*</span></label>
                     <input type="text"


### PR DESCRIPTION
## Résumé
- Refactorisation des champs titre et sous-titre pour une saisie directe avec enregistrement automatique
- Gestion de l'auto-sauvegarde générique dans `champ-init.js`
- Mise à jour des scripts d'énigme pour recalculer le statut après modification de la réponse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0cdcdc7a88332a6dda8a14ae49035