### PR TITLE
feat: standardiser l'icône d'aide

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -228,14 +228,19 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         <?= $peut_editer ? '' : 'disabled'; ?>
                       >
                       <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
-                      <button
-                        type="button"
-                        class="mode-fin-aide"
-                        data-mode="automatique"
-                        aria-label="<?= esc_attr__('Explication du mode automatique', 'chassesautresor-com'); ?>"
-                      >
-                        <i class="fa-regular fa-circle-question"></i>
-                      </button>
+                      <?php
+                      get_template_part(
+                          'template-parts/common/help-icon',
+                          null,
+                          [
+                              'aria_label' => __('Explication du mode automatique', 'chassesautresor-com'),
+                              'classes'    => 'mode-fin-aide',
+                              'attributes' => [
+                                  'data-mode' => 'automatique',
+                              ],
+                          ]
+                      );
+                      ?>
                     </label>
                     <label>
                       <input
@@ -246,14 +251,19 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         <?= $peut_editer ? '' : 'disabled'; ?>
                       >
                       <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
-                      <button
-                        type="button"
-                        class="mode-fin-aide"
-                        data-mode="manuelle"
-                        aria-label="<?= esc_attr__('Explication du mode manuel', 'chassesautresor-com'); ?>"
-                      >
-                        <i class="fa-regular fa-circle-question"></i>
-                      </button>
+                      <?php
+                      get_template_part(
+                          'template-parts/common/help-icon',
+                          null,
+                          [
+                              'aria_label' => __('Explication du mode manuel', 'chassesautresor-com'),
+                              'classes'    => 'mode-fin-aide',
+                              'attributes' => [
+                                  'data-mode' => 'manuelle',
+                              ],
+                          ]
+                      );
+                      ?>
                     </label>
                   </div>
                   <?php ob_start(); ?>
@@ -387,7 +397,16 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                   <div class="champ-edition" style="display: flex; align-items: center;">
                     <label>Coût <span class="txt-small">(points)</span>
-                      <button type="button" class="bouton-aide-points open-points-modal" aria-label="En savoir plus sur les points"><i class="fa-solid fa-circle-question" aria-hidden="true"></i></button>
+                      <?php
+                      get_template_part(
+                          'template-parts/common/help-icon',
+                          null,
+                          [
+                              'aria_label' => __('En savoir plus sur les points', 'chassesautresor-com'),
+                              'classes'    => 'bouton-aide-points open-points-modal',
+                          ]
+                      );
+                      ?>
                     </label>
 
                     <input type="number"

--- a/wp-content/themes/chassesautresor/template-parts/common/help-icon.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/help-icon.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Reusable help icon button component.
+ *
+ * @param string $aria_label  ARIA label for the button.
+ * @param string $message     Optional help message (added as data-message attribute).
+ * @param string $classes     CSS classes to apply on the button.
+ * @param array  $attributes  Additional HTML attributes for the button.
+ */
+
+defined('ABSPATH') || exit;
+
+$args = wp_parse_args(
+    $args ?? [],
+    [
+        'aria_label' => '',
+        'message'    => '',
+        'classes'    => '',
+        'attributes' => [],
+    ]
+);
+
+$aria_label = $args['aria_label'];
+$message    = $args['message'];
+$classes    = $args['classes'];
+$attributes = $args['attributes'];
+
+if ($message !== '') {
+    $attributes['data-message'] = $message;
+}
+
+$attr_string = '';
+if ($aria_label !== '') {
+    $attr_string .= ' aria-label="' . esc_attr($aria_label) . '"';
+}
+foreach ($attributes as $attr => $value) {
+    $attr_string .= ' ' . esc_attr($attr) . '="' . esc_attr($value) . '"';
+}
+?>
+<button type="button" class="<?= esc_attr($classes); ?>"<?= $attr_string; ?>>
+    <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
+</button>

--- a/wp-content/themes/chassesautresor/template-parts/common/stat-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/stat-card.php
@@ -26,9 +26,17 @@ $help_label = $args['help_label'] ?? $help_label ?? '';
   <h3>
     <?= esc_html($label); ?>
     <?php if ($help) : ?>
