### PR TITLE
Déplace le tableau de conversion vers les commandes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -309,7 +309,12 @@ function myaccount_get_important_messages(): string
         $repo       = new PointsRepository($wpdb);
         $pendingOwn = $repo->getConversionRequests($current_user_id, 'pending');
         if (!empty($pendingOwn)) {
-            $messages[] = __('Vous avez une demande de conversion en attente de règlement.', 'chassesautresor');
+            $messages[] = sprintf(
+                /* translators: 1: opening anchor tag, 2: closing anchor tag */
+                __('Vous avez une %1$sdemande de conversion%2$s en attente de règlement.', 'chassesautresor'),
+                '<a href="' . esc_url(home_url('/mon-compte/commandes/')) . '">',
+                '</a>'
+            );
         }
 
         if ($organisateur_id) {

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-dashboard-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-dashboard-organisateur.php
@@ -16,10 +16,6 @@ $user_id      = $current_user->ID;
 
 $orders_output = afficher_commandes_utilisateur($user_id, 3);
 
-ob_start();
-afficher_tableau_paiements_organisateur($user_id, 'en_attente');
-$pending_table = trim(ob_get_clean());
-
 if (function_exists('woocommerce_account_content')) {
     woocommerce_account_content();
 }
@@ -30,16 +26,6 @@ if (isset($_GET['paiement_envoye']) && $_GET['paiement_envoye'] === '1') {
         '</div>';
 }
 
-if ($pending_table !== '') {
-    echo '<div class="dashboard-card mb-6">';
-    echo '<div class="dashboard-card-header">';
-    echo '<h4>' . esc_html__('Demande de conversion en attente', 'chassesautresor') . '</h4>';
-    echo '</div>';
-    echo '<div class="dashboard-card-content">';
-    echo $pending_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    echo '</div>';
-    echo '</div>';
-}
 
 $args = array(
     'orders_output' => $orders_output,

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -115,7 +115,7 @@ class MyAccountMessagesTest extends TestCase
         $output = myaccount_get_important_messages();
 
         $this->assertStringContainsString('<a', $output);
-        $this->assertStringContainsString('?edition=open&onglet=revenus', $output);
+        $this->assertStringContainsString('/mon-compte/commandes/', $output);
         $this->assertStringContainsString('demande de conversion', $output);
     }
 

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -139,6 +139,18 @@ if ($is_organizer) {
     }
 }
 
+if ($is_organizer) {
+    ob_start();
+    afficher_tableau_paiements_organisateur((int) $current_user->ID, 'en_attente');
+    $pending_table = trim(ob_get_clean());
+    if ($pending_table !== '') {
+        echo '<div class="stats-table-wrapper">';
+        echo '<h3>' . esc_html__('Demande de conversion en attente', 'chassesautresor') . '</h3>';
+        echo $pending_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo '</div>';
+    }
+}
+
 echo render_points_history_table((int) $current_user->ID);
 
 if ($has_orders) : ?>


### PR DESCRIPTION
## Résumé
- lie l’alerte de conversion à la page des commandes
- déplace le tableau des conversions en attente au-dessus de l’historique
- supprime l’ancien tableau du tableau de bord

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0d0f132fc8332bf82045559462c8c