### PR TITLE
Améliore l'affichage des tentatives dans Mon Compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -598,6 +598,36 @@
     font-size: 1rem;
 }
 
+/* 🏷️ Étiquettes de résultat */
+.etiquette {
+    display: inline-block;
+    padding: 2px 6px;
+    border: 1px solid var(--color-grey-medium);
+    border-radius: 4px;
+    background-color: var(--color-grey-light);
+    color: var(--color-text-fond-clair);
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+
+.etiquette-success {
+    background-color: var(--color-success);
+    border-color: var(--color-success);
+    color: var(--color-white);
+}
+
+.etiquette-error {
+    background-color: var(--color-error);
+    border-color: var(--color-error);
+    color: var(--color-white);
+}
+
+.etiquette-pending {
+    background-color: var(--color-grey-medium);
+    border-color: var(--color-grey-medium);
+    color: var(--color-white);
+}
+
 .pager-info {
     margin: 0 8px;
     color: hsl(var(--foreground));

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
@@ -107,12 +107,12 @@ $pages = (int) ceil($total / $per_page);
     <h3><?php esc_html_e('Tentatives', 'chassesautresor-com'); ?></h3>
     <div class="table-header">
         <?php if ($pending > 0) : ?>
-        <span class="stat-badge"><?php printf(esc_html__('%d tentatives en attente', 'chassesautresor-com'), $pending); ?></span>
+        <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $pending, 'chassesautresor-com')), $pending); ?></span>
         <?php endif; ?>
-        <span class="stat-badge"><?php printf(esc_html__('%d tentatives', 'chassesautresor-com'), $total); ?></span>
+        <span class="stat-badge"><?php printf(esc_html(_n('%d tentative', '%d tentatives', $total, 'chassesautresor-com')), $total); ?></span>
         <?php if ($success > 0) : ?>
         <span class="stat-badge" style="color:var(--color-success);">
-            <?php printf(esc_html__('%d bonne réponse', 'chassesautresor-com'), $success); ?>
+            <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes réponses', $success, 'chassesautresor-com')), $success); ?>
         </span>
         <?php endif; ?>
     </div>
@@ -130,7 +130,20 @@ $pages = (int) ceil($total / $per_page);
                 <tr>
                     <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
                     <td><?php echo esc_html($tent->post_title); ?></td>
-                    <td><?php echo esc_html($tent->resultat); ?></td>
+                    <?php
+                    $result = $tent->resultat;
+                    $class  = 'etiquette-error';
+                    if ($result === 'bon') {
+                        $class = 'etiquette-success';
+                    } elseif ($result === 'attente') {
+                        $class = 'etiquette-pending';
+                    }
+                    ?>
+                    <td>
+                        <span class="etiquette <?php echo esc_attr($class); ?>">
+                            <?php echo esc_html($result); ?>
+                        </span>
+                    </td>
                 </tr>
                 <?php endforeach; ?>
             </tbody>


### PR DESCRIPTION
## Résumé
- Ajuste le libellé des statistiques de tentatives selon le nombre
- Affiche le résultat des tentatives avec des étiquettes colorées

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a47567c3f48332bf4b3b4bada39d9f