### PR TITLE
Encapsule les logs de debug derriere WP_DEBUG

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -316,7 +316,7 @@ function utilisateur_peut_creer_post($post_type, $chasse_id = null)
 function utilisateur_peut_modifier_post($post_id)
 {
     if (!is_user_logged_in() || !$post_id) {
-        error_log('❌ utilisateur_peut_modifier_post: utilisateur non connecté ou post_id invalide');
+        cat_debug('❌ utilisateur_peut_modifier_post: utilisateur non connecté ou post_id invalide');
         return false;
     }
 
@@ -350,7 +350,7 @@ function utilisateur_peut_modifier_post($post_id)
             return $organisateur_id ? utilisateur_peut_modifier_post($organisateur_id) : false;
 
         default:
-            error_log("❌ utilisateur_peut_modifier_post: post_type inconnu ($post_type)");
+            cat_debug("❌ utilisateur_peut_modifier_post: post_type inconnu ($post_type)");
             return false;
     }
 }
@@ -365,7 +365,7 @@ function utilisateur_peut_modifier_post($post_id)
 function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): bool
 {
     if (get_post_type($enigme_id) !== 'enigme') {
-        error_log("❌ [voir énigme] post #$enigme_id n'est pas une énigme.");
+        cat_debug("❌ [voir énigme] post #$enigme_id n'est pas une énigme.");
         return false;
     }
 
@@ -374,53 +374,53 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
     $user_id      = $user_id ?? get_current_user_id();
     $chasse_id    = recuperer_id_chasse_associee($enigme_id);
 
-    error_log("🔎 [voir énigme] #$enigme_id | statut = $post_status | etat = $etat_systeme | user_id = $user_id");
+    cat_debug("🔎 [voir énigme] #$enigme_id | statut = $post_status | etat = $etat_systeme | user_id = $user_id");
 
     // 🔓 Administrateur → accès total
     if (current_user_can('administrator')) {
-        error_log("✅ [voir énigme] accès admin");
+        cat_debug("✅ [voir énigme] accès admin");
         return true;
     }
 
     // 🎯 Pas de chasse liée = refus
     if (!$chasse_id) {
-        error_log("❌ [voir énigme] pas de chasse associée");
+        cat_debug("❌ [voir énigme] pas de chasse associée");
         return false;
     }
 
     // ✅ Abonné engagé dans la chasse → peut voir l’image si énigme accessible
     if (utilisateur_est_engage_dans_chasse($user_id, $chasse_id)) {
         $autorise = ($post_status === 'publish') && ($etat_systeme === 'accessible');
-        error_log("✅ [voir énigme] joueur engagé dans chasse #$chasse_id → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
+        cat_debug("✅ [voir énigme] joueur engagé dans chasse #$chasse_id → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
         return $autorise;
     }
 
     // 👤 Visiteur/abonné non engagé → accès uniquement si énigme publique + accessible
     if (is_user_logged_in() && in_array('abonne', wp_get_current_user()->roles, true)) {
         $autorise = ($post_status === 'publish') && ($etat_systeme === 'accessible');
-        error_log("👤 [voir énigme] abonné non engagé → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
+        cat_debug("👤 [voir énigme] abonné non engagé → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
         return $autorise;
     }
 
     // ❌ Brouillon interdit
     if ($post_status === 'draft') {
-        error_log("❌ [voir énigme] brouillon interdit pour utilisateur #$user_id");
+        cat_debug("❌ [voir énigme] brouillon interdit pour utilisateur #$user_id");
         return false;
     }
 
     // 🔐 L’utilisateur doit être lié à l’organisateur de la chasse
     if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
-        error_log("❌ [voir énigme] user #$user_id n'est pas lié à la chasse #$chasse_id");
+        cat_debug("❌ [voir énigme] user #$user_id n'est pas lié à la chasse #$chasse_id");
         return false;
     }
 
     // ✅ Exception organisateur (chasse non publiée)
     $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
-    error_log("🧪 [voir énigme] chasse #$chasse_id → statut_validation = $statut_validation");
+    cat_debug("🧪 [voir énigme] chasse #$chasse_id → statut_validation = $statut_validation");
 
     if (in_array($statut_validation, ['creation', 'correction', 'en_attente'], true)) {
         $autorise = in_array($post_status, ['publish', 'pending'], true);
-        error_log("🟡 [voir énigme] organisateur → chasse = $statut_validation → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
+        cat_debug("🟡 [voir énigme] organisateur → chasse = $statut_validation → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
         return $autorise;
     }
 
@@ -430,13 +430,13 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
         $post_status === 'publish' &&
         $etat_systeme === 'bloquee_chasse'
     ) {
-        error_log("🟢 [voir énigme] organisateur associé à une chasse publiée mais à venir → accès OK");
+        cat_debug("🟢 [voir énigme] organisateur associé à une chasse publiée mais à venir → accès OK");
         return true;
     }
 
     // ✅ Cas standard : publish + accessible
     $autorise = ($post_status === 'publish') && ($etat_systeme === 'accessible');
-    error_log("🟠 [voir énigme] cas standard → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
+    cat_debug("🟠 [voir énigme] cas standard → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
     return $autorise;
 }
 
@@ -458,18 +458,18 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
 function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): bool
 {
     if (get_post_type($chasse_id) !== 'chasse') {
-        error_log("❌ [ajout énigme] ID $chasse_id n'est pas une chasse.");
+        cat_debug("❌ [ajout énigme] ID $chasse_id n'est pas une chasse.");
         return false;
     }
 
     $user_id = $user_id ?? get_current_user_id();
     if (!$user_id || !is_user_logged_in()) {
-        error_log("❌ [ajout énigme] utilisateur non connecté.");
+        cat_debug("❌ [ajout énigme] utilisateur non connecté.");
         return false;
     }
 
     if (!est_organisateur($user_id)) {
-        error_log("❌ [ajout énigme] rôle utilisateur #$user_id invalide");
+        cat_debug("❌ [ajout énigme] rôle utilisateur #$user_id invalide");
         return false;
     }
 
@@ -477,18 +477,18 @@ function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): 
     $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
 
     if ($statut_metier !== 'revision') {
-        error_log("❌ [ajout énigme] chasse #$chasse_id statut metier : $statut_metier");
+        cat_debug("❌ [ajout énigme] chasse #$chasse_id statut metier : $statut_metier");
         return false;
     }
 
     if (!in_array($statut_validation, ['creation', 'correction'], true)) {
-        error_log("❌ [ajout énigme] chasse #$chasse_id statut validation : $statut_validation");
+        cat_debug("❌ [ajout énigme] chasse #$chasse_id statut validation : $statut_validation");
         return false;
     }
 
     $est_associe = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
     if (!$est_associe) {
-        error_log("❌ [ajout énigme] utilisateur #$user_id non associé à la chasse #$chasse_id");
+        cat_debug("❌ [ajout énigme] utilisateur #$user_id non associé à la chasse #$chasse_id");
         return false;
     }
 
@@ -496,11 +496,11 @@ function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): 
     $nb = count($ids);
 
     if ($nb >= 40) {
-        error_log("❌ [ajout énigme] chasse #$chasse_id a déjà $nb énigmes (limite 40)");
+        cat_debug("❌ [ajout énigme] chasse #$chasse_id a déjà $nb énigmes (limite 40)");
         return false;
     }
 
-    error_log("✅ [ajout énigme] autorisé pour user #$user_id sur chasse #$chasse_id ($nb / 40)");
+    cat_debug("✅ [ajout énigme] autorisé pour user #$user_id sur chasse #$chasse_id ($nb / 40)");
     return true;
 }
 
@@ -979,7 +979,7 @@ add_action('template_redirect', function () {
 
 add_action('init', function () {
     if (isset($_GET['voir_fichier'])) {
-        error_log('[🔍 DEBUG] $_GET[voir_fichier] = ' . $_GET['voir_fichier']);
+        cat_debug('[🔍 DEBUG] $_GET[voir_fichier] = ' . $_GET['voir_fichier']);
     }
 });
 

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -124,7 +124,7 @@ function traiter_gestion_points() {
     // Mettre à jour les points de l'utilisateur
     update_user_points($user_id, $delta, $reason, 'admin');
 
-    error_log("✅ Points modifiés : $nombre_points $type_modification pour l'utilisateur $utilisateur");
+    cat_debug("✅ Points modifiés : $nombre_points $type_modification pour l'utilisateur $utilisateur");
 
     // ✅ Redirection après soumission
     $redirect_url = add_query_arg(
@@ -610,7 +610,7 @@ function traiter_demande_paiement() {
     global $wpdb;
     $repo   = new PointsRepository($wpdb);
     $log_id = $repo->logConversionRequest($user_id, -$points_a_convertir, $montant_euros);
-    error_log("✅ Demande enregistrée : log_id {$log_id}");
+    cat_debug("✅ Demande enregistrée : log_id {$log_id}");
 
     // 📧 Notification admin
     $admin_email = get_option('admin_email');
@@ -623,7 +623,7 @@ function traiter_demande_paiement() {
     $message .= "Statut : En attente";
 
     wp_mail($admin_email, $subject, $message);
-    error_log("📧 Notification envoyée à l'administrateur.");
+    cat_debug("📧 Notification envoyée à l'administrateur.");
 
     // ✅ Redirection après soumission
     wp_safe_redirect(home_url('/mon-compte/?section=points'));
@@ -681,7 +681,7 @@ function ajax_update_request_status(): void
     }
 
     $repo->updateRequestStatus($paiement_id, $repoStatus, $dates);
-    error_log("✅ Statut mis à jour pour l'entrée {$paiement_id} : {$repoStatus}");
+    cat_debug("✅ Statut mis à jour pour l'entrée {$paiement_id} : {$repoStatus}");
 
     if (in_array($repoStatus, ['cancelled', 'refused'], true)) {
         $request = $repo->getRequestById($paiement_id);
@@ -766,7 +766,7 @@ function traiter_reinitialisation_stats() {
     if (!isset($_POST['reset_stats']) || !check_admin_referer('reset_stats_action', 'reset_stats_nonce')) return;
     if (!get_option('activer_reinitialisation_stats', false)) return; // Vérification activée
 
-    error_log("🛠 Début de la suppression des statistiques...");
+    cat_debug("🛠 Début de la suppression des statistiques...");
 
     supprimer_metas_utilisateur([
         'total_enigmes_jouees', 'total_chasses_terminees', 'total_indices_debloques',
@@ -797,9 +797,9 @@ function traiter_reinitialisation_stats() {
     if (!empty($paiements_post)) {
         $post_id = $paiements_post[0]->ID;
         delete_field('taux_conversion', $post_id);
-        error_log("✅ Taux de conversion réinitialisé pour le post ID : {$post_id}");
+        cat_debug("✅ Taux de conversion réinitialisé pour le post ID : {$post_id}");
     } else {
-        error_log("⚠️ Aucun post 'Paiements' trouvé, impossible de réinitialiser les taux.");
+        cat_debug("⚠️ Aucun post 'Paiements' trouvé, impossible de réinitialiser les taux.");
     }
     supprimer_metas_globales();
     supprimer_metas_organisateur();
@@ -808,17 +808,17 @@ function traiter_reinitialisation_stats() {
     // 🔄 Désactiver l'option après suppression
     delete_option('activer_reinitialisation_stats');
 
-    error_log("✅ Statistiques réinitialisées avec succès.");
+    cat_debug("✅ Statistiques réinitialisées avec succès.");
 
     // ✅ Vérification du problème d'écran blanc
-    error_log("✅ Fin du script, lancement de la redirection...");
+    cat_debug("✅ Fin du script, lancement de la redirection...");
     
     // Vérifier si les headers sont déjà envoyés
     if (!headers_sent()) {
         wp_redirect(home_url('/administration/outils/?updated=true'));
         exit;
     } else {
-        error_log("⛔ Problème de redirection : headers déjà envoyés.");
+        cat_debug("⛔ Problème de redirection : headers déjà envoyés.");
         die("⛔ Problème de redirection. Recharge manuelle nécessaire.");
     }
 }
@@ -886,26 +886,26 @@ function ajouter_bouton_reinitialisation_stats() {
  * 📌 Gestion de l'activation/désactivation de la réinitialisation des stats
  */
 function gerer_activation_reinitialisation_stats() {
-    error_log("🛠 Début du traitement de l'activation/désactivation");
+    cat_debug("🛠 Début du traitement de l'activation/désactivation");
 
     // ✅ Vérification des permissions administrateur
     if (!current_user_can('manage_options')) {
-        error_log("⛔ Problème de permission : utilisateur non autorisé.");
+        cat_debug("⛔ Problème de permission : utilisateur non autorisé.");
         wp_die( __( '⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action.', 'chassesautresor-com' ) );
     }
-    error_log("🔎 Permission OK");
+    cat_debug("🔎 Permission OK");
 
     // ✅ Vérification de la requête POST et de la sécurité
     if (!isset($_POST['enregistrer_reinit']) || !check_admin_referer('toggle_reinit_stats_action', 'toggle_reinit_stats_nonce')) {
-        error_log("⛔ Problème de nonce ou bouton non soumis.");
+        cat_debug("⛔ Problème de nonce ou bouton non soumis.");
         wp_die( __( '⛔ Erreur de sécurité. Veuillez réessayer.', 'chassesautresor-com' ) );
     }
-    error_log("🔎 Nonce OK");
+    cat_debug("🔎 Nonce OK");
 
     // ✅ Mise à jour de l'option d'activation
     $activer = isset($_POST['activer_reinit']) ? 1 : 0;
     update_option('activer_reinitialisation_stats', $activer);
-    error_log("✅ Option mise à jour : " . ($activer ? 'Activée' : 'Désactivée'));
+    cat_debug("✅ Option mise à jour : " . ($activer ? 'Activée' : 'Désactivée'));
 
     // ✅ Ajout d’un message d’alerte WordPress
     add_action('admin_notices', function() use ($activer) {
@@ -920,12 +920,12 @@ function gerer_activation_reinitialisation_stats() {
         $redirect_url = home_url('/administration/outils/?updated=true');
     }
 
-    error_log("🔄 Redirection vers : " . $redirect_url);
+    cat_debug("🔄 Redirection vers : " . $redirect_url);
     if (!headers_sent()) {
         wp_redirect($redirect_url);
         exit;
     } else {
-        error_log("⛔ Problème de redirection : headers déjà envoyés.");
+        cat_debug("⛔ Problème de redirection : headers déjà envoyés.");
     }
 
     exit;
@@ -952,7 +952,7 @@ function supprimer_metas_organisateur() {
     ]);
 
     if (empty($organisateurs)) {
-        error_log("ℹ️ Aucun organisateur trouvé. Rien à supprimer.");
+        cat_debug("ℹ️ Aucun organisateur trouvé. Rien à supprimer.");
         return;
     }
 
@@ -964,22 +964,22 @@ function supprimer_metas_organisateur() {
                 if ($meta_key === 'demande_paiement') {
                     // Suppression forcée via SQL pour l'historique des paiements
                     $wpdb->delete($wpdb->usermeta, ['user_id' => $user_id, 'meta_key' => $meta_key]);
-                    error_log("✅ Suppression forcée via SQL pour : {$meta_key} (user_id {$user_id})");
+                    cat_debug("✅ Suppression forcée via SQL pour : {$meta_key} (user_id {$user_id})");
                 } else {
                     // Suppression normale pour les autres méta
                     delete_user_meta($user_id, $meta_key);
-                    error_log("✅ Suppression réussie de : {$meta_key} pour user_id {$user_id}");
+                    cat_debug("✅ Suppression réussie de : {$meta_key} pour user_id {$user_id}");
                 }
 
                 // Vérification post-suppression
                 $meta_post_suppression = get_user_meta($user_id, $meta_key, true);
                 if (!empty($meta_post_suppression)) {
-                    error_log("⚠️ Problème : {$meta_key} n'a pas été supprimé pour user_id {$user_id}.");
+                    cat_debug("⚠️ Problème : {$meta_key} n'a pas été supprimé pour user_id {$user_id}.");
                 } else {
-                    error_log("✅ Vérification OK : {$meta_key} a bien été supprimé pour user_id {$user_id}.");
+                    cat_debug("✅ Vérification OK : {$meta_key} a bien été supprimé pour user_id {$user_id}.");
                 }
             } else {
-                error_log("ℹ️ Aucune méta trouvée pour : {$meta_key} de user_id {$user_id}.");
+                cat_debug("ℹ️ Aucune méta trouvée pour : {$meta_key} de user_id {$user_id}.");
             }
         }
     }
@@ -1000,7 +1000,7 @@ function supprimer_metas_utilisateur($meta_keys) {
 
     // Vérification d'erreur SQL
     if (!empty($wpdb->last_error)) {
-        error_log("⚠️ Erreur SQL lors de la suppression des metas utilisateur : " . $wpdb->last_error);
+        cat_debug("⚠️ Erreur SQL lors de la suppression des metas utilisateur : " . $wpdb->last_error);
     }
     $wpdb->query("DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE 'enigme_%_resolue'");
 
@@ -1021,7 +1021,7 @@ function supprimer_metas_globales() {
 
     foreach ($metas_globales as $meta) {
         delete_option($meta);
-        error_log("✅ Suppression réussie de l'option : $meta");
+        cat_debug("✅ Suppression réussie de l'option : $meta");
     }
 }
 
@@ -1038,7 +1038,7 @@ function supprimer_metas_post($post_type, $meta_keys) {
     ]);
 
     if (empty($post_ids)) {
-        error_log("ℹ️ Aucun post trouvé pour le type : {$post_type}. Rien à supprimer.");
+        cat_debug("ℹ️ Aucun post trouvé pour le type : {$post_type}. Rien à supprimer.");
         return;
     }
 
@@ -1055,9 +1055,9 @@ function supprimer_metas_post($post_type, $meta_keys) {
                 "DELETE FROM {$wpdb->postmeta} WHERE meta_key LIKE %s",
                 $meta_key . '%'
             ));
-            error_log("✅ Suppression réussie pour : {$meta_key}%");
+            cat_debug("✅ Suppression réussie pour : {$meta_key}%");
         } else {
-            error_log("ℹ️ Aucune méta trouvée pour : {$meta_key}%");
+            cat_debug("ℹ️ Aucune méta trouvée pour : {$meta_key}%");
         }
     }
 }
@@ -1072,9 +1072,9 @@ function supprimer_souscriptions_utilisateur() {
     $wpdb->query("DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE 'enigme_%_souscrit'");
 
     if (!empty($wpdb->last_error)) {
-        error_log("⚠️ Erreur SQL lors de la suppression des souscriptions utilisateur : " . $wpdb->last_error);
+        cat_debug("⚠️ Erreur SQL lors de la suppression des souscriptions utilisateur : " . $wpdb->last_error);
     } else {
-        error_log("✅ Suppression réussie des souscriptions aux énigmes.");
+        cat_debug("✅ Suppression réussie des souscriptions aux énigmes.");
     }
 }
 
@@ -1090,16 +1090,16 @@ function supprimer_souscriptions_utilisateur() {
  */
 function reinitialiser_enigme($user_id, $enigme_id) {
     if (!is_numeric($user_id) || !is_numeric($enigme_id)) {
-        error_log("⚠️ Paramètres invalides : user_id={$user_id}, enigme_id={$enigme_id}");
+        cat_debug("⚠️ Paramètres invalides : user_id={$user_id}, enigme_id={$enigme_id}");
         return;
     }
 
-    error_log("🔄 DÉBUT de la réinitialisation pour l'utilisateur (ID: {$user_id}) sur l'énigme (ID: {$enigme_id})");
+    cat_debug("🔄 DÉBUT de la réinitialisation pour l'utilisateur (ID: {$user_id}) sur l'énigme (ID: {$enigme_id})");
 
     // 🧹 1. Suppression du statut et de la date de résolution
     delete_user_meta($user_id, "statut_enigme_{$enigme_id}");
     delete_user_meta($user_id, "enigme_{$enigme_id}_resolution_date");
-    error_log("🧹 Statut et date de résolution supprimés pour l'énigme (ID: {$enigme_id})");
+    cat_debug("🧹 Statut et date de résolution supprimés pour l'énigme (ID: {$enigme_id})");
 
     // 🗑️ 2. Réinitialisation des indices débloqués
     $indices = get_field('indices', $enigme_id); 
@@ -1107,7 +1107,7 @@ function reinitialiser_enigme($user_id, $enigme_id) {
         foreach ($indices as $index => $indice) {
             delete_user_meta($user_id, "indice_debloque_{$enigme_id}_{$index}");
         }
-        error_log("🧹 Indices débloqués réinitialisés pour l'énigme (ID: {$enigme_id})");
+        cat_debug("🧹 Indices débloqués réinitialisés pour l'énigme (ID: {$enigme_id})");
     }
 
     // 🏴‍☠️ 3. Gestion de la chasse associée
@@ -1132,14 +1132,14 @@ function reinitialiser_enigme($user_id, $enigme_id) {
             wp_cache_delete($chasse_id, 'post_meta');
             clean_post_cache($chasse_id);
         
-            error_log("🔄 Chasse (ID: {$chasse_id}) réinitialisée : statut 'en cours', gagnant et date supprimés.");
+            cat_debug("🔄 Chasse (ID: {$chasse_id}) réinitialisée : statut 'en cours', gagnant et date supprimés.");
         }
     }
 
     // 🚀 5. (Optionnel) Réinitialisation de la souscription pour permettre de rejouer immédiatement
     // Décommentez la ligne suivante si vous souhaitez que le bouton "JOUER" apparaisse directement après réinitialisation :
     // update_user_meta($user_id, "statut_enigme_{$enigme_id}", 'souscrit');
-    // error_log("🔄 Souscription réinitialisée pour l'énigme (ID: {$enigme_id}) → bouton 'JOUER' réactivé.");
+    // cat_debug("🔄 Souscription réinitialisée pour l'énigme (ID: {$enigme_id}) → bouton 'JOUER' réactivé.");
 
     // 🧹 6. Nettoyage des caches
     // 🚀 5. Rafraîchissement des caches WordPress pour garantir l'affichage correct
@@ -1150,8 +1150,8 @@ wp_cache_delete($enigme_id, 'post_meta'); // Supprime le cache des métas du pos
 clean_user_cache($user_id); // Nettoie le cache complet de l'utilisateur
 clean_post_cache($enigme_id); // Nettoie le cache du post énigme
 
-error_log("🔄 Caches utilisateur et post nettoyés après réinitialisation.");
-error_log("✅ Réinitialisation complète terminée pour l'utilisateur (ID: {$user_id}) sur l'énigme (ID: {$enigme_id})");
+cat_debug("🔄 Caches utilisateur et post nettoyés après réinitialisation.");
+cat_debug("✅ Réinitialisation complète terminée pour l'utilisateur (ID: {$user_id}) sur l'énigme (ID: {$enigme_id})");
 
 }
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -156,21 +156,21 @@ function verifier_souscription_chasse($user_id, $enigme_id)
 {
 
     if (!$user_id || !$enigme_id) {
-        error_log("🚨 ERREUR : ID utilisateur ou énigme manquant.");
+        cat_debug("🚨 ERREUR : ID utilisateur ou énigme manquant.");
         return;
     }
 
     // 🏴‍☠️ Récupération de la chasse associée à l’énigme
     $chasse_id = get_field('chasse_associee', $enigme_id);
     if (!$chasse_id) {
-        error_log("⚠️ Aucune chasse associée à l'énigme ID {$enigme_id}");
+        cat_debug("⚠️ Aucune chasse associée à l'énigme ID {$enigme_id}");
         return;
     }
 
     // 🔍 Vérification si l'utilisateur a déjà joué une énigme de cette chasse
     $enigmes_associees = get_field('enigmes_associees', $chasse_id);
     if (!$enigmes_associees || !is_array($enigmes_associees)) {
-        error_log("⚠️ Pas d'énigmes associées à la chasse ID {$chasse_id}");
+        cat_debug("⚠️ Pas d'énigmes associées à la chasse ID {$chasse_id}");
         return;
     }
 
@@ -179,12 +179,12 @@ function verifier_souscription_chasse($user_id, $enigme_id)
 
         // 🚫 Si une énigme a déjà été souscrite, tentée ou trouvée, la chasse est déjà souscrite
         if ($statut && $statut !== 'non_souscrit') {
-            error_log("🔄 L'utilisateur ID {$user_id} a déjà interagi avec l'énigme ID {$eid}. Chasse ID {$chasse_id} déjà souscrite.");
+            cat_debug("🔄 L'utilisateur ID {$user_id} a déjà interagi avec l'énigme ID {$eid}. Chasse ID {$chasse_id} déjà souscrite.");
             return;
         }
     }
 
-    error_log("🔍 Vérification avant mise à jour souscription chasse ID {$chasse_id} : Utilisateur ID {$user_id}");
+    cat_debug("🔍 Vérification avant mise à jour souscription chasse ID {$chasse_id} : Utilisateur ID {$user_id}");
 
     // ✅ Première souscription à une énigme de cette chasse => Marquer la chasse comme souscrite
     update_user_meta($user_id, "souscription_chasse_{$chasse_id}", true);
@@ -346,7 +346,7 @@ function gerer_chasse_terminee($chasse_id)
     $max_winners = (int) get_field('chasse_infos_nb_max_gagants', $chasse_id);
     if ($max_winners > 0 && count($results) > $max_winners) {
         $total_found = count($results);
-        error_log("⚠️ Plus de gagnants ({$total_found}) que la limite ({$max_winners}) pour la chasse {$chasse_id}. Seuls les premiers arrivés seront retenus.");
+        cat_debug("⚠️ Plus de gagnants ({$total_found}) que la limite ({$max_winners}) pour la chasse {$chasse_id}. Seuls les premiers arrivés seront retenus.");
         $results = array_slice($results, 0, $max_winners);
     }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -191,13 +191,13 @@ function modifier_dates_chasse()
   $date_fin    = sanitize_text_field($_POST['date_fin'] ?? '');
   $illimitee   = isset($_POST['illimitee']) ? (int) $_POST['illimitee'] : 0;
 
-  error_log("[modifier_dates_chasse] post_id={$post_id} date_debut={$date_debut} date_fin={$date_fin} illimitee={$illimitee}");
+  cat_debug("[modifier_dates_chasse] post_id={$post_id} date_debut={$date_debut} date_fin={$date_fin} illimitee={$illimitee}");
 
   // 📦 Valeurs existantes avant mise à jour (pour debug)
   $old_debut = get_post_meta($post_id, 'chasse_infos_date_debut', true);
   $old_fin   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
   $old_illim = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
-  error_log("[modifier_dates_chasse] metas_avant: debut={$old_debut} fin={$old_fin} illim={$old_illim}");
+  cat_debug("[modifier_dates_chasse] metas_avant: debut={$old_debut} fin={$old_fin} illim={$old_illim}");
 
   if (!$post_id || get_post_type($post_id) !== 'chasse') {
     wp_send_json_error('post_invalide');
@@ -220,7 +220,7 @@ function modifier_dates_chasse()
   if (!$dt_debut) {
     wp_send_json_error('format_debut_invalide');
   }
-  error_log('[modifier_dates_chasse] dt_debut=' . $dt_debut->format('c'));
+  cat_debug('[modifier_dates_chasse] dt_debut=' . $dt_debut->format('c'));
 
   $dt_fin = null;
   if (!$illimitee) {
@@ -237,14 +237,14 @@ function modifier_dates_chasse()
     if ($dt_fin->getTimestamp() <= $dt_debut->getTimestamp()) {
       wp_send_json_error('date_fin_avant_debut');
     }
-    error_log('[modifier_dates_chasse] dt_fin=' . $dt_fin->format('c'));
+    cat_debug('[modifier_dates_chasse] dt_fin=' . $dt_fin->format('c'));
   }
 
   $ok1 = update_field('chasse_infos_date_debut', $dt_debut->format('Y-m-d H:i:s'), $post_id);
-  error_log('[modifier_dates_chasse] update chasse_infos_date_debut=' . var_export($ok1, true));
+  cat_debug('[modifier_dates_chasse] update chasse_infos_date_debut=' . var_export($ok1, true));
 
   $ok2 = update_field('chasse_infos_duree_illimitee', $illimitee ? 1 : 0, $post_id);
-  error_log('[modifier_dates_chasse] update chasse_infos_duree_illimitee=' . var_export($ok2, true));
+  cat_debug('[modifier_dates_chasse] update chasse_infos_duree_illimitee=' . var_export($ok2, true));
 
   if ($illimitee) {
     // Ne pas modifier la date de fin en base
@@ -252,13 +252,13 @@ function modifier_dates_chasse()
   } else {
     $ok3 = update_field('chasse_infos_date_fin', $dt_fin->format('Y-m-d'), $post_id);
   }
-  error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
+  cat_debug('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
   // 🔎 Métas après mise à jour
   $new_debut = get_post_meta($post_id, 'chasse_infos_date_debut', true);
   $new_fin   = get_post_meta($post_id, 'chasse_infos_date_fin', true);
   $new_illim = get_post_meta($post_id, 'chasse_infos_duree_illimitee', true);
-  error_log("[modifier_dates_chasse] metas_apres: debut={$new_debut} fin={$new_fin} illim={$new_illim}");
+  cat_debug("[modifier_dates_chasse] metas_apres: debut={$new_debut} fin={$new_fin} illim={$new_illim}");
 
   // Lecture directe pour éviter un cache ACF éventuel
   $saved_debut_raw = get_post_meta($post_id, 'chasse_infos_date_debut', true);
@@ -275,11 +275,11 @@ function modifier_dates_chasse()
   $fin_ok   = $illimitee ? true : ($saved_fin_dt && $saved_fin_dt->format('Y-m-d H:i:s') === $dt_fin->format('Y-m-d H:i:s'));
   $illim_ok = (int) $saved_illim === ($illimitee ? 1 : 0);
 
-  error_log("[modifier_dates_chasse] verifs: debut_ok=" . var_export($debut_ok, true) . ' fin_ok=' . var_export($fin_ok, true) . ' illim_ok=' . var_export($illim_ok, true));
+  cat_debug("[modifier_dates_chasse] verifs: debut_ok=" . var_export($debut_ok, true) . ' fin_ok=' . var_export($fin_ok, true) . ' illim_ok=' . var_export($illim_ok, true));
 
   if (($ok1 || $debut_ok) && ($ok2 || $illim_ok) && ($ok3 || $fin_ok)) {
     mettre_a_jour_statuts_chasse($post_id);
-    error_log('[modifier_dates_chasse] mise a jour reussie');
+    cat_debug('[modifier_dates_chasse] mise a jour reussie');
     wp_send_json_success([
       'date_debut' => $dt_debut->format('Y-m-d H:i:s'),
       'date_fin'   => $illimitee ? '' : $dt_fin->format('Y-m-d'),
@@ -287,8 +287,8 @@ function modifier_dates_chasse()
     ]);
   }
 
-  error_log('[modifier_dates_chasse] conditions: ok1=' . var_export($ok1, true) . ' ok2=' . var_export($ok2, true) . ' ok3=' . var_export($ok3, true));
-  error_log('[modifier_dates_chasse] echec mise a jour');
+  cat_debug('[modifier_dates_chasse] conditions: ok1=' . var_export($ok1, true) . ' ok2=' . var_export($ok2, true) . ' ok3=' . var_export($ok3, true));
+  cat_debug('[modifier_dates_chasse] echec mise a jour');
   wp_send_json_error('echec_mise_a_jour');
 }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -777,9 +777,9 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
     return false;
   }
 
-  error_log("[mettre_a_jour_sous_champ_group] post_id={$post_id} group={$group_key_or_name} subfield={$subfield_name} valeur=" . (is_array($new_value) ? json_encode($new_value) : $new_value));
+  cat_debug("[mettre_a_jour_sous_champ_group] post_id={$post_id} group={$group_key_or_name} subfield={$subfield_name} valeur=" . (is_array($new_value) ? json_encode($new_value) : $new_value));
 
-  error_log("[mettre_a_jour_sous_champ_group] post_id={$post_id} group={$group_key_or_name} subfield={$subfield_name} valeur=" . (is_array($new_value) ? json_encode($new_value) : $new_value));
+  cat_debug("[mettre_a_jour_sous_champ_group] post_id={$post_id} group={$group_key_or_name} subfield={$subfield_name} valeur=" . (is_array($new_value) ? json_encode($new_value) : $new_value));
 
 
 
@@ -821,7 +821,7 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
     $type = $sub_field['type'];
     if ($name === $subfield_name) {
       $sub_field_type = $type;
-      error_log("[mettre_a_jour_sous_champ_group] mapping {$subfield_name} -> {$key}");
+      cat_debug("[mettre_a_jour_sous_champ_group] mapping {$subfield_name} -> {$key}");
     }
 
     $valeur = $groupe[$name] ?? '';
@@ -858,7 +858,7 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
 
   $ok = update_field($group_object['name'], $champ_a_enregistrer, $post_id);
   cat_debug('[DEBUG] update_field() retourne : ' . var_export($ok, true));
-  error_log('[mettre_a_jour_sous_champ_group] update_field ok=' . var_export($ok, true));
+  cat_debug('[mettre_a_jour_sous_champ_group] update_field ok=' . var_export($ok, true));
 
 
   // L'écriture ACF pouvant être asynchrone, on laisse une
@@ -905,7 +905,7 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
         $dt_read->setTimezone($tz);
 
         $result = $dt_new->format('Y-m-d H:i:s') === $dt_read->format('Y-m-d H:i:s');
-        error_log('[mettre_a_jour_sous_champ_group] compare datetime result=' . var_export($result, true));
+        cat_debug('[mettre_a_jour_sous_champ_group] compare datetime result=' . var_export($result, true));
         return $result;
       }
       cat_debug('[DEBUG] Impossible de convertir les dates pour comparaison');
@@ -916,11 +916,11 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
     cat_debug('[DEBUG] str_new=' . $str_new . ' str_relue=' . $str_relue);
 
     $result = wp_strip_all_tags($str_new) === wp_strip_all_tags($str_relue);
-    error_log('[mettre_a_jour_sous_champ_group] compare generic result=' . var_export($result, true));
+    cat_debug('[mettre_a_jour_sous_champ_group] compare generic result=' . var_export($result, true));
     return $result;
   }
 
   cat_debug("❌ Échec de vérification pour $subfield_name dans {$group_object['name']}");
-  error_log('[mettre_a_jour_sous_champ_group] verification failed for ' . $subfield_name);
+  cat_debug('[mettre_a_jour_sous_champ_group] verification failed for ' . $subfield_name);
   return false;
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -248,7 +248,7 @@ defined('ABSPATH') || exit;
         } elseif (locate_template($fallback)) {
             get_template_part("{$base_path}/{$slug_final}", null, $args);
         } else {
-            error_log("❌ Aucun partial trouvé pour $slug (style: $style)");
+            cat_debug("❌ Aucun partial trouvé pour $slug (style: $style)");
         }
     }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -31,16 +31,16 @@ function enigme_get_liste_prerequis_possibles(int $enigme_id): array
 {
     $chasse = get_field('enigme_chasse_associee', $enigme_id, false);
     $chasse_id = is_object($chasse) ? $chasse->ID : (int)$chasse;
-    error_log("[DEBUG] Récupération des prérequis possibles pour énigme #$enigme_id (chasse #$chasse_id)");
+    cat_debug("[DEBUG] Récupération des prérequis possibles pour énigme #$enigme_id (chasse #$chasse_id)");
 
     if (!$chasse_id) {
-        error_log("[DEBUG] Aucun chasse associée trouvée pour énigme #$enigme_id");
+        cat_debug("[DEBUG] Aucun chasse associée trouvée pour énigme #$enigme_id");
         return [];
     }
 
     $ids = recuperer_enigmes_associees($chasse_id);
     if (empty($ids)) {
-        error_log("[DEBUG] Aucune énigme associée à la chasse #$chasse_id");
+        cat_debug("[DEBUG] Aucune énigme associée à la chasse #$chasse_id");
         return [];
     }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -252,7 +252,7 @@ function soumettre_reponse_automatique()
         $uid = traiter_tentative($user_id, $enigme_id, $reponse, $resultat, true, false, false);
     } catch (Throwable $e) {
         wp_cache_delete($lock_key, 'enigme');
-        error_log('Erreur tentative : ' . $e->getMessage());
+        cat_debug('Erreur tentative : ' . $e->getMessage());
         wp_send_json_error('erreur_interne');
     }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -69,16 +69,16 @@ defined('ABSPATH') || exit;
         $table = $wpdb->prefix . 'enigme_tentatives';
 
 
-        error_log("👣 Tentative traitement UID=$uid par IP=" . ($_SERVER['REMOTE_ADDR'] ?? 'inconnue'));
+        cat_debug("👣 Tentative traitement UID=$uid par IP=" . ($_SERVER['REMOTE_ADDR'] ?? 'inconnue'));
 
         $tentative = get_tentative_by_uid($uid);
         if (!$tentative) {
-            error_log("❌ Tentative introuvable");
+            cat_debug("❌ Tentative introuvable");
             return false;
         }
 
         if ($tentative->resultat !== 'attente') {
-            error_log("⛔ Tentative déjà traitée → statut actuel = " . $tentative->resultat);
+            cat_debug("⛔ Tentative déjà traitée → statut actuel = " . $tentative->resultat);
             return false;
         }
 
@@ -94,7 +94,7 @@ defined('ABSPATH') || exit;
         ));
 
         if ($statut_user === 'resolue') {
-            error_log("⛔ Statut utilisateur déjà 'resolue' → refus de traitement UID=$uid");
+            cat_debug("⛔ Statut utilisateur déjà 'resolue' → refus de traitement UID=$uid");
             return false;
         }
 
@@ -108,7 +108,7 @@ defined('ABSPATH') || exit;
             !current_user_can('manage_options') &&
             !in_array($current_user_id, array_map('intval', $organisateur_user_ids), true)
         ) {
-            error_log("⛔ Accès interdit au traitement pour UID=$uid");
+            cat_debug("⛔ Accès interdit au traitement pour UID=$uid");
             return false;
         }
 
@@ -123,7 +123,7 @@ defined('ABSPATH') || exit;
 
         traiter_tentative($user_id, $enigme_id, (string) $tentative->reponse_saisie, $resultat, false, true, true);
 
-        error_log("✅ Tentative UID=$uid traitée comme $resultat");
+        cat_debug("✅ Tentative UID=$uid traitée comme $resultat");
         return true;
     }
 

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -380,13 +380,13 @@ function compter_enigmes_resolues($chasse_id, $user_id): int
  */
 function verifier_fin_de_chasse($user_id, $enigme_id)
 {
-    error_log("🔍 Vérification de fin de chasse pour l'utilisateur {$user_id} (énigme : {$enigme_id})");
+    cat_debug("🔍 Vérification de fin de chasse pour l'utilisateur {$user_id} (énigme : {$enigme_id})");
 
     // 🧭 Récupération de la chasse associée
     $chasse_id = recuperer_id_chasse_associee($enigme_id);
 
     if (!$chasse_id) {
-        error_log("❌ Aucune chasse associée trouvée.");
+        cat_debug("❌ Aucune chasse associée trouvée.");
         return;
     }
 
@@ -398,7 +398,7 @@ function verifier_fin_de_chasse($user_id, $enigme_id)
     // 📄 Récupération des énigmes associées (IDs uniquement)
     $enigmes_associees = recuperer_enigmes_associees($chasse_id);
     if (empty($enigmes_associees)) {
-        error_log("⚠️ Pas d'énigmes associées à la chasse (ID: {$chasse_id})");
+        cat_debug("⚠️ Pas d'énigmes associées à la chasse (ID: {$chasse_id})");
         return;
     }
 

--- a/wp-content/themes/chassesautresor/inc/handlers/voir-fichier.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-fichier.php
@@ -3,7 +3,7 @@
 $log_prefix = '[voir-fichier.php]';
 
 function logf($message) {
-    error_log("[voir-fichier.php] $message");
+    cat_debug("[voir-fichier.php] $message");
 }
 
 // Vérifier l'utilisateur connecté

--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -357,7 +357,7 @@ function organisateur_get_nb_chasses_publiees(int $organisateur_id): int
 function get_chasses_en_creation($organisateur_id)
 {
   if (!is_numeric($organisateur_id)) {
-    error_log("⛔ get_chasses_en_creation : ID non numérique : " . print_r($organisateur_id, true));
+    cat_debug("⛔ get_chasses_en_creation : ID non numérique : " . print_r($organisateur_id, true));
     return [];
   }
 
@@ -365,7 +365,7 @@ function get_chasses_en_creation($organisateur_id)
   $chasse_ids    = is_a($chasses_query, 'WP_Query') ? $chasses_query->posts : (array) $chasses_query;
 
   if (empty($chasse_ids)) {
-    error_log("🔍 Aucune chasse liée à l’organisateur $organisateur_id");
+    cat_debug("🔍 Aucune chasse liée à l’organisateur $organisateur_id");
     return [];
   }
 
@@ -375,14 +375,14 @@ function get_chasses_en_creation($organisateur_id)
     $statut_validation = get_field('chasse_cache_statut_validation', $id);
     $statut_metier    = get_field('chasse_cache_statut', $id);
 
-    error_log("🧪 #$id | statut=$statut_wp | validation=$statut_validation | metier=$statut_metier");
+    cat_debug("🧪 #$id | statut=$statut_wp | validation=$statut_validation | metier=$statut_metier");
 
     return $statut_wp === 'pending'
       && $statut_validation === 'creation'
       && $statut_metier === 'revision';
   });
 
-  error_log("📦 Chasses en création retrouvées : " . count($filtrees));
+  cat_debug("📦 Chasses en création retrouvées : " . count($filtrees));
 
   return array_values($filtrees);
 }
@@ -409,7 +409,7 @@ function get_chasses_en_creation($organisateur_id)
 function recuperer_enigmes_associees(int $chasse_id): array
 {
   if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
-    error_log("❌ [recuperer_enigmes_associees] Appel invalide pour ID $chasse_id");
+    cat_debug("❌ [recuperer_enigmes_associees] Appel invalide pour ID $chasse_id");
     return [];
   }
 
@@ -425,7 +425,7 @@ function recuperer_enigmes_associees(int $chasse_id): array
   // Détection et log des doublons
   $doublons = array_diff_key($ids, array_unique($ids));
   if (!empty($doublons)) {
-    error_log("⚠️ [recuperer_enigmes_associees] Doublons détectés pour la chasse #$chasse_id : " . implode(', ', $doublons));
+    cat_debug("⚠️ [recuperer_enigmes_associees] Doublons détectés pour la chasse #$chasse_id : " . implode(', ', $doublons));
   }
 
   $ids_valides = array_filter(array_unique($ids), function ($id) {
@@ -544,7 +544,7 @@ function assigner_organisateur_automatiquement($post_id, $post)
   if (est_organisateur($auteur_id)) {
     update_field('organisateur_id', $auteur_id, $post_id);
   } else {
-    error_log("⚠️ Avertissement : L'auteur {$auteur_id} n'a pas un rôle valide (organisateur ou organisateur_creation).");
+    cat_debug("⚠️ Avertissement : L'auteur {$auteur_id} n'a pas un rôle valide (organisateur ou organisateur_creation).");
   }
 }
 add_action('save_post', 'assigner_organisateur_automatiquement', 10, 2);
@@ -576,7 +576,7 @@ add_action('save_post', 'assigner_organisateur_automatiquement', 10, 2);
  */
 function synchroniser_cache_enigmes_chasse($chasse_id, $forcer_recalcul = false, $nettoyer_cache = false)
 {
-  error_log("🌀 [SYNC] Début de synchronisation pour chasse #$chasse_id");
+  cat_debug("🌀 [SYNC] Début de synchronisation pour chasse #$chasse_id");
 
   $resultat1 = verifier_chasse_cache_enigmes($chasse_id, $forcer_recalcul);
   $resultat2 = verifier_cache_chasse_enigmes_valides($chasse_id, $nettoyer_cache);
@@ -591,31 +591,31 @@ function synchroniser_cache_enigmes_chasse($chasse_id, $forcer_recalcul = false,
   $cache       = $resultat1['cache']      ?? [];
   $invalides   = $resultat2['invalides']  ?? [];
 
-  error_log("📥 [ATTENDU] Énigmes réellement liées à la chasse : " . implode(', ', $attendu));
-  error_log("📦 [CACHE AVANT] Contenu actuel de chasse_cache_enigmes : " . implode(', ', $cache));
-  error_log("🗑️ [INVALIDES] Énigmes invalides détectées dans le cache : " . implode(', ', $invalides));
+  cat_debug("📥 [ATTENDU] Énigmes réellement liées à la chasse : " . implode(', ', $attendu));
+  cat_debug("📦 [CACHE AVANT] Contenu actuel de chasse_cache_enigmes : " . implode(', ', $cache));
+  cat_debug("🗑️ [INVALIDES] Énigmes invalides détectées dans le cache : " . implode(', ', $invalides));
 
   if (!isset($resultat1['synchro'])) {
-    error_log("⚠️ [INCOHÉRENCE] Clé 'synchro' manquante dans resultat1 (verifier_chasse_cache_enigmes)");
+    cat_debug("⚠️ [INCOHÉRENCE] Clé 'synchro' manquante dans resultat1 (verifier_chasse_cache_enigmes)");
   }
   if (!isset($resultat2['synchro'])) {
-    error_log("⚠️ [INCOHÉRENCE] Clé 'synchro' manquante dans resultat2 (verifier_cache_chasse_enigmes_valides)");
+    cat_debug("⚠️ [INCOHÉRENCE] Clé 'synchro' manquante dans resultat2 (verifier_cache_chasse_enigmes_valides)");
   }
 
   $ok = null;
   if ($correction1 || $correction2) {
-    error_log("🔧 [ACTION] Mise à jour de chasse_cache_enigmes nécessaire");
+    cat_debug("🔧 [ACTION] Mise à jour de chasse_cache_enigmes nécessaire");
 
     $ok = synchroniser_relations_cache_enigmes($chasse_id);
 
     if ($ok) {
-      error_log("✅ [RÉSULTAT] Relations mises à jour proprement via synchroniser_relations_cache_enigmes()");
+      cat_debug("✅ [RÉSULTAT] Relations mises à jour proprement via synchroniser_relations_cache_enigmes()");
     } else {
-      error_log("❌ [ÉCHEC] La synchronisation ACF relation a échoué pour la chasse #$chasse_id");
+      cat_debug("❌ [ÉCHEC] La synchronisation ACF relation a échoué pour la chasse #$chasse_id");
     }
   }
 
-  error_log("🌀 [SYNC] Fin de synchronisation pour chasse #$chasse_id");
+  cat_debug("🌀 [SYNC] Fin de synchronisation pour chasse #$chasse_id");
 
   return [
     'valide'                    => $valide1 && $valide2,
@@ -768,10 +768,10 @@ function verifier_cache_chasse_enigmes_valides($chasse_id, $retirer_si_invalide 
  */
 function synchroniser_relations_cache_enigmes(int $chasse_id): bool
 {
-    error_log("🔄 [SYNC] Début de synchronisation pour chasse #$chasse_id");
+    cat_debug("🔄 [SYNC] Début de synchronisation pour chasse #$chasse_id");
 
     if (get_post_type($chasse_id) !== 'chasse') {
-        error_log("❌ [SYNC] ID $chasse_id n’est pas une chasse");
+        cat_debug("❌ [SYNC] ID $chasse_id n’est pas une chasse");
         return false;
     }
 
@@ -807,20 +807,20 @@ function synchroniser_relations_cache_enigmes(int $chasse_id): bool
     $diff_cache    = array_diff($cache_ids, $ids_detectes);
 
     if (empty($diff_detectes) && empty($diff_cache)) {
-        error_log("✅ [SYNC] Aucune mise à jour nécessaire pour chasse #$chasse_id");
+        cat_debug("✅ [SYNC] Aucune mise à jour nécessaire pour chasse #$chasse_id");
         return true;
     }
 
-    error_log("🔧 [SYNC] Cache obsolète → écrasement nécessaire pour chasse #$chasse_id");
-    error_log("🗑️ Ancien cache : " . implode(', ', $cache_ids));
-    error_log("🆕 Nouvel ensemble : " . implode(', ', $ids_detectes));
+    cat_debug("🔧 [SYNC] Cache obsolète → écrasement nécessaire pour chasse #$chasse_id");
+    cat_debug("🗑️ Ancien cache : " . implode(', ', $cache_ids));
+    cat_debug("🆕 Nouvel ensemble : " . implode(', ', $ids_detectes));
 
     $success = update_field('chasse_cache_enigmes', $ids_detectes, $chasse_id);
 
     if ($success) {
-        error_log("✅ [SYNC] Mise à jour réussie de chasse_cache_enigmes pour chasse #$chasse_id");
+        cat_debug("✅ [SYNC] Mise à jour réussie de chasse_cache_enigmes pour chasse #$chasse_id");
     } else {
-        error_log("❌ [SYNC] Échec de la mise à jour pour chasse #$chasse_id");
+        cat_debug("❌ [SYNC] Échec de la mise à jour pour chasse #$chasse_id");
     }
 
     return (bool) $success;
@@ -850,7 +850,7 @@ function forcer_relation_enigme_dans_chasse_si_absente(int $enigme_id): void
   $chasse_id = is_object($chasse) ? $chasse->ID : (int)$chasse;
 
   if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
-    error_log("❌ [RELATION AUTO] Chasse non valide pour énigme #$enigme_id");
+    cat_debug("❌ [RELATION AUTO] Chasse non valide pour énigme #$enigme_id");
     return;
   }
 
@@ -866,9 +866,9 @@ function forcer_relation_enigme_dans_chasse_si_absente(int $enigme_id): void
     );
 
     if ($ok) {
-      error_log("✅ [RELATION AUTO] Énigme #$enigme_id ajoutée à la chasse #$chasse_id (groupe champs_caches)");
+      cat_debug("✅ [RELATION AUTO] Énigme #$enigme_id ajoutée à la chasse #$chasse_id (groupe champs_caches)");
     } else {
-      error_log("❌ [RELATION AUTO] Échec ajout énigme #$enigme_id → chasse #$chasse_id");
+      cat_debug("❌ [RELATION AUTO] Échec ajout énigme #$enigme_id → chasse #$chasse_id");
     }
   }
 }

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -130,7 +130,7 @@ function charger_template_utilisateur($template) {
         $content_template = get_stylesheet_directory() . '/templates/myaccount/' . $mapping_templates[$request_uri];
 
         if (!file_exists($content_template)) {
-            error_log('Fichier de contenu introuvable : ' . $content_template);
+            cat_debug('Fichier de contenu introuvable : ' . $content_template);
         } else {
             // Stocke le chemin pour l'injection dans le layout
             $GLOBALS['myaccount_content_template'] = $content_template;
@@ -672,7 +672,7 @@ function ajouter_role_organisateur_creation($post_id, $post, $update) {
     // 🔹 Vérifie si l'utilisateur est "subscriber" avant de lui attribuer "organisateur_creation"
     if (in_array('subscriber', $user->roles, true)) {
         $user->add_role(ROLE_ORGANISATEUR_CREATION); // ✅ Ajoute le rôle sans retirer "subscriber"
-        error_log("✅ L'utilisateur $user_id a maintenant aussi le rôle 'organisateur_creation'.");
+        cat_debug("✅ L'utilisateur $user_id a maintenant aussi le rôle 'organisateur_creation'.");
     }
 }
 add_action('save_post', 'ajouter_role_organisateur_creation', 10, 3);

--- a/wp-content/themes/chassesautresor/inc/utils.php
+++ b/wp-content/themes/chassesautresor/inc/utils.php
@@ -4,15 +4,16 @@ defined('ABSPATH') || exit;
 /**
  * Logs debug messages conditionally.
  *
- * Use the CAT_DEBUG_VERBOSE constant or the `cat_debug_enabled` filter to
- * control output.
+ * Output is controlled by the `WP_DEBUG` constant or the `cat_debug_enabled`
+ * filter.
  *
  * @param mixed $message Message to log. Arrays/objects are exported.
  * @param bool $force    Force logging regardless of settings.
  * @return void
  */
-function cat_debug($message, bool $force = false): void {
-    $enabled = defined('CAT_DEBUG_VERBOSE') && CAT_DEBUG_VERBOSE;
+function cat_debug($message, bool $force = false): void
+{
+    $enabled = defined('WP_DEBUG') && WP_DEBUG;
     $enabled = apply_filters('cat_debug_enabled', $enabled);
 
     if ($enabled || $force) {

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -90,7 +90,7 @@ $statut_validation = $infos_chasse['statut_validation'];
 $nb_joueurs = $infos_chasse['nb_joueurs'];
 
 get_header();
-error_log("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
+cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
 ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -59,14 +59,14 @@ $organisateur_nom = $organisateur_id ? get_the_title($organisateur_id) : get_the
 if (current_user_can('administrator')) {
   $chasse_id = get_the_ID();
 
-  error_log("📦 [TEST] Statut stocké (admin) : " . get_field('chasse_cache_statut', $chasse_id));
+  cat_debug("📦 [TEST] Statut stocké (admin) : " . get_field('chasse_cache_statut', $chasse_id));
 
   verifier_ou_recalculer_statut_chasse($chasse_id);
 
 
   mettre_a_jour_statuts_chasse($chasse_id);
 
-  error_log("✅ [TEST] Recalcul exécuté via mettre_a_jour_statuts_chasse($chasse_id)");
+  cat_debug("✅ [TEST] Recalcul exécuté via mettre_a_jour_statuts_chasse($chasse_id)");
 }
 
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-validation-actions.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-validation-actions.php
@@ -3,7 +3,7 @@ defined('ABSPATH') || exit;
 
 $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
-    error_log('[chasse-validation-actions] appel invalide, chasse_id=' . var_export($chasse_id, true));
+    cat_debug('[chasse-validation-actions] appel invalide, chasse_id=' . var_export($chasse_id, true));
     return;
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -4,7 +4,7 @@ defined('ABSPATH') || exit;
 $post_id = $args['post_id'] ?? null;
 $user_id = $args['user_id'] ?? get_current_user_id(); // ✅ sécurisation
 
-error_log("👤 STATUT ACTUEL : " . enigme_get_statut_utilisateur($post_id, $user_id));
+cat_debug("👤 STATUT ACTUEL : " . enigme_get_statut_utilisateur($post_id, $user_id));
 
 
 if (!$post_id || !$user_id) return;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
@@ -3,13 +3,13 @@ defined('ABSPATH') || exit;
 
 $post_id = $args['post_id'] ?? null;
 if (!$post_id) {
-  error_log("[images] ❌ post_id manquant dans partial");
+  cat_debug("[images] ❌ post_id manquant dans partial");
   return;
 }
 
 // Récupération standard des images (format tableau ACF avec clés 'ID', etc.)
 $images = get_field('enigme_visuel_image', $post_id);
-error_log("[images] 🔍 Énigme #$post_id → images récupérées : " . print_r($images, true));
+cat_debug("[images] 🔍 Énigme #$post_id → images récupérées : " . print_r($images, true));
 
 // Test : au moins une image != placeholder
 $has_valid_images = is_array($images) && array_filter($images, function ($img) {
@@ -17,14 +17,14 @@ $has_valid_images = is_array($images) && array_filter($images, function ($img) {
 });
 
 if ($has_valid_images && function_exists('afficher_visuels_enigme')) {
-  error_log("[images] ✅ Galerie active pour #$post_id");
+  cat_debug("[images] ✅ Galerie active pour #$post_id");
 ?>
   <div class="galerie-enigme-wrapper">
     <?php afficher_visuels_enigme($post_id); ?>
   </div>
 <?php
 } else {
-  error_log("[images] 🟡 Aucune image valide → fallback picture");
+  cat_debug("[images] 🟡 Aucune image valide → fallback picture");
 ?>
     <div class="image-principale">
       <?php afficher_picture_vignette_enigme(

--- a/wp-content/themes/chassesautresor/template-parts/modals/modal-conversion-historique.php
+++ b/wp-content/themes/chassesautresor/template-parts/modals/modal-conversion-historique.php
@@ -17,7 +17,7 @@ $historique_taux = get_option('historique_taux_conversion', []);
                 $historique_taux = get_option('historique_taux_conversion', []);
                 
                 if (!is_array($historique_taux)) {
-                    error_log("❌ `historique_taux_conversion` n'est pas un tableau. Valeur actuelle : " . print_r($historique_taux, true));
+                    cat_debug("❌ `historique_taux_conversion` n'est pas un tableau. Valeur actuelle : " . print_r($historique_taux, true));
                     $historique_taux = []; // Éviter l'erreur en remplaçant par un tableau vide
                 }
                 ?>


### PR DESCRIPTION
Encapsule les journaux de debug du thème derrière `WP_DEBUG`.

- remplace tous les appels `error_log` par `cat_debug`
- `cat_debug` vérifie désormais `WP_DEBUG` avant d’écrire

## Testing
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2ad05efdc8332b6cd7ca607a1dcda