### PR TITLE
docs: documente le champ indice_cache_complet

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -454,7 +454,7 @@ Requis : non
 🔹 Groupe : paramètres indices
 🆔 ID : 9568
 🔑 Key : group_68a1fb240748a
-📦 Champs trouvés : 8
+📦 Champs trouvés : 9
 
 — indice_image —
 Type : image
@@ -515,4 +515,10 @@ Choices :
   - programme : programmé
   - expire : expiré
   - desactive : désactivé
+----------------------------------------
+— indice_cache_complet —
+Type : true_false
+Label : complétion de l'indice
+Instructions : (vide)
+Requis : non
 ----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -418,6 +418,7 @@ Groupe : paramètres indices
 * indice_date_disponibilite (date_time_picker, retour d/m/Y g:i a)
 * indice_cout_points (number)
 * indice_cache_etat_systeme (select, accessible/programme/expire/desactive)
+* indice_cache_complet (true_false)
 
 liste avec tous les détails des groupes de champs ACF dans champs-acf-liste.md
 


### PR DESCRIPTION
## Résumé
- Ajout du champ `indice_cache_complet` dans la documentation ACF des indices
- Référence du nouveau champ dans la liste globale des champs ACF

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2b5eb58788332a075c6c02f370821