### PR TITLE
Rafraîchissement instantané de l’indicateur d’image chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -44,6 +44,10 @@ function initChampImage(bloc) {
       bloc.classList.remove('champ-vide');
       input.value = id;
 
+      if (typeof window.mettreAJourResumeInfos === 'function') {
+        window.mettreAJourResumeInfos();
+      }
+
       if (feedback) {
         feedback.textContent = 'Enregistrement...';
         feedback.className = 'champ-feedback champ-loading';


### PR DESCRIPTION
## Résumé
- Rafraîchit immédiatement l’indicateur de complétion lorsqu’une image de chasse est sélectionnée.

## Changements notables
- Appel immédiat à `mettreAJourResumeInfos` après le choix de l’image.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41cbdd1288332b1acba0d0d870e4a