### PR TITLE
Retire le message de résolution en doublon

### DIFF
--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -399,16 +399,14 @@ function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
     }
 
     $formulaire = in_array($statut, ['en_cours', 'non_souscrite'], true);
-    $message = ($statut === 'resolue');
-    $message_html = $message ? '<p class="message-statut">Vous avez déjà résolu cette énigme.</p>' : '';
 
     return [
         'etat' => $statut,
         'rediriger' => false,
         'url' => null,
         'afficher_formulaire' => $formulaire,
-        'afficher_message' => $message,
-        'message_html' => $message_html,
+        'afficher_message' => false,
+        'message_html' => '',
     ];
 }
 


### PR DESCRIPTION
## Résumé
- Supprime l'affichage du message "Vous avez déjà résolu cette énigme." hors de la section de participation.

## Changements notables
- Désactive l'injection du message de résolution global dans `traiter_statut_enigme`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a364bb60048332a13042052c29183a