### PR TITLE
Redirect organizers to orders page after conversion request

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -623,11 +623,7 @@ function traiter_demande_paiement() {
     error_log("📧 Notification envoyée à l'administrateur.");
 
     // ✅ Redirection après soumission
-    $redirect = wp_get_raw_referer();
-    if (!$redirect || strpos($redirect, 'admin-ajax.php') !== false) {
-        $redirect = home_url('/mon-compte/');
-    }
-    wp_safe_redirect(add_query_arg('paiement_envoye', '1', $redirect));
+    wp_safe_redirect(home_url('/mon-compte/commandes/'));
     exit;
 }
 add_action('init', 'traiter_demande_paiement');


### PR DESCRIPTION
## Résumé
- redirection vers la page des commandes après une demande de paiement

## Changements notables
- redirige les organisateurs vers `/mon-compte/commandes/` après une demande de conversion

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0db2482748332877d4cd490c5d85f