### PR TITLE
Supprimer le bloc réponse pour les organisateurs

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -396,7 +396,8 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
     function render_enigme_participation(int $enigme_id, string $style, int $user_id): void
     {
         echo '<section class="participation">';
-        echo '<div class="zone-reponse">';
+
+        ob_start();
         enigme_get_partial(
             'bloc-reponse',
             $style,
@@ -405,7 +406,11 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                 'user_id' => $user_id,
             ]
         );
-        echo '</div>';
+        $bloc_reponse = trim(ob_get_clean());
+
+        if ($bloc_reponse !== '') {
+            echo '<div class="zone-reponse">' . $bloc_reponse . '</div>';
+        }
 
         $hints = get_field('indices', $enigme_id);
         if (!empty($hints)) {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -15,9 +15,6 @@ if (
   current_user_can('manage_options') ||
   utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
   ) {
-    echo '<p class="message-organisateur">'
-        . esc_html__('🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché.', 'chassesautresor-com')
-        . '</p>';
     return;
   }
 


### PR DESCRIPTION
## Résumé
- retire le message et le bloc réponse pour les organisateurs
- n'affiche plus de conteneur de réponse lorsque le bloc est vide

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a311839a2083329811067e89385ff1