### PR TITLE
Charge paresseuse des scripts d’édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1,4 +1,9 @@
 // ✅ chasse-edit.js
+if (window.chasseEditLoaded) {
+  console.warn('chasse-edit.js already loaded');
+} else {
+  window.chasseEditLoaded = true;
+}
 var DEBUG = window.DEBUG || false;
 DEBUG && console.log('✅ chasse-edit.js chargé');
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1,4 +1,9 @@
 // ✅ enigme-edit.js
+if (window.enigmeEditLoaded) {
+  console.warn('enigme-edit.js already loaded');
+} else {
+  window.enigmeEditLoaded = true;
+}
 var DEBUG = window.DEBUG || false;
 DEBUG && console.log('✅ enigme-edit.js chargé');
 

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -1,3 +1,8 @@
+if (window.organisateurEditLoaded) {
+  console.warn('organisateur-edit.js already loaded');
+} else {
+  window.organisateurEditLoaded = true;
+}
 var DEBUG = window.DEBUG || false;
 DEBUG && console.log('✅ organisateur-edit.js chargé');
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -56,7 +56,26 @@ function register_script_chasse_edit()
         fetch('<?php echo esc_url(admin_url('admin-ajax.php?action=charger_scripts_chasse_edit')); ?>')
           .then(r => r.text())
           .then(html => {
-            document.head.insertAdjacentHTML('beforeend', html);
+            const frag = document.createRange().createContextualFragment(html);
+            const scripts = Array.from(frag.querySelectorAll('script'));
+            let loaded = 0;
+            const check = () => {
+              loaded++;
+              if (loaded === scripts.length) {
+                this.click();
+              }
+            };
+            scripts.forEach((old) => {
+              const s = document.createElement('script');
+              if (old.src) {
+                s.src = old.src;
+                s.onload = check;
+              } else {
+                s.textContent = old.textContent;
+                check();
+              }
+              document.head.appendChild(s);
+            });
           });
       });
     </script>

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -25,7 +25,7 @@ defined('ABSPATH') || exit;
 // ==================================================
 // 🔹 forcer_chargement_acf_scripts_chasse() → Force le chargement ACF en front
 // 🔹 personnaliser_acf_wysiwyg_toolbars() → Barre WYSIWYG personnalisée
-// 🔹 enqueue_core_edit_scripts() → Enfile les JS mutualisés
+// 🔹 register_core_edit_scripts() → Enregistre les JS mutualisés
 
 /**
  * Force le chargement des scripts ACF sur les fiches chasse (is_singular('chasse')).
@@ -75,11 +75,11 @@ add_filter('tiny_mce_before_init', function ($init) {
 
 
 /**
- * Charge les scripts JS partagés pour l’édition frontale (texte, image, liens, etc.).
+ * Enregistre les scripts JS partagés pour l’édition frontale (texte, image, liens, etc.).
  *
  * @return void
  */
-function enqueue_core_edit_scripts(array $additional = [])
+function register_core_edit_scripts(array $additional = [])
 {
   static $versions = [];
 
@@ -109,10 +109,10 @@ function enqueue_core_edit_scripts(array $additional = [])
       $versions[$handle] = file_exists($file) ? filemtime($file) : null;
     }
 
-    wp_enqueue_script(
+    wp_register_script(
       $handle,
       $theme_uri . $path,
-      $previous_handle ? [$previous_handle] : [], // le script dépend du précédent
+      $previous_handle ? [$previous_handle] : [],
       $versions[$handle],
       true
     );
@@ -128,7 +128,7 @@ function enqueue_core_edit_scripts(array $additional = [])
       $versions[$handle] = file_exists($file) ? filemtime($file) : null;
     }
 
-    wp_enqueue_script(
+    wp_register_script(
       $handle,
       $theme_uri . $path,
       ['helpers', 'ajax', 'ui', 'champ-init'],

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -57,7 +57,26 @@ function register_script_enigme_edit()
         fetch('<?php echo esc_url(admin_url('admin-ajax.php?action=charger_scripts_enigme_edit')); ?>')
           .then(r => r.text())
           .then(html => {
-            document.head.insertAdjacentHTML('beforeend', html);
+            const frag = document.createRange().createContextualFragment(html);
+            const scripts = Array.from(frag.querySelectorAll('script'));
+            let loaded = 0;
+            const check = () => {
+              loaded++;
+              if (loaded === scripts.length) {
+                this.click();
+              }
+            };
+            scripts.forEach((old) => {
+              const s = document.createElement('script');
+              if (old.src) {
+                s.src = old.src;
+                s.onload = check;
+              } else {
+                s.textContent = old.textContent;
+                check();
+              }
+              document.head.appendChild(s);
+            });
           });
       });
     </script>

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -144,7 +144,26 @@ function register_script_organisateur_edit()
           fetch('<?php echo esc_url(admin_url('admin-ajax.php?action=charger_scripts_organisateur_edit')); ?>')
             .then(r => r.text())
             .then(html => {
-              document.head.insertAdjacentHTML('beforeend', html);
+              const frag = document.createRange().createContextualFragment(html);
+              const scripts = Array.from(frag.querySelectorAll('script'));
+              let loaded = 0;
+              const check = () => {
+                loaded++;
+                if (loaded === scripts.length) {
+                  this.click();
+                }
+              };
+              scripts.forEach((old) => {
+                const s = document.createElement('script');
+                if (old.src) {
+                  s.src = old.src;
+                  s.onload = check;
+                } else {
+                  s.textContent = old.textContent;
+                  check();
+                }
+                document.head.appendChild(s);
+              });
             });
         });
       </script>


### PR DESCRIPTION
## Résumé
Enregistre les scripts d’édition et les charge uniquement à l’ouverture du panneau.

## Changements
- Utilisation de `wp_register_script` pour préparer les modules communs et spécifiques
- Ajout de points d’entrée AJAX pour charger les scripts lors du clic sur les toggles
- Protection contre les doubles chargements dans les fichiers `*-edit.js`

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a156e20d88833295c4e1900a23a8f8