### PR TITLE
Prevent duplicate add enigma button in sidebar

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1481,8 +1481,13 @@ window.mettreAJourBoutonAjoutEnigme = function () {
   const nav = document.querySelector('.enigme-navigation');
   if (!nav) return;
 
-  const existing = document.getElementById('carte-ajout-enigme');
-  if (existing) return;
+  const existing = nav.querySelectorAll('#carte-ajout-enigme');
+  if (existing.length > 0) {
+    existing.forEach((btn, idx) => {
+      if (idx > 0) btn.remove();
+    });
+    return;
+  }
 
   const chasseId = nav.dataset.chasseId;
   if (!chasseId) return;


### PR DESCRIPTION
## Summary
- Empêche la duplication du bouton d'ajout d'énigme dans l'aside des énigmes.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a41fb7f8d88332b5de965391ff2357