### PR TITLE
feat: add account orders page title

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -223,14 +223,14 @@ function is_woocommerce_account_page() {
 }
 
 /**
- * Rename WooCommerce "orders" endpoint title to "Commandes".
+ * Rename WooCommerce "orders" endpoint title to "Vos commandes".
  *
  * @param string $title Original title.
  * @return string Modified title.
  */
 function ca_orders_endpoint_title($title)
 {
-    return __('Commandes', 'chassesautresor');
+    return __('Vos commandes', 'chassesautresor-com');
 }
 add_filter('woocommerce_endpoint_orders_title', 'ca_orders_endpoint_title');
 

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -17,8 +17,8 @@ do_action('woocommerce_before_account_orders', $has_orders);
 
 if ($has_orders) : ?>
 
+<h1 class="myaccount-page-title"><?php esc_html_e('Vos commandes', 'chassesautresor-com'); ?></h1>
 <div class="stats-table-wrapper">
-    <h3><?php esc_html_e('Vos commandes', 'chassesautresor'); ?></h3>
     <table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">
 <thead>
 <tr>


### PR DESCRIPTION
Ajout d'un titre clair pour la page des commandes du compte utilisateur.

- Ajoute le titre de page "Vos commandes" dans le template des commandes.
- Aligne le filtre d'intitulé d'endpoint sur ce libellé.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a442cd210c83329862c8268dbce044