### PR TITLE
Improve disabled link button styling

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -189,6 +189,7 @@ button,
     border-radius: 5px;
     font-size: 1rem;
     cursor: not-allowed;
+    pointer-events: none;
     text-align: center;
     width: fit-content;
     display: flex;
@@ -798,6 +799,13 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 /* ========== 🚫 NO-CLICK ========== */
 
 .no-click {
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+a.disabled,
+a[aria-disabled="true"] {
+    cursor: not-allowed;
     pointer-events: none;
 }
 


### PR DESCRIPTION
### Résumé
- Désactive l'interaction des liens utilisés comme boutons

### Modifications notables
- Remplacement du curseur par `not-allowed` pour les éléments non cliquables
- Ajout de `pointer-events: none` sur `.bouton-secondaire.no-click`
- Prise en charge des liens désactivés via `.disabled` ou `[aria-disabled="true"]`

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a1828376fc8332a7a89511e8796b29