### PR TITLE
Localise les chaînes des partiels d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -14,10 +14,12 @@ $chasse_id = recuperer_id_chasse_associee($post_id);
 if (
   current_user_can('manage_options') ||
   utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
-) {
-  echo '<p class="message-organisateur">🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché.</p>';
-  return;
-}
+  ) {
+    echo '<p class="message-organisateur">'
+        . esc_html__('🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché.', 'chassesautresor-com')
+        . '</p>';
+    return;
+  }
 
 // Récupération du mode de validation
 $mode_validation = get_field('enigme_mode_validation', $post_id);
@@ -40,21 +42,23 @@ if ($mode_validation === 'manuelle') {
 }
 
 $statut_actuel = enigme_get_statut_utilisateur($post_id, $user_id);
-if ($statut_actuel === 'resolue') {
-  echo '<p class="message-joueur-statut">Vous avez déjà résolu cette énigme.</p>';
-  return;
-}
+  if ($statut_actuel === 'resolue') {
+    echo '<p class="message-joueur-statut">'
+        . esc_html__('Vous avez déjà résolu cette énigme.', 'chassesautresor-com')
+        . '</p>';
+    return;
+  }
 
 $tentatives_du_jour = compter_tentatives_du_jour($user_id, $post_id);
-$boutique_url = esc_url(home_url('/boutique/'));
-$disabled = '';
-$label_btn = 'Valider';
-$points_manquants = 0;
-$message_tentatives = '';
+  $boutique_url = esc_url(home_url('/boutique/'));
+  $disabled = '';
+  $label_btn = esc_html__('Valider', 'chassesautresor-com');
+  $points_manquants = 0;
+  $message_tentatives = '';
 
-if ($max && $tentatives_du_jour >= $max) {
-  $disabled = 'disabled';
-  $message_tentatives = 'tentatives quotidiennes épuisées';
+  if ($max && $tentatives_du_jour >= $max) {
+    $disabled = 'disabled';
+    $message_tentatives = __('tentatives quotidiennes épuisées', 'chassesautresor-com');
 
   $tz = new DateTimeZone('Europe/Paris');
   $now = new DateTime('now', $tz);
@@ -62,8 +66,12 @@ if ($max && $tentatives_du_jour >= $max) {
   $diff = $midnight->getTimestamp() - $now->getTimestamp();
   $hours = floor($diff / 3600);
   $minutes = floor(($diff % 3600) / 60);
-  $label_btn = sprintf('%dh et %dmn avant réactivation', $hours, $minutes);
-}
+    $label_btn = sprintf(
+        esc_html__('%dh et %dmn avant réactivation', 'chassesautresor-com'),
+        $hours,
+        $minutes
+    );
+  }
 
 if ($cout > get_user_points($user_id)) {
   $disabled = 'disabled';
@@ -74,13 +82,15 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
 ?>
 
 <form class="bloc-reponse formulaire-reponse-auto">
-  <label for="reponse_auto_<?= esc_attr($post_id); ?>">Votre réponse :</label>
+    <label for="reponse_auto_<?= esc_attr($post_id); ?>">
+      <?= esc_html__('Votre réponse :', 'chassesautresor-com'); ?>
+    </label>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
   <?php elseif ($points_manquants > 0) : ?>
     <p class="message-limite" data-points="manquants">
       <?= esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $points_manquants)); ?>
-      <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="Accéder à la boutique">
+        <a href="<?= esc_url($boutique_url); ?>" class="points-link points-boutique-icon" title="<?= esc_attr__('Accéder à la boutique', 'chassesautresor-com'); ?>">
         <span class="points-plus-circle">+</span>
       </a>
     </p>
@@ -90,16 +100,16 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
   <input type="hidden" name="enigme_id" value="<?= esc_attr($post_id); ?>">
   <input type="hidden" name="nonce" value="<?= esc_attr($nonce); ?>">
   <div class="reponse-cta-row">
-    <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
-    <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
-      <span class="badge-cout"><?= esc_html($cout); ?> pts</span>
-    <?php endif; ?>
+      <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
+      <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
+        <span class="badge-cout"><?= esc_html($cout); ?> <?= esc_html__('pts', 'chassesautresor-com'); ?></span>
+      <?php endif; ?>
   </div>
 </form>
 <div class="reponse-feedback" style="display:none"></div>
 <?php if ($max > 0) : ?>
   <div class="tentatives-counter compteur-tentatives txt-small" data-max="<?= esc_attr($max); ?>" style="margin-top:4px;">
