### PR TITLE
Assure les liens des énigmes pour les chasses non publiées

### DIFF
--- a/tests/MyAccountOrganizerNavTest.php
+++ b/tests/MyAccountOrganizerNavTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class MyAccountOrganizerNavTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_enigmes_are_linked_when_chasse_pending(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/');
+        }
+
+        eval('function get_organisateur_from_user($user_id){return 99;}');
+        eval(
+            'function get_post_status($post_id){' .
+            '$s=[99=>"publish",100=>"pending",200=>"pending"];' .
+            'return $s[$post_id]??"publish";}'
+        );
+        eval(
+            'function get_field($key,$id){' .
+            '$f=[' .
+            '99=>["organisateur_cache_complet"=>true],' .
+            '100=>["chasse_cache_statut_validation"=>"en_attente","chasse_cache_complet"=>true],' .
+            '200=>["enigme_cache_complet"=>true,"enigme_cache_etat_systeme"=>"accessible"]' .
+            '];' .
+            'return $f[$id][$key]??null;}'
+        );
+        eval('function get_posts($args=[]){return [(object)["ID"=>100]];}');
+        eval('function recuperer_enigmes_tentatives_en_attente($org){return [];}');
+        eval('function recuperer_ids_enigmes_pour_chasse($cid){return [200];}');
+        eval('function get_permalink($id){return "https://example.com/post-$id";}');
+        eval('function get_the_title($id){return "Post $id";}');
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/myaccount-functions.php';
+
+        $nav = myaccount_get_organizer_nav(1);
+
+        $this->assertNotNull($nav);
+        $this->assertSame('https://example.com/post-200', $nav['chasses'][0]['enigmes'][0]['url']);
+    }
+}
+

--- a/wp-content/themes/chassesautresor/inc/myaccount-functions.php
+++ b/wp-content/themes/chassesautresor/inc/myaccount-functions.php
@@ -133,10 +133,6 @@ function myaccount_get_organizer_nav(int $user_id): ?array
                 $sub_classes .= ' status-important';
             }
 
-            if (strpos($classes, 'status-published') === false) {
-                $url = null;
-            }
-
             $chasse_item['enigmes'][] = [
                 'title'   => get_the_title($enigme_id),
                 'url'     => $url,


### PR DESCRIPTION
## Résumé
- corrige la disparition des liens vers les énigmes lorsque la chasse n'est pas publiée
- ajoute un test pour garantir la présence de ces liens

## Changements notables
- conserve l'URL des énigmes dans le menu organisateur même si la chasse est en attente
- couvre le comportement par un test unitaire dédié

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a44bb9bdf483328f4d544999339642