### PR TITLE
Affiche un message en cas d'échec de chargement AJAX dans le compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -57,7 +57,18 @@ document.addEventListener('DOMContentLoaded', () => {
         window.history.replaceState(null, '', '/mon-compte/');
       }
     } catch (err) {
-      window.location.assign(link.href);
+      content.innerHTML = `
+        <section class="msg-important">
+          <p>Impossible de charger la section.</p>
+          <p><a href="#" class="reload-section">Recharger</a> ou <a href="${link.href}">ouvrir la page complète</a>.</p>
+        </section>`;
+      const reload = content.querySelector('.reload-section');
+      if (reload) {
+        reload.addEventListener('click', (e) => {
+          e.preventDefault();
+          loadSection(link);
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Résumé
- affiche un message dans la zone Mon Compte si une section ne se charge pas
- ajoute des liens pour recharger la section ou ouvrir la page complète

## Testing
- `source ./setup-env.sh && echo 'env setup done'`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a188b405cc8332ada05edee5487158