### PR TITLE
Ajout du pager AJAX aux tentatives d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1424,35 +1424,18 @@ function initPagerTentatives() {
   const wrapper = document.querySelector('#enigme-tab-soumission .liste-tentatives');
   const postId = document.querySelector('.edition-panel-enigme')?.dataset.postId;
   const compteur = document.querySelector('#enigme-tab-soumission .total-tentatives');
-  const info = wrapper?.querySelector('.pager-info');
   if (!wrapper || !postId) return;
 
-  wrapper.addEventListener('click', (e) => {
-    if (e.target.closest('.pager-first')) {
-      e.preventDefault();
-      charger(1);
-    }
-    if (e.target.closest('.pager-prev')) {
-      e.preventDefault();
-      const page = parseInt(wrapper.dataset.page || '1', 10);
-      if (page > 1) charger(page - 1);
-    }
-    if (e.target.closest('.pager-next')) {
-      e.preventDefault();
-      const page = parseInt(wrapper.dataset.page || '1', 10);
-      const pages = parseInt(wrapper.dataset.pages || '1', 10);
-      if (page < pages) charger(page + 1);
-    }
-    if (e.target.closest('.pager-last')) {
-      e.preventDefault();
-      const pages = parseInt(wrapper.dataset.pages || '1', 10);
-      charger(pages);
-    }
-  });
-
-  if (info) {
-    info.textContent = (wrapper.dataset.page || '1') + ' / ' + (wrapper.dataset.pages || '1');
+  function attachPager() {
+    const pager = wrapper.querySelector('.pager');
+    if (!pager) return;
+    pager.addEventListener('pager:change', (e) => {
+      const page = e.detail?.page || 1;
+      charger(page);
+    });
   }
+
+  attachPager();
 
   function charger(page) {
     fetch(ajaxurl, {
@@ -1470,9 +1453,9 @@ function initPagerTentatives() {
         wrapper.innerHTML = res.data.html;
         wrapper.dataset.page = res.data.page;
         wrapper.dataset.pages = res.data.pages;
+        wrapper.dataset.total = res.data.total;
         if (compteur) compteur.textContent = '(' + res.data.total + ')';
-        const span = wrapper.querySelector('.pager-info');
-        if (span) span.textContent = res.data.page + ' / ' + res.data.pages;
+        attachPager();
       });
   }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -203,7 +203,7 @@ function get_etat_tentative(string $uid): string
  * @return array         Liste des tentatives triées par priorité manuelle puis
  *                       par date de soumission décroissante.
  */
-function recuperer_tentatives_enigme(int $enigme_id, int $limit = 10, int $offset = 0): array
+function recuperer_tentatives_enigme(int $enigme_id, int $limit = 5, int $offset = 0): array
 {
     global $wpdb;
     $table = $wpdb->prefix . 'enigme_tentatives';
@@ -245,7 +245,7 @@ function ajax_lister_tentatives_enigme()
 
     $enigme_id = isset($_POST['enigme_id']) ? (int) $_POST['enigme_id'] : 0;
     $page      = max(1, (int) ($_POST['page'] ?? 1));
-    $par_page  = 10;
+    $par_page  = 5;
 
     if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
         wp_send_json_error('post_invalide');

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -566,7 +566,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
   }
 
   $page_tentatives = max(1, intval($_GET['page_tentatives'] ?? 1));
-  $par_page = 10;
+  $par_page = 5;
   $offset = ($page_tentatives - 1) * $par_page;
   $tentatives = recuperer_tentatives_enigme($enigme_id, $par_page, $offset);
   $total_tentatives = compter_tentatives_enigme($enigme_id);

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
@@ -12,7 +12,7 @@ defined('ABSPATH') || exit;
 $args = $args ?? [];
 $tentatives = $args['tentatives'] ?? $tentatives ?? [];
 $page = $args['page'] ?? $page ?? 1;
-$par_page = $args['par_page'] ?? $par_page ?? 10;
+$par_page = $args['par_page'] ?? $par_page ?? 5;
 $total = $args['total'] ?? $total ?? 0;
 $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
 ?>
@@ -59,23 +59,5 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
   <?php endforeach; ?>
   </tbody>
 </table>
-<div class="pager">
-    <?php if ($page > 1) : ?>
-      <button class="pager-first" aria-label="<?= esc_attr__('Première page', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angles-left"></i>
-      </button>
-      <button class="pager-prev" aria-label="<?= esc_attr__('Page précédente', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angle-left"></i>
-      </button>
-    <?php endif; ?>
-  <span class="pager-info"><?= esc_html($page); ?> / <?= esc_html($pages); ?></span>
-    <?php if ($page < $pages) : ?>
-      <button class="pager-next" aria-label="<?= esc_attr__('Page suivante', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angle-right"></i>
-      </button>
-      <button class="pager-last" aria-label="<?= esc_attr__('Dernière page', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angles-right"></i>
-      </button>
-    <?php endif; ?>
-</div>
+<?php echo cta_render_pager($page, $pages, 'enigme-tentatives-pager'); ?>
 <?php endif; ?>


### PR DESCRIPTION
## Résumé
- implémente le composant de pagination du thème pour les tentatives d'une énigme
- limite l'affichage des tentatives à cinq éléments par page

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a3952717f88332aef6a12c0a360539