### PR TITLE
Conditionne l'édition du menu des énigmes aux utilisateurs autorisés

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/enigme.css
+++ b/wp-content/themes/chassesautresor/assets/css/enigme.css
@@ -40,9 +40,12 @@
   position: relative;
   margin-bottom: var(--space-xxs);
   padding-left: calc(var(--space-md) + 16px);
-  cursor: grab;
   --bullet-fill: var(--etat-enigme-menu-en-cours);
   --bullet-outline: var(--etat-enigme-menu-en-cours);
+}
+
+.enigme-menu--editable li {
+  cursor: grab;
 }
 
 .enigme-menu li::before {
@@ -58,7 +61,7 @@
   border-radius: 50%;
 }
 
-.enigme-menu li .enigme-menu__handle {
+.enigme-menu--editable li .enigme-menu__handle {
   position: absolute;
   top: 50%;
   left: 0;
@@ -72,7 +75,7 @@
   transition: opacity 0.2s;
 }
 
-.enigme-menu li:hover .enigme-menu__handle {
+.enigme-menu--editable li:hover .enigme-menu__handle {
   opacity: 1;
 }
 
@@ -84,6 +87,9 @@
   color: inherit;
   text-decoration: none;
   border-radius: 4px;
+}
+
+.enigme-menu--editable li a {
   cursor: inherit;
 }
 
@@ -95,7 +101,7 @@
   cursor: default;
 }
 
-.enigme-menu li.dragging {
+.enigme-menu--editable li.dragging {
   cursor: grabbing;
 }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -349,10 +349,14 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
 
             if (!empty($menu_items)) {
                 $data_chasse = $chasse_id ? ' data-chasse-id="' . intval($chasse_id) . '"' : '';
+                $menu_class  = 'enigme-menu';
+                if ($edition_active) {
+                    $menu_class .= ' enigme-menu--editable';
+                }
                 echo '<section class="enigme-navigation"' . $data_chasse . '>';
                 echo '<h3>' . esc_html__('Énigmes', 'chassesautresor-com') . '</h3>';
                 echo '%AJOUT%';
-                echo '<ul class="enigme-menu">' . implode('', $menu_items) . '</ul>';
+                echo '<ul class="' . esc_attr($menu_class) . '">' . implode('', $menu_items) . '</ul>';
                 echo '</section>';
             }
             echo '</div>';
@@ -661,10 +665,16 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                 $classes[] = 'active';
             }
 
+            $handle = '';
+            if ($edition_active) {
+                $handle = '<span class="enigme-menu__handle" aria-hidden="true"></span>';
+            }
+
             $submenu_items[] = sprintf(
-                '<li class="%s" data-enigme-id="%d"><span class="enigme-menu__handle" aria-hidden="true"></span><a href="%s">%s</a></li>',
+                '<li class="%s" data-enigme-id="%d">%s<a href="%s">%s</a></li>',
                 esc_attr(implode(' ', $classes)),
                 $post->ID,
+                $handle,
                 esc_url(get_permalink($post->ID)),
                 esc_html(get_the_title($post->ID))
             );


### PR DESCRIPTION
## Résumé
- Restreint l'affichage de la poignée de réordonnancement aux utilisateurs en mode édition
- Ajoute la classe `.enigme-menu--editable` et adapte le CSS pour gérer le curseur et la poignée

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a4635a70a88332987972b9a354e26a