### PR TITLE
Use default pager for Tentatives table

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -20,6 +20,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
+  const decorateMessages = () => {
+    const container = content.querySelector('.msg-important');
+    if (container) {
+      container
+        .querySelectorAll('p:not(.flash)')
+        .forEach((p) => p.classList.add('alerte-discret'));
+    }
+  };
+
   const loadSection = async (link, push = true) => {
     const section = link.dataset.section;
     if (!section) {
@@ -43,6 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const messages = data.data.messages || '';
       content.innerHTML = `<section class="msg-important">${messages}</section>` + data.data.html;
+      decorateMessages();
       fadeFlash();
       document
         .querySelectorAll('.dashboard-nav-link[data-section]')
@@ -93,5 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  decorateMessages();
   fadeFlash();
 });

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -1,0 +1,20 @@
+/**
+ * Handle navigation for the Tentatives table using the default pager.
+ */
+(function () {
+  document.addEventListener('pager:change', function (e) {
+    var pager = e.target;
+    if (!pager.classList.contains('tentatives-pager')) {
+      return;
+    }
+    var page = e.detail.page || 1;
+    var url = new URL(window.location.href);
+    url.searchParams.set('section', 'chasses');
+    if (page > 1) {
+      url.searchParams.set('page', String(page));
+    } else {
+      url.searchParams.delete('page');
+    }
+    window.location.href = url.toString();
+  });
+})();

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
@@ -12,6 +12,25 @@ defined('ABSPATH') || exit;
 $current_user = wp_get_current_user();
 $user_id      = (int) $current_user->ID;
 
+$dir = get_stylesheet_directory();
+$uri = get_stylesheet_directory_uri();
+
+wp_enqueue_script(
+    'pager',
+    $uri . '/assets/js/core/pager.js',
+    [],
+    filemtime($dir . '/assets/js/core/pager.js'),
+    true
+);
+
+wp_enqueue_script(
+    'tentatives-pager',
+    $uri . '/assets/js/tentatives-pager.js',
+    ['pager'],
+    filemtime($dir . '/assets/js/tentatives-pager.js'),
+    true
+);
+
 // Retrieve last 4 engaged hunts and their latest enigme
 $chasse_ids  = [];
 $enigme_map = [];
@@ -99,41 +118,25 @@ $pages = (int) ceil($total / $per_page);
     <?php endif; ?>
 </div>
 <?php if ($total > 0) : ?>
-<table class="stats-table">
-    <thead>
-        <tr>
-            <th><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
-            <th><?php esc_html_e('Énigme', 'chassesautresor-com'); ?></th>
-            <th><?php esc_html_e('Résultat', 'chassesautresor-com'); ?></th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php foreach ($tentatives as $tent) : ?>
-        <tr>
-            <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
-            <td><?php echo esc_html($tent->post_title); ?></td>
-            <td><?php echo esc_html($tent->resultat); ?></td>
-        </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
-<div class="pager">
-    <?php if ($page > 1) : ?>
-    <button class="pager-first" aria-label="<?php esc_attr_e('Première page', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angles-left"></i>
-    </button>
-    <button class="pager-prev" aria-label="<?php esc_attr_e('Page précédente', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angle-left"></i>
-    </button>
-    <?php endif; ?>
-    <span class="pager-info"><?php echo esc_html($page); ?> / <?php echo esc_html($pages); ?></span>
-    <?php if ($page < $pages) : ?>
-    <button class="pager-next" aria-label="<?php esc_attr_e('Page suivante', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angle-right"></i>
-    </button>
-    <button class="pager-last" aria-label="<?php esc_attr_e('Dernière page', 'chassesautresor-com'); ?>">
-        <i class="fa-solid fa-angles-right"></i>
-    </button>
-    <?php endif; ?>
+<div class="stats-table-wrapper" data-per-page="<?php echo esc_attr($per_page); ?>">
+    <table class="stats-table">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
+                <th><?php esc_html_e('Énigme', 'chassesautresor-com'); ?></th>
+                <th><?php esc_html_e('Résultat', 'chassesautresor-com'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($tentatives as $tent) : ?>
+            <tr>
+                <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
+                <td><?php echo esc_html($tent->post_title); ?></td>
+                <td><?php echo esc_html($tent->resultat); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php echo cta_render_pager($page, $pages, 'tentatives-pager'); ?>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
## Résumé
Applique le pager par défaut au tableau des tentatives dans l'onglet "Chasses" du compte et corrige le style des messages persistants.

## Changements notables
- Remplacement du pager manuel par `cta_render_pager` et chargement des scripts associés.
- Ajout du script `tentatives-pager.js` pour gérer la navigation et conserver l'onglet actif.
- Correction de l'affichage des messages persistants dans `myaccount.js`.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3994b4a08833282a615496b9ef846