### PR TITLE
Ajoute un titre à l'historique des conversions

### DIFF
--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -50,8 +50,16 @@ if (current_user_can('administrator')) {
             </div>
         </div>
     </div>
-    <div id="historique-paiements-admin" class="liste-paiements" data-page="<?php echo esc_attr($historique['page']); ?>" data-pages="<?php echo esc_attr($historique['pages']); ?>">
-        <?php echo $historique['html']; ?>
+    <div class="stats-table-wrapper">
+        <h3><?php esc_html_e('Historique des conversions', 'chassesautresor'); ?></h3>
+        <div
+            id="historique-paiements-admin"
+            class="liste-paiements"
+            data-page="<?php echo esc_attr($historique['page']); ?>"
+            data-pages="<?php echo esc_attr($historique['pages']); ?>"
+        >
+            <?php echo $historique['html']; ?>
+        </div>
     </div>
     <?php
 }


### PR DESCRIPTION
## Résumé
- Ajout d'un titre au tableau listant l'historique des demandes de paiement pour les administrateurs
- Encapsulation du tableau dans `stats-table-wrapper` pour respecter la charte graphique

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0decc97f48332a4b773815f1d2ad2