### PR TITLE
feat: rafraîchissement du menu énigme en cas de succès

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
@@ -70,6 +70,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (compteur) {
               compteur.remove();
             }
+            const currentMenuItem = document.querySelector('.enigme-menu li.active');
+            if (currentMenuItem) {
+              currentMenuItem.classList.remove('non-engagee', 'bloquee');
+              currentMenuItem.classList.add('succes');
+            }
           } else {
             feedback.textContent = 'Mauvaise réponse';
             feedback.style.display = 'block';


### PR DESCRIPTION
## Résumé
- rafraîchit la pastille du menu d'énigme lorsque la réponse est correcte

## Changements notables
- ajoute la classe `succes` à l'énigme active après une bonne réponse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35ef230248332b0e0d8edf434c1fd