### PR TITLE
Fix solution cards layout in enigme editing panel

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -1364,6 +1364,13 @@ body.panneau-ouvert::before {
   margin: var(--space-md) 0 var(--space-3xl);
 }
 
+.dashboard-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 20px;
+}
+
 .dashboard-card {
   background-color: var(--color-editor-background);
   border: 1px solid var(--color-editor-border);


### PR DESCRIPTION
Corrige la disposition des cartes de solution dans le panneau d'édition d'énigme.

- Ajoute la grille `dashboard-grid` pour aligner les cartes de solution

### Testing
- `npm ci`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a367daa10c833292cff61d01640ef5