### PR TITLE
Remove edition card from admin dashboard

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/myaccount/dashboard-admin.php
+++ b/wp-content/themes/chassesautresor/template-parts/myaccount/dashboard-admin.php
@@ -32,37 +32,6 @@ defined('ABSPATH') || exit;
         </div>
         <?php endif; ?>
 
-        <?php
-        $chasses_creation = new WP_Query([
-            'post_type'      => 'chasse',
-            'post_status'    => 'pending',
-            'meta_query'     => [
-                [
-                    'key'     => 'chasse_cache_statut_validation',
-                    'value'   => ['creation', 'correction'],
-                    'compare' => 'IN'
-                ]
-            ],
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-            'posts_per_page' => 5,
-            'fields'        => 'ids'
-        ]);
-        if ($chasses_creation->have_posts()) : ?>
-        <div class="dashboard-card">
-            <div class="dashboard-card-header">
-                <i class="fas fa-hammer"></i>
-                <h3>en édition</h3>
-            </div>
-            <div class="stats-content">
-                <ul>
-                    <?php foreach ($chasses_creation->posts as $cid) : ?>
-                        <li><a href="<?php echo esc_url(get_permalink($cid)); ?>"><?php echo esc_html(get_the_title($cid)); ?></a></li>
-                    <?php endforeach; ?>
-                </ul>
-            </div>
-        </div>
-        <?php endif; ?>
     </div>
 </div>
 


### PR DESCRIPTION
## Résumé
- supprime la carte "en édition" du tableau de bord admin

## Changements notables
- retire l'affichage des chasses en cours d'édition dans `dashboard-admin.php`

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2a2a6b3cc83329d35d9e5efbe401a