### PR TITLE
Ajout d’un emoji de chargement sur la tentative manuelle

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-manuelle.js
@@ -11,7 +11,7 @@ function initFormulaireManuel() {
 
   const i18n = window.REPONSE_MANUELLE_I18N || {};
   const txtSuccess = i18n.success || 'Tentative bien reçue.';
-  const txtProcessing = i18n.processing || 'Votre tentative est en cours de traitement.';
+  const txtProcessing = i18n.processing || '⏳ Votre tentative est en cours de traitement.';
 
   form.addEventListener('submit', e => {
     e.preventDefault();

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -506,7 +506,7 @@ function charger_script_reponse_manuelle() {
 
         wp_localize_script('reponse-manuelle', 'REPONSE_MANUELLE_I18N', [
             'success'    => esc_html__('Tentative bien reçue.', 'chassesautresor-com'),
-            'processing' => esc_html__('Votre tentative est en cours de traitement.', 'chassesautresor-com'),
+            'processing' => esc_html__('⏳ Votre tentative est en cours de traitement.', 'chassesautresor-com'),
         ]);
     }
 }

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -277,7 +277,7 @@ msgstr ""
 
 #: inc/enigme/reponses.php:509
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:35
-msgid "Votre tentative est en cours de traitement."
+msgid "⏳ Votre tentative est en cours de traitement."
 msgstr ""
 
 #: inc/enigme/visuels.php:129

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -29,7 +29,7 @@ if ($mode_validation === 'manuelle') {
   if (!utilisateur_peut_repondre_manuelle($user_id, $post_id)) {
     $statut = enigme_get_statut_utilisateur($post_id, $user_id);
     $texte = $statut === 'soumis'
-      ? __('Votre tentative est en cours de traitement.', 'chassesautresor-com')
+      ? __('⏳ Votre tentative est en cours de traitement.', 'chassesautresor-com')
       : __('Énigme résolue', 'chassesautresor-com');
     echo '<p class="message-joueur-statut">' . esc_html($texte) . '</p>';
     return;


### PR DESCRIPTION
## Résumé
- affiche une icône de chargement lors de la soumission manuelle d’une énigme

## Changements notables
- message PHP et JS de traitement enrichi d’un emoji
- mise à jour du fichier de traduction

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a36dfa47d48332881dbaac77c91410