-      <button type="button" class="mode-fin-aide stat-help" data-message="<?= esc_attr($help); ?>"<?php echo $help_label ? ' aria-label="' . esc_attr($help_label) . '"' : ''; ?>>
-        <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
-      </button>
+      <?php
+      get_template_part(
+          'template-parts/common/help-icon',
+          null,
+          [
+              'aria_label' => $help_label,
+              'classes'    => 'mode-fin-aide stat-help',
+              'message'    => $help,
+          ]
+      );
+      ?>
     <?php endif; ?>
   </h3>
   <p class="stat-value"><?= esc_html($value); ?></p>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -219,26 +219,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                 <label>
                   <input id="enigme_mode_validation" type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                   <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
-                  <button
-                    type="button"
-                    class="mode-fin-aide validation-aide"
-                    data-mode="automatique"
-                    aria-label="<?= esc_attr__('Explication du mode automatique', 'chassesautresor-com'); ?>"
-                  >
-                    <i class="fa-regular fa-circle-question"></i>
-                  </button>
+                  <?php
+                  get_template_part(
+                      'template-parts/common/help-icon',
+                      null,
+                      [
+                          'aria_label' => __('Explication du mode automatique', 'chassesautresor-com'),
+                          'classes'    => 'mode-fin-aide validation-aide',
+                          'attributes' => [
+                              'data-mode' => 'automatique',
+                          ],
+                      ]
+                  );
+                  ?>
                 </label>
                 <label>
                   <input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                   <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
-                  <button
-                    type="button"
-                    class="mode-fin-aide validation-aide"
-                    data-mode="manuelle"
-                    aria-label="<?= esc_attr__('Explication du mode manuel', 'chassesautresor-com'); ?>"
-                  >
-                    <i class="fa-regular fa-circle-question"></i>
-                  </button>
+                  <?php
+                  get_template_part(
+                      'template-parts/common/help-icon',
+                      null,
+                      [
+                          'aria_label' => __('Explication du mode manuel', 'chassesautresor-com'),
+                          'classes'    => 'mode-fin-aide validation-aide',
+                          'attributes' => [
+                              'data-mode' => 'manuelle',
+                          ],
+                      ]
+                  );
+                  ?>
                 </label>
                 <label>
                   <input type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
@@ -260,13 +270,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             <div class="champ-enigme champ-variantes-resume champ-groupe-reponse-automatique cache<?= $has_variantes ? ' champ-rempli' : ' champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_variantes" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <label>
                 <?= esc_html__('Variantes', 'chassesautresor-com'); ?>
-                <button
-                  type="button"
-                  class="bouton-aide-points variantes-aide"
-                  aria-label="<?= esc_attr__('Explication des variantes', 'chassesautresor-com'); ?>"
-                >
-                  <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                </button>
+                <?php
+                get_template_part(
+                    'template-parts/common/help-icon',
+                    null,
+                    [
+                        'aria_label' => __('Explication des variantes', 'chassesautresor-com'),
+                        'classes'    => 'bouton-aide-points variantes-aide',
+                    ]
+                );
+                ?>
               </label>
 
               <?php if ($has_variantes) : ?>
@@ -293,9 +306,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             <div class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_cout_points" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 1rem;">
                 <label for="enigme-tentative-cout">Coût tentative
-                  <button type="button" class="bouton-aide-points open-points-modal" aria-label="En savoir plus sur les points">
-                    <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                  </button>
+                  <?php
+                  get_template_part(
+                      'template-parts/common/help-icon',
+                      null,
+                      [
+                          'aria_label' => __('En savoir plus sur les points', 'chassesautresor-com'),
+                          'classes'    => 'bouton-aide-points open-points-modal',
+                      ]
+                  );
+                  ?>
                 </label>
                 <input type="number" id="enigme-tentative-cout" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
                 <span class="txt-small">points</span>
@@ -314,13 +334,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <div class="champ-edition" style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px;">
                 <label for="enigme-nb-tentatives">Nb tentatives
