### PR TITLE
Respecte la préférence de réduction des mouvements

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/components.css
+++ b/wp-content/themes/chassesautresor/assets/css/components.css
@@ -1,4 +1,11 @@
 
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
 /* 📋 Blocs */
 
   /* ✨ Bloc élgégant */

--- a/wp-content/themes/chassesautresor/assets/css/variables.css
+++ b/wp-content/themes/chassesautresor/assets/css/variables.css
@@ -68,6 +68,14 @@
   --breakpoint-mobile: 544px;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-fast: 0s;
+    --transition-medium: 0s;
+    --transition-slow: 0s;
+  }
+}
+
 /* 📝 Variables d’édition */
 .mode-edition {
   --color-editor-button:           #1A73E8;   /* 🔘 Boutons */


### PR DESCRIPTION
## Résumé
- Ajout de styles pour désactiver animations et transitions si l’utilisateur préfère réduire les mouvements
- Définition de variables de transition nulles en mode réduit

## Changements notables
- Désactivation globale des animations et transitions quand `prefers-reduced-motion: reduce`
- Ajustement des variables de transition pour respecter la préférence utilisateur

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a1849ebbb08332bee0ece31d803779