### PR TITLE
feat(outils): ajoute carte de compilation CSS

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/compil-css-card.js
+++ b/wp-content/themes/chassesautresor/assets/js/compil-css-card.js
@@ -1,0 +1,41 @@
+function initCssCompilerCard() {
+    const btn = document.getElementById('toggle-css-compiler');
+    if (!btn || typeof compilCssCard === 'undefined') {
+        return;
+    }
+
+    btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        btn.disabled = true;
+        fetch(compilCssCard.ajax_url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            body: `action=cta_toggle_css_compiler&nonce=${encodeURIComponent(compilCssCard.nonce)}`,
+        })
+            .then((resp) => resp.json())
+            .then((data) => {
+                if (data.success) {
+                    btn.textContent = data.data.active
+                        ? compilCssCard.text_deactivate
+                        : compilCssCard.text_activate;
+                } else {
+                    alert('Erreur : ' + data.data);
+                }
+            })
+            .catch(() => {
+                alert('Erreur AJAX');
+            })
+            .finally(() => {
+                btn.disabled = false;
+            });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initCssCompilerCard);
+document.addEventListener('myaccountSectionLoaded', (e) => {
+    if (e.detail.section === 'outils') {
+        initCssCompilerCard();
+    }
+});

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -33,10 +33,11 @@ add_action('wp_enqueue_scripts', function () {
     wp_enqueue_style('astra-style', get_template_directory_uri() . '/style.css');
 
     // Détermine l'environnement via WP_ENVIRONMENT_TYPE ou une constante dédiée.
-    $env            = defined('CHASSESAUTRESOR_ENV') ? CHASSESAUTRESOR_ENV : wp_get_environment_type();
-    $is_edition_env = 'edition' === $env || current_user_can('administrator');
+    $env                  = defined('CHASSESAUTRESOR_ENV') ? CHASSESAUTRESOR_ENV : wp_get_environment_type();
+    $is_compil_active     = get_option('cta_css_compilation_active', '1') === '1';
+    $is_edition_env       = 'edition' === $env;
 
-    if ($is_edition_env) {
+    if (!$is_compil_active || $is_edition_env) {
         wp_enqueue_style(
             'mon-theme-enfant-style',
             $theme_uri . '/style.css',

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-outils.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-outils.php
@@ -12,7 +12,8 @@ if (!current_user_can('administrator')) {
     exit;
 }
 
-$taux_conversion = get_taux_conversion_actuel();
+$taux_conversion    = get_taux_conversion_actuel();
+$css_compil_active = get_option('cta_css_compilation_active', '1') === '1';
 ?>
 <section>
     <h1 class="mb-4 text-xl font-semibold"><?php esc_html_e('Outils', 'chassesautresor-com'); ?></h1>
@@ -53,6 +54,16 @@ $taux_conversion = get_taux_conversion_actuel();
                     <textarea id="acf-fields-output" style="width:100%;height:300px;" readonly></textarea>
                 </div>
             </div>
+        </div>
+
+        <div class="dashboard-card">
+            <i class="fas fa-code"></i>
+            <h3><?php esc_html_e('Compil CSS', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value">
+                <button id="toggle-css-compiler" class="bouton-primaire" data-nonce="<?php echo esc_attr(wp_create_nonce('cta_toggle_css_compiler')); ?>">
+                    <?php echo $css_compil_active ? esc_html__('Désactiver', 'chassesautresor-com') : esc_html__('Activer', 'chassesautresor-com'); ?>
+                </button>
+            </p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Résumé
- ajoute une carte "Compil CSS" dans l'onglet Outils
- permet d'activer ou désactiver la compilation CSS via AJAX
- adapte le chargement des styles selon l'option

## Testing
- `npm test`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a3403ed52483329fd019ca574617a9