-    <span class="etiquette">Tentatives quotidiennes</span>
+      <span class="etiquette"><?= esc_html__('Tentatives quotidiennes', 'chassesautresor-com'); ?></span>
     <span class="valeur"><?= esc_html($tentatives_du_jour); ?>/<?= esc_html($max); ?></span>
   </div>
 <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
@@ -26,8 +26,12 @@ if ($has_valid_images && function_exists('afficher_visuels_enigme')) {
 } else {
   error_log("[images] 🟡 Aucune image valide → fallback picture");
 ?>
-  <div class="image-principale">
-    <?php afficher_picture_vignette_enigme($post_id, 'Image par défaut de l’énigme', ['large']); ?>
-  </div>
+    <div class="image-principale">
+      <?php afficher_picture_vignette_enigme(
+          $post_id,
+          __('Image par défaut de l’énigme', 'chassesautresor-com'),
+          ['large']
+      ); ?>
+    </div>
 <?php
 }

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
@@ -34,18 +34,36 @@ if ($orderby === 'tentatives') {
 
 if (empty($participants)) :
     ?>
-<p>Aucun participant engagé.</p>
+<p><?= esc_html__('Aucun participant engagé.', 'chassesautresor-com'); ?></p>
 <?php else : ?>
 <table class="stats-table compact">
   <thead>
-    <tr>
-      <th scope="col">Nom</th>
-      <th scope="col"><button class="sort" data-orderby="date" aria-label="Trier par engagement">Engagement <i class="fa-solid <?= esc_attr($icon_date); ?>"></i></button></th>
-      <?php if ($mode_validation !== 'aucune') : ?>
-      <th scope="col" data-format="etiquette"><button class="sort" data-orderby="tentatives" aria-label="Trier par tentatives">Tentatives <i class="fa-solid <?= esc_attr($icon_tentatives); ?>"></i></button></th>
-      <?php endif; ?>
-      <th scope="col">Trouvé</th>
-    </tr>
+      <tr>
+        <th scope="col"><?= esc_html__('Nom', 'chassesautresor-com'); ?></th>
+        <th scope="col">
+          <button
+            class="sort"
+            data-orderby="date"
+            aria-label="<?= esc_attr__('Trier par engagement', 'chassesautresor-com'); ?>"
+          >
+            <?= esc_html__('Engagement', 'chassesautresor-com'); ?>
+            <i class="fa-solid <?= esc_attr($icon_date); ?>"></i>
+          </button>
+        </th>
+        <?php if ($mode_validation !== 'aucune') : ?>
+        <th scope="col" data-format="etiquette">
+          <button
+            class="sort"
+            data-orderby="tentatives"
+            aria-label="<?= esc_attr__('Trier par tentatives', 'chassesautresor-com'); ?>"
+          >
+            <?= esc_html__('Tentatives', 'chassesautresor-com'); ?>
+            <i class="fa-solid <?= esc_attr($icon_tentatives); ?>"></i>
+          </button>
+        </th>
+        <?php endif; ?>
+        <th scope="col"><?= esc_html__('Trouvé', 'chassesautresor-com'); ?></th>
+      </tr>
   </thead>
   <tbody>
     <?php foreach ($participants as $p) : ?>
@@ -61,14 +79,22 @@ if (empty($participants)) :
   </tbody>
 </table>
 <div class="pager">
-  <?php if ($page > 1) : ?>
-    <button class="pager-first" aria-label="Première page"><i class="fa-solid fa-angles-left"></i></button>
-    <button class="pager-prev" aria-label="Page précédente"><i class="fa-solid fa-angle-left"></i></button>
-  <?php endif; ?>
+    <?php if ($page > 1) : ?>
+      <button class="pager-first" aria-label="<?= esc_attr__('Première page', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angles-left"></i>
+      </button>
+      <button class="pager-prev" aria-label="<?= esc_attr__('Page précédente', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angle-left"></i>
+      </button>
+    <?php endif; ?>
   <span class="pager-info"><?= esc_html($page); ?> / <?= esc_html($pages); ?></span>
-  <?php if ($page < $pages) : ?>
-    <button class="pager-next" aria-label="Page suivante"><i class="fa-solid fa-angle-right"></i></button>
-    <button class="pager-last" aria-label="Dernière page"><i class="fa-solid fa-angles-right"></i></button>
-  <?php endif; ?>
+    <?php if ($page < $pages) : ?>
+      <button class="pager-next" aria-label="<?= esc_attr__('Page suivante', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angle-right"></i>
+      </button>
+      <button class="pager-last" aria-label="<?= esc_attr__('Dernière page', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angles-right"></i>
+      </button>
+    <?php endif; ?>
 </div>
 <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
@@ -22,16 +22,20 @@ if ($mode === 'pdf' && !$fichier_url) return;
 if ($mode === 'texte' && !$texte) return;
 
 echo '<div class="bloc-solution">';
-echo '<h2>🧠 Solution de l’énigme</h2>';
+echo '<h2>' . esc_html__('🧠 Solution de l’énigme', 'chassesautresor-com') . '</h2>';
 
 if ($mode === 'pdf' && $fichier_url) {
-  echo '<p><a href="' . esc_url($fichier_url) . '" target="_blank" class="lien-solution-pdf">📄 Télécharger la solution (PDF)</a></p>';
+    echo '<p><a href="' . esc_url($fichier_url) . '" target="_blank" class="lien-solution-pdf">'
+        . esc_html__('📄 Télécharger la solution (PDF)', 'chassesautresor-com')
+        . '</a></p>';
 } elseif ($mode === 'texte' && $texte) {
   echo '<div class="contenu-solution">';
   echo wp_kses_post($texte);
   echo '</div>';
 } else {
-  echo '<p class="placeholder-solution">❌ Aucune solution disponible pour cette énigme.</p>';
+    echo '<p class="placeholder-solution">'
+        . esc_html__('❌ Aucune solution disponible pour cette énigme.', 'chassesautresor-com')
+        . '</p>';
 }
 
 echo '</div>';

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
@@ -17,21 +17,21 @@ $total = $args['total'] ?? $total ?? 0;
 $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
 ?>
 <?php if (empty($tentatives)) : ?>
-<p>Aucune tentative de soumission.</p>
+<p><?= esc_html__('Aucune tentative de soumission.', 'chassesautresor-com'); ?></p>
 <?php else : ?>
 <table class="table-tentatives">
   <thead>
-    <tr>
-      <th>Date</th>
-      <th>Utilisateur</th>
-      <th>Réponse</th>
-      <th>Actions</th>
-    </tr>
+      <tr>
+        <th><?= esc_html__('Date', 'chassesautresor-com'); ?></th>
+        <th><?= esc_html__('Utilisateur', 'chassesautresor-com'); ?></th>
+        <th><?= esc_html__('Réponse', 'chassesautresor-com'); ?></th>
+        <th><?= esc_html__('Actions', 'chassesautresor-com'); ?></th>
+      </tr>
   </thead>
   <tbody>
   <?php foreach ($tentatives as $tent) :
     $user  = get_userdata($tent->user_id);
-    $login = ($user && isset($user->user_login)) ? $user->user_login : 'Inconnu';
+    $login = ($user && isset($user->user_login)) ? $user->user_login : esc_html__('Inconnu', 'chassesautresor-com');
     $date  = mysql2date('d/m/y H:i', $tent->date_tentative);
     $pending = ($tent->resultat === 'attente' && (int) $tent->traitee === 0) ? ' tentative-pending' : '';
   ?>
@@ -44,8 +44,12 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
           <form method="post" style="display:inline;">
             <?php wp_nonce_field('traiter_tentative_' . $tent->tentative_uid); ?>
             <input type="hidden" name="uid" value="<?= esc_attr($tent->tentative_uid); ?>">
-            <button type="submit" name="action_traitement" value="valider" class="bouton-cta">Valider</button>
-            <button type="submit" name="action_traitement" value="invalider" class="bouton-secondaire">Invalider</button>
+            <button type="submit" name="action_traitement" value="valider" class="bouton-cta">
+              <?= esc_html__('Valider', 'chassesautresor-com'); ?>
+            </button>
+            <button type="submit" name="action_traitement" value="invalider" class="bouton-secondaire">
+              <?= esc_html__('Invalider', 'chassesautresor-com'); ?>
+            </button>
           </form>
         <?php else: ?>
           <?= esc_html($tent->resultat); ?>
@@ -56,14 +60,22 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
   </tbody>
 </table>
 <div class="pager">
-  <?php if ($page > 1) : ?>
-    <button class="pager-first" aria-label="Première page"><i class="fa-solid fa-angles-left"></i></button>
-    <button class="pager-prev" aria-label="Page précédente"><i class="fa-solid fa-angle-left"></i></button>
-  <?php endif; ?>
+    <?php if ($page > 1) : ?>
+      <button class="pager-first" aria-label="<?= esc_attr__('Première page', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angles-left"></i>
+      </button>
+      <button class="pager-prev" aria-label="<?= esc_attr__('Page précédente', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angle-left"></i>
+      </button>
+    <?php endif; ?>
   <span class="pager-info"><?= esc_html($page); ?> / <?= esc_html($pages); ?></span>
-  <?php if ($page < $pages) : ?>
-    <button class="pager-next" aria-label="Page suivante"><i class="fa-solid fa-angle-right"></i></button>
-    <button class="pager-last" aria-label="Dernière page"><i class="fa-solid fa-angles-right"></i></button>
-  <?php endif; ?>
+    <?php if ($page < $pages) : ?>
+      <button class="pager-next" aria-label="<?= esc_attr__('Page suivante', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angle-right"></i>
+      </button>
+      <button class="pager-last" aria-label="<?= esc_attr__('Dernière page', 'chassesautresor-com'); ?>">
+        <i class="fa-solid fa-angles-right"></i>
+      </button>
+    <?php endif; ?>
 </div>
 <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-images.php
@@ -5,5 +5,7 @@ $post_id = $args['post_id'] ?? null;
 if (!$post_id) return;
 
 echo '<div class="style-pirate-test">';
-echo '<p>🏴‍☠️ Ceci est <strong>images.php</strong> depuis le thème <code>pirate</code>.</p>';
+echo '<p>'
+    . wp_kses_post(__('🏴‍☠️ Ceci est <strong>images.php</strong> depuis le thème <code>pirate</code>.', 'chassesautresor-com'))
+    . '</p>';
 echo '</div>';

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-retour-chasse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-retour-chasse.php
@@ -1,5 +1,7 @@
 <?php
 defined('ABSPATH') || exit;
 
-echo '<div class="test-partial">🏴‍☠️ Retour à la chasse (pirate)</div>';
+echo '<div class="test-partial">'
+    . esc_html__('🏴‍☠️ Retour à la chasse (pirate)', 'chassesautresor-com')
+    . '</div>';
 ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-solution.php
@@ -1,5 +1,7 @@
 <?php
 defined('ABSPATH') || exit;
 
-echo '<div class="test-partial">🏴‍☠️ Solution (pirate)</div>';
+echo '<div class="test-partial">'
+    . esc_html__('🏴‍☠️ Solution (pirate)', 'chassesautresor-com')
+    . '</div>';
 ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-texte.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-texte.php
@@ -1,5 +1,7 @@
 <?php
 defined('ABSPATH') || exit;
 
-echo '<div class="test-partial">🏴‍☠️ Texte (pirate)</div>';
+echo '<div class="test-partial">'
+    . esc_html__('🏴‍☠️ Texte (pirate)', 'chassesautresor-com')
+    . '</div>';
 ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-titre.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/pirate/enigme-partial-titre.php
@@ -1,5 +1,7 @@
 <?php
 defined('ABSPATH') || exit;
 
-echo '<div class="test-partial">🏴‍☠️ Titre (pirate)</div>';
+echo '<div class="test-partial">'
+    . esc_html__('🏴‍☠️ Titre (pirate)', 'chassesautresor-com')
+    . '</div>';
 ?>


### PR DESCRIPTION
## Résumé
- ajoute la localisation des chaînes de texte dans les partiels d’énigme
- corrige les labels et messages des formulaires et tableaux pour l’i18n

## Changements notables
- internationalisation du bloc solution et des messages d’erreur
- mise à jour des formulaires de réponse avec textes traduisibles
- localisation des entêtes et légendes des tableaux de participants et tentatives
- ajout des traductions pour les partiels du thème pirate

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2ab8de9748332b1d95497a025f746