### PR TITLE
Ajout du titre et de l’icône de résolution dans la liste des participants

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-participants.php
@@ -44,6 +44,7 @@ if (empty($participants)) :
         <?php
     endif;
 else : ?>
+<h3><?= esc_html__('Liste participants', 'chassesautresor-com'); ?></h3>
 <table class="stats-table compact">
   <thead>
       <tr>
@@ -81,7 +82,11 @@ else : ?>
       <?php if ($mode_validation !== 'aucune') : ?>
       <td><?= esc_html($p['nb_tentatives']); ?></td>
       <?php endif; ?>
-      <td><?= $p['trouve'] && !empty($p['date_resolution']) ? esc_html(mysql2date('d/m/Y H:i', $p['date_resolution'])) : ''; ?></td>
+      <td>
+        <?php if ($p['trouve']) : ?>
+          <i class="fa-solid fa-check fa-xl"></i>
+        <?php endif; ?>
+      </td>
     </tr>
     <?php endforeach; ?>
   </tbody>


### PR DESCRIPTION
## Résumé
- affiche le titre standard "Liste participants" dans l’onglet statistiques d’une énigme
- marque la résolution avec une icône de validation

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a470a230c8833282e17a42da470176