### PR TITLE
Enregistrer l'engagement lors de l'accès à une énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -212,11 +212,11 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
         case 'non_commencee':
             return array_merge($cta, [
                 'type'       => 'engager',
-                'label'      => "Commencer",
-                'action'     => 'form',
-                'url'        => site_url('/traitement-engagement'),
+                'label'      => __('Commencer', 'chassesautresor-com'),
+                'action'     => 'link',
+                'url'        => get_permalink($enigme_id),
                 'classe_css' => 'cta-engager',
-                'badge'      => 'À tenter',
+                'badge'      => __('À tenter', 'chassesautresor-com'),
             ]);
 
         case 'en_cours':
@@ -266,21 +266,21 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
         case 'echouee':
             return array_merge($cta, [
                 'type'       => 'engager',
-                'label'      => "Réessayer",
-                'action'     => 'form',
-                'url'        => site_url('/traitement-engagement'),
+                'label'      => __('Réessayer', 'chassesautresor-com'),
+                'action'     => 'link',
+                'url'        => get_permalink($enigme_id),
                 'classe_css' => 'cta-echouee',
-                'badge'      => 'Échouée',
+                'badge'      => __('Échouée', 'chassesautresor-com'),
             ]);
 
         case 'abandonnee':
             return array_merge($cta, [
                 'type'       => 'engager',
-                'label'      => "Recommencer",
-                'action'     => 'form',
-                'url'        => site_url('/traitement-engagement'),
+                'label'      => __('Recommencer', 'chassesautresor-com'),
+                'action'     => 'link',
+                'url'        => get_permalink($enigme_id),
                 'classe_css' => 'cta-abandonnee',
-                'badge'      => 'Abandonnée',
+                'badge'      => __('Abandonnée', 'chassesautresor-com'),
             ]);
 
         default:

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -24,6 +24,19 @@ if (!is_user_logged_in()) {
     exit;
 }
 
+// 🔹 Engagement automatique si autorisé
+if (
+    utilisateur_est_engage_dans_chasse($user_id, $chasse_id) &&
+    !utilisateur_est_engage_dans_enigme($user_id, $enigme_id) &&
+    utilisateur_peut_engager_enigme($enigme_id, $user_id)
+) {
+    marquer_enigme_comme_engagee($user_id, $enigme_id);
+
+    if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
+        verifier_fin_de_chasse($user_id, $enigme_id);
+    }
+}
+
 // 🔹 Redirection si non visible
 if (!enigme_est_visible_pour($user_id, $enigme_id)) {
     $fallback_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');

--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -14,7 +14,6 @@ if (!$current_user_id) {
 }
 
 $chasse_id = isset($_POST['chasse_id']) ? intval($_POST['chasse_id']) : 0;
-$enigme_id = isset($_POST['enigme_id']) ? intval($_POST['enigme_id']) : 0;
 
 // --------------------------------------------------
 // 🎯 Traitement engagement chasse
@@ -46,54 +45,22 @@ if ($chasse_id) {
     enregistrer_engagement_chasse($current_user_id, $chasse_id);
 
     if ($cout_points > 0) {
-        $reason = sprintf('Déblocage de la chasse #%d', $chasse_id);
-        deduire_points_utilisateur($current_user_id, $cout_points, $reason, 'chasse', $chasse_id);
+        $reason = sprintf(
+            __('Déblocage de la chasse #%d', 'chassesautresor-com'),
+            $chasse_id
+        );
+        deduire_points_utilisateur(
+            $current_user_id,
+            $cout_points,
+            $reason,
+            'chasse',
+            $chasse_id
+        );
     }
 
     wp_safe_redirect(get_permalink($chasse_id));
     exit;
 }
 
-// --------------------------------------------------
-// 🧩 Traitement engagement énigme
-// --------------------------------------------------
-
-if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
-    wp_redirect(home_url());
-    exit;
-}
-
-// Vérification du nonce
-if (
-    !isset($_POST['engager_enigme_nonce']) ||
-    !wp_verify_nonce($_POST['engager_enigme_nonce'], 'engager_enigme_' . $enigme_id)
-) {
-    wp_die(__('Échec de vérification de sécurité', 'chassesautresor-com'));
-}
-
-// Chargement des fonctions critiques
-require_once get_theme_file_path('inc/statut-functions.php');
-
-// Vérifier si l’énigme est engageable
-$etat_systeme = enigme_get_etat_systeme($enigme_id);
-$statut_utilisateur = enigme_get_statut_utilisateur($enigme_id, $current_user_id);
-
-$statuts_engageables = ['non_commencee', 'abandonnee', 'echouee'];
-
-if ($etat_systeme !== 'accessible' || !in_array($statut_utilisateur, $statuts_engageables, true)) {
-    wp_redirect(get_permalink($enigme_id)); // Redirection silencieuse
-    exit;
-}
-
-
-// Déduction + enregistrement du statut
-marquer_enigme_comme_engagee($current_user_id, $enigme_id);
-
-// Vérifie la fin de chasse si l'énigme ne nécessite pas de validation
-if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
-    verifier_fin_de_chasse($current_user_id, $enigme_id);
-}
-
-// Redirection vers la page de l’énigme
-wp_redirect(get_permalink($enigme_id));
+wp_redirect(home_url());
 exit;


### PR DESCRIPTION
## Résumé
- Enregistre l'engagement d'une énigme dès l'ouverture de la page.

## Changements notables
- Engagement automatique si l'utilisateur peut tenter l'énigme.
- Les CTA « Commencer », « Réessayer » et « Recommencer » pointent vers la page de l'énigme.
- La route de traitement ne gère plus l'engagement des énigmes.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2c45f7db4833297c1390982695e2e