### PR TITLE
Fix status update on manual attempt validation

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -393,7 +393,7 @@ function traiter_tentative(
     global $wpdb;
     $table = $wpdb->prefix . 'enigme_tentatives';
 
-    if ($resultat === 'bon') {
+    if ($resultat === 'bon' && $inserer) {
         $existe = (int) $wpdb->get_var(
             $wpdb->prepare(
                 "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND enigme_id = %d AND resultat = 'bon'",
@@ -408,7 +408,7 @@ function traiter_tentative(
     }
 
     $cout = (int) get_field('enigme_tentative_cout_points', $enigme_id);
-    if ($cout > 0) {
+    if ($cout > 0 && $inserer) {
         $reason = sprintf("Tentative de réponse pour l'énigme #%d", $enigme_id);
         deduire_points_utilisateur($user_id, $cout, $reason, 'tentative', $enigme_id);
     }


### PR DESCRIPTION
## Résumé
- corrige la mise à jour du statut après validation d'une tentative manuelle

## Changements notables
- évite le retour anticipé lors de la validation d'une tentative existante
- empêche une double déduction de points lorsque l'insertion n'est pas requise

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a472164a7483328c6512a61395d944