### PR TITLE
Met à jour la navigation des énigmes

### DIFF
--- a/tests/EnigmeMenuRenderingTest.php
+++ b/tests/EnigmeMenuRenderingTest.php
@@ -138,6 +138,13 @@ if (!function_exists('recuperer_enigmes_pour_chasse')) {
     }
 }
 
+if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
+    function recuperer_ids_enigmes_pour_chasse($chasse_id)
+    {
+        return array_map(static fn($e) => $e->ID, $GLOBALS['enigma_list'] ?? []);
+    }
+}
+
 if (!function_exists('get_post_status')) {
     function get_post_status($id)
     {
@@ -221,6 +228,20 @@ if (!function_exists('get_template_part')) {
     }
 }
 
+if (!function_exists('chasse_calculer_taux_engagement')) {
+    function chasse_calculer_taux_engagement($chasse_id)
+    {
+        return 0;
+    }
+}
+
+if (!function_exists('chasse_calculer_taux_progression')) {
+    function chasse_calculer_taux_progression($chasse_id)
+    {
+        return 0;
+    }
+}
+
 if (!function_exists('cat_debug')) {
     function cat_debug($message)
     {
@@ -254,6 +275,21 @@ class EnigmeMenuRenderingTest extends TestCase
         $GLOBALS['is_admin'] = false;
         $GLOBALS['is_associated'] = true;
         $GLOBALS['is_organizer'] = true;
+
+        global $wpdb;
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+
+            public function prepare($query, ...$args)
+            {
+                return $query;
+            }
+
+            public function get_var($sql)
+            {
+                return 0;
+            }
+        };
     }
 
     public function test_menu_rendered_for_draft_enigme_for_associated_organizer(): void

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -299,17 +299,9 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
 
             if (!empty($menu_items)) {
                 echo '<section class="enigme-navigation">';
-                echo '<h3>' . esc_html__('Navigation', 'chassesautresor-com') . '</h3>';
+                echo '<h3>' . esc_html__('Énigmes', 'chassesautresor-com') . '</h3>';
                 echo '<ul class="enigme-menu">' . implode('', $menu_items) . '</ul>';
                 echo '</section>';
-            }
-
-            if ($chasse_id) {
-                $url_retour = get_permalink($chasse_id);
-                echo '<a href="' . esc_url($url_retour) . '" class="bouton-retour bouton-retour-chasse">';
-                echo '<i class="fa-solid fa-arrow-left"></i>';
-                echo '<span class="screen-reader-text">' . esc_html__('Retour à la chasse', 'chassesautresor-com') . '</span>';
-                echo '</a>';
             }
 
             echo '<section class="enigme-progressivometre"><h3>' .


### PR DESCRIPTION
## Résumé
- Simplifie l’aside des énigmes en renommant la section de navigation et en supprimant le bouton de retour
- Ajoute des stubs de fonctions dans les tests pour couvrir les nouvelles dépendances

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a30cf55d2083328b9980ce9bac5d99