### PR TITLE
Fix admin conversion request link

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -281,7 +281,7 @@ function myaccount_get_important_messages(): string
         $pendingRequests = $repo->getConversionRequests(null, 'pending');
 
         if (!empty($pendingRequests)) {
-            $url = esc_url(home_url('/mon-compte/organisateurs/'));
+            $url = esc_url(home_url('/mon-compte/?section=points'));
             $messages[] = sprintf(
                 /* translators: 1: opening anchor tag, 2: closing anchor tag */
                 __('Vous avez des %1$sdemandes de conversion%2$s en attente.', 'chassesautresor'),


### PR DESCRIPTION
## Résumé
- redirige l’alerte d’administration vers l’onglet Points

## Changements notables
- ajuste le lien des demandes de conversion en attente pour pointer vers `?section=points`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0f01fc2e4833288cf78b263f67137