### PR TITLE
Ajout d’un cache pour les énigmes d’une chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -40,12 +40,20 @@ defined('ABSPATH') || exit;
             echo $statut_data['message_html'];
         }
 
-        $user_id       = get_current_user_id();
-        $style         = get_field('enigme_style_affichage', $enigme_id) ?? 'defaut';
-        $chasse_id     = recuperer_id_chasse_associee($enigme_id);
+        $user_id        = get_current_user_id();
+        $style          = get_field('enigme_style_affichage', $enigme_id) ?? 'defaut';
+        $chasse_id      = recuperer_id_chasse_associee($enigme_id);
         $edition_active = utilisateur_peut_modifier_post($enigme_id);
 
-        $liste      = $chasse_id ? recuperer_enigmes_pour_chasse($chasse_id) : [];
+        $liste = [];
+        if ($chasse_id) {
+            $cache_key = 'enigmes_chasse_' . $chasse_id;
+            $liste     = wp_cache_get($cache_key, 'chassesautresor');
+            if ($liste === false) {
+                $liste = recuperer_enigmes_pour_chasse($chasse_id);
+                wp_cache_set($cache_key, $liste, 'chassesautresor', HOUR_IN_SECONDS);
+            }
+        }
         $menu_items = [];
 
         foreach ($liste as $post) {

--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -495,6 +495,27 @@ function recuperer_ids_enigmes_pour_chasse(int $chasse_id): array
 }
 
 
+/**
+ * Clear the cached enigme list for a chasse when an enigme is saved.
+ *
+ * @param int $post_id Post ID of the enigme being saved.
+ */
+function clear_enigmes_chasse_cache(int $post_id): void
+{
+    if (get_post_type($post_id) !== 'enigme') {
+        return;
+    }
+
+    $chasse_id = (int) get_field('enigme_chasse_associee', $post_id);
+    if (!$chasse_id) {
+        return;
+    }
+
+    wp_cache_delete('enigmes_chasse_' . $chasse_id, 'chassesautresor');
+}
+add_action('save_post_enigme', 'clear_enigmes_chasse_cache', 20, 1);
+
+
 // ==================================================
 // 📦 ASSIGNATION AUTOMATIQUES
 // ==================================================


### PR DESCRIPTION
## Résumé
- mise en cache de la liste d’énigmes d’une chasse
- invalidation du cache lors de l’enregistrement d’une énigme

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2a9ad14748332940665e1a62f35f4