### PR TITLE
Internationalize various theme strings

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -5,6 +5,7 @@
  * @returns {string} HTML
  */
 function renderLiensPublics(liens = []) {
+  const { __ } = wp.i18n;
   const icones = {
     site_web: 'fa-solid fa-globe',
     discord: 'fa-brands fa-discord',
@@ -14,21 +15,21 @@ function renderLiensPublics(liens = []) {
   };
 
   const labels = {
-    site_web: 'Site Web',
-    discord: 'Discord',
-    facebook: 'Facebook',
-    twitter: 'Twitter/X',
-    instagram: 'Instagram'
+    site_web: __('Site Web', 'chassesautresor-com'),
+    discord: __('Discord', 'chassesautresor-com'),
+    facebook: __('Facebook', 'chassesautresor-com'),
+    twitter: __('Twitter/X', 'chassesautresor-com'),
+    instagram: __('Instagram', 'chassesautresor-com')
   };
 
   if (!Array.isArray(liens) || liens.length === 0) {
-    return `
-      <div class="liens-placeholder">
-        <p class="liens-placeholder-message">Aucun lien ajouté pour le moment.</p>
-        ${Object.entries(icones).map(([type, icone]) =>
-      `<i class="fa ${icone} icone-grisee" title="${labels[type]}"></i>`
-    ).join('')}
-      </div>`;
+      return `
+        <div class="liens-placeholder">
+          <p class="liens-placeholder-message">${__('Aucun lien ajouté pour le moment.', 'chassesautresor-com')}</p>
+          ${Object.entries(icones).map(([type, icone]) =>
+        `<i class="fa ${icone} icone-grisee" title="${labels[type]}"></i>`
+      ).join('')}
+        </div>`;
   }
 
   return `
@@ -205,7 +206,7 @@ function initLiensPublics(bloc, { panneauId, formId, action, reload = false }) {
             const btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'champ-modifier ouvrir-panneau-liens';
-            btn.setAttribute('aria-label', 'Configurer vos liens');
+              btn.setAttribute('aria-label', __('Configurer vos liens', 'chassesautresor-com'));
             btn.textContent = '✏️';
             zoneAffichage.appendChild(btn);
           }
@@ -228,7 +229,7 @@ function initLiensPublics(bloc, { panneauId, formId, action, reload = false }) {
                 const btn = document.createElement('button');
                 btn.type = 'button';
                 btn.className = 'champ-modifier ouvrir-panneau-liens';
-                btn.setAttribute('aria-label', 'Configurer vos liens');
+                btn.setAttribute('aria-label', __('Configurer vos liens', 'chassesautresor-com'));
                 btn.textContent = '✏️';
                 zone.appendChild(btn);
               }
@@ -251,7 +252,7 @@ function initLiensPublics(bloc, { panneauId, formId, action, reload = false }) {
                 const btn = document.createElement('button');
                 btn.type = 'button';
                 btn.className = 'champ-modifier ouvrir-panneau-liens';
-                btn.setAttribute('aria-label', 'Configurer vos liens');
+                btn.setAttribute('aria-label', __('Configurer vos liens', 'chassesautresor-com'));
                 btn.textContent = '✏️';
                 zone.appendChild(btn);
               }

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -429,7 +429,7 @@ function render_tableau_paiements_admin(array $requests): string
 {
     ob_start();
     echo '<table class="widefat fixed">';
-    echo '<thead><tr><th>Organisateur</th><th>Montant / Points</th><th>Date demande</th><th>IBAN / BIC</th><th>Statut</th><th>Action</th></tr></thead>';
+    echo '<thead><tr><th>' . esc_html__( 'Organisateur', 'chassesautresor-com' ) . '</th><th>' . esc_html__( 'Montant / Points', 'chassesautresor-com' ) . '</th><th>' . esc_html__( 'Date demande', 'chassesautresor-com' ) . '</th><th>' . esc_html__( 'IBAN / BIC', 'chassesautresor-com' ) . '</th><th>' . esc_html__( 'Statut', 'chassesautresor-com' ) . '</th><th>' . esc_html__( 'Action', 'chassesautresor-com' ) . '</th></tr></thead>';
     echo '<tbody>';
 
     foreach ($requests as $request) {
@@ -442,20 +442,20 @@ function render_tableau_paiements_admin(array $requests): string
             $iban = get_field('gagnez_de_largent_iban', $organisateur_id);
             $bic  = get_field('gagnez_de_largent_bic', $organisateur_id);
         }
-        $iban = $iban ?: 'Non renseigné';
+        $iban = $iban ?: esc_html__( 'Non renseigné', 'chassesautresor-com' );
 
         switch ($request['request_status']) {
             case 'paid':
-                $statut = '✅ Réglé';
+                $statut = esc_html__( '✅ Réglé', 'chassesautresor-com' );
                 break;
             case 'cancelled':
-                $statut = '❌ Annulé';
+                $statut = esc_html__( '❌ Annulé', 'chassesautresor-com' );
                 break;
             case 'refused':
-                $statut = '🚫 Refusé';
+                $statut = esc_html__( '🚫 Refusé', 'chassesautresor-com' );
                 break;
             default:
-                $statut = '🟡 En attente';
+                $statut = esc_html__( '🟡 En attente', 'chassesautresor-com' );
         }
 
         $action = '-';
@@ -466,7 +466,7 @@ function render_tableau_paiements_admin(array $requests): string
             $action .= '<option value="annule">' . esc_html__('Annuler', 'chassesautresor-com') . '</option>';
             $action .= '<option value="refuse">' . esc_html__('Refuser', 'chassesautresor-com') . '</option>';
             $action .= '</select>';
-            $action .= '<button type="submit" class="button">OK</button>';
+            $action .= '<button type="submit" class="button">' . esc_html__( 'OK', 'chassesautresor-com' ) . '</button>';
             $action .= '</form>';
         }
 
@@ -497,7 +497,7 @@ function afficher_tableau_paiements_admin(): void
     $requests = $repo->getConversionRequests();
 
     if (empty($requests)) {
-        echo '<p>Aucune demande de paiement en attente.</p>';
+        echo '<p>' . esc_html__( 'Aucune demande de paiement en attente.', 'chassesautresor-com' ) . '</p>';
         return;
     }
 
@@ -517,7 +517,7 @@ function recuperer_historique_paiements_admin(int $page = 1): array
     $pages = max(1, (int) ceil($total / $per_page));
 
     if (empty($requests)) {
-        $html = '<p>Aucune demande de paiement.</p>';
+        $html = '<p>' . esc_html__( 'Aucune demande de paiement.', 'chassesautresor-com' ) . '</p>';
     } else {
         $html  = render_tableau_paiements_admin($requests);
         $html .= '<div class="pager">';

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -499,14 +499,14 @@ function afficher_chasse_associee_callback()
 
     ob_start(); ?>
     <section class="chasse-associee">
-        <h3>Chasse au Trésor</h3>
+        <h3><?php esc_html_e('Chasse au Trésor', 'chassesautresor-com'); ?></h3>
         <h2><strong><a href="<?= $url; ?>" class="lien-chasse-associee"><?= $titre; ?></a></strong></h2>
-        <p>🏆 <strong>Lot :</strong> <?= esc_html($infos_chasse['lot']); ?></p>
-        <p>📅 <strong>Durée :</strong> <?= esc_html($infos_chasse['date_de_debut']); ?> au <?= esc_html($infos_chasse['date_de_fin']); ?></p>
+        <p>🏆 <strong><?php esc_html_e('Lot :', 'chassesautresor-com'); ?></strong> <?= esc_html($infos_chasse['lot']); ?></p>
+        <p>📅 <strong><?php esc_html_e('Durée :', 'chassesautresor-com'); ?></strong> <?= esc_html($infos_chasse['date_de_debut']); ?> <?php esc_html_e('au', 'chassesautresor-com'); ?> <?= esc_html($infos_chasse['date_de_fin']); ?></p>
 
         <?php if (!empty($lien_discord)) : ?>
             <p>
-                <a href="<?= esc_url($lien_discord); ?>" target="_blank" rel="noopener noreferrer" aria-label="Rejoindre le Discord">
+                <a href="<?= esc_url($lien_discord); ?>" target="_blank" rel="noopener noreferrer" aria-label="<?php esc_attr_e('Rejoindre le Discord', 'chassesautresor-com'); ?>">
                     <img src="<?= $icone_discord; ?>" alt="Discord" class="discord-icon">
                 </a>
             </p>
@@ -603,8 +603,8 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     // 🧑‍💻 Utilisateur non connecté
     if (!$user_id) {
         return [
-            'cta_html'    => '<a href="' . esc_url(site_url('/mon-compte')) . '" class="bouton-cta">S\'identifier</a>',
-            'cta_message' => 'Vous devez être identifié pour participer à cette chasse',
+            'cta_html'    => '<a href="' . esc_url(site_url('/mon-compte')) . '" class="bouton-cta">' . esc_html__("S'identifier", 'chassesautresor-com') . '</a>',
+            'cta_message' => esc_html__( 'Vous devez être identifié pour participer à cette chasse', 'chassesautresor-com' ),
             'type'        => 'connexion',
         ];
     }
@@ -629,11 +629,15 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     $type    = '';
 
     if ($statut === 'a_venir') {
-        $html = '<button class="bouton-cta" disabled>Indisponible</button>';
+        $html = '<button class="bouton-cta" disabled>' . esc_html__( 'Indisponible', 'chassesautresor-com' ) . '</button>';
         $type = 'indisponible';
         $message = $date_debut
-            ? 'Chasse disponible à partir du ' . date_i18n('d/m/Y \à H:i', strtotime($date_debut))
-            : 'Chasse disponible prochainement';
+            ? sprintf(
+                /* translators: %s: formatted start date */
+                esc_html__( 'Chasse disponible à partir du %s', 'chassesautresor-com' ),
+                date_i18n( 'd/m/Y \à H:i', strtotime( $date_debut ) )
+            )
+            : esc_html__( 'Chasse disponible prochainement', 'chassesautresor-com' );
     } elseif ($statut === 'en_cours' || $statut === 'payante') {
         $cout_points        = (int) get_field('chasse_infos_cout_points', $chasse_id);
         $points_disponibles = get_user_points($user_id);
@@ -660,9 +664,9 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             $html  = '<form method="post" action="' . esc_url(site_url('/traitement-engagement')) . '" class="cta-chasse-form">';
             $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
             $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
-            $html .= '<button type="submit" class="bouton-cta">Participer</button>';
+            $html .= '<button type="submit" class="bouton-cta">' . esc_html__( 'Participer', 'chassesautresor-com' ) . '</button>';
             $html .= '</form>';
-            $message = 'Accès libre à cette chasse. Les tentatives seront tarifées individuellement.';
+            $message = esc_html__( 'Accès libre à cette chasse. Les tentatives seront tarifées individuellement.', 'chassesautresor-com' );
             $type    = 'engager';
         }
     } elseif ($statut === 'termine') {
@@ -670,12 +674,16 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         $html  = '<form method="post" action="' . esc_url(site_url('/traitement-engagement')) . '" class="cta-chasse-form">';
         $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
         $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
-        $html .= '<button type="submit" class="bouton-cta">Voir</button>';
+        $html .= '<button type="submit" class="bouton-cta">' . esc_html__( 'Voir', 'chassesautresor-com' ) . '</button>';
         $html .= '</form>';
         $type = 'voir';
         $message = $date_fin
-            ? 'Cette chasse est terminée depuis le ' . date_i18n('d/m/Y', strtotime($date_fin))
-            : 'Cette chasse est terminée';
+            ? sprintf(
+                /* translators: %s: formatted end date */
+                esc_html__( 'Cette chasse est terminée depuis le %s', 'chassesautresor-com' ),
+                date_i18n( 'd/m/Y', strtotime( $date_fin ) )
+            )
+            : esc_html__( 'Cette chasse est terminée', 'chassesautresor-com' );
     }
 
     return [

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -161,10 +161,11 @@ function afficher_points_utilisateur_callback() {
 
         // ✅ Sécurité : On s'assure que les points gagnés sont un entier valide et positif
         if ($points_gagnes > 0) {
-            $points_gagnes_html = "
-                <div class='points-gagnes'>
-                    +<strong>{$points_gagnes}</strong> points gagnés !
-                </div>";
+            $points_gagnes_html = sprintf(
+                "<div class='points-gagnes'>+<strong>%d</strong> %s</div>",
+                $points_gagnes,
+                esc_html__( 'points gagnés !', 'chassesautresor-com' )
+            );
         }
     }
 
@@ -172,7 +173,7 @@ function afficher_points_utilisateur_callback() {
     return "
     <div class='zone-points'>
         {$points_gagnes_html}
-        <a href='{$boutique_url}' class='points-link' title='Accéder à la boutique'>
+        <a href='{$boutique_url}' class='points-link' title='" . esc_attr__( 'Accéder à la boutique', 'chassesautresor-com' ) . "'>
             <span class='points-plus-circle'>+</span>
             <span class='points-value'>{$points}</span>
             <span class='points-euro'>pts</span>

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -400,7 +400,7 @@ function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
 
     $formulaire = in_array($statut, ['en_cours', 'non_souscrite'], true);
     $message = ($statut === 'resolue');
-    $message_html = $message ? '<p class="message-statut">Vous avez déjà résolu cette énigme.</p>' : '';
+        $message_html = $message ? '<p class="message-statut">' . esc_html__( 'Vous avez déjà résolu cette énigme.', 'chassesautresor-com' ) . '</p>' : '';
 
     return [
         'etat' => $statut,

--- a/wp-content/themes/chassesautresor/inc/utils/liens.php
+++ b/wp-content/themes/chassesautresor/inc/utils/liens.php
@@ -129,7 +129,7 @@ function render_liens_publics(array $liens, string $contexte = 'organisateur', a
 
     // Placeholder si aucun lien
     $out = '<div class="liens-placeholder">';
-    $out .= '<p class="liens-placeholder-message">Aucun lien ajouté pour le moment.</p>';
+    $out .= '<p class="liens-placeholder-message">' . esc_html__( 'Aucun lien ajouté pour le moment.', 'chassesautresor-com' ) . '</p>';
     foreach ($types as $type => $infos) {
         $out .= '<i class="fa ' . esc_attr($infos['icone']) . ' icone-grisee" title="' . esc_attr($infos['label']) . '"></i>';
     }

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -161,10 +161,10 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     ?>
 
     <?php if (!empty($_GET['erreur']) && $_GET['erreur'] === 'points_insuffisants') : ?>
-      <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
-        ❌ Vous n’avez pas assez de points pour engager cette énigme.
-        <a href="<?= esc_url(home_url('/boutique')); ?>">Accéder à la boutique</a>
-      </div>
+        <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+          <?php esc_html_e('❌ Vous n’avez pas assez de points pour engager cette énigme.', 'chassesautresor-com'); ?>
+          <a href="<?= esc_url(home_url('/boutique')); ?>"><?php esc_html_e('Accéder à la boutique', 'chassesautresor-com'); ?></a>
+        </div>
     <?php endif; ?>
 
     <!-- 📦 Fiche complète (images + méta + actions) -->
@@ -231,8 +231,8 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         </div>
       </header>
 
-      <div class="titre-enigmes-wrapper">
-        <h2>Énigmes</h2>
+        <div class="titre-enigmes-wrapper">
+          <h2><?php esc_html_e('Énigmes', 'chassesautresor-com'); ?></h2>
         <?php if ($peut_ajouter_enigme && $total_enigmes > 0 && !$has_incomplete_enigme) :
           get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
             'has_enigmes' => true,

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -14,10 +14,10 @@ $chasse_id = recuperer_id_chasse_associee($post_id);
 if (
   current_user_can('manage_options') ||
   utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
-) {
-  echo '<p class="message-organisateur">🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché.</p>';
-  return;
-}
+  ) {
+    echo '<p class="message-organisateur">' . esc_html__( '🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché.', 'chassesautresor-com' ) . '</p>';
+    return;
+  }
 
 // Récupération du mode de validation
 $mode_validation = get_field('enigme_mode_validation', $post_id);
@@ -40,21 +40,21 @@ if ($mode_validation === 'manuelle') {
 }
 
 $statut_actuel = enigme_get_statut_utilisateur($post_id, $user_id);
-if ($statut_actuel === 'resolue') {
-  echo '<p class="message-joueur-statut">Vous avez déjà résolu cette énigme.</p>';
-  return;
-}
+  if ($statut_actuel === 'resolue') {
+    echo '<p class="message-joueur-statut">' . esc_html__( 'Vous avez déjà résolu cette énigme.', 'chassesautresor-com' ) . '</p>';
+    return;
+  }
 
 $tentatives_du_jour = compter_tentatives_du_jour($user_id, $post_id);
 $boutique_url = esc_url(home_url('/boutique/'));
 $disabled = '';
-$label_btn = 'Valider';
+  $label_btn = esc_html__( 'Valider', 'chassesautresor-com' );
 $points_manquants = 0;
 $message_tentatives = '';
 
 if ($max && $tentatives_du_jour >= $max) {
   $disabled = 'disabled';
-  $message_tentatives = 'tentatives quotidiennes épuisées';
+    $message_tentatives = esc_html__( 'tentatives quotidiennes épuisées', 'chassesautresor-com' );
 
   $tz = new DateTimeZone('Europe/Paris');
   $now = new DateTime('now', $tz);
@@ -62,7 +62,7 @@ if ($max && $tentatives_du_jour >= $max) {
   $diff = $midnight->getTimestamp() - $now->getTimestamp();
   $hours = floor($diff / 3600);
   $minutes = floor(($diff % 3600) / 60);
-  $label_btn = sprintf('%dh et %dmn avant réactivation', $hours, $minutes);
+    $label_btn = sprintf( esc_html__( '%dh et %dmn avant réactivation', 'chassesautresor-com' ), $hours, $minutes );
 }
 
 if ($cout > get_user_points($user_id)) {
@@ -73,14 +73,14 @@ if ($cout > get_user_points($user_id)) {
 $nonce = wp_create_nonce('reponse_auto_nonce');
 ?>
 
-<form class="bloc-reponse formulaire-reponse-auto">
-  <label for="reponse_auto_<?= esc_attr($post_id); ?>">Votre réponse :</label>
+  <form class="bloc-reponse formulaire-reponse-auto">
+    <label for="reponse_auto_<?= esc_attr($post_id); ?>"><?php esc_html_e('Votre réponse :', 'chassesautresor-com'); ?></label>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
   <?php elseif ($points_manquants > 0) : ?>
     <p class="message-limite" data-points="manquants">
       <?= esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $points_manquants)); ?>
-      <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
+        <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="<?php esc_attr_e('Accéder à la boutique', 'chassesautresor-com'); ?>">
         <span class="points-plus-circle">+</span>
       </a>
     </p>
@@ -99,7 +99,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
 <div class="reponse-feedback" style="display:none"></div>
 <?php if ($max > 0) : ?>
   <div class="tentatives-counter compteur-tentatives txt-small" data-max="<?= esc_attr($max); ?>" style="margin-top:4px;">
-    <span class="etiquette">Tentatives quotidiennes</span>
+      <span class="etiquette"><?php esc_html_e('Tentatives quotidiennes', 'chassesautresor-com'); ?></span>
     <span class="valeur"><?= esc_html($tentatives_du_jour); ?>/<?= esc_html($max); ?></span>
   </div>
 <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/myaccount/dashboard-admin.php
+++ b/wp-content/themes/chassesautresor/template-parts/myaccount/dashboard-admin.php
@@ -2,7 +2,7 @@
 defined('ABSPATH') || exit;
 ?>
 <div class="dashboard-section">
-    <h3 class="dashboard-section-title">Chasse</h3>
+    <h3 class="dashboard-section-title"><?php esc_html_e('Chasse', 'chassesautresor-com'); ?></h3>
     <div class="dashboard-grid">
         <?php
         $creations = array_filter(
@@ -15,7 +15,7 @@ defined('ABSPATH') || exit;
         <div class="dashboard-card creation-card">
             <div class="dashboard-card-header">
                 <i class="fas fa-user-plus"></i>
-                <h3>à valider</h3>
+                  <h3><?php esc_html_e('à valider', 'chassesautresor-com'); ?></h3>
             </div>
             <div class="stats-content">
                 <ul>
@@ -52,7 +52,7 @@ defined('ABSPATH') || exit;
         <div class="dashboard-card">
             <div class="dashboard-card-header">
                 <i class="fas fa-hammer"></i>
-                <h3>en édition</h3>
+                  <h3><?php esc_html_e('en édition', 'chassesautresor-com'); ?></h3>
             </div>
             <div class="stats-content">
                 <ul>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
@@ -60,7 +60,7 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
               </ul>
             <?php else : ?>
               <div class="liens-placeholder">
-                <p class="liens-placeholder-message">Aucun lien ajouté pour le moment.</p>
+                <p class="liens-placeholder-message"><?php esc_html_e('Aucun lien ajouté pour le moment.', 'chassesautresor-com'); ?></p>
                 <?php foreach ($types_disponibles as $type => $infos) : ?>
                   <i class="fa <?= esc_attr($infos['icone']); ?> icone-grisee" title="<?= esc_attr($infos['label']); ?>"></i>
                 <?php endforeach; ?>

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -26,14 +26,14 @@ if (current_user_can('administrator')) {
         <div class="dashboard-card">
             <div class="dashboard-card-header">
                 <i class="fas fa-coins"></i>
-                <h3><?php esc_html_e('Gestion Points', 'chassesautresor'); ?></h3>
+              <h3><?php esc_html_e('Gestion Points', 'chassesautresor-com'); ?></h3>
             </div>
             <div class="stats-content">
                 <form method="POST" class="form-gestion-points">
                     <?php wp_nonce_field('gestion_points_action', 'gestion_points_nonce'); ?>
                     <div class="gestion-points-ligne">
                         <label for="utilisateur-points"></label>
-                        <input type="text" id="utilisateur-points" placeholder="Rechercher un utilisateur..." required>
+                          <input type="text" id="utilisateur-points" placeholder="<?php esc_attr_e('Rechercher un utilisateur...', 'chassesautresor-com'); ?>" required>
                         <input type="hidden" id="utilisateur-id" name="utilisateur">
                         <label for="type-modification"></label>
                         <select id="type-modification" name="type_modification" required>
@@ -43,7 +43,7 @@ if (current_user_can('administrator')) {
                     </div>
                     <div class="gestion-points-ligne">
                         <label for="nombre-points"></label>
-                        <input type="number" id="nombre-points" name="nombre_points" placeholder="nb de points" min="1" required>
+                          <input type="number" id="nombre-points" name="nombre_points" placeholder="<?php esc_attr_e('nb de points', 'chassesautresor-com'); ?>" min="1" required>
                         <button type="submit" name="modifier_points" class="btn-icon bouton-tertiaire">✅</button>
                     </div>
                 </form>
@@ -51,7 +51,7 @@ if (current_user_can('administrator')) {
         </div>
     </div>
     <div class="stats-table-wrapper">
-        <h3><?php esc_html_e('Historique des conversions', 'chassesautresor'); ?></h3>
+          <h3><?php esc_html_e('Historique des conversions', 'chassesautresor-com'); ?></h3>
         <div
             id="historique-paiements-admin"
             class="liste-paiements"
@@ -98,7 +98,7 @@ if (current_user_can('administrator')) {
     <?php
     if ($points === 0) {
         $shop_url = esc_url(home_url('/boutique'));
-        echo '<p class="myaccount-points"><a href="' . $shop_url . '">' . esc_html__('Ajouter des points', 'chassesautresor') . '</a></p>';
+          echo '<p class="myaccount-points"><a href="' . $shop_url . '">' . esc_html__('Ajouter des points', 'chassesautresor-com') . '</a></p>';
     }
 }
 

--- a/wp-content/themes/chassesautresor/templates/page-confirmation-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-confirmation-organisateur.php
@@ -21,9 +21,9 @@ get_header();
 ?>
 <div class="conteneur-confirmation">
 <?php if ($success) : ?>
-    <p>Votre inscription est confirmée. Vous pouvez maintenant vous connecter.</p>
+    <p><?php esc_html_e('Votre inscription est confirmée. Vous pouvez maintenant vous connecter.', 'chassesautresor-com'); ?></p>
 <?php else : ?>
-    <p>Token invalide ou expiré.</p>
+    <p><?php esc_html_e('Token invalide ou expiré.', 'chassesautresor-com'); ?></p>
 <?php endif; ?>
 </div>
 <?php get_footer();

--- a/wp-content/themes/chassesautresor/templates/page-creer-profil.php
+++ b/wp-content/themes/chassesautresor/templates/page-creer-profil.php
@@ -27,8 +27,11 @@ if (isset($_GET['resend'])) {
 
 $token = get_user_meta($current_user_id, 'organisateur_demande_token', true);
 if ($token) {
-    echo '<p>⚠️ Une demande de création de profil organisateur est déjà en cours pour ce compte.</p>';
-    echo '<p><a href="?resend=1">Renvoyer l\'email de confirmation</a></p>';
+    echo '<p>' . esc_html__(
+        '⚠️ Une demande de création de profil organisateur est déjà en cours pour ce compte.',
+        'chassesautresor-com'
+    ) . '</p>';
+    echo '<p><a href="?resend=1">' . esc_html__("Renvoyer l'email de confirmation", 'chassesautresor-com') . '</a></p>';
     exit;
 }
 

--- a/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
@@ -41,14 +41,14 @@ if (has_post_thumbnail()) {
 get_header(); ?>
 <?php if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') : ?>
 <div class="woocommerce-message" role="alert">
-  ✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.
+  <?php esc_html_e('✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.', 'chassesautresor-com'); ?>
 </div>
 <?php endif; ?>
 <section class="bandeau-hero">
   <div class="hero-overlay" style="background-image: url('<?php echo esc_url($image_url); ?>');">
     <div class="contenu-hero">
       <h1 class="hero-title"><?php the_title(); ?></h1>
-      <p class="hero-subtitle">Créez, publiez et partagez vos aventures interactives.</p>
+      <p class="hero-subtitle"><?php esc_html_e('Créez, publiez et partagez vos aventures interactives.', 'chassesautresor-com'); ?></p>
       <?php $cta = get_cta_devenir_organisateur(); ?>
       <a href="<?php echo $cta['url'] ? esc_url($cta['url']) : '#'; ?>" class="bouton-cta" id="creer-profil-btn" data-event="clic_creer_profil" <?php echo $cta['disabled'] ? 'style="pointer-events:none;opacity:0.6"' : ''; ?>>
         <?php echo esc_html($cta['label']); ?>

--- a/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-tentative.php
@@ -31,26 +31,26 @@ if (
 
 // 💚 Réinitialisations
 if (isset($_GET['reset_tentatives'])) {
-  global $wpdb;
-  $reset = $wpdb->delete($wpdb->prefix . 'enigme_tentatives', ['enigme_id' => $enigme_id], ['%d']);
-  echo '<p style="text-align:center;">🧹 ' . $reset . ' tentative(s) supprimée(s).</p>';
-  return;
-}
+    global $wpdb;
+    $reset = $wpdb->delete($wpdb->prefix . 'enigme_tentatives', ['enigme_id' => $enigme_id], ['%d']);
+    printf('<p style="text-align:center;">%s</p>', sprintf( esc_html__( '🧹 %d tentative(s) supprimée(s).', 'chassesautresor-com' ), $reset ));
+    return;
+  }
 
 if (isset($_GET['reset_statuts'])) {
-  global $wpdb;
-  $reset = $wpdb->delete($wpdb->prefix . 'enigme_statuts_utilisateur', ['enigme_id' => $enigme_id], ['%d']);
-  echo '<p style="text-align:center;">🗑️ ' . $reset . ' statut(s) utilisateur supprimé(s).</p>';
-  return;
-}
+    global $wpdb;
+    $reset = $wpdb->delete($wpdb->prefix . 'enigme_statuts_utilisateur', ['enigme_id' => $enigme_id], ['%d']);
+    printf('<p style="text-align:center;">%s</p>', sprintf( esc_html__( '🗑️ %d statut(s) utilisateur supprimé(s).', 'chassesautresor-com' ), $reset ));
+    return;
+  }
 
 if (isset($_GET['reset_all'])) {
-  global $wpdb;
-  $reset1 = $wpdb->delete($wpdb->prefix . 'enigme_tentatives', ['enigme_id' => $enigme_id], ['%d']);
-  $reset2 = $wpdb->delete($wpdb->prefix . 'enigme_statuts_utilisateur', ['enigme_id' => $enigme_id], ['%d']);
-  echo '<p style="text-align:center;">🔥 ' . $reset1 . ' tentative(s) & ' . $reset2 . ' statut(s) supprimés.</p>';
-  return;
-}
+    global $wpdb;
+    $reset1 = $wpdb->delete($wpdb->prefix . 'enigme_tentatives', ['enigme_id' => $enigme_id], ['%d']);
+    $reset2 = $wpdb->delete($wpdb->prefix . 'enigme_statuts_utilisateur', ['enigme_id' => $enigme_id], ['%d']);
+    printf('<p style="text-align:center;">%s</p>', sprintf( esc_html__( '🔥 %1$d tentative(s) & %2$d statut(s) supprimés.', 'chassesautresor-com' ), $reset1, $reset2 ));
+    return;
+  }
 
 // ✅ Traitement si POST (validation ou refus)
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action_traitement'], $_POST['uid'])) {
@@ -72,14 +72,19 @@ get_header();
 <main class="page-traitement-tentative">
   <div class="container">
     <section class="bloc-infos">
-      <h2>
-        Tentative de <strong><?= esc_html($infos['nom_user'] ?? 'Inconnu'); ?></strong>
-        pour l’énigme <strong><?= esc_html(get_the_title($enigme_id)); ?></strong>
-      </h2>
+        <h2>
+          <?php
+          printf(
+            esc_html__( 'Tentative de %1$s pour l’énigme %2$s', 'chassesautresor-com' ),
+            '<strong>' . esc_html( $infos['nom_user'] ?? esc_html__( 'Inconnu', 'chassesautresor-com' ) ) . '</strong>',
+            '<strong>' . esc_html( get_the_title( $enigme_id ) ) . '</strong>'
+          );
+          ?>
+        </h2>
 
-      <p><strong>Identifiant unique de tentative :</strong> <?= esc_html($uid); ?></p>
-      <p><strong>Statut :</strong> <?= ucfirst(esc_html($etat)); ?></p>
-      <p><a href="<?= esc_url($permalink); ?>" class="lien-enigme">🔍 Voir l’énigme</a></p>
+        <p><strong><?php esc_html_e('Identifiant unique de tentative :', 'chassesautresor-com'); ?></strong> <?= esc_html($uid); ?></p>
+        <p><strong><?php esc_html_e('Statut :', 'chassesautresor-com'); ?></strong> <?= esc_html( ucfirst( $etat ) ); ?></p>
+        <p><a href="<?= esc_url($permalink); ?>" class="lien-enigme"><?php esc_html_e('🔍 Voir l’énigme', 'chassesautresor-com'); ?></a></p>
     </section>
 
     <?php if ($etat === 'attente'): ?>
@@ -87,36 +92,39 @@ get_header();
         <?php wp_nonce_field('traiter_tentative_' . $uid); ?>
         <input type="hidden" name="uid" value="<?= esc_attr($uid); ?>">
 
-        <div class="boutons">
-          <button type="submit" name="action_traitement" value="valider" class="bouton-cta">✅ Valider</button>
-          <button type="submit" name="action_traitement" value="invalider" class="btn-danger">❌ Refuser</button>
-        </div>
+          <div class="boutons">
+            <button type="submit" name="action_traitement" value="valider" class="bouton-cta"><?php esc_html_e('✅ Valider', 'chassesautresor-com'); ?></button>
+            <button type="submit" name="action_traitement" value="invalider" class="btn-danger"><?php esc_html_e('❌ Refuser', 'chassesautresor-com'); ?></button>
+          </div>
       </form>
     <?php else: ?>
-      <div class="bloc-deja-traitee">
-        Cette tentative a été <strong><?= esc_html($etat === 'validee' ? 'validée' : 'refusée'); ?></strong>.
-      </div>
+        <div class="bloc-deja-traitee">
+          <?php
+          $etat_label = $etat === 'validee' ? esc_html__( 'validée', 'chassesautresor-com' ) : esc_html__( 'refusée', 'chassesautresor-com' );
+          printf( esc_html__( 'Cette tentative a été %s.', 'chassesautresor-com' ), '<strong>' . esc_html( $etat_label ) . '</strong>' );
+          ?>
+        </div>
     <?php endif; ?>
   </div>
 
   <div class="traitement-actions">
-    <a href="<?= esc_url(add_query_arg('reset_statuts', '1')); ?>"
-      onclick="return confirm('Supprimer tous les statuts utilisateurs pour cette énigme ?');"
-      class="btn-danger">
-      🧹 Réinitialiser les statuts
-    </a>
+      <a href="<?= esc_url(add_query_arg('reset_statuts', '1')); ?>"
+        onclick="return confirm('<?php echo esc_js( __( 'Supprimer tous les statuts utilisateurs pour cette énigme ?', 'chassesautresor-com' ) ); ?>');"
+        class="btn-danger">
+        <?php esc_html_e('🧹 Réinitialiser les statuts', 'chassesautresor-com'); ?>
+      </a>
 
-    <a href="<?= esc_url(add_query_arg('reset_tentatives', '1')); ?>"
-      onclick="return confirm('Supprimer toutes les tentatives pour cette énigme ?');"
-      class="btn-danger">
-      ❌ Supprimer les tentatives
-    </a>
+      <a href="<?= esc_url(add_query_arg('reset_tentatives', '1')); ?>"
+        onclick="return confirm('<?php echo esc_js( __( 'Supprimer toutes les tentatives pour cette énigme ?', 'chassesautresor-com' ) ); ?>');"
+        class="btn-danger">
+        <?php esc_html_e('❌ Supprimer les tentatives', 'chassesautresor-com'); ?>
+      </a>
 
-    <a href="<?= esc_url(add_query_arg('reset_all', '1')); ?>"
-      onclick="return confirm('Supprimer TOUT (statuts + tentatives) ?');"
-      class="btn-danger">
-      🔥 Tout supprimer
-    </a>
+      <a href="<?= esc_url(add_query_arg('reset_all', '1')); ?>"
+        onclick="return confirm('<?php echo esc_js( __( 'Supprimer TOUT (statuts + tentatives) ?', 'chassesautresor-com' ) ); ?>');"
+        class="btn-danger">
+        <?php esc_html_e('🔥 Tout supprimer', 'chassesautresor-com'); ?>
+      </a>
   </div>
 </main>
 

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/my-account.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/my-account.php
@@ -5,7 +5,10 @@
 defined('ABSPATH') || exit;
 
 if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') {
-    echo '<div class="woocommerce-message" role="alert">✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.</div>';
+    echo '<div class="woocommerce-message" role="alert">' . esc_html__(
+        '✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.',
+        'chassesautresor-com'
+    ) . '</div>';
 }
 
 // S'assure que la variable globale est définie.


### PR DESCRIPTION
## Summary
- Internationalisation des messages d’alerte et de bienvenue dans les pages compte et inscription
- Ajout de fonctions de traduction pour les CTA, tableaux administratifs et messages d’erreur
- Support de l’i18n côté JavaScript pour les liens publics

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a1808d82cc833288e1c314cb11ed36