### PR TITLE
Fix autocomplete initialization for admin points section

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
+++ b/wp-content/themes/chassesautresor/assets/js/autocomplete-utilisateurs.js
@@ -110,7 +110,7 @@ document.addEventListener("DOMContentLoaded", () => {
     init();
 
     document.addEventListener("myaccountSectionLoaded", (e) => {
-        if (e.detail && e.detail.section === "outils") {
+        if (e.detail && e.detail.section === "points") {
             init();
         }
     });


### PR DESCRIPTION
## Résumé
Corrige l'initialisation de l'autocomplétion des utilisateurs dans la carte Gestion Points.

## Changements
- Réinitialise le script d'autocomplétion lors du chargement de la section **points**

## Testing
- `composer install` ✅
- `vendor/bin/phpunit -c tests/phpunit.xml` ✅
- `npm test` ⚠️ avertissement de doublon de module mais tests réussis


------
https://chatgpt.com/codex/tasks/task_e_68a13f8035f883328d7b5695a4bdffe2