### PR TITLE
Supprimer le bandeau d'édition des chasses sur les pages énigme

### DIFF
--- a/tests/LayoutFunctionsTest.php
+++ b/tests/LayoutFunctionsTest.php
@@ -137,13 +137,12 @@ class LayoutFunctionsTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_banner_displayed_on_enigme_page(): void
+    public function test_banner_not_displayed_on_enigme_page(): void
     {
         global $current_post_type, $current_post_id;
         $current_post_type = 'enigme';
         $current_post_id = 456;
 
-        $output = $this->getBannerOutput();
-        $this->assertStringContainsString('bandeau-info-chasse', $output);
+        $this->assertSame('', $this->getBannerOutput());
     }
 }

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -373,51 +373,10 @@ function limiter_texte_avec_toggle($texte, $limite = 200, $label_plus = 'Lire la
     return ob_get_clean();
 }
 /**
- * Affiche un bandeau d'information global invitant l'organisateur
- * à valider sa chasse lorsque toutes les conditions sont réunies.
- *
- * @hook astra_header_after
+ * Previously displayed a banner encouraging organizers to validate their hunt.
+ * This feature has been removed and the function now performs no action.
  */
-function afficher_bandeau_validation_chasse_global() {
-    if (!is_user_logged_in()) {
-        return;
-    }
-
-    $user_id = get_current_user_id();
-    if (!$user_id) {
-        return;
-    }
-
-    if (!function_exists('trouver_chasse_a_valider')) {
-        return;
-    }
-
-    if (!is_singular('enigme')) {
-        return;
-    }
-
-    $chasse_id = trouver_chasse_a_valider($user_id);
-    if (!$chasse_id) {
-        return;
-    }
-
-    if (!function_exists('recuperer_id_chasse_associee')) {
-        return;
-    }
-
-    $enigme_chasse_id = recuperer_id_chasse_associee(get_the_ID());
-    if ((int) $enigme_chasse_id !== (int) $chasse_id) {
-        return;
-    }
-
-    $titre = get_the_title($chasse_id);
-    $lien  = get_permalink($chasse_id);
-    echo '<div class="bandeau-info-chasse">';
-    printf(
-        '<span>Votre chasse : <a href="%s">%s</a> est en cours d\'édition</span>',
-        esc_url($lien),
-        esc_html($titre)
-    );
-    echo '</div>';
+function afficher_bandeau_validation_chasse_global()
+{
+    // Intentionally left blank.
 }
-add_action('astra_header_after', 'afficher_bandeau_validation_chasse_global');


### PR DESCRIPTION
## Résumé
- retire l'affichage du bandeau invitant à valider la chasse sur les pages d'énigmes
- adapte les tests unitaires pour refléter la disparition du bandeau

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a40a7ce9c48332b5a2318d6b09862d