### PR TITLE
Masquer la section participation vide

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -399,8 +399,6 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
      */
     function render_enigme_participation(int $enigme_id, string $style, int $user_id): void
     {
-        echo '<section class="participation">';
-
         ob_start();
         enigme_get_partial(
             'bloc-reponse',
@@ -412,15 +410,20 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
         );
         $bloc_reponse = trim(ob_get_clean());
 
+        $content = '';
+
         if ($bloc_reponse !== '') {
-            echo '<div class="zone-reponse">' . $bloc_reponse . '</div>';
+            $content .= '<div class="zone-reponse">' . $bloc_reponse . '</div>';
         }
 
         $hints = get_field('indices', $enigme_id);
         if (!empty($hints)) {
-            echo '<div class="zone-indices"><h3>' . esc_html__('Indices', 'chassesautresor-com') . '</h3></div>';
+            $content .= '<div class="zone-indices"><h3>' . esc_html__('Indices', 'chassesautresor-com') . '</h3></div>';
         }
-        echo '</section>';
+
+        if ($content !== '') {
+            echo '<section class="participation">' . $content . '</section>';
+        }
     }
 
     /**


### PR DESCRIPTION
## Résumé
- Supprime l'affichage d'une section de participation vide afin d'éviter un espace inutilisé.

## Changements notables
- Ne rend plus la section « participation » lorsqu'aucun formulaire de réponse ou indice n'est disponible.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a3221566f48332a40272f5a507a99b