### PR TITLE
Align edition style loading with association permissions

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -98,7 +98,7 @@ add_action('wp_enqueue_scripts', function () {
 
         if (is_singular(['organisateur', 'chasse', 'enigme'])) {
             $post_id = get_queried_object_id();
-            if (current_user_can('edit_post', $post_id)) {
+            if (utilisateur_peut_modifier_post($post_id)) {
                 $should_load_edition = true;
             }
         } elseif (


### PR DESCRIPTION
## Résumé
- Aligne le chargement de `edition.css` sur la fonction `utilisateur_peut_modifier_post`

## Changements notables
- Charge `edition.css` pour les organisateurs associés même sans capacité `edit_post`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a34fb1897483328e90febd41fff2f6