### PR TITLE
feat: add new button styles

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -196,6 +196,76 @@ button,
     opacity: 0.6;
 }
 
+/* ========== 🔲 BOUTON TERTIAIRE ========== */
+
+.bouton-tertiaire {
+    background: transparent;
+    color: var(--color-text-primary);
+    border: 1px solid currentColor;
+    transition: background 0.3s ease, transform 0.2s ease;
+    padding: 10px 15px;
+    border-radius: 3px;
+    margin: 6px 0;
+    display: inline-block;
+    text-align: center;
+    line-height: 16px;
+}
+
+.bouton-tertiaire:hover {
+    background: var(--color-text-primary);
+    color: var(--color-text-fond-clair);
+    transform: scale(1.05);
+}
+
+.bouton-tertiaire:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+/* ========== ⚠️ BOUTON DANGER ========== */
+
+.btn-danger {
+    background: var(--color-editor-error);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-editor-error);
+    transition: background 0.3s ease, transform 0.2s ease;
+    padding: 10px 15px;
+    border-radius: 3px;
+    margin: 6px 0;
+    display: inline-block;
+    text-align: center;
+    line-height: 16px;
+}
+
+.btn-danger:hover {
+    filter: brightness(1.1);
+    transform: scale(1.05);
+}
+
+.btn-danger:disabled {
+    background: var(--color-gris-3);
+    border-color: var(--color-gris-3);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+/* ========== 🖱️ BOUTON ICÔNE ========== */
+
+.btn-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border-radius: 50%;
+}
+
+.btn-icon:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
 
 /* ========== ➕ BOUTON D’AJOUT ========== */
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-validation-actions.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-validation-actions.php
@@ -21,9 +21,9 @@ $titre_bloc = $org_status === 'pending'
     <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
     <div class="boutons">
       <button type="submit" name="validation_admin_action" value="valider" class="bouton-cta">✅ Valider la chasse</button>
-      <button type="submit" name="validation_admin_action" value="correction" class="bouton-secondaire btn-correction">✍️ Correction</button>
-      <button type="submit" name="validation_admin_action" value="bannir" class="bouton-secondaire">❌ Bannir</button>
-      <button type="submit" name="validation_admin_action" value="supprimer" class="bouton-secondaire" onclick="return confirm('Supprimer cette chasse ?');">🗑️ Supprimer</button>
+      <button type="submit" name="validation_admin_action" value="correction" class="bouton-tertiaire btn-correction">✍️ Correction</button>
+      <button type="submit" name="validation_admin_action" value="bannir" class="btn-danger">❌ Bannir</button>
+      <button type="submit" name="validation_admin_action" value="supprimer" class="btn-danger" onclick="return confirm('Supprimer cette chasse ?');">🗑️ Supprimer</button>
     </div>
   </form>
 </section>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -76,25 +76,25 @@ if ($peut_modifier && !$est_complet) {
       </div>
 
       <div class="champ-edition" style="display: none;">
-        <button type="button" class="champ-enregistrer">✓</button>
-        <button type="button" class="champ-annuler">✖</button>
+        <button type="button" class="champ-enregistrer btn-icon bouton-tertiaire">✓</button>
+        <button type="button" class="champ-annuler btn-icon btn-danger">✖</button>
       </div>
 
       <div class="champ-feedback"></div>
 
-      <div class="header-organisateur__actions">
-        <button type="button" class="bouton-toggle-description" aria-label="Voir la description">
-          <i class="fa-solid fa-circle-info"></i>
-        </button>
-        <a href="<?= esc_url($url_contact); ?>" class="lien-contact" aria-label="Contact">
-          <i class="fa-solid fa-envelope"></i>
-        </a>
-        <?php if ($peut_modifier) : ?>
-          <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="Paramètres organisateur">
-            <i class="fa-solid fa-gear"></i>
+        <div class="header-organisateur__actions">
+          <button type="button" class="bouton-toggle-description btn-icon bouton-tertiaire" aria-label="Voir la description">
+            <i class="fa-solid fa-circle-info"></i>
           </button>
-        <?php endif; ?>
-      </div>
+          <a href="<?= esc_url($url_contact); ?>" class="lien-contact btn-icon bouton-tertiaire" aria-label="Contact">
+            <i class="fa-solid fa-envelope"></i>
+          </a>
+          <?php if ($peut_modifier) : ?>
+            <button id="toggle-mode-edition" class="bouton-edition-toggle btn-icon bouton-tertiaire" aria-label="Paramètres organisateur">
+              <i class="fa-solid fa-gear"></i>
+            </button>
+          <?php endif; ?>
+        </div>
     </div>
 
   </header>

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-outils.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-outils.php
@@ -48,7 +48,7 @@ $taux_conversion = get_taux_conversion_actuel();
                 <h3>ACF</h3>
             </div>
             <div class="stats-content">
-                <button id="afficher-champs-acf" class="bouton-secondaire"><?php esc_html_e('Afficher les champs ACF', 'chassesautresor'); ?></button>
+                <button id="afficher-champs-acf" class="bouton-tertiaire"><?php esc_html_e('Afficher les champs ACF', 'chassesautresor'); ?></button>
                 <div id="acf-fields-container" style="display:none;margin-top:10px;">
                     <textarea id="acf-fields-output" style="width:100%;height:300px;" readonly></textarea>
                 </div>

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -44,7 +44,7 @@ if (current_user_can('administrator')) {
                     <div class="gestion-points-ligne">
                         <label for="nombre-points"></label>
                         <input type="number" id="nombre-points" name="nombre_points" placeholder="nb de points" min="1" required>
-                        <button type="submit" name="modifier_points" class="bouton-secondaire">✅</button>
+                        <button type="submit" name="modifier_points" class="btn-icon bouton-tertiaire">✅</button>
                     </div>
                 </form>
             </div>

--- a/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
@@ -89,7 +89,7 @@ get_header();
 
         <div class="boutons">
           <button type="submit" name="action_traitement" value="valider" class="bouton-cta">✅ Valider</button>
-          <button type="submit" name="action_traitement" value="invalider" class="bouton-secondaire">❌ Refuser</button>
+          <button type="submit" name="action_traitement" value="invalider" class="btn-danger">❌ Refuser</button>
         </div>
       </form>
     <?php else: ?>
@@ -102,19 +102,19 @@ get_header();
   <div class="traitement-actions">
     <a href="<?= esc_url(add_query_arg('reset_statuts', '1')); ?>"
       onclick="return confirm('Supprimer tous les statuts utilisateurs pour cette énigme ?');"
-      class="bouton-secondaire">
+      class="btn-danger">
       🧹 Réinitialiser les statuts
     </a>
 
     <a href="<?= esc_url(add_query_arg('reset_tentatives', '1')); ?>"
       onclick="return confirm('Supprimer toutes les tentatives pour cette énigme ?');"
-      class="bouton-secondaire">
+      class="btn-danger">
       ❌ Supprimer les tentatives
     </a>
 
     <a href="<?= esc_url(add_query_arg('reset_all', '1')); ?>"
       onclick="return confirm('Supprimer TOUT (statuts + tentatives) ?');"
-      class="bouton-secondaire">
+      class="btn-danger">
       🔥 Tout supprimer
     </a>
   </div>


### PR DESCRIPTION
Ajout de nouveaux styles de boutons pour les actions secondaires et destructrices.

- Ajoute `.bouton-tertiaire`, `.btn-danger` et `.btn-icon` dans les composants CSS.
- Adapte les templates d’administration et de navigation pour utiliser ces classes.
- Harmonise les boutons icône et les actions destructrices.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a17898354483328d621329086b91c5