### PR TITLE
Affiche le bouton d'ajout d'énigme après complétion

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -204,6 +204,9 @@ window.mettreAJourResumeInfos = function () {
   if (typeof window.mettreAJourCarteAjoutEnigme === 'function') {
     window.mettreAJourCarteAjoutEnigme();
   }
+  if (typeof window.mettreAJourBoutonAjoutEnigme === 'function') {
+    window.mettreAJourBoutonAjoutEnigme();
+  }
   if (typeof window.mettreAJourEtatIntroChasse === 'function') {
     window.mettreAJourEtatIntroChasse();
   }

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1473,3 +1473,44 @@ function initPagerTentatives() {
       });
   }
 }
+
+// ==============================
+// ➕ Affichage dynamique du bouton d'ajout d'énigme
+// ==============================
+window.mettreAJourBoutonAjoutEnigme = function () {
+  const nav = document.querySelector('.enigme-navigation');
+  if (!nav) return;
+
+  const existing = document.getElementById('carte-ajout-enigme');
+  if (existing) return;
+
+  const chasseId = nav.dataset.chasseId;
+  if (!chasseId) return;
+
+  const data = new FormData();
+  data.append('action', 'verifier_enigmes_completes');
+  data.append('chasse_id', chasseId);
+
+  fetch(window.ajaxurl, {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: data
+  })
+    .then(r => r.json())
+    .then(res => {
+      if (!res.success || res.data.has_incomplete) {
+        return;
+      }
+
+      const link = document.createElement('a');
+      link.id = 'carte-ajout-enigme';
+      link.dataset.postId = '0';
+      link.href = `${window.location.origin}/creer-enigme/?chasse_id=${chasseId}`;
+      link.innerHTML =
+        '<i class="fa-solid fa-circle-plus fa-lg" aria-hidden="true"></i>' +
+        `<span>${wp.i18n.__('Ajouter une énigme', 'chassesautresor-com')}</span>`;
+      const menu = nav.querySelector('.enigme-menu');
+      nav.insertBefore(link, menu);
+    })
+    .catch(() => {});
+};

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -617,6 +617,37 @@ function supprimer_enigme_ajax()
 }
 add_action('wp_ajax_supprimer_enigme', 'supprimer_enigme_ajax');
 
+/**
+ * Vérifie s'il reste des énigmes incomplètes pour une chasse.
+ *
+ * @hook wp_ajax_verifier_enigmes_completes
+ * @return void
+ */
+function verifier_enigmes_completes_ajax()
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $chasse_id = isset($_POST['chasse_id']) ? (int) $_POST['chasse_id'] : 0;
+    if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+        wp_send_json_error('id_invalide');
+    }
+
+    $ids            = recuperer_enigmes_associees($chasse_id);
+    $has_incomplete = false;
+    foreach ($ids as $eid) {
+        verifier_ou_mettre_a_jour_cache_complet($eid);
+        if (!get_field('enigme_cache_complet', $eid)) {
+            $has_incomplete = true;
+            break;
+        }
+    }
+
+    wp_send_json_success(['has_incomplete' => $has_incomplete]);
+}
+add_action('wp_ajax_verifier_enigmes_completes', 'verifier_enigmes_completes_ajax');
+
 
 
 // ==================================================

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -348,7 +348,8 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
             }
 
             if (!empty($menu_items)) {
-                echo '<section class="enigme-navigation">';
+                $data_chasse = $chasse_id ? ' data-chasse-id="' . intval($chasse_id) . '"' : '';
+                echo '<section class="enigme-navigation"' . $data_chasse . '>';
                 echo '<h3>' . esc_html__('Énigmes', 'chassesautresor-com') . '</h3>';
                 echo '%AJOUT%';
                 echo '<ul class="enigme-menu">' . implode('', $menu_items) . '</ul>';


### PR DESCRIPTION
## Résumé
Affiche dynamiquement le bouton d'ajout d'énigme lorsque toutes les énigmes d'une chasse sont complètes.

## Changements
- Ajout d'un endpoint AJAX pour vérifier la présence d'énigmes incomplètes
- Mise à jour du JavaScript d'édition pour insérer le bouton d'ajout si nécessaire
- Rafraîchissement du bouton lors des mises à jour du résumé
- Ajout de l'identifiant de chasse dans la navigation des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a41a84b0ac8332af57d87ec362ae41