### PR TITLE
Add utility to check paid enigmas

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme-functions.php
+++ b/wp-content/themes/chassesautresor/inc/enigme-functions.php
@@ -8,3 +8,4 @@ require_once $base . 'visuels.php';
 require_once $base . 'affichage.php';
 require_once $base . 'reponses.php';
 require_once $base . 'tentatives.php';
+require_once $base . 'utils.php';

--- a/wp-content/themes/chassesautresor/inc/enigme/README.md
+++ b/wp-content/themes/chassesautresor/inc/enigme/README.md
@@ -1,0 +1,8 @@
+# Enigme utilities
+
+## `enigme_is_paid( $enigme_id )`
+
+Détermine si une énigme est payante :
+
+- `enigme_tentative_cout_points` > 0
+- `enigme_mode_validation` différent de `"aucune"`

--- a/wp-content/themes/chassesautresor/inc/enigme/utils.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/utils.php
@@ -1,0 +1,23 @@
+<?php
+defined('ABSPATH') || exit;
+
+/**
+ * Determine whether an enigma requires payment to attempt.
+ *
+ * An enigma is considered paid if it has a positive attempt cost and
+ * a validation mode different from "aucune".
+ *
+ * @param int $enigme_id Enigma post ID.
+ * @return bool True when the enigma is paid.
+ */
+function enigme_is_paid(int $enigme_id): bool
+{
+    if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
+        return false;
+    }
+
+    $cost = (int) get_field('enigme_tentative_cout_points', $enigme_id);
+    $mode = strtolower((string) get_field('enigme_mode_validation', $enigme_id));
+
+    return $cost > 0 && $mode !== 'aucune';
+}


### PR DESCRIPTION
### Summary
- Ajoute la fonction `enigme_is_paid()` pour déterminer si une énigme nécessite des points
- Intègre cette fonction via un nouveau fichier utilitaire
- Documente son utilisation dans `inc/enigme/README.md`

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a2c09b0e0c8332a0356fcbbaf9eb76