### PR TITLE
Fix organizer payout status handling

### DIFF
--- a/tests/AjaxUpdateRequestStatusTest.php
+++ b/tests/AjaxUpdateRequestStatusTest.php
@@ -21,6 +21,8 @@ if (!function_exists('wp_send_json_error')) {
 if (!function_exists('wp_send_json_success')) {
     function wp_send_json_success($data = null)
     {
+        global $json_success_data;
+        $json_success_data = $data;
         return $data;
     }
 }
@@ -100,5 +102,24 @@ class AjaxUpdateRequestStatusTest extends TestCase
 
         $this->assertSame(150, $user_points[7]);
         $this->assertSame('admin', $last_origin_type);
+    }
+
+    public function test_status_regle_returns_success(): void
+    {
+        global $request_fixture, $json_success_data;
+        $request_fixture = [
+            'user_id'    => 7,
+            'points'     => -150,
+            'amount_eur' => 10.0,
+        ];
+
+        $_POST['paiement_id'] = 99;
+        $_POST['statut'] = 'regle';
+        $json_success_data = null;
+
+        ajax_update_request_status();
+
+        $this->assertIsArray($json_success_data);
+        $this->assertSame('paid', $json_success_data['status']);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -635,6 +635,19 @@ add_action('init', 'traiter_demande_paiement');
 // 🎛️ Mise à jour du statut des demandes de paiement (Admin)
 // ----------------------------------------------------------
 /**
+ * Update monthly total of organizer payouts.
+ */
+function mettre_a_jour_paiements_organisateurs(float $amount): void
+{
+    $option = 'total_paiements_effectues_mensuel_' . date('Y_m');
+
+    if (function_exists('get_option') && function_exists('update_option')) {
+        $current = (float) get_option($option, 0);
+        update_option($option, $current + $amount);
+    }
+}
+
+/**
  * Handle AJAX status updates for payment requests.
  */
 function ajax_update_request_status(): void


### PR DESCRIPTION
## Summary
- ajoute une fonction pour tracer les paiements aux organisateurs
- couvre le statut `regle` dans les tests d'Ajax

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef4025cc8332a07dbd9677afb59a