### PR TITLE
Use shared button classes for actions

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1377,21 +1377,6 @@ body.panneau-ouvert::before {
   margin-right: 4px;
 }
 
-.table-tentatives .btn-valider {
-  background-color: var(--color-editor-success);
-  color: white;
-  padding: 2px 6px;
-  border: none;
-  border-radius: 4px;
-}
-
-.table-tentatives .btn-refuser {
-  background-color: var(--color-editor-error);
-  color: white;
-  padding: 2px 6px;
-  border: none;
-  border-radius: 4px;
-}
 
 .table-tentatives tr.tentative-pending {
   background-color: var(--color-editor-field-hover);
@@ -1921,19 +1906,6 @@ body.panneau-ouvert::before {
   padding: var(--space-md);
 }
 
-.edition-panel-footer .btn-admin-danger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xxs);
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--color-editor-text);
-}
-
-.edition-panel-footer .btn-admin-danger:hover {
-  opacity: 1;
-}
 
 /* ========== 🧩 PRÉ-REQUIS – LISTE D'ÉNIGMES ========== */
 .champ-pre-requis .liste-pre-requis {

--- a/wp-content/themes/chassesautresor/assets/css/gamification.css
+++ b/wp-content/themes/chassesautresor/assets/css/gamification.css
@@ -185,20 +185,6 @@
     margin-top: 10px;
     animation: fadeInUp 1s ease-out forwards;
 }
