### PR TITLE
Utilise des variables CSS pour les couleurs des composants

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -178,7 +178,7 @@ button,
 
 .bouton-secondaire:hover {
     background: var(--color-primary);
-    color: #000;
+    color: var(--color-text-fond-clair);
     transform: scale(1.05);
 }
 .bouton-secondaire.no-click {
@@ -481,7 +481,7 @@ a.ajout-link:focus-visible {
   font-size: 0.75rem;
   font-weight: bold;
   border-radius: 999px;
-  color: #fff;
+  color: var(--color-text-primary);
   text-transform: uppercase;
   letter-spacing: 0.03em;
   line-height: 1;
@@ -807,7 +807,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .message-succes {
     text-align: center;
     font-weight: bold;
-    color: green;
+    color: var(--color-success);
     font-size: 16px;
     margin-top: 15px;
 }
@@ -816,7 +816,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .message-info {
     text-align: center;
     font-weight: bold;
-    color: #333;
+    color: var(--color-text-fond-clair);
     font-size: 16px;
     margin-top: 15px;
 }


### PR DESCRIPTION
## Résumé
- Remplace les valeurs de couleur en dur dans `components.css` par les variables du thème.

## Changements notables
- Utilisation de `var(--color-text-fond-clair)` pour les textes foncés.
- Substitution de la couleur verte par `var(--color-success)` pour les messages de succès.
- Alignement des badges et messages info sur les couleurs du nuancier.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a17f3e4ac88332b993ca91cfbb4b6c