### PR TITLE
docs: synchroniser notices ACF

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -82,6 +82,15 @@ Contenu imbriqué :
   Requis : non
   ----------------------------------------
 ----------------------------------------
+— chasse_mode_fin —
+Type : radio
+Label : chasse mode fin
+Instructions : (vide)
+Requis : non
+Choices :
+  - manuelle : Manuelle
+  - automatique : Automatique
+----------------------------------------
 — chasse_infos_nb_max_gagants —
 Type : number
 Label : Nombre maximum de gagants
@@ -91,7 +100,7 @@ Requis : non
 — chasse_cache_gagnants —
 Type : text
 Label : Gagnants
-Instructions : Texte libre listant les gagnants
+Instructions : (vide)
 Requis : non
 ----------------------------------------
 — chasse_cache_date_decouverte —
@@ -147,15 +156,6 @@ Type : true_false
 Label : chasse_cache_complet
 Instructions : (vide)
 Requis : non
-----------------------------------------
-— chasse_mode_fin —
-Type : radio
-Label : chasse mode fin
-Instructions : (vide)
-Requis : non
-Choices :
-  - manuelle : Manuelle
-  - automatique : Automatique
 ----------------------------------------
 
 🔹 Groupe : Paramètres de l’énigme
@@ -440,13 +440,67 @@ Requis : non
 ----------------------------------------
 — description_longue —
 Type : wysiwyg
-Label : 
+Label : Description
 Instructions : (vide)
-Requis : non
+Requis : oui
 ----------------------------------------
 — organisateur_cache_complet —
 Type : true_false
 Label : organisateur_cache_complet
+Instructions : (vide)
+Requis : non
+----------------------------------------
+
+🔹 Groupe : paramètres indices
+🆔 ID : 9568
+🔑 Key : group_68a1fb240748a
+📦 Champs trouvés : 7
+
+— indice_image —
+Type : image
+Label : image de l indice
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— indice_contenu —
+Type : wysiwyg
+Label : texte de l indice
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— indice_cible —
+Type : radio
+Label : contenu ciblé
+Instructions : (vide)
+Requis : non
+Choices :
+  - chasse : chasse
+  - enigme : énigme
+----------------------------------------
+— indice_cible_objet —
+Type : relationship
+Label : cible
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— indice_disponibilite —
+Type : radio
+Label : disponibilité
+Instructions : (vide)
+Requis : non
+Choices :
+  - immediate : immédiate
+  - differe : différé
+----------------------------------------
+— indice_date_disponibilite —
+Type : date_time_picker
+Label : date de disponibilité
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— indice_cout_points —
+Type : number
+Label : coût en points
 Instructions : (vide)
 Requis : non
 ----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -352,7 +352,6 @@ Groupe : paramètre de la chasse
 * chasse_principale_description (wysiwyg)
 * chasse_infos_recompense_titre (text)
 * chasse_infos_recompense_valeur (number)
-* chasse_infos_nb_max_gagants (number)
 * chasse_infos_cout_points (number)
 * chasse_infos_recompense_texte (wysiwyg)
 * chasse_infos_date_debut (date_time_picker)
@@ -361,6 +360,8 @@ Groupe : paramètre de la chasse
 * chasse_principale_liens (repeater)
   * chasse_principale_liens_type (select)
   * chasse_principale_liens_url (url)
+* chasse_mode_fin (radio)
+* chasse_infos_nb_max_gagants (number)
 * chasse_cache_gagnants (text)
 * chasse_cache_date_decouverte (date_picker)
 * chasse_cache_statut (select)
@@ -369,7 +370,6 @@ Groupe : paramètre de la chasse
 * chasse_cache_commentaire (textarea)
 * chasse_cache_organisateur (relationship)
 * chasse_cache_complet (true_false)
-* chasse_mode_fin (radio)
 
 CPT : enigme
 Groupe : Paramètres de l’énigme
@@ -406,6 +406,17 @@ Groupe : Paramètres de l’énigme
 * enigme_solution_fichier (file)
 * enigme_solution_explication (wysiwyg)
 * enigme_cache_complet (true_false)
+
+CPT : indice
+Groupe : paramètres indices
+
+* indice_image (image)
+* indice_contenu (wysiwyg)
+* indice_cible (radio)
+* indice_cible_objet (relationship)
+* indice_disponibilite (radio)
+* indice_date_disponibilite (date_time_picker)
+* indice_cout_points (number)
 
 liste avec tous les détails des groupes de champs ACF dans champs-acf-liste.md
 


### PR DESCRIPTION
## Résumé
- met à jour les listes des champs ACF pour chasse, énigme et organisateur
- documente le nouveau groupe de champs "indices"

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a29b44bee083328979f836024d88fd