### PR TITLE
Simplify badge styles

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -462,12 +462,12 @@ a.ajout-link:focus-visible {
 /* ========== 🟢 BADGE ROND ========== */
 
 .badge-rond {
-    margin: 0px 0px 0px 0px;
+    margin: 0;
     padding: 2px 0;
     background-color: var(--color-primary); /* Jaune or */
     transition: background 0.5s;
-    border-radius: 200px 200px 200px 200px;
-    font-size : 12px;
+    border-radius: 200px;
+    font-size: 12px;
 }
 
 


### PR DESCRIPTION
## Résumé
Simplifie la feuille de style du badge rond.

## Changements notables
- Raccourcit la propriété de marge à `margin: 0;`
- Simplifie la définition de l'arrondi à `border-radius: 200px;`
- Corrige l'espacement de `font-size`

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a17f38d6dc8332aa8bdcfa61fc3931