### PR TITLE
Refactor enigme display sections

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -9,6 +9,137 @@ defined('ABSPATH') || exit;
      * 🔸 enigme_get_partial() → Charge un partiel adapté au style (ex: pirate/images.php), avec fallback global.
      */
 
+    /**
+     * Renders the sidebar of the enigma layout.
+     *
+     * @param bool     $edition_active Whether the edition mode is active.
+     * @param int|null $chasse_id      Associated hunt ID.
+     * @param array    $menu_items     Menu items to display.
+     */
+    function render_enigme_sidebar(bool $edition_active, ?int $chasse_id, array $menu_items): void
+    {
+        echo '<aside class="enigme-sidebar">';
+
+        if ($edition_active) {
+            echo '<button id="toggle-mode-edition-enigme" type="button" ' .
+                'class="bouton-edition-toggle bouton-edition-toggle--clair" data-cpt="enigme" aria-label="' .
+                esc_attr__('Activer Orgy', 'chassesautresor-com') .
+                '"><i class="fa-solid fa-gear"></i></button>';
+        }
+
+        if ($chasse_id) {
+            $logo = get_the_post_thumbnail($chasse_id, 'thumbnail');
+            if ($logo) {
+                echo '<div class="enigme-chasse-logo">' . $logo . '</div>';
+            }
+            $titre_chasse = get_the_title($chasse_id);
+            echo '<div class="enigme-chasse-titre">' . esc_html($titre_chasse) . '</div>';
+        }
+
+        if (!empty($menu_items)) {
+            echo '<ul class="enigme-menu">' . implode('', $menu_items) . '</ul>';
+        }
+
+        if ($chasse_id) {
+            $url_retour = get_permalink($chasse_id);
+            echo '<a href="' . esc_url($url_retour) . '" class="bouton-retour bouton-retour-chasse">';
+            echo '<i class="fa-solid fa-arrow-left"></i>';
+            echo '<span class="screen-reader-text">' . esc_html__('Retour à la chasse', 'chassesautresor-com') . '</span>';
+            echo '</a>';
+        }
+
+        echo '</aside>';
+    }
+
+    /**
+     * Render the hero section for the enigma.
+     *
+     * @param int    $enigme_id Enigma identifier.
+     * @param string $style     Display style.
+     * @param int    $user_id   Current user ID.
+     */
+    function render_enigme_hero(int $enigme_id, string $style, int $user_id): void
+    {
+        foreach ([
+            'titre',
+            'images',
+        ] as $slug) {
+            echo '<div class="enigme-section enigme-section-' . esc_attr($slug) . '">';
+            enigme_get_partial(
+                $slug,
+                $style,
+                [
+                    'post_id' => $enigme_id,
+                    'user_id' => $user_id,
+                ]
+            );
+            echo '</div>';
+        }
+    }
+
+    /**
+     * Render the main content section of the enigma.
+     *
+     * @param int    $enigme_id Enigma identifier.
+     * @param string $style     Display style.
+     * @param int    $user_id   Current user ID.
+     */
+    function render_enigme_content(int $enigme_id, string $style, int $user_id): void
+    {
+        echo '<div class="enigme-section enigme-section-texte">';
+        enigme_get_partial(
+            'texte',
+            $style,
+            [
+                'post_id' => $enigme_id,
+                'user_id' => $user_id,
+            ]
+        );
+        echo '</div>';
+    }
+
+    /**
+     * Render the participation section of the enigma.
+     *
+     * @param int    $enigme_id Enigma identifier.
+     * @param string $style     Display style.
+     * @param int    $user_id   Current user ID.
+     */
+    function render_enigme_participation(int $enigme_id, string $style, int $user_id): void
+    {
+        echo '<div class="enigme-section enigme-section-bloc-reponse">';
+        enigme_get_partial(
+            'bloc-reponse',
+            $style,
+            [
+                'post_id' => $enigme_id,
+                'user_id' => $user_id,
+            ]
+        );
+        echo '</div>';
+    }
+
+    /**
+     * Render the solution section of the enigma.
+     *
+     * @param int    $enigme_id Enigma identifier.
+     * @param string $style     Display style.
+     * @param int    $user_id   Current user ID.
+     */
+    function render_enigme_solution(int $enigme_id, string $style, int $user_id): void
+    {
+        echo '<div class="enigme-section enigme-section-solution">';
+        enigme_get_partial(
+            'solution',
+            $style,
+            [
+                'post_id' => $enigme_id,
+                'user_id' => $user_id,
+            ]
+        );
+        echo '</div>';
+    }
+
     /**     
      * Affiche l’énigme avec son style et son état selon le contexte utilisateur.
      *
@@ -73,51 +204,14 @@ defined('ABSPATH') || exit;
                 esc_html(get_the_title($post->ID))
             );
         }
-
         echo '<div class="container container--xl-full enigme-layout">';
-        echo '<aside class="enigme-sidebar">';
-
-        if ($edition_active) {
-            echo '<button id="toggle-mode-edition-enigme" type="button" ' .
-                'class="bouton-edition-toggle bouton-edition-toggle--clair" data-cpt="enigme" aria-label="' .
-                esc_attr__('Activer Orgy', 'chassesautresor') .
-                '"><i class="fa-solid fa-gear"></i></button>';
-        }
-
-        if ($chasse_id) {
-            $logo = get_the_post_thumbnail($chasse_id, 'thumbnail');
-            if ($logo) {
-                echo '<div class="enigme-chasse-logo">' . $logo . '</div>';
-            }
-            $titre_chasse = get_the_title($chasse_id);
-            echo '<div class="enigme-chasse-titre">' . esc_html($titre_chasse) . '</div>';
-        }
-
-        if (!empty($menu_items)) {
-            echo '<ul class="enigme-menu">' . implode('', $menu_items) . '</ul>';
-        }
-
-        if ($chasse_id) {
-            $url_retour = get_permalink($chasse_id);
-            echo '<a href="' . esc_url($url_retour) . '" class="bouton-retour bouton-retour-chasse">';
-            echo '<i class="fa-solid fa-arrow-left"></i>';
-            echo '<span class="screen-reader-text">' . esc_html__('Retour à la chasse', 'chassesautresor') . '</span>';
-            echo '</a>';
-        }
-
-        echo '</aside>';
+        render_enigme_sidebar($edition_active, $chasse_id, $menu_items);
         echo '<div class="enigme-main">';
         echo '<main class="enigme-content enigme-style-' . esc_attr($style) . '">';
-
-        foreach (['titre', 'images', 'texte', 'bloc-reponse'] as $slug) {
-            echo '<div class="enigme-section enigme-section-' . esc_attr($slug) . '">';
-            enigme_get_partial($slug, $style, [
-                'post_id' => $enigme_id,
-                'user_id' => $user_id,
-            ]);
-            echo '</div>';
-        }
-
+        render_enigme_hero($enigme_id, $style, $user_id);
+        render_enigme_content($enigme_id, $style, $user_id);
+        render_enigme_participation($enigme_id, $style, $user_id);
+        render_enigme_solution($enigme_id, $style, $user_id);
         echo '</main>';
         echo '</div>';
         echo '</div>';


### PR DESCRIPTION
## Résumé
- refactorise l'affichage des énigmes en fonctions dédiées pour chaque section
- simplifie l'appel des blocs dans `afficher_enigme_stylisee`

## Détails
- extraction de la sidebar, du hero, du contenu, de la participation et de la solution dans `render_enigme_*`
- `afficher_enigme_stylisee` appelle désormais ces fonctions, facilitant l'ajout de nouvelles étapes

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2a97aa2288332b4e58a9ce1b548e3