### PR TITLE
Load minified CSS outside edition environment

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -29,25 +29,30 @@ add_action('wp_enqueue_scripts', function () {
     $theme_uri  = get_stylesheet_directory_uri();
     $theme_path = get_stylesheet_directory();
 
-    // 🎨 Chargement des styles du thème parent (Astra) et enfant
+    // 🎨 Chargement du style du thème parent (Astra)
     wp_enqueue_style('astra-style', get_template_directory_uri() . '/style.css');
+
+    // Détermine l'environnement via WP_ENVIRONMENT_TYPE ou une constante dédiée.
+    $env            = defined('CHASSESAUTRESOR_ENV') ? CHASSESAUTRESOR_ENV : wp_get_environment_type();
+    $is_edition_env = 'edition' === $env;
+
+    if (!$is_edition_env) {
+        $dist_file = '/dist/style.min.css';
+        wp_enqueue_style(
+            'chassesautresor-style',
+            $theme_uri . $dist_file,
+            ['astra-style'],
+            filemtime($theme_path . $dist_file)
+        );
+        return;
+    }
+
     wp_enqueue_style(
         'mon-theme-enfant-style',
         $theme_uri . '/style.css',
         ['astra-style'],
         filemtime($theme_path . '/style.css')
     );
-
-    if ('production' === wp_get_environment_type()) {
-        $dist_file = '/dist/style.min.css';
-        wp_enqueue_style(
-            'chassesautresor-style',
-            $theme_uri . $dist_file,
-            ['mon-theme-enfant-style'],
-            filemtime($theme_path . $dist_file)
-        );
-        return;
-    }
 
     $css_uri  = $theme_uri . '/assets/css/';
     $css_path = $theme_path . '/assets/css/';


### PR DESCRIPTION
## Résumé
- Utilise `dist/style.min.css` pour tous les environnements hors édition.
- Garde le chargement détaillé des CSS uniquement en mode édition/debug.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a16d77d964833285b42c10ac60d0f4