### PR TITLE
Document PostCSS breakpoint preprocessing tasks

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -15,3 +15,15 @@ throughout the project instead of the old `wp_enigme_engagements` table.
 This plan will keep business logic intact and simply update the table name
 references.
 
+
+## Breakpoint preprocessing
+
+To ensure CSS breakpoints declared as custom properties are resolved before minification, introduce a preprocessing step with PostCSS custom media.
+
+### Tasks
+1. Install the `postcss-custom-media` plugin as a dev dependency.
+2. Update `build-css.js` to include the plugin before autoprefixing.
+3. Define breakpoints using `@custom-media` rules in `variables.css`.
+4. Replace usages of `var(--bp-*)` in media queries with the corresponding `@media (--bp-*)` syntax across CSS files.
+5. Run the existing CSS build and ensure the compiled output contains concrete pixel values for breakpoints.
+6. Execute the PHP and JS test suites to confirm no regressions.


### PR DESCRIPTION
## Summary
- document tasks to preprocess CSS breakpoints with PostCSS custom media

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a2f12d98648332a10e7d25138bf16e