### PR TITLE
Intégrer le groupe ACF des indices dans la carte d’outils

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1348,6 +1348,7 @@ function recuperer_details_acf() {
         'group_67b58c51b9a49', // Paramètre de la chasse (ID 27)
         'group_67b58134d7647', // Paramètres de l’énigme (ID 9)
         'group_67c7dbfea4a39', // Paramètres organisateur (ID 657)
+        'group_68a1fb240748a', // Paramètres indices
     ];
 
     ob_start();


### PR DESCRIPTION
## Résumé
- Ajout du groupe de champs ACF "Paramètres indices" à la carte ACF d’administration

## Modifications
- Inclusion du groupe `group_68a1fb240748a` dans la liste des groupes inspectés

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a247b575fc83329563d091a137ba9b