### PR TITLE
feat: gère les pré-requis dans la boucle d'énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -173,21 +173,33 @@ function get_cta_enigme(int $enigme_id, ?int $user_id = null): array
         ]);
     }
 
+    // 🔒 Pré-requis : l'utilisateur doit les remplir
+    if ($etat_systeme === 'bloquee_pre_requis') {
+        if (enigme_pre_requis_remplis($enigme_id, $user_id)) {
+            $etat_systeme = 'accessible';
+            $cta['etat_systeme'] = $etat_systeme;
+        }
+    }
+
     // 🚫 Énigme bloquée ou mal configurée
     if (!in_array($etat_systeme, ['accessible'], true)) {
-        $type = in_array($etat_systeme, ['bloquee_date', 'bloquee_chasse']) ? 'bloquee' : 'invalide';
+        $type = in_array($etat_systeme, ['bloquee_date', 'bloquee_chasse', 'bloquee_pre_requis']) ? 'bloquee' : 'invalide';
         $badge = [
-            'bloquee_date'       => 'À venir',
-            'bloquee_chasse'     => 'Chasse verrouillée',
-            'bloquee_pre_requis' => 'Pré-requis',
-            'invalide'           => 'Invalide',
-            'cache_invalide'     => 'Erreur config'
-        ][$etat_systeme] ?? 'Bloquée';
+            'bloquee_date'       => esc_html__('À venir', 'chassesautresor-com'),
+            'bloquee_chasse'     => esc_html__('Chasse verrouillée', 'chassesautresor-com'),
+            'bloquee_pre_requis' => esc_html__('Pré-requis', 'chassesautresor-com'),
+            'invalide'           => esc_html__('Invalide', 'chassesautresor-com'),
+            'cache_invalide'     => esc_html__('Erreur config', 'chassesautresor-com'),
+        ][$etat_systeme] ?? esc_html__('Bloquée', 'chassesautresor-com');
+
+        $sous_label = $etat_systeme === 'bloquee_pre_requis'
+            ? esc_html__('Résolvez d\'abord les énigmes prérequises.', 'chassesautresor-com')
+            : esc_html__('Cette énigme est bloquée ou mal configurée.', 'chassesautresor-com');
 
         return array_merge($cta, [
             'type'       => $type,
-            'label'      => 'Indisponible',
-            'sous_label' => 'Cette énigme est bloquée ou mal configurée.',
+            'label'      => esc_html__('Indisponible', 'chassesautresor-com'),
+            'sous_label' => $sous_label,
             'action'     => 'disabled',
             'classe_css' => 'cta-' . $type,
             'badge'      => $badge,

--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -346,9 +346,9 @@ function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
  */
 function get_mapping_visuel_enigme(int $enigme_id): array
 {
-    $etat_systeme = get_field('enigme_cache_etat_systeme', $enigme_id);
     $cta_data     = get_cta_enigme($enigme_id);
     $cta_type     = $cta_data['type'] ?? 'erreur';
+    $etat_systeme = $cta_data['etat_systeme'] ?? get_field('enigme_cache_etat_systeme', $enigme_id);
 
 
     $cle = match (true) {

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -485,12 +485,17 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
     // 🔐 Accès programmé / prérequis
     $condition = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
 
-    if ($etat === 'accessible' && $condition === 'date_programmee') {
-        $date = get_field('enigme_acces_date', $enigme_id);
-        $date_obj = convertir_en_datetime($date);
-        if (!$date_obj || $date_obj->getTimestamp() > time()) {
-            $etat = 'bloquee_date';
-            cat_debug("🧩 #$enigme_id → bloquee_date (accès programmé futur ou vide)");
+    if ($etat === 'accessible') {
+        if ($condition === 'date_programmee') {
+            $date = get_field('enigme_acces_date', $enigme_id);
+            $date_obj = convertir_en_datetime($date);
+            if (!$date_obj || $date_obj->getTimestamp() > time()) {
+                $etat = 'bloquee_date';
+                cat_debug("🧩 #$enigme_id → bloquee_date (accès programmé futur ou vide)");
+            }
+        } elseif ($condition === 'pre_requis') {
+            $etat = 'bloquee_pre_requis';
+            cat_debug("🧩 #$enigme_id → bloquee_pre_requis (pré-requis exigés)");
         }
     }
 


### PR DESCRIPTION
## Résumé
- prise en compte des pré-requis pour calculer l'état d'une énigme
- blocage conditionnel du CTA si les pré-requis ne sont pas remplis
- affichage cohérent des visuels selon l'état réel de l'énigme

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a41b8f50c88332ab59cdaa18331530