### PR TITLE
Retirer le tableau des paiements et corriger le lien de conversion

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -286,10 +286,10 @@ function myaccount_get_important_messages(): string
         $pendingRequests = $repo->getConversionRequests(null, 'pending');
 
         if (!empty($pendingRequests)) {
-            $url = esc_url(home_url('/mon-compte/?section=points'));
+            $url = esc_url(add_query_arg('section', 'points', home_url('/mon-compte/')));
             $messages[] = sprintf(
                 /* translators: 1: opening anchor tag, 2: closing anchor tag */
-                __('Vous avez des %1$sdemandes de conversion%2$s en attente.', 'chassesautresor'),
+                __('Vous avez des %1$sdemandes de conversion%2$s en attente.', 'chassesautresor-com'),
                 '<a href="' . $url . '">',
                 '</a>'
             );

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-organisateurs.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-organisateurs.php
@@ -41,7 +41,4 @@ $organisateurs_liste = recuperer_organisateurs_pending();
         </div>
         <?php afficher_tableau_organisateurs_pending($organisateurs_liste); ?>
     <?php endif; ?>
-
-    <h2 class="text-lg font-semibold mt-8 mb-2"><?php esc_html_e('Demandes de paiement', 'chassesautresor'); ?></h2>
-    <?php afficher_tableau_paiements_admin(); ?>
 </section>

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -71,6 +71,13 @@ if (!function_exists('esc_url')) {
     }
 }
 
+if (!function_exists('home_url')) {
+    function home_url($path = '')
+    {
+        return 'https://example.com' . $path;
+    }
+}
+
 if (!function_exists('esc_html__')) {
     function esc_html__($text, $domain = 'default')
     {
@@ -120,6 +127,15 @@ class MyAccountMessagesTest extends TestCase
             $output
         );
         $this->assertStringContainsString('demande de conversion', $output);
+    }
+
+    public function test_admin_conversion_request_link_points_to_points_tab(): void
+    {
+        $output = myaccount_get_important_messages();
+        $this->assertStringContainsString(
+            'https://example.com/mon-compte/?section=points',
+            $output
+        );
     }
 
     public function test_pending_validation_message_is_displayed(): void


### PR DESCRIPTION
## Résumé
Suppression du tableau des demandes de paiement et correction du lien des messages de conversion vers l'onglet Points.

## Changements notables
- Suppression du tableau "Demandes de paiement" dans l'onglet Organisateurs.
- Correction du lien du message important de conversion vers l'onglet Points pour un administrateur.
- Ajout d'un test unitaire pour vérifier ce lien.

## Testing
- ✅ `composer install`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2cd3c67988332aba58ae51c63a8ad