### PR TITLE
Add caching headers for voir-image-enigme handler

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -1,32 +1,32 @@
 <?php
 // 🔒 Vérification minimale
 if (!isset($_GET['id']) || !ctype_digit($_GET['id'])) {
-  http_response_code(400);
-  exit('ID manquant ou invalide');
+    http_response_code(400);
+    exit('ID manquant ou invalide');
 }
 
 $image_id = (int) $_GET['id'];
-$taille = $_GET['taille'] ?? 'full';
+$taille   = $_GET['taille'] ?? 'full';
 
 // 🔁 Chargement des fonctions
 if (!function_exists('trouver_chemin_image')) {
-  require_once get_stylesheet_directory() . '/inc/enigme-functions.php';
+    require_once get_stylesheet_directory() . '/inc/enigme-functions.php';
 }
 if (!function_exists('utilisateur_peut_voir_enigme')) {
-  require_once get_stylesheet_directory() . '/inc/statut-functions.php';
+    require_once get_stylesheet_directory() . '/inc/statut-functions.php';
 }
 
 // 🧩 Récupération de l'énigme associée à cette image
 $parent_id = wp_get_post_parent_id($image_id);
 if (!$parent_id || get_post_type($parent_id) !== 'enigme') {
-  http_response_code(403);
-  exit('Image non autorisée');
+    http_response_code(403);
+    exit('Image non autorisée');
 }
 
 // 🔐 Vérification d'accès
 if (!utilisateur_peut_voir_enigme($parent_id)) {
-  http_response_code(403);
-  exit('Accès refusé');
+    http_response_code(403);
+    exit('Accès refusé');
 }
 
 // 📦 Récupération du chemin de l'image
@@ -36,14 +36,14 @@ $mime = $info['mime'] ?? 'application/octet-stream';
 
 // 🔁 Fallback automatique vers full si fichier manquant
 if (!$path && $taille !== 'full') {
-  $info = trouver_chemin_image($image_id, 'full');
-  $path = $info['path'] ?? null;
-  $mime = $info['mime'] ?? 'application/octet-stream';
+    $info = trouver_chemin_image($image_id, 'full');
+    $path = $info['path'] ?? null;
+    $mime = $info['mime'] ?? 'application/octet-stream';
 }
 
 if (!$path) {
-  http_response_code(404);
-  exit('Fichier introuvable');
+    http_response_code(404);
+    exit('Fichier introuvable');
 }
 
 // 🧹 Nettoyage WordPress
@@ -53,7 +53,25 @@ remove_all_actions('shutdown');
 remove_all_actions('template_redirect');
 
 // ✅ Envoi du fichier
+// 📅 Cache
+$mtime = filemtime($path);
+$etag  = '"' . md5($mtime . filesize($path)) . '"';
+
+header('Cache-Control: private, max-age=86400');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');
+header('ETag: ' . $etag);
+
+$if_none_match    = $_SERVER['HTTP_IF_NONE_MATCH'] ?? '';
+$if_modified_since = $_SERVER['HTTP_IF_MODIFIED_SINCE'] ?? '';
+
+if (($if_none_match && trim($if_none_match) === $etag) ||
+    ($if_modified_since && strtotime($if_modified_since) >= $mtime)) {
+    http_response_code(304);
+    exit;
+}
+
 header('Content-Type: ' . $mime);
 header('Content-Length: ' . filesize($path));
 readfile($path);
 exit;
+


### PR DESCRIPTION
Ajoute des en-têtes HTTP de cache et la gestion des réponses conditionnelles pour les images d'énigmes.

- Ajout des en-têtes `Cache-Control`, `Last-Modified` et `ETag`.
- Réponse `304 Not Modified` lorsque l'image n'a pas changé.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a32c73f00c833296423fa095290eba