### PR TITLE
Cast ACF fields to string before trim

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -22,8 +22,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($titre_defaut);
 
 $visuel = get_field('enigme_visuel_image', $enigme_id); // champ "gallery" → tableau d’IDs
 $has_images = is_array($visuel) && count($visuel) > 0;
-$legende = get_field('enigme_visuel_legende', $enigme_id);
-$texte = get_field('enigme_visuel_texte', $enigme_id);
+$legende = (string) get_field('enigme_visuel_legende', $enigme_id);
+$texte = (string) get_field('enigme_visuel_texte', $enigme_id);
 $reponse = get_field('enigme_reponse_bonne', $enigme_id);
 $casse = get_field('enigme_reponse_casse', $enigme_id);
 $max = (int) get_field('enigme_tentative_max', $enigme_id);


### PR DESCRIPTION
## Résumé
Corrige un avertissement de dépréciation PHP lorsque `trim()` reçoit une valeur nulle.

## Changements notables
- Force les champs ACF `legende` et `texte` en chaînes avant utilisation de `trim`.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2f4e5d5088332a1a44ca2d5c94834