### PR TITLE
Afficher le titre d’énigme avant le visuel principal

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -129,15 +129,15 @@ defined('ABSPATH') || exit;
     }
 
     /**
-     * Render the main content section of the enigma.
+     * Render the title and subtitle section of the enigma.
      *
      * @param int    $enigme_id Enigma identifier.
      * @param string $style     Display style.
      * @param int    $user_id   Current user ID.
      */
-    function render_enigme_content(int $enigme_id, string $style, int $user_id): void
+    function render_enigme_title(int $enigme_id, string $style, int $user_id): void
     {
-        echo '<article class="contenu-principal">';
+        echo '<section class="bloc-titre">';
         enigme_get_partial(
             'titre',
             $style,
@@ -146,6 +146,19 @@ defined('ABSPATH') || exit;
                 'user_id' => $user_id,
             ]
         );
+        echo '</section>';
+    }
+
+    /**
+     * Render the textual content section of the enigma.
+     *
+     * @param int    $enigme_id Enigma identifier.
+     * @param string $style     Display style.
+     * @param int    $user_id   Current user ID.
+     */
+    function render_enigme_content(int $enigme_id, string $style, int $user_id): void
+    {
+        echo '<article class="contenu-principal">';
         enigme_get_partial(
             'texte',
             $style,
@@ -327,6 +340,7 @@ defined('ABSPATH') || exit;
         echo '<div class="container container--xl-full enigme-layout">';
         render_enigme_sidebar($enigme_id, $edition_active, $chasse_id, $menu_items);
         echo '<main class="page-enigme enigme-style-' . esc_attr($style) . '">';
+        render_enigme_title($enigme_id, $style, $user_id);
         render_enigme_hero($enigme_id, $style, $user_id);
         render_enigme_content($enigme_id, $style, $user_id);
         render_enigme_participation($enigme_id, $style, $user_id);


### PR DESCRIPTION
## Résumé
Affiche le bloc titre/sous-titre avant l’image principale sur la page énigme.

## Modifications
- Ajout d’un rendu dédié pour le bloc titre
- Séparation du texte principal du titre
- Réorganisation de l’ordre d’affichage de l’énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2d0bb8aa4833294382a040b360738