### PR TITLE
Harmonise l'appellation du statut "resolue"

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1170,7 +1170,7 @@ function bouton_reinitialiser_enigme_callback() {
     $enigme_id = get_the_ID();
     $statut = enigme_get_statut($enigme_id, $user_id); // 🔄 Utilisation du statut centralisé
 
-    // ✅ Affiche le bouton uniquement si l'énigme est résolue ou terminée-résolue
+    // ✅ Affiche le bouton uniquement si l'énigme est resolue ou terminee_resolue
     if (!in_array($statut, ['resolue', 'terminee_resolue'])) return '';
 
     return "

--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -92,7 +92,7 @@ function enigme_normaliser_mode_validation($mode): string
  * - connexion   → utilisateur non connecté
  * - engager     → première tentative ou ré-engagement possible
  * - continuer   → énigme en cours
- * - revoir      → énigme résolue
+ * - revoir      → énigme resolue
  * - terminee    → énigme finalisée (lecture seule)
  * - soumis      → réponse en attente de validation
  * - bloquee     → bloquée par la chasse, une date ou un prérequis

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -86,7 +86,7 @@ defined('ABSPATH') || exit;
         $user_id = (int) $tentative->user_id;
         $enigme_id = (int) $tentative->enigme_id;
 
-        // 🔐 Sécurité : si déjà "résolue", on refuse toute tentative de traitement
+        // 🔐 Sécurité : si déjà "resolue", on refuse toute tentative de traitement
         $statut_user = $wpdb->get_var($wpdb->prepare(
             "SELECT statut FROM {$wpdb->prefix}enigme_statuts_utilisateur WHERE user_id = %d AND enigme_id = %d",
             $user_id,


### PR DESCRIPTION
### Résumé
Uniformise l'utilisation du statut `resolue` sans accent.

### Changements
- Corrige les commentaires mentionnant `résolue` pour utiliser `resolue`
- Clarifie les indications autour du bouton de réinitialisation

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2bf5632b883328308f76b2e5a6be7