### PR TITLE
Affiche les énigmes en étiquettes et ajoute la pagination standard

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-stats.js
@@ -83,40 +83,26 @@ function initChasseStats() {
         });
     }
 
+    participantsWrapper.addEventListener('pager:change', (e) => {
+      const orderby = participantsWrapper.dataset.orderby || 'inscription';
+      const order = participantsWrapper.dataset.order || 'asc';
+      charger(e.detail.page, orderby, order);
+    });
+
     participantsWrapper.addEventListener('click', (e) => {
-      const btn = e.target.closest('button');
-      if (!btn) return;
-      if (btn.classList.contains('pager-first')) {
-        e.preventDefault();
-        charger(1);
+      const btn = e.target.closest('button.sort');
+      if (!btn) {
+        return;
       }
-      if (btn.classList.contains('pager-prev')) {
-        e.preventDefault();
-        const page = parseInt(participantsWrapper.dataset.page || '1', 10);
-        if (page > 1) charger(page - 1);
+      e.preventDefault();
+      const orderby = btn.dataset.orderby || 'inscription';
+      let order = participantsWrapper.dataset.order || 'asc';
+      if (participantsWrapper.dataset.orderby !== orderby) {
+        order = 'asc';
+      } else {
+        order = order === 'asc' ? 'desc' : 'asc';
       }
-      if (btn.classList.contains('pager-next')) {
-        e.preventDefault();
-        const page = parseInt(participantsWrapper.dataset.page || '1', 10);
-        const pages = parseInt(participantsWrapper.dataset.pages || '1', 10);
-        if (page < pages) charger(page + 1);
-      }
-      if (btn.classList.contains('pager-last')) {
-        e.preventDefault();
-        const pages = parseInt(participantsWrapper.dataset.pages || '1', 10);
-        charger(pages);
-      }
-      if (btn.classList.contains('sort')) {
-        e.preventDefault();
-        const orderby = btn.dataset.orderby || 'inscription';
-        let order = participantsWrapper.dataset.order || 'asc';
-        if (participantsWrapper.dataset.orderby !== orderby) {
-          order = 'asc';
-        } else {
-          order = order === 'asc' ? 'desc' : 'asc';
-        }
-        charger(1, orderby, order);
-      }
+      charger(1, orderby, order);
     });
   }
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
@@ -74,31 +74,31 @@ if ($orderby === 'resolution') {
   <tbody>
     <?php foreach ($participants as $p) :
         $titles = [];
-        foreach ($p['enigmes'] as $e) {
-            $titles[] = esc_html($e['title']);
-        }
-        $taux_participation = $total_enigmes > 0 ? (100 * $p['nb_engagees'] / $total_enigmes) : 0;
-        $taux_resolution    = $total_enigmes > 0 ? (100 * $p['nb_resolues'] / $total_enigmes) : 0;
-    ?>
+    foreach ($p['enigmes'] as $e) {
+        $titles[] = esc_html($e['title']);
+    }
+    $taux_participation = $total_enigmes > 0 ? (100 * $p['nb_engagees'] / $total_enigmes) : 0;
+    $taux_resolution    = $total_enigmes > 0 ? (100 * $p['nb_resolues'] / $total_enigmes) : 0;
+?>
     <tr>
       <td><?= esc_html($p['username']); ?></td>
       <td><?= $p['date_inscription'] ? esc_html(mysql2date('d/m/Y H:i', $p['date_inscription'])) : ''; ?></td>
-      <td><?= implode(', ', $titles); ?></td>
+      <td>
+        <?php
+        $etiquettes = array_map(
+            static function ($title) {
+                return '<span class="etiquette">' . $title . '</span>';
+            },
+            $titles
+        );
+        echo implode(' ', $etiquettes);
+        ?>
+      </td>
       <td><?= esc_html(number_format_i18n($taux_participation, 0)); ?>%</td>
       <td><?= esc_html(number_format_i18n($taux_resolution, 0)); ?>%</td>
     </tr>
     <?php endforeach; ?>
   </tbody>
 </table>
-<div class="pager">
-  <?php if ($page > 1) : ?>
-    <button class="pager-first" aria-label="Première page"><i class="fa-solid fa-angles-left"></i></button>
-    <button class="pager-prev" aria-label="Page précédente"><i class="fa-solid fa-angle-left"></i></button>
-  <?php endif; ?>
-  <span class="pager-info"><?= esc_html($page); ?> / <?= esc_html($pages); ?></span>
-  <?php if ($page < $pages) : ?>
-    <button class="pager-next" aria-label="Page suivante"><i class="fa-solid fa-angle-right"></i></button>
-    <button class="pager-last" aria-label="Dernière page"><i class="fa-solid fa-angles-right"></i></button>
-  <?php endif; ?>
-</div>
+<?php echo cta_render_pager($page, $pages, 'chasse-participants-pager'); ?>
 <?php endif; ?>


### PR DESCRIPTION
## Résumé
- affiche les énigmes des joueurs sous forme d’étiquettes
- remplace la navigation des joueurs par le pager par défaut
- met à jour le script des statistiques pour écouter `pager:change`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a1f89313c48332865149e430e7a201