### PR TITLE
Fix layout of enigma aside

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/aside.css
+++ b/wp-content/themes/chassesautresor/assets/css/aside.css
@@ -8,13 +8,27 @@
   padding-bottom: 0;
   border-radius: 6px;
   align-self: start;
-  height: fit-content;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - var(--space-md));
+  max-height: calc(100vh - var(--space-md));
   color: rgba(var(--color-white-rgb, 255, 255, 255), 0.4);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
-.menu-lateral.has-open-accordeon {
-  padding-bottom: var(--space-4xl);
+.menu-lateral__content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.menu-lateral__accordeons {
+  margin-top: auto;
+  flex-shrink: 0;
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background-color: inherit;
 }
 
 .menu-lateral__header {
@@ -138,6 +152,8 @@
 /* Premier bloc après le contenu principal */
 .accordeon-bloc {
   margin-top: var(--space-md);
+  display: flex;
+  flex-direction: column;
 }
 
 .accordeon-bloc + .accordeon-bloc {
@@ -191,6 +207,7 @@
 
 .accordeon-contenu {
   overflow: hidden;
+  width: 100%;
   max-height: 0;
   transition: max-height 0.3s ease;
 }

--- a/wp-content/themes/chassesautresor/assets/js/accordeon.js
+++ b/wp-content/themes/chassesautresor/assets/js/accordeon.js
@@ -1,5 +1,3 @@
-const menuLateral = document.querySelector('.menu-lateral');
-
 document.querySelectorAll('.accordeon-bloc').forEach(bloc => {
   const toggle = bloc.querySelector('.accordeon-toggle');
   const contenu = bloc.querySelector('.accordeon-contenu');
@@ -9,9 +7,6 @@ document.querySelectorAll('.accordeon-bloc').forEach(bloc => {
   // Synchronise l’état initial
   const estOuvert = toggle.getAttribute('aria-expanded') === 'true';
   contenu.classList.toggle('accordeon-ferme', !estOuvert);
-  if (estOuvert) {
-    menuLateral?.classList.add('has-open-accordeon');
-  }
 
   toggle.addEventListener('click', () => {
     const estActuellementOuvert = toggle.getAttribute('aria-expanded') === 'true';
@@ -31,9 +26,6 @@ document.querySelectorAll('.accordeon-bloc').forEach(bloc => {
     if (!estActuellementOuvert) {
       toggle.setAttribute('aria-expanded', 'true');
       contenu.classList.remove('accordeon-ferme');
-      menuLateral?.classList.add('has-open-accordeon');
-    } else {
-      menuLateral?.classList.remove('has-open-accordeon');
     }
   });
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -284,7 +284,6 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
             ob_start();
             echo '<aside class="menu-lateral">';
 
-            echo '<div class="menu-lateral__core">';
             echo '<div class="menu-lateral__header">';
             if ($chasse_id) {
                 $url_chasse = get_permalink($chasse_id);
@@ -300,6 +299,7 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
             }
             echo '</div>';
 
+            echo '<div class="menu-lateral__content">';
             if ($chasse_id) {
                 $logo = get_the_post_thumbnail($chasse_id, 'thumbnail');
                 if ($logo) {
@@ -317,17 +317,17 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
 
             echo '<div class="menu-lateral__accordeons">';
             echo '<div class="accordeon-bloc">';
-            echo '<button class="accordeon-toggle" type="button" aria-expanded="false">'
-                . '<i class="fa-solid fa-chevron-down" aria-hidden="true"></i>'
-                . '<span class="screen-reader-text">'
-                . esc_html__('Afficher la progression', 'chassesautresor-com')
-                . '</span></button>';
             echo '<div class="accordeon-contenu accordeon-ferme">';
             echo '<section class="enigme-progression">';
             echo '<h3>' . esc_html__('Progression', 'chassesautresor-com') . '</h3>';
             echo '%STATS%';
             echo '</section>';
             echo '</div>';
+            echo '<button class="accordeon-toggle" type="button" aria-expanded="false">'
+                . '<i class="fa-solid fa-chevron-down" aria-hidden="true"></i>'
+                . '<span class="screen-reader-text">'
+                . esc_html__('Afficher la progression', 'chassesautresor-com')
+                . '</span></button>';
             echo '</div>';
             echo '</div>';
             echo '</aside>';


### PR DESCRIPTION
## Résumé
- réorganise la sidebar des énigmes en colonne flex pour placer le bouton d’extension en bas
- ajuste les styles pour garder l’entête et le bouton visibles et éviter les débordements horizontaux
- simplifie le script des accordéons

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a3f34d688083329d42855442840bb8