### PR TITLE
Fix conversion request link to organizer points tab

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -314,10 +314,22 @@ function myaccount_get_important_messages(): string
         $repo       = new PointsRepository($wpdb);
         $pendingOwn = $repo->getConversionRequests($current_user_id, 'pending');
         if (!empty($pendingOwn)) {
+            $conversion_url = $organisateur_id
+                ? esc_url(
+                    add_query_arg(
+                        [
+                            'edition' => 'open',
+                            'onglet'  => 'revenus',
+                        ],
+                        get_permalink($organisateur_id)
+                    )
+                )
+                : esc_url(home_url('/mon-compte/?section=points'));
+
             $messages[] = sprintf(
                 /* translators: 1: opening anchor tag, 2: closing anchor tag */
                 __('Vous avez une %1$sdemande de conversion%2$s en attente de règlement.', 'chassesautresor'),
-                '<a href="' . esc_url(home_url('/mon-compte/?section=points')) . '">',
+                '<a href="' . $conversion_url . '">',
                 '</a>'
             );
         }

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -115,7 +115,10 @@ class MyAccountMessagesTest extends TestCase
         $output = myaccount_get_important_messages();
 
         $this->assertStringContainsString('<a', $output);
-        $this->assertStringContainsString('/mon-compte/?section=points', $output);
+        $this->assertStringContainsString(
+            'https://example.com/organisateur?edition=open&onglet=revenus',
+            $output
+        );
         $this->assertStringContainsString('demande de conversion', $output);
     }
 


### PR DESCRIPTION
## Résumé
- Corrige le lien de notification de conversion pour ouvrir le panneau d'édition organisateur sur l'onglet Points
- Met à jour le test associé pour refléter cette redirection

## Changements notables
- Génération d'une URL vers le CPT organisateur avec les paramètres `edition=open&onglet=revenus`
- Vérification du lien actualisé dans `myaccount_messages.test.php`

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a17a53791483329a4892086b5fd085