### PR TITLE
feat: améliorer l'historique des conversions de points

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/conversion-history.js
+++ b/wp-content/themes/chassesautresor/assets/js/conversion-history.js
@@ -1,0 +1,35 @@
+jQuery(function ($) {
+  const wrapper = $('.conversion-history');
+  wrapper.each(function () {
+    const container = $(this);
+    const toggle = container.find('.conversion-history-toggle');
+    const tableWrapper = container.find('.conversion-history-table');
+
+    if (toggle.attr('aria-expanded') !== 'true') {
+      tableWrapper.hide();
+    }
+
+    toggle.on('click', function () {
+      const expanded = $(this).attr('aria-expanded') === 'true';
+      $(this).attr('aria-expanded', expanded ? 'false' : 'true');
+      $(this).text(expanded ? toggle.data('label-open') : toggle.data('label-close'));
+      tableWrapper.slideToggle();
+    });
+
+    container.on('click', '.points-history-pager .page-link', function (e) {
+      e.preventDefault();
+      const page = $(this).data('page');
+      $.post(ConversionHistoryAjax.ajax_url, {
+        action: 'load_conversion_history',
+        nonce: ConversionHistoryAjax.nonce,
+        page: page,
+      }).done(function (response) {
+        if (response.success) {
+          tableWrapper.find('tbody').html(response.data.rows);
+          container.find('.points-history-pager .page-link').removeClass('active');
+          container.find('.points-history-pager .page-link[data-page="' + page + '"]').addClass('active');
+        }
+      });
+    });
+  });
+});

--- a/wp-content/themes/chassesautresor/inc/PointsRepository.php
+++ b/wp-content/themes/chassesautresor/inc/PointsRepository.php
@@ -100,6 +100,32 @@ class PointsRepository
     }
 
     /**
+     * Count conversion requests for a user.
+     *
+     * @param int      $userId User identifier.
+     * @param string|null $status Optional request status filter.
+     *
+     * @return int Number of requests.
+     */
+    public function countConversionRequests(int $userId, ?string $status = null): int
+    {
+        $where   = "origin_type = 'conversion' AND user_id = %d";
+        $params  = [$userId];
+
+        if ($status !== null) {
+            $where  .= ' AND request_status = %s';
+            $params[] = $status;
+        }
+
+        $sql = $this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table} WHERE {$where}",
+            $params
+        );
+
+        return (int) $this->wpdb->get_var($sql);
+    }
+
+    /**
      * Count total number of operations for a user.
      */
     public function countHistory(int $userId): int

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -146,40 +146,7 @@ if (current_user_can('administrator')) {
 }
 
 if ($is_organizer) {
-    ob_start();
-    afficher_tableau_paiements_organisateur((int) $current_user->ID, 'toutes');
-    $conversion_table = trim(ob_get_clean());
-    if ($conversion_table !== '') {
-        global $wpdb;
-        $repo            = new PointsRepository($wpdb);
-        $paid_requests   = $repo->getConversionRequests((int) $current_user->ID, 'paid');
-        $total_points    = 0;
-        $total_eur       = 0.0;
-        foreach ($paid_requests as $request) {
-            $total_points += abs((int) $request['points']);
-            $total_eur    += (float) $request['amount_eur'];
-        }
-
-        $total_points_label = sprintf(
-            '%s : %s',
-            esc_html__('Total points', 'chassesautresor'),
-            number_format_i18n($total_points)
-        );
-        $total_eur_label = sprintf(
-            '%s : %s €',
-            esc_html__('Total €', 'chassesautresor'),
-            number_format_i18n($total_eur, 2)
-        );
-
-        echo '<div class="stats-table-wrapper">';
-        echo '<h3>' . esc_html__('Historique conversion de points', 'chassesautresor') . '</h3>';
-        echo '<div class="stats-table-summary">';
-        echo '<span class="etiquette etiquette-grande">' . esc_html($total_points_label) . '</span>';
-        echo '<span class="etiquette etiquette-grande">' . esc_html($total_eur_label) . '</span>';
-        echo '</div>';
-        echo $conversion_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo '</div>';
-    }
+    echo render_conversion_history((int) $current_user->ID);
 }
 
 echo render_points_history_table((int) $current_user->ID);


### PR DESCRIPTION
## Résumé
- Ajout d'un suivi AJAX des conversions avec pagination et pliage de la section
- Calcul et affichage des totaux de points et d'euros sous forme d'étiquettes distinctes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a166cb22008332bbe4a0b118a1e526