### PR TITLE
feat: centralize responsive breakpoints

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/cartes.css
+++ b/wp-content/themes/chassesautresor/assets/css/cartes.css
@@ -31,13 +31,13 @@
   gap: 1.5rem;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: var(--bp-lg)) {
   .grille-3 {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .grille-3 {
     grid-template-columns: 1fr;
   }

--- a/wp-content/themes/chassesautresor/assets/css/chasse.css
+++ b/wp-content/themes/chassesautresor/assets/css/chasse.css
@@ -97,7 +97,7 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
 
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .chasse-fiche-container {
     flex-direction: column;
   }

--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -145,12 +145,12 @@ button,
     font-weight: 600;
     vertical-align: middle;
 }
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .bouton-cta {
         padding: 8px 13px;
     }
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     .bouton-cta {
         padding: 6px 10px;
     }
@@ -246,7 +246,7 @@ button,
   color: var(--color-background);
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .btn-lire-plus {
     width: 100%;
   }
@@ -279,7 +279,7 @@ button,
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
   .bouton-retour {
     width: 100%;
     font-size: 14px;
@@ -338,7 +338,7 @@ button,
 .meta-etiquette strong {
   font-weight: 600;
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     .bloc-metas-inline {
         gap:0.8rem;
     }
@@ -510,7 +510,7 @@ button,
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     .separateur-2 {
         margin: 0 auto;
     }
@@ -534,7 +534,7 @@ button,
 body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     color: var(--color-text-primary);
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
   .formulaire-contact-wrapper {
     padding-left: 1rem;
     padding-right: 1rem;
@@ -621,7 +621,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     text-align: center;
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .countdown-container { font-size: 1rem; }
 }
 

--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -574,7 +574,7 @@ input[disabled].champ-texte-edit {
 /* ========== 📱 RESPONSIVE GLOBAL ========== */
 
 /* Empilage à partir de tablette */
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -629,7 +629,7 @@ input[disabled].champ-texte-edit {
 /* ========== 📱 RESPONSIVE HEADER ========== */
 
 /* Empilage à partir de tablette */
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -1000,13 +1000,13 @@ li.ligne-email .champ-affichage {
 
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .edition-panel-body {
     flex-direction: column;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
   .edition-panel-body {
     flex-direction: column;
   }

--- a/wp-content/themes/chassesautresor/assets/css/enigme.css
+++ b/wp-content/themes/chassesautresor/assets/css/enigme.css
@@ -29,7 +29,7 @@
   margin-top: 1rem;
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .enigme-layout {
     grid-template-columns: 1fr;
   }

--- a/wp-content/themes/chassesautresor/assets/css/gamification.css
+++ b/wp-content/themes/chassesautresor/assets/css/gamification.css
@@ -358,23 +358,23 @@ header .points-link:hover {
 
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */
-@media (max-width: 1024px) {
+@media (max-width: var(--bp-lg)) {
     .points-value {
         font-size: 16px;
     }
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .points-value {
         font-size: 14px;
     }
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
   .points-unite {
     display: none;
   }
 }
-@media (max-width: 374px) {
+@media (max-width: var(--bp-xs)) {
   .points-unite {
     display: none;
   }

--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -28,6 +28,14 @@
 
 :root {
     --font-main: 'Poppins', sans-serif; /* Police principale */
+    /* 📱 Breakpoints */
+    --bp-xs: 374px;
+    --bp-sm: 480px;
+    --bp-540: 540px;
+    --bp-600: 600px;
+    --bp-md: 768px;
+    --bp-921: 921px;
+    --bp-lg: 1024px;
 }
    
 /* ========== 🔠 H1 – TITRE PRINCIPAL ========== */
@@ -47,7 +55,7 @@ h1.h1-diff {/* variation couleur bronze, plus petite, centrée */
   letter-spacing: 1px;
   color: var(--color-accent);
 }
-@media (max-width: 1024px) {
+@media (max-width: var(--bp-lg)) {
   h1, .entry-content h1 {
     font-size: 36px;
   }
@@ -55,7 +63,7 @@ h1.h1-diff {/* variation couleur bronze, plus petite, centrée */
       font-size:30px;
   }
 }
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   h1, .entry-content h1 {
     font-size: 30px;
   }
@@ -78,13 +86,13 @@ h2, .entry-content h2 {
   font-size: 32px;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: var(--bp-lg)) {
   h2, .entry-content h2 {
     font-size: 28px;
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   h2, .entry-content h2 {
     font-size: 24px;
   }
@@ -103,7 +111,7 @@ h3, .entry-content h3 {
   margin-bottom: 0.75rem;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: var(--bp-lg)) {
   .page header.entry-header .entry-title {
     font-size: 36px;
   }
@@ -112,7 +120,7 @@ h3, .entry-content h3 {
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .page header.entry-header .entry-title {
     font-size: 30px;
   }
@@ -205,12 +213,12 @@ span.champ-obligatoire {
 
 /* ========== 📱 RESPONSIVE ========== */
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     address, blockquote, body, dd, dl, dt, fieldset, figure, h1, h2, h3, h4, h5, h6, hr, html, iframe, legend, li, ol, p, pre, textarea, ul  {
         font-size:96%;
     }
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     address, blockquote, body, dd, dl, dt, fieldset, figure, h1, h2, h3, h4, h5, h6, hr, html, iframe, legend, li, ol, p, pre, textarea, ul {
         font-size:93%;
     }

--- a/wp-content/themes/chassesautresor/assets/css/grid.css
+++ b/wp-content/themes/chassesautresor/assets/css/grid.css
@@ -52,14 +52,14 @@
 .col-11 { --col-span: 11; }
 .col-12 { --col-span: 12; }
 
-@media (max-width: 1024px) {
+@media (max-width: var(--bp-lg)) {
   .row { --grid-columns: 8; }
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .row { --grid-columns: 6; }
 }
 
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
   .row { --grid-columns: 4; }
 }

--- a/wp-content/themes/chassesautresor/assets/css/layout.css
+++ b/wp-content/themes/chassesautresor/assets/css/layout.css
@@ -47,12 +47,12 @@
 .ast-above-header-bar .ast-builder-layout-element {
     margin-left:10px;
 }
-@media (max-width: 921px) {
+@media (max-width: var(--bp-921)) {
     header.site-header   {
         padding: 0 10px ;
     }
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
    header.site-header {
        padding: 0 7px;
    }
@@ -139,7 +139,7 @@
 .has-hero .contenu-hero .sous-titre {
   text-shadow: 1px 1px 4px rgba(0,0,0,0.7);
 }
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .has-hero .contenu-hero h1 {
         font-size:1.8rem;
     }
@@ -154,7 +154,7 @@
       padding-top: 300px;
   }
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     .has-hero .contenu-hero h1 {
         font-size:1.5rem;
     }
@@ -195,7 +195,7 @@ body #primary {
   align-items: flex-start; /* ✅ important : alignement haut */
   flex-wrap: wrap; /* ✅ si l’un est trop large */
 }
-@media (max-width: 921px) {
+@media (max-width: var(--bp-921)) {
     .ast-container, .ast-container-fluid {
         margin-left: auto;
         margin-right: auto;
@@ -277,7 +277,7 @@ body #primary {
   opacity: 0.9;
   line-height: 1.5;
 }
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
   .bloc-temoignages .temoignage-colonnes {
     flex-direction: column;
     align-items: center;
@@ -455,7 +455,7 @@ footer .ast-footer-widget a {
 }
 
 
-@media (max-width: 540px) {
+@media (max-width: var(--bp-540)) {
   .site-footer-primary-section-1 {
     order: 2;
     margin: 30px 0;

--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -256,7 +256,7 @@
 
 
 /* ✅ Mobile : Les éléments s'empilent */
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .dashboard-profile-wrapper {
         flex-direction: column; /* ✅ Empile les éléments */
         justify-content: center; /* ✅ Centre les éléments verticalement */
@@ -318,7 +318,7 @@
     vertical-align: middle;
 }
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .menu-deroulant .submenu {
         left: -50px;
     }
@@ -588,7 +588,7 @@
 
 
 /* Tablette : 2 colonnes */
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .image-container {
         height: 260px;
     }

--- a/wp-content/themes/chassesautresor/assets/css/organisateurs.css
+++ b/wp-content/themes/chassesautresor/assets/css/organisateurs.css
@@ -214,7 +214,7 @@
 
 /* ========== 📱 RESPONSIVE – TABLETTES (≤ 768PX) ========== */
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .conteneur-organisateur {
         flex-direction: column;
         align-items: center;
@@ -252,7 +252,7 @@
 
 /* ========== 📱 RESPONSIVE – TABLETTES (600PX À 768PX) ========== */
 
-@media (min-width: 600px) and (max-width: 768px) {
+@media (min-width: 600px) and (max-width: var(--bp-md)) {
     .conteneur-organisateur {
         flex-direction: row;
         align-items: center;
@@ -282,7 +282,7 @@
 
 /* ========== 📱 BASCULE EN COLONNE (≤ 600PX) ========== */
 
-@media (max-width: 600px) {
+@media (max-width: var(--bp-600)) {
     .conteneur-organisateur {
         gap:1rem;
     }
@@ -296,7 +296,7 @@
 
 /* ========== 📱 RESPONSIVE – MOBILE (≤ 480PX) ========== */
 
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
   .conteneur-organisateur {
     gap: 0.2rem;
   }
@@ -463,7 +463,7 @@ section#presentation .presentation-fermer {
 
 
 /* ========== 📱 RESPONSIVE ========== */
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     .lien-public .texte-lien {
         display: none;
     }
@@ -569,7 +569,7 @@ section#presentation .presentation-fermer {
 
 /* ========== 📱 RESPONSIVE ========== */
 
-@media (max-width: 768px) {
+@media (max-width: var(--bp-md)) {
     .separateur-avec-icone {
         margin: 2.1rem 0;
     }
@@ -585,7 +585,7 @@ section#presentation .presentation-fermer {
         height: 50px;
     }
 }
-@media (max-width: 480px) {
+@media (max-width: var(--bp-sm)) {
     .separateur-avec-icone {
         margin: 1.5rem 0;
     }

--- a/wp-content/themes/chassesautresor/docs/style-guide.md
+++ b/wp-content/themes/chassesautresor/docs/style-guide.md
@@ -1,0 +1,23 @@
+# Guide de style
+
+## Points de rupture
+
+Les feuilles de style utilisent des variables CSS définies dans `assets/css/general.css` pour les tailles d'écran.
+
+| Variable | Valeur | Description |
+| --- | --- | --- |
+| `--bp-xs` | 374px | Très petits écrans |
+| `--bp-sm` | 480px | Mobiles |
+| `--bp-540` | 540px | Petits mobiles larges |
+| `--bp-600` | 600px | Petites tablettes |
+| `--bp-md` | 768px | Tablettes |
+| `--bp-921` | 921px | Tablettes larges |
+| `--bp-lg` | 1024px | Bureau |
+
+Exemple d'utilisation :
+
+```css
+@media (max-width: var(--bp-md)) {
+  /* styles pour les tablettes */
+}
+```


### PR DESCRIPTION
Centralise les points de rupture responsive.

- Déclare des variables CSS pour les breakpoints.
- Remplace les requêtes @media par ces variables.
- Documente les points de rupture dans un guide de style.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a15de4dbc48332add87055e52a6d3c