-.btn-fermer-wow {
-    background: var(--color-background-button);
-    color: var(--color-text);
-    border: none;
-    padding: 10px 20px;
-    font-size: 1.2rem;
-    border-radius: 5px;
-    margin-top: 20px;
-    cursor: pointer;
-    transition: background 0.3s;
-}
-.btn-fermer-wow:hover {
-    background: darkred;
-}
 @keyframes zoomIn {
     from {
         transform: scale(0.5);

--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -491,22 +491,6 @@
     letter-spacing: 0.5px;
     max-width: 80%;
 }
-/* 📌 Bouton "Modifier" centré */
-.overlay-taux button {
-    background: var(--color-secondary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-primary);
-    padding: 8px 12px;
-    border-radius: 5px;
-    cursor: pointer;
-    transition: background 0.3s ease, transform 0.2s ease;
-}
-
-.overlay-taux button:hover {
-    background: var(--color-primary);
-    color: #000;
-    transform: scale(1.05);
-}
 /* tuile gestion des points */
 /* 📌 Ligne d'entrée utilisateur + action */
 .gestion-points-ligne {

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -129,7 +129,7 @@ if ($afficher_bienvenue) :
             <div class="modal-contenu">
                 <?php echo $contenu_html; ?>
                 <div class="boutons-modal">
-                    <button id="fermer-modal-bienvenue" class="btn-fermer">C'est parti !</button>
+                    <button id="fermer-modal-bienvenue" class="bouton-cta">C'est parti !</button>
                 </div>
             </div>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -663,10 +663,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
           <?php wp_nonce_field('validation_admin_' . $chasse_id, 'validation_admin_nonce'); ?>
           <input type="hidden" name="action" value="traiter_validation_chasse">
           <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
-          <button type="button" class="btn-admin-danger btn-correction">
+          <button type="button" class="bouton-secondaire btn-correction">
             <i class="fa-solid fa-triangle-exclamation"></i> Correction
           </button>
-          <button type="submit" name="validation_admin_action" value="bannir" class="btn-admin-danger" onclick="return confirm('Bannir cette chasse&nbsp;?');">
+          <button type="submit" name="validation_admin_action" value="bannir" class="bouton-secondaire" onclick="return confirm('Bannir cette chasse&nbsp;?');">
             <i class="fa-solid fa-triangle-exclamation"></i> Bannir
           </button>
         </form>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-validation-actions.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-validation-actions.php
@@ -20,10 +20,10 @@ $titre_bloc = $org_status === 'pending'
     <input type="hidden" name="action" value="traiter_validation_chasse">
     <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
     <div class="boutons">
-      <button type="submit" name="validation_admin_action" value="valider" class="btn btn-valider">✅ Valider la chasse</button>
-      <button type="submit" name="validation_admin_action" value="correction" class="btn btn-correction">✍️ Correction</button>
-      <button type="submit" name="validation_admin_action" value="bannir" class="btn btn-bannir">❌ Bannir</button>
-      <button type="submit" name="validation_admin_action" value="supprimer" class="btn btn-warning" onclick="return confirm('Supprimer cette chasse ?');">🗑️ Supprimer</button>
+      <button type="submit" name="validation_admin_action" value="valider" class="bouton-cta">✅ Valider la chasse</button>
+      <button type="submit" name="validation_admin_action" value="correction" class="bouton-secondaire btn-correction">✍️ Correction</button>
+      <button type="submit" name="validation_admin_action" value="bannir" class="bouton-secondaire">❌ Bannir</button>
+      <button type="submit" name="validation_admin_action" value="supprimer" class="bouton-secondaire" onclick="return confirm('Supprimer cette chasse ?');">🗑️ Supprimer</button>
     </div>
   </form>
 </section>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
@@ -44,8 +44,8 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
           <form method="post" style="display:inline;">
             <?php wp_nonce_field('traiter_tentative_' . $tent->tentative_uid); ?>
             <input type="hidden" name="uid" value="<?= esc_attr($tent->tentative_uid); ?>">
-            <button type="submit" name="action_traitement" value="valider" class="btn-valider">Valider</button>
-            <button type="submit" name="action_traitement" value="invalider" class="btn-refuser">Invalider</button>
+            <button type="submit" name="action_traitement" value="valider" class="bouton-cta">Valider</button>
+            <button type="submit" name="action_traitement" value="invalider" class="bouton-secondaire">Invalider</button>
           </form>
         <?php else: ?>
           <?= esc_html($tent->resultat); ?>

--- a/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
@@ -88,8 +88,8 @@ get_header();
         <input type="hidden" name="uid" value="<?= esc_attr($uid); ?>">
 
         <div class="boutons">
-          <button type="submit" name="action_traitement" value="valider" class="btn btn-valider">✅ Valider</button>
-          <button type="submit" name="action_traitement" value="invalider" class="btn btn-refuser">❌ Refuser</button>
+          <button type="submit" name="action_traitement" value="valider" class="bouton-cta">✅ Valider</button>
+          <button type="submit" name="action_traitement" value="invalider" class="bouton-secondaire">❌ Refuser</button>
         </div>
       </form>
     <?php else: ?>
@@ -102,19 +102,19 @@ get_header();
   <div class="traitement-actions">
     <a href="<?= esc_url(add_query_arg('reset_statuts', '1')); ?>"
       onclick="return confirm('Supprimer tous les statuts utilisateurs pour cette énigme ?');"
-      class="btn btn-red">
+      class="bouton-secondaire">
       🧹 Réinitialiser les statuts
     </a>
 
     <a href="<?= esc_url(add_query_arg('reset_tentatives', '1')); ?>"
       onclick="return confirm('Supprimer toutes les tentatives pour cette énigme ?');"
-      class="btn btn-dark">
+      class="bouton-secondaire">
       ❌ Supprimer les tentatives
     </a>
 
     <a href="<?= esc_url(add_query_arg('reset_all', '1')); ?>"
       onclick="return confirm('Supprimer TOUT (statuts + tentatives) ?');"
-      class="btn btn-warning">
+      class="bouton-secondaire">
       🔥 Tout supprimer
     </a>
   </div>


### PR DESCRIPTION
Uniformise les boutons en remplaçant les règles locales par les classes .bouton-cta et .bouton-secondaire.

- Retire les styles spécifiques de l'overlay du taux et de l'effet "wow".
- Utilise les classes partagées dans les formulaires de validation et de modération.
- Supprime les définitions CSS redondantes.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a17659f85c8332afcf7f76f2d4a4ad