### PR TITLE
feat: renommer le bouton d'ajout de galerie

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -652,6 +652,32 @@ if (document.readyState === 'loading') {
 
 
 // ==============================
+// 🖼️ Libellé du bouton galerie ACF
+// ==============================
+function initLibelleBoutonGalerie() {
+  if (!window.acf) return;
+
+  const mettreAJour = (field) => {
+    const bouton = field.querySelector('.acf-gallery-add');
+    if (bouton) {
+      bouton.textContent = wp.i18n.__('Ajouter une illustration', 'chassesautresor-com');
+    }
+  };
+
+  window.acf.add_action('ready_field/type=gallery', mettreAJour);
+  window.acf.add_action('append_field/type=gallery', mettreAJour);
+
+  document.querySelectorAll('.acf-field[data-type="gallery"]').forEach(mettreAJour);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initLibelleBoutonGalerie);
+} else {
+  initLibelleBoutonGalerie();
+}
+
+
+// ==============================
 // 🧩 Gestion du panneau variantes
 // ==============================
 function initPanneauVariantes() {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -658,9 +658,13 @@ function initLibelleBoutonGalerie() {
   if (!window.acf) return;
 
   const mettreAJour = (field) => {
-    const bouton = field.querySelector('.acf-gallery-add');
+    const el = field && field.nodeType ? field : field?.[0];
+    if (!el) return;
+
+    const bouton = el.querySelector('.acf-gallery-add');
     if (bouton) {
-      bouton.textContent = wp.i18n.__('Ajouter une illustration', 'chassesautresor-com');
+      const label = window.wp?.i18n?.__('Ajouter une illustration', 'chassesautresor-com') ?? 'Ajouter une illustration';
+      bouton.textContent = label;
     }
   };
 


### PR DESCRIPTION
## Summary
- Remplace le libellé du bouton d'ajout de galerie ACF par « Ajouter une illustration »

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a472fe5b608332ba1c6a6f522761a7