-                  <button
-                    type="button"
-                    class="bouton-aide-points tentatives-aide"
-                    aria-label="<?= esc_attr__('Explication du nombre de tentatives', 'chassesautresor-com'); ?>"
-                  >
-                    <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                  </button>
+                  <?php
+                  get_template_part(
+                      'template-parts/common/help-icon',
+                      null,
+                      [
+                          'aria_label' => __('Explication du nombre de tentatives', 'chassesautresor-com'),
+                          'classes'    => 'bouton-aide-points tentatives-aide',
+                      ]
+                  );
+                  ?>
                 </label>
                 <input type="number" id="enigme-nb-tentatives" class="champ-input champ-nb-tentatives" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
                 <span class="txt-small">max par jour</span>
@@ -609,14 +632,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                       <i class="fa-regular fa-clock" aria-hidden="true"></i>
                       <h3>
                         Délai après fin de chasse
-                        <button
-                          type="button"
-                          class="mode-fin-aide stat-help"
-                          data-message="<?= esc_attr($aide_delai); ?>"
-                          aria-label="<?= esc_attr__('Informations sur la publication de la solution', 'chassesautresor-com'); ?>"
-                        >
-                          <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
-                        </button>
+                        <?php
+                        get_template_part(
+                            'template-parts/common/help-icon',
+                            null,
+                            [
+                                'aria_label' => __('Informations sur la publication de la solution', 'chassesautresor-com'),
+                                'classes'    => 'mode-fin-aide stat-help',
+                                'message'    => $aide_delai,
+                            ]
+                        );
+                        ?>
                       </h3>
                       <p class="stat-value champ-solution-timing">
                         <input

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -179,14 +179,19 @@ $is_complete = (
                     <span class="champ-valeur">
                       <?= esc_html($email_contact ?: get_the_author_meta('user_email', get_post_field('post_author', $organisateur_id))); ?>
                     </span>
-                    <button
-                      type="button"
-                      class="icone-info"
-                      aria-label="Informations sur l’adresse email de contact"
-                      onclick="alert('Quand aucune adresse n est renseignée, votre email utilisateur est utilisé par défaut.');"
-                    >
-                      <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-                    </button>
+                    <?php
+                    get_template_part(
+                        'template-parts/common/help-icon',
+                        null,
+                        [
+                            'aria_label' => __('Informations sur l’adresse email de contact', 'chassesautresor-com'),
+                            'classes'    => 'icone-info',
+                            'attributes' => [
+                                'onclick' => "alert('Quand aucune adresse n est renseignée, votre email utilisateur est utilisé par défaut.');",
+                            ],
+                        ]
+                    );
+                    ?>
                     <?php if ($peut_editer) : ?>
                         <button
                           type="button"
@@ -261,17 +266,20 @@ $is_complete = (
               <i class="fa-solid fa-building-columns" aria-hidden="true"></i>
               <h3>
                 Coordonnées bancaires
-                <button
-                  type="button"
-                  class="mode-fin-aide stat-help"
-                  data-message="<?php echo esc_attr__(
-                      'Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d\'argent.',
-                      'chassesautresor-com'
-                  ); ?>"
-                  aria-label="<?php esc_attr_e('Informations sur les coordonnées bancaires', 'chassesautresor-com'); ?>"
-                >
-                  <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
-                </button>
+                <?php
+                get_template_part(
+                    'template-parts/common/help-icon',
+                    null,
+                    [
+                        'aria_label' => __('Informations sur les coordonnées bancaires', 'chassesautresor-com'),
+                        'classes'    => 'mode-fin-aide stat-help',
+                        'message'    => __(
+                            "Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d'argent.",
+                            'chassesautresor-com'
+                        ),
+                    ]
+                );
+                ?>
               </h3>
               <?php if ($peut_editer) : ?>
                 <?php


### PR DESCRIPTION
## Résumé
- centralise le bouton d'aide dans un composant réutilisable
- applique le style Font Awesome régulier et gère les attributs ARIA

## Changements notables
- ajout du template `help-icon.php` pour générer un bouton d'aide standard
- remplacement des balises `<button>` + `<i>` directes dans les templates de chasse, énigme, organisateur et stat card

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2e827688083328804765bfbdb67e7