### PR TITLE
feat: show organiser conversion history

### DIFF
--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -493,7 +493,7 @@ function render_points_history_table(int $user_id): string
     ob_start();
     ?>
     <div class="stats-table-wrapper" data-per-page="<?php echo esc_attr($per_page); ?>">
-        <h3><?php esc_html_e('Historique', 'chassesautresor-com'); ?></h3>
+        <h3><?php esc_html_e('Historique de vos points', 'chassesautresor-com'); ?></h3>
         <table class="stats-table">
             <thead>
             <tr>

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -305,10 +305,10 @@ add_action('wp_ajax_conversion_modal_content', 'ajax_conversion_modal_content');
 /**
  * Affiche le tableau des demandes de paiement d'un organisateur.
  *
- * @param int $user_id L'ID de l'utilisateur organisateur.
- * @param string $filtre_statut Filtrer par statut ('en_attente' pour les demandes en cours, 'toutes' pour l'historique complet).
+ * @param int    $user_id       L'ID de l'utilisateur organisateur.
+ * @param string $filtre_statut Filtre optionnel : 'en_attente' pour les demandes en cours, 'toutes' (par défaut) pour l'historique complet.
  */
-function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'en_attente') {
+function afficher_tableau_paiements_organisateur($user_id, $filtre_statut = 'toutes') {
     global $wpdb;
     $repo      = new PointsRepository($wpdb);
     $paiements = $repo->getConversionRequests($user_id);

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -141,12 +141,12 @@ if ($is_organizer) {
 
 if ($is_organizer) {
     ob_start();
-    afficher_tableau_paiements_organisateur((int) $current_user->ID, 'en_attente');
-    $pending_table = trim(ob_get_clean());
-    if ($pending_table !== '') {
+    afficher_tableau_paiements_organisateur((int) $current_user->ID, 'toutes');
+    $conversion_table = trim(ob_get_clean());
+    if ($conversion_table !== '') {
         echo '<div class="stats-table-wrapper">';
-        echo '<h3>' . esc_html__('Demande de conversion en attente', 'chassesautresor') . '</h3>';
-        echo $pending_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo '<h3>' . esc_html__('Historique conversion de points', 'chassesautresor') . '</h3>';
+        echo $conversion_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo '</div>';
     }
 }


### PR DESCRIPTION
## Summary
- affiche l'historique de conversion des points sur la page commandes
- renomme le tableau des points en « Historique de vos points »

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0dd161da4833283d3d29a6c48ca39