### PR TITLE
Pagination Ajax sur l'historique des points

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/conversion-history.js
+++ b/wp-content/themes/chassesautresor/assets/js/conversion-history.js
@@ -1,16 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const wrapper = document.querySelector('.points-history');
+    const wrapper = document.querySelector('.conversion-history');
     if (!wrapper) {
         return;
     }
 
     function load(page) {
         const params = new URLSearchParams();
-        params.append('action', 'load_points_history');
-        params.append('nonce', PointsHistoryAjax.nonce);
+        params.append('action', 'load_conversion_history');
+        params.append('nonce', ConversionHistory.nonce);
         params.append('page', page);
 
-        fetch(PointsHistoryAjax.ajax_url, {
+        fetch(ConversionHistory.ajax_url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: params.toString(),

--- a/wp-content/themes/chassesautresor/inc/PointsRepository.php
+++ b/wp-content/themes/chassesautresor/inc/PointsRepository.php
@@ -223,6 +223,37 @@ class PointsRepository
     }
 
     /**
+     * Count conversion requests.
+     *
+     * @param int|null    $userId Optional user filter.
+     * @param string|null $status Optional request status filter.
+     * @return int
+     */
+    public function countConversionRequests(?int $userId = null, ?string $status = null): int
+    {
+        $where  = "origin_type = 'conversion'";
+        $params = [];
+
+        if ($userId !== null) {
+            $where   .= ' AND user_id = %d';
+            $params[] = $userId;
+        }
+
+        if ($status !== null) {
+            $where   .= ' AND request_status = %s';
+            $params[] = $status;
+        }
+
+        $sql = "SELECT COUNT(*) FROM {$this->table} WHERE {$where}";
+
+        if (!empty($params)) {
+            $sql = $this->wpdb->prepare($sql, $params);
+        }
+
+        return (int) $this->wpdb->get_var($sql);
+    }
+
+    /**
      * Retrieve a single conversion request by ID.
      */
     public function getRequestById(int $id): ?array

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -146,9 +146,7 @@ if (current_user_can('administrator')) {
 }
 
 if ($is_organizer) {
-    ob_start();
-    afficher_tableau_paiements_organisateur((int) $current_user->ID, 'toutes');
-    $conversion_table = trim(ob_get_clean());
+    $conversion_table = render_conversion_history_table((int) $current_user->ID);
     if ($conversion_table !== '') {
         global $wpdb;
         $repo            = new PointsRepository($wpdb);


### PR DESCRIPTION
## Résumé
- mise en place d'une pagination Ajax pour les historiques de points et conversions
- harmonisation du style des pagers avec le mode édition

## Détails
- ajout d'un comptage des conversions et d'un affichage paginé (10 lignes) côté organisateur
- refonte du tableau "Historique de vos points" avec pager Ajax complet et limite à 20 entrées
- nouveaux scripts JavaScript pour gérer les navigations Ajax

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a13d5ecf5c8332a3ed8e8b9309651c