### PR TITLE
feat: add conversion totals summary

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1691,6 +1691,12 @@ body.panneau-ouvert::before {
   margin-bottom: 1.5rem;
 }
 
+.stats-table-summary {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 /* Pagination for stats tables */
 .points-history-pager {
   margin-top: 0.5rem;

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -150,8 +150,33 @@ if ($is_organizer) {
     afficher_tableau_paiements_organisateur((int) $current_user->ID, 'toutes');
     $conversion_table = trim(ob_get_clean());
     if ($conversion_table !== '') {
+        global $wpdb;
+        $repo            = new PointsRepository($wpdb);
+        $paid_requests   = $repo->getConversionRequests((int) $current_user->ID, 'paid');
+        $total_points    = 0;
+        $total_eur       = 0.0;
+        foreach ($paid_requests as $request) {
+            $total_points += abs((int) $request['points']);
+            $total_eur    += (float) $request['amount_eur'];
+        }
+
+        $total_points_label = sprintf(
+            '%s : %s',
+            esc_html__('Total points', 'chassesautresor'),
+            number_format_i18n($total_points)
+        );
+        $total_eur_label = sprintf(
+            '%s : %s €',
+            esc_html__('Total €', 'chassesautresor'),
+            number_format_i18n($total_eur, 2)
+        );
+
         echo '<div class="stats-table-wrapper">';
         echo '<h3>' . esc_html__('Historique conversion de points', 'chassesautresor') . '</h3>';
+        echo '<div class="stats-table-summary">';
+        echo '<span class="etiquette etiquette-grande">' . esc_html($total_points_label) . '</span>';
+        echo '<span class="etiquette etiquette-grande">' . esc_html($total_eur_label) . '</span>';
+        echo '</div>';
         echo $conversion_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo '</div>';
     }


### PR DESCRIPTION
## Résumé
Ajoute un récapitulatif des conversions validées dans l'onglet Points.

## Changements
- calcule le total des points convertis et des montants versés
- affiche ces totaux sous forme d'étiquettes au-dessus de l'historique
- ajoute le style CSS pour l'entête des étiquettes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0eaf40a4483329198f7947bf28ec6