### PR TITLE
Utiliser wp_get_attachment_image pour l'image fallback des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
@@ -3,8 +3,8 @@ defined('ABSPATH') || exit;
 
 $post_id = $args['post_id'] ?? null;
 if (!$post_id) {
-  cat_debug("[images] ❌ post_id manquant dans partial");
-  return;
+    cat_debug("[images] ❌ post_id manquant dans partial");
+    return;
 }
 
 // Récupération standard des images (format tableau ACF avec clés 'ID', etc.)
@@ -13,25 +13,34 @@ cat_debug("[images] 🔍 Énigme #$post_id → images récupérées : " . print_
 
 // Test : au moins une image != placeholder
 $has_valid_images = is_array($images) && array_filter($images, function ($img) {
-  return isset($img['ID']) && (int) $img['ID'] !== ID_IMAGE_PLACEHOLDER_ENIGME;
+    return isset($img['ID']) && (int) $img['ID'] !== ID_IMAGE_PLACEHOLDER_ENIGME;
 });
 
 if ($has_valid_images && function_exists('afficher_visuels_enigme')) {
-  cat_debug("[images] ✅ Galerie active pour #$post_id");
-?>
-  <div class="galerie-enigme-wrapper">
-    <?php afficher_visuels_enigme($post_id); ?>
-  </div>
-<?php
-} else {
-  cat_debug("[images] 🟡 Aucune image valide → fallback picture");
-?>
-    <div class="image-principale">
-      <?php afficher_picture_vignette_enigme(
-          $post_id,
-          __('Image par défaut de l’énigme', 'chassesautresor-com'),
-          ['large']
-      ); ?>
+    cat_debug("[images] ✅ Galerie active pour #$post_id");
+    ?>
+    <div class="galerie-enigme-wrapper">
+        <?php afficher_visuels_enigme($post_id); ?>
     </div>
-<?php
+    <?php
+} else {
+    cat_debug("[images] 🟡 Aucune image valide → fallback picture");
+    ?>
+    <div class="image-principale">
+        <?php
+        echo wp_get_attachment_image(
+            ID_IMAGE_PLACEHOLDER_ENIGME,
+            'large',
+            false,
+            [
+                'srcset' => wp_get_attachment_image_srcset(ID_IMAGE_PLACEHOLDER_ENIGME, 'large'),
+                'sizes' => wp_get_attachment_image_sizes(ID_IMAGE_PLACEHOLDER_ENIGME, 'large'),
+                'loading' => 'lazy',
+                'alt' => esc_attr__('Image par défaut de l’énigme', 'chassesautresor-com'),
+            ]
+        );
+        ?>
+    </div>
+    <?php
 }
+


### PR DESCRIPTION
## Résumé
Remplace le HTML manuel du fallback d'image par `wp_get_attachment_image` avec génération automatique de `srcset`, `sizes` et chargement paresseux.

## Changements notables
- Utilisation de `wp_get_attachment_image` pour l'image par défaut des énigmes.
- Ajout des attributs `srcset`, `sizes`, `loading="lazy"` et d'un `alt` traduit.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2ae7a09a483329eed4fb773d0a9e0