### PR TITLE
Corrige la recréation de demandes de conversion refusées

### DIFF
--- a/tests/AjaxUpdateRequestStatusTest.php
+++ b/tests/AjaxUpdateRequestStatusTest.php
@@ -42,8 +42,9 @@ if (!function_exists('current_time')) {
 if (!function_exists('update_user_points')) {
     function update_user_points($user_id, $points_change, $reason = '', $origin_type = 'admin', $origin_id = null): void
     {
-        global $user_points;
+        global $user_points, $last_origin_type;
         $user_points[$user_id] = ($user_points[$user_id] ?? 0) + $points_change;
+        $last_origin_type     = $origin_type;
     }
 }
 
@@ -84,8 +85,9 @@ class AjaxUpdateRequestStatusTest extends TestCase
      */
     public function test_status_cancel_or_refuse_restores_balance(string $status): void
     {
-        global $request_fixture, $user_points;
-        $user_points = [];
+        global $request_fixture, $user_points, $last_origin_type;
+        $user_points      = [];
+        $last_origin_type = null;
         $request_fixture = [
             'user_id' => 7,
             'points'  => -150,
@@ -97,5 +99,6 @@ class AjaxUpdateRequestStatusTest extends TestCase
         ajax_update_request_status();
 
         $this->assertSame(150, $user_points[7]);
+        $this->assertSame('admin', $last_origin_type);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -682,7 +682,7 @@ function ajax_update_request_status(): void
                 (int) $request['user_id'],
                 $points,
                 $reason,
-                'conversion',
+                'admin',
                 $paiement_id
             );
         }


### PR DESCRIPTION
## Résumé
- Empêche la restauration de points de générer une nouvelle demande de conversion
- Vérifie via un test que l'opération de remboursement est bien classée côté admin

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0ebfdbcd483328c354af4ff1d3ae8