### PR TITLE
Remplace les labels de réponse par des h3

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -35,7 +35,7 @@ defined('ABSPATH') || exit;
         ob_start();
     ?>
     <form method="post" class="bloc-reponse formulaire-reponse-manuelle">
-        <label for="reponse_manuelle_<?php echo esc_attr($enigme_id); ?>">Votre réponse :</label>
+        <h3><?php echo esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
         <?php if ($data['points_manquants'] > 0) : ?>
             <p class="message-limite" data-points="manquants">
                 <?php echo esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $data['points_manquants'])); ?>

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -804,8 +804,9 @@ msgstr ""
 msgid "%dh et %dmn avant réactivation"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:86
-msgid "Votre réponse :"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
+#: inc/enigme/reponses.php:38
+msgid "Votre réponse"
 msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:93

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -79,9 +79,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
 ?>
 
 <form class="bloc-reponse formulaire-reponse-auto">
-    <label for="reponse_auto_<?= esc_attr($post_id); ?>">
-      <?= esc_html__('Votre réponse :', 'chassesautresor-com'); ?>
-    </label>
+    <h3><?= esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
   <?php elseif ($points_manquants > 0) : ?>


### PR DESCRIPTION
## Résumé
- remplace les balises `label` des blocs de réponse par des `h3`
- ajuste la chaîne traduite `Votre réponse`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a349dd618c8332981fb5fb4d114b96