### PR TITLE
Modularise les styles de titres

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/chasse.css
+++ b/wp-content/themes/chassesautresor/assets/css/chasse.css
@@ -30,8 +30,8 @@
   flex: 1;
   min-width: 240px;
 }
-.chasse-details-wrapper h1 {
-    font-size: 30px;
+.header-chasse {
+  font-size: 30px;
 }
 .chasse-details-wrapper .auteur-organisateur a {
     color:var(--color-text-primary);
@@ -106,9 +106,9 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
   .chasse-details-wrapper {
     width: 100%;
   }
-  .chasse-details-wrapper h1 {
+  .header-chasse {
     font-size: 22px;
-}
+  }
 }
 
 

--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -528,8 +528,8 @@ a.ajout-link {
   margin:2rem auto;
   max-width: 600px;
 }
-.formulaire-contact-wrapper h1 {
-    margin-bottom: 0.8rem;
+.titre-contact {
+  margin-bottom: 0.8rem;
 }
 body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/assets/css/layout.css
+++ b/wp-content/themes/chassesautresor/assets/css/layout.css
@@ -118,56 +118,53 @@
     transform: translateY(0);
   }
 }
-.has-hero .contenu-hero h1 {
+.hero-title {
   font-size: 2.6rem;
   font-weight: 700;
   text-transform: uppercase;
-  color: var(--color-primary); /* 🟡 Jaune or */
+  color: var(--color-primary);
   letter-spacing: 1px;
   margin-bottom: 1rem;
+  text-shadow: 1px 1px 4px rgba(0,0,0,0.7);
 }
-.has-hero .sous-titre {
+.hero-subtitle {
   font-size: 1.3rem;
-  color: var(--color-text-primary); /* 📜 Beige clair */
+  color: var(--color-text-primary);
   opacity: 0.95;
   margin-bottom: 2rem;
   max-width: 700px;
   margin-left: auto;
   margin-right: auto;
-}
-.has-hero .contenu-hero h1,
-.has-hero .contenu-hero .sous-titre {
   text-shadow: 1px 1px 4px rgba(0,0,0,0.7);
 }
 @media (max-width: var(--bp-md)) {
-    .has-hero .contenu-hero h1 {
-        font-size:1.8rem;
-    }
-    .has-hero .sous-titre {
-        font-size: 1.5rem;
-        margin-bottom: 1.1rem ;
-    }
+  .hero-title {
+    font-size: 1.8rem;
+  }
+  .hero-subtitle {
+    font-size: 1.5rem;
+    margin-bottom: 1.1rem;
+  }
   .has-hero .hero-overlay {
     height: 280px;
   }
   .has-hero #content {
-      padding-top: 300px;
+    padding-top: 300px;
   }
 }
 @media (max-width: var(--bp-sm)) {
-    .has-hero .contenu-hero h1 {
-        font-size:1.5rem;
-    }
-    .has-hero .sous-titre {
-        font-size: 1rem;
-        margin-bottom: 0.5rem ;
-    }
+  .hero-title {
+    font-size: 1.5rem;
+  }
+  .hero-subtitle {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
   .has-hero .hero-overlay {
     height: 220px;
   }
-
   .has-hero #content {
-      padding-top: 235px;
+    padding-top: 235px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/css/modal-bienvenue.css
+++ b/wp-content/themes/chassesautresor/assets/css/modal-bienvenue.css
@@ -61,8 +61,7 @@
   border-color: var(--color-accent, #ffc400);
 }
 
-.modal-bienvenue-inner h1,
-.modal-contenu h1 {
+.modal-title {
   text-align: center;
   font-size: 1.4rem;
   font-weight: 700;
@@ -72,8 +71,7 @@
   text-transform: uppercase;
 }
 
-.modal-bienvenue-inner h2,
-.modal-contenu h2 {
+.modal-subtitle {
   text-align: center;
   font-size: 1.3rem;
   font-weight: 600;
@@ -107,13 +105,11 @@
     font-size: 0.95rem;
   }
 
-  .modal-bienvenue-inner h1,
-  .modal-contenu h1 {
+  .modal-title {
     font-size: 1.2rem;
   }
 
-  .modal-bienvenue-inner h2,
-  .modal-contenu h2 {
+  .modal-subtitle {
     font-size: 1.1rem;
   }
 }

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -268,6 +268,23 @@ if (!$modal_deja_vue) :
   if ($post_bienvenue && $post_bienvenue->post_status === 'publish') :
     update_post_meta($chasse_id, 'chasse_modal_bienvenue_vue', '1');
     $contenu = apply_filters('the_content', $post_bienvenue->post_content);
+    $dom = new DOMDocument();
+    libxml_use_internal_errors(true);
+    $dom->loadHTML('<?xml encoding="utf-8" ?>' . $contenu);
+    libxml_clear_errors();
+
+    foreach ($dom->getElementsByTagName('h1') as $node) {
+        $node->setAttribute('class', trim('modal-title ' . $node->getAttribute('class')));
+    }
+    foreach ($dom->getElementsByTagName('h2') as $node) {
+        $node->setAttribute('class', trim('modal-subtitle ' . $node->getAttribute('class')));
+    }
+
+    $body = $dom->getElementsByTagName('body')->item(0);
+    $contenu = '';
+    foreach ($body->childNodes as $child) {
+        $contenu .= $dom->saveHTML($child);
+    }
 ?>
     <div class="modal-bienvenue-wrapper" role="dialog" aria-modal="true" aria-labelledby="modal-titre">
       <div class="modal-bienvenue-inner">

--- a/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
@@ -25,11 +25,11 @@ $image_url   = isset( $args['image_fond'] ) ? esc_url( $args['image_fond'] ) : '
   <div class="hero-overlay" <?php if ( $image_url ) : ?>style="background-image: url('<?php echo $image_url; ?>');"<?php endif; ?>>
     <div class="contenu-hero">
       <?php if ( $titre ) : ?>
-        <h1><?php echo $titre; ?></h1>
+        <h1 class="hero-title"><?php echo $titre; ?></h1>
       <?php endif; ?>
 
       <?php if ( $sous_titre ) : ?>
-        <p class="sous-titre"><?php echo $sous_titre; ?></p>
+        <p class="hero-subtitle"><?php echo $sous_titre; ?></p>
       <?php endif; ?>
     </div>
   </div>

--- a/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
@@ -47,8 +47,8 @@ get_header(); ?>
 <section class="bandeau-hero">
   <div class="hero-overlay" style="background-image: url('<?php echo esc_url($image_url); ?>');">
     <div class="contenu-hero">
-      <h1><?php the_title(); ?></h1>
-      <p class="sous-titre">Créez, publiez et partagez vos aventures interactives.</p>
+      <h1 class="hero-title"><?php the_title(); ?></h1>
+      <p class="hero-subtitle">Créez, publiez et partagez vos aventures interactives.</p>
       <?php $cta = get_cta_devenir_organisateur(); ?>
       <a href="<?php echo $cta['url'] ? esc_url($cta['url']) : '#'; ?>" class="bouton-cta" id="creer-profil-btn" data-event="clic_creer_profil" <?php echo $cta['disabled'] ? 'style="pointer-events:none;opacity:0.6"' : ''; ?>>
         <?php echo esc_html($cta['label']); ?>


### PR DESCRIPTION
## Résumé
Réorganisation des styles typographiques pour éviter les redéfinitions contextuelles.

## Changements notables
- Ajout des classes `hero-title` et `hero-subtitle` pour le bandeau héro.
- Conversion des sélecteurs de titres en classes modulaires dans plusieurs composants.
- Injection automatique des classes `modal-title` et `modal-subtitle` dans la modale de bienvenue.
- Suppression des définitions redondantes des titres `h1`.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a1647d2f7c833296170a110a8a73c8