### PR TITLE
Réorganise le tableau de conversion des points

### DIFF
--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -331,10 +331,10 @@ function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'en_
 
     echo '<table class="stats-table">';
     echo '<thead><tr>';
-    echo '<th>' . esc_html__('Montant (€)', 'chassesautresor') . '</th>';
-    echo '<th>' . esc_html__('Points utilisés', 'chassesautresor') . '</th>';
     echo '<th>' . esc_html__('Date demande', 'chassesautresor') . '</th>';
-    echo '<th>' . esc_html__('Statut', 'chassesautresor') . '</th>';
+    echo '<th>' . esc_html__('Montant (€)', 'chassesautresor') . '</th>';
+    echo '<th data-format="etiquette">' . esc_html__('Points utilisés', 'chassesautresor') . '</th>';
+    echo '<th data-format="etiquette">' . esc_html__('Statut', 'chassesautresor') . '</th>';
     echo '</tr></thead>';
     echo '<tbody>';
 
@@ -355,9 +355,9 @@ function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'en_
         $points_utilises = esc_html(abs((int) $paiement['points']));
 
         echo '<tr>';
+        echo '<td>' . esc_html(date_i18n('d/m/Y à H:i', strtotime($paiement['request_date']))) . '</td>';
         echo '<td>' . esc_html($paiement['amount_eur']) . ' €</td>';
         echo '<td>' . $points_utilises . '</td>';
-        echo '<td>' . esc_html(date_i18n('Y-m-d H:i', strtotime($paiement['request_date']))) . '</td>';
         echo '<td>' . esc_html($statut_affiche) . '</td>';
         echo '</tr>';
     }

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -333,8 +333,8 @@ function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'en_
     echo '<thead><tr>';
     echo '<th>' . esc_html__('Date demande', 'chassesautresor') . '</th>';
     echo '<th>' . esc_html__('Montant (€)', 'chassesautresor') . '</th>';
-    echo '<th data-format="etiquette">' . esc_html__('Points utilisés', 'chassesautresor') . '</th>';
-    echo '<th data-format="etiquette">' . esc_html__('Statut', 'chassesautresor') . '</th>';
+    echo '<th>' . esc_html__('Points utilisés', 'chassesautresor') . '</th>';
+    echo '<th>' . esc_html__('Statut', 'chassesautresor') . '</th>';
     echo '</tr></thead>';
     echo '<tbody>';
 
@@ -357,8 +357,8 @@ function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'en_
         echo '<tr>';
         echo '<td>' . esc_html(date_i18n('d/m/Y à H:i', strtotime($paiement['request_date']))) . '</td>';
         echo '<td>' . esc_html($paiement['amount_eur']) . ' €</td>';
-        echo '<td>' . $points_utilises . '</td>';
-        echo '<td>' . esc_html($statut_affiche) . '</td>';
+        echo '<td><span class="etiquette etiquette-grande">' . $points_utilises . '</span></td>';
+        echo '<td><span class="etiquette">' . esc_html($statut_affiche) . '</span></td>';
         echo '</tr>';
     }
 


### PR DESCRIPTION
## Résumé
Réorganise le tableau des demandes de conversion des organisateurs.

## Changements
- Place la date de demande en première colonne et l'affiche au format `dd/mm/yyyy à hh:mm`
- Ajoute le style « étiquette » aux colonnes Points utilisés et Statut

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0d3dec7248332b07836d0d32c3b6d