### PR TITLE
Refactorisation du bloc réponse des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/enigme.css
+++ b/wp-content/themes/chassesautresor/assets/css/enigme.css
@@ -127,6 +127,33 @@
   gap: var(--space-md);
 }
 
+.zone-reponse {
+  background-color: rgba(var(--aside-bg-rgb, 255, 255, 255), var(--aside-opacity, 0.4));
+  padding: var(--space-md);
+  border: none;
+  width: 50%;
+  min-width: 600px;
+  display: flex;
+  flex-direction: column;
+}
+
+.bloc-reponse label {
+  color: var(--color-white);
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.bloc-reponse input[type="text"],
+.bloc-reponse textarea {
+  width: 100%;
+}
+
+.tentatives-counter {
+  text-align: center;
+  margin-top: var(--space-md);
+  align-self: center;
+}
+
 .solution details {
   background: var(--bg-solution, var(--ca-color-bg, #f5f5f5));
   padding: var(--space-md);

--- a/wp-content/themes/chassesautresor/assets/css/gamification.css
+++ b/wp-content/themes/chassesautresor/assets/css/gamification.css
@@ -335,6 +335,8 @@ header .points-link:hover {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-sm);
 }
 
 .points-link.points-boutique-icon {

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -35,7 +35,7 @@ defined('ABSPATH') || exit;
         ob_start();
     ?>
     <form method="post" class="bloc-reponse formulaire-reponse-manuelle">
-        <label for="reponse_manuelle_<?php echo esc_attr($enigme_id); ?>">Votre réponse :</label>
+        <label for="reponse_manuelle_<?php echo esc_attr($enigme_id); ?>"><?php esc_html_e('Votre réponse', 'chassesautresor-com'); ?></label>
         <?php if ($data['points_manquants'] > 0) : ?>
             <p class="message-limite" data-points="manquants">
                 <?php echo esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $data['points_manquants'])); ?>
@@ -49,10 +49,10 @@ defined('ABSPATH') || exit;
         <input type="hidden" name="enigme_id" value="<?php echo esc_attr($enigme_id); ?>">
         <input type="hidden" name="reponse_manuelle_nonce" value="<?php echo esc_attr($nonce); ?>">
         <div class="reponse-cta-row">
-            <button type="submit" class="bouton-cta" <?php echo $data['disabled']; ?>>Envoyer</button>
             <?php if ($data['cout'] > 0) : ?>
-                <span class="badge-cout"><?php echo esc_html($data['cout']); ?> pts</span>
+                <span class="badge-cout"><?php echo esc_html($data['cout']); ?> <?php esc_html_e('pts', 'chassesautresor-com'); ?></span>
             <?php endif; ?>
+            <button type="submit" class="bouton-cta" <?php echo $data['disabled']; ?>><?php esc_html_e('Valider', 'chassesautresor-com'); ?></button>
         </div>
     </form>
     <div class="reponse-feedback" style="display:none"></div>

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -790,33 +790,32 @@ msgstr ""
 msgid "Vous avez déjà résolu cette énigme."
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:55
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:48
+#: inc/enigme/reponses.php:55 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:52 template-parts/enigme/partials/enigme-partial-tentatives.php:48
 msgid "Valider"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:61
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:58
 msgid "tentatives quotidiennes épuisées"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:70
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:67
 #, php-format
 msgid "%dh et %dmn avant réactivation"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:86
-msgid "Votre réponse :"
+#: inc/enigme/reponses.php:38 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:83
+msgid "Votre réponse"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:93
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:90
 msgid "Accéder à la boutique"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:105
+#: inc/enigme/reponses.php:53 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:101
 msgid "pts"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:112
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:109
 msgid "Tentatives quotidiennes"
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -80,7 +80,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
 
 <form class="bloc-reponse formulaire-reponse-auto">
     <label for="reponse_auto_<?= esc_attr($post_id); ?>">
-      <?= esc_html__('Votre réponse :', 'chassesautresor-com'); ?>
+      <?= esc_html__('Votre réponse', 'chassesautresor-com'); ?>
     </label>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
@@ -97,10 +97,10 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
   <input type="hidden" name="enigme_id" value="<?= esc_attr($post_id); ?>">
   <input type="hidden" name="nonce" value="<?= esc_attr($nonce); ?>">
   <div class="reponse-cta-row">
-      <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
-      <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
-        <span class="badge-cout"><?= esc_html($cout); ?> <?= esc_html__('pts', 'chassesautresor-com'); ?></span>
-      <?php endif; ?>
+    <?php if ($cout > 0 && $statut_actuel !== 'resolue') : ?>
+      <span class="badge-cout"><?= esc_html($cout); ?> <?= esc_html__('pts', 'chassesautresor-com'); ?></span>
+    <?php endif; ?>
+    <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
   </div>
 </form>
 <div class="reponse-feedback" style="display:none"></div>


### PR DESCRIPTION
## Résumé
- Harmonisation visuelle du bloc de réponse des énigmes
- Mise à jour des libellés et de la traduction

## Changements
- Ajuste le formulaire automatique et manuel avec le texte "Votre réponse" et un bouton "Valider"
- Applique un fond blanc translucide, padding moyen et largeur 50% (min 600px) avec champ texte pleine largeur
- Centre le compteur de tentatives et aligne le CTA à droite
- Met à jour le fichier de traduction pour les nouveaux libellés

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a33db8b2648332b5193add2b40f5ff