### PR TITLE
Réouverture du panneau d'édition chasse après description

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-description.php
@@ -29,7 +29,10 @@ if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
       'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
       'html_before_fields'  => '<div class="champ-wrapper">',
       'html_after_fields'   => '</div>',
-      'return'              => get_permalink() . '#chasse-description',
+      'return'              => add_query_arg(
+        ['edition' => 'open', 'tab' => 'param'],
+        get_permalink()
+      ) . '#chasse-description',
         'updated_message'     => __( 'Description mise à jour.', 'chassesautresor-com' )
       ]);
     ?>


### PR DESCRIPTION
## Résumé
- réouverture automatique du panneau d'édition chasse après validation de la description

## Changements notables
- ouverture forcée du panneau édition sur l'onglet paramètres via l'URL de retour

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a41d834d288332835a0d6c787c32e7