### PR TITLE
Ajout d'un bouton d'ajout d'énigme dans l'aside

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -24,8 +24,8 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
     id="carte-ajout-enigme"
     data-post-id="0"
   >
-    <i class="fa-solid fa-circle-plus fa-lg"></i>
-    <span class="screen-reader-text">Ajouter une énigme</span>
+    <i class="fa-solid fa-circle-plus fa-lg" aria-hidden="true"></i>
+    <span><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
   </a>
 <?php else : ?>
   <a


### PR DESCRIPTION
## Résumé
- ajout du bouton "Ajouter une énigme" dans l'aside des pages d'énigme
- amélioration du partial d'ajout pour afficher l'icône et le texte

## Changements notables
- calcul des conditions d'affichage et injection dynamique dans le menu latéral
- bouton d'ajout d'énigme visible avec icône et libellé

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a410ab3170833285591ebbd662ec14