### PR TITLE
Synchro du titre d’énigme dans le menu d’édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -107,6 +107,17 @@ window.mettreAJourLegendeEnigme = function (valeur) {
   }
 };
 
+/**
+ * 🔁 Met à jour dynamiquement le titre de l’énigme dans le menu latéral.
+ * @param {string} valeur - Le nouveau titre à afficher
+ */
+window.mettreAJourTitreMenuEnigme = function (valeur) {
+  const item = document.querySelector('.enigme-menu li.active a');
+  if (item) {
+    item.textContent = valeur;
+  }
+};
+
 
 
 /**

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -223,6 +223,9 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
     if (typeof window.mettreAJourTitreHeader === 'function') {
       window.mettreAJourTitreHeader(cpt, valeur);
     }
+    if (cpt === 'enigme' && typeof window.mettreAJourTitreMenuEnigme === 'function') {
+      window.mettreAJourTitreMenuEnigme(valeur);
+    }
   }
 
   // ✅ ORGANISATEUR : mise à jour image


### PR DESCRIPTION
## Résumé
- synchro du titre de l’énigme modifiée avec l’élément actif du menu latéral
- appel automatique lors de la mise à jour d’un titre d’énigme

## Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a4776d47b083329a8e4ecc54e31184