### PR TITLE
feat: ajoute une icône check pour les énigmes résolues

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -39,12 +39,12 @@ if ($mode_validation === 'manuelle') {
 }
 
 $statut_actuel = enigme_get_statut_utilisateur($post_id, $user_id);
-  if ($statut_actuel === 'resolue') {
-    echo '<p class="message-joueur-statut">'
+if ($statut_actuel === 'resolue') {
+    echo '<p class="message-joueur-statut">✅ '
         . esc_html__('Vous avez déjà résolu cette énigme.', 'chassesautresor-com')
         . '</p>';
     return;
-  }
+}
 
 $tentatives_du_jour = compter_tentatives_du_jour($user_id, $post_id);
   $boutique_url = esc_url(home_url('/boutique/'));


### PR DESCRIPTION
### Résumé
- Ajout d'une icône de validation devant le message pour les énigmes déjà résolues

### Changements notables
- Affichage d'une icône ✅ précédant l'information "Vous avez déjà résolu cette énigme."

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a3f4d07a508332a54ee67f7ce994fe