### PR TITLE
Masquer le bloc des indices vides sur les énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -177,7 +177,11 @@ defined('ABSPATH') || exit;
             ]
         );
         echo '</div>';
-        echo '<div class="zone-indices"><h3>' . esc_html__('Indices', 'chassesautresor-com') . '</h3></div>';
+
+        $hints = get_field('indices', $enigme_id);
+        if (!empty($hints)) {
+            echo '<div class="zone-indices"><h3>' . esc_html__('Indices', 'chassesautresor-com') . '</h3></div>';
+        }
         echo '</section>';
     }
 


### PR DESCRIPTION
## Résumé
- Cache le bloc "Indices" s'il n'existe aucun indice pour l'énigme

## Changements notables
- Affiche la zone de réponse de l'énigme
- Supprime le conteneur des indices lorsqu'il est vide

## Testing
- `source ./setup-env.sh && echo env setup`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2d093f83883328a23bab7da4707ac