### PR TITLE
Augmente la pagination des tentatives à 20

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -263,7 +263,7 @@ function ajax_lister_tentatives_enigme()
 
     $enigme_id = isset($_POST['enigme_id']) ? (int) $_POST['enigme_id'] : 0;
     $page      = max(1, (int) ($_POST['page'] ?? 1));
-    $par_page  = 5;
+    $par_page  = 20;
 
     if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
         wp_send_json_error('post_invalide');

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -566,7 +566,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
   }
 
   $page_tentatives = max(1, intval($_GET['page_tentatives'] ?? 1));
-  $par_page = 5;
+  $par_page = 20;
   $offset = ($page_tentatives - 1) * $par_page;
   $tentatives = recuperer_tentatives_enigme($enigme_id, $par_page, $offset);
   $total_tentatives = compter_tentatives_enigme($enigme_id);

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
@@ -12,7 +12,7 @@ defined('ABSPATH') || exit;
 $args = $args ?? [];
 $tentatives = $args['tentatives'] ?? $tentatives ?? [];
 $page = $args['page'] ?? $page ?? 1;
-$par_page = $args['par_page'] ?? $par_page ?? 5;
+$par_page = $args['par_page'] ?? $par_page ?? 20;
 $total = $args['total'] ?? $total ?? 0;
 $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
 ?>


### PR DESCRIPTION
## Résumé
- Ajuste la pagination des tentatives pour afficher 20 entrées par page
- Harmonise la valeur par défaut dans l'appel AJAX et le gabarit du tableau

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a39edb19f88332b31b619876e4b017