### PR TITLE
Fix cursor style for disabled secondary buttons

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -188,7 +188,7 @@ button,
     padding: 12px 20px;
     border-radius: 5px;
     font-size: 1rem;
-    cursor: pointer;
+    cursor: not-allowed;
     text-align: center;
     width: fit-content;
     display: flex;


### PR DESCRIPTION
## Summary
- Corrige le curseur des boutons secondaires désactivés

## Changes
- Remplace `cursor: pointer` par `cursor: not-allowed` sur `.bouton-secondaire.no-click`

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a17efe47ac8332b197d095b01c5fb1