### PR TITLE
Harmonise l'affichage des titres des pages de compte

### DIFF
--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -139,8 +139,15 @@ get_header();
     </aside>
     <div class="myaccount-main">
         <header class="myaccount-header">
-            <?php if (is_wc_endpoint_url('edit-account')) : ?>
-            <h1 class="myaccount-title"><?php esc_html_e('Votre profil', 'chassesautresor-com'); ?></h1>
+            <?php
+            $page_title = '';
+            if (is_wc_endpoint_url('edit-account')) {
+                $page_title = __('Votre profil', 'chassesautresor-com');
+            } elseif (is_wc_endpoint_url('orders')) {
+                $page_title = __('Vos commandes', 'chassesautresor-com');
+            }
+            if ($page_title) : ?>
+            <h1 class="myaccount-title"><?php echo esc_html($page_title); ?></h1>
             <?php endif; ?>
             <!-- TODO: header content -->
         </header>

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/orders.php
@@ -16,7 +16,7 @@ defined('ABSPATH') || exit;
 do_action('woocommerce_before_account_orders', $has_orders);
 
 ?>
-<h1 class="myaccount-page-title"><?php esc_html_e('Vos commandes', 'chassesautresor-com'); ?></h1>
+<?php /* Title moved to layout header for consistency */ ?>
 <?php if ($has_orders) : ?>
 <div class="stats-table-wrapper">
     <table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">


### PR DESCRIPTION
## Résumé
- Uniformise l’emplacement des titres pour les pages Profil et Commandes du compte

## Changements notables
- Affiche désormais tous les titres d’onglets dans l’en-tête commun
- Retire le titre redondant de la page Commandes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a4496f13408332977e552c54be284b