### PR TITLE
Nettoie les messages persistants lors du reset des stats

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1411,6 +1411,8 @@ function cta_reset_stats() {
         $wpdb->query("TRUNCATE TABLE {$table}");
     }
 
+    delete_metadata('user', 0, '_myaccount_messages', '', true);
+
     wp_send_json_success();
 }
 add_action('wp_ajax_cta_reset_stats', 'cta_reset_stats');

--- a/wp-content/themes/chassesautresor/tests/reset_stats_clears_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/reset_stats_clears_messages.test.php
@@ -1,0 +1,63 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($cap)
+    {
+        return 'administrator' === $cap;
+    }
+}
+
+if (!function_exists('check_ajax_referer')) {
+    function check_ajax_referer($action, $nonce_name)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('wp_send_json_error')) {
+    function wp_send_json_error($data = null)
+    {
+        // no-op
+    }
+}
+
+if (!function_exists('wp_send_json_success')) {
+    function wp_send_json_success($data = null)
+    {
+        $GLOBALS['wp_send_json_success_data'] = $data;
+    }
+}
+
+if (!function_exists('delete_metadata')) {
+    function delete_metadata($type, $object_id, $meta_key, $meta_value = '', $delete_all = false)
+    {
+        $GLOBALS['delete_metadata_args'] = func_get_args();
+        return true;
+    }
+}
+
+global $wpdb;
+$wpdb = new class {
+    public $prefix = 'wp_';
+    public function query($sql)
+    {
+        // no-op
+    }
+};
+
+require_once __DIR__ . '/../inc/admin-functions.php';
+
+class ResetStatsClearsMessagesTest extends TestCase
+{
+    public function test_reset_stats_clears_messages(): void
+    {
+        $_POST['nonce'] = 'dummy';
+        cta_reset_stats();
+
+        $this->assertSame(
+            ['user', 0, '_myaccount_messages', '', true],
+            $GLOBALS['delete_metadata_args']
+        );
+    }
+}


### PR DESCRIPTION
## Résumé
- nettoie les métadonnées `_myaccount_messages` lors de la réinitialisation des statistiques
- ajoute un test pour garantir cette suppression

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a435a93ce08332aeb5823c02bf078a