### PR TITLE
Add admin points summary cards

### DIFF
--- a/wp-content/themes/chassesautresor/inc/PointsRepository.php
+++ b/wp-content/themes/chassesautresor/inc/PointsRepository.php
@@ -262,4 +262,28 @@ class PointsRepository
 
         return $row ?: null;
     }
+
+    /**
+     * Sum of all points used by players excluding conversion requests.
+     */
+    public function getTotalPointsUsed(): int
+    {
+        $sql = $this->wpdb->prepare(
+            "SELECT COALESCE(SUM(-points), 0) FROM {$this->table} WHERE points < 0 AND origin_type <> %s",
+            'conversion'
+        );
+
+        return (int) $this->wpdb->get_var($sql);
+    }
+
+    /**
+     * Sum of all points currently held by users.
+     */
+    public function getTotalPointsInCirculation(): int
+    {
+        $subquery = "SELECT MAX(id) AS id FROM {$this->table} GROUP BY user_id";
+        $sql      = "SELECT COALESCE(SUM(balance), 0) FROM {$this->table} WHERE id IN ($subquery)";
+
+        return (int) $this->wpdb->get_var($sql);
+    }
 }

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -15,13 +15,26 @@ $is_organizer = in_array(ROLE_ORGANISATEUR, $roles, true) || in_array(ROLE_ORGAN
 
 if (current_user_can('administrator')) {
     $historique = recuperer_historique_paiements_admin();
-    $points     = function_exists('get_user_points') ? get_user_points((int) $current_user->ID) : 0;
+    global $wpdb;
+    $repo              = new PointsRepository($wpdb);
+    $used_points       = $repo->getTotalPointsUsed();
+    $circulation_points = $repo->getTotalPointsInCirculation();
     ?>
     <div class="dashboard-grid stats-cards myaccount-points-cards">
-        <div class="dashboard-card" data-stat="points">
-            <i class="fa-solid fa-coins" aria-hidden="true"></i>
-            <h3><?php esc_html_e('Points', 'chassesautresor-com'); ?></h3>
-            <p class="stat-value"><?php echo esc_html($points); ?></p>
+        <div class="dashboard-card" data-stat="points-used">
+            <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points utilisés', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php echo esc_html($used_points); ?></p>
+        </div>
+        <div class="dashboard-card" data-stat="points-bought">
+            <i class="fa-solid fa-cart-shopping" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points achetés', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php esc_html_e('À implémenter', 'chassesautresor-com'); ?></p>
+        </div>
+        <div class="dashboard-card" data-stat="points-circulation">
+            <i class="fa-solid fa-arrows-rotate" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points en circulation', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php echo esc_html($circulation_points); ?></p>
         </div>
         <div class="dashboard-card">
             <div class="dashboard-card-header">


### PR DESCRIPTION
## Summary
- remplacer la carte Points par des cartes synthétiques pour les administrateurs
- exposer les totaux de points utilisés et en circulation, avec un placeholder pour les points achetés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a2ca24fe14833298306f7eed9b2fa6