### PR TITLE
feat: add reusable edition row component

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/edition.css
+++ b/wp-content/themes/chassesautresor/assets/css/edition.css
@@ -90,6 +90,28 @@
   width: 100%;
 }
 
+/* 🧩 Lignes d'édition réutilisables */
+.edition-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  min-height: 40px;
+}
+
+.edition-row-icon {
+  width: var(--editor-icon-width);
+  margin-right: 0.3rem;
+  text-align: center;
+}
+
+.edition-row-label {
+  width: var(--editor-label-width);
+}
+
+.edition-row-content {
+  flex: 1;
+}
+
 .cache {
   display: none;
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -83,19 +83,35 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <ul class="resume-infos">
 
                 <!-- Titre -->
-                <li class="champ-chasse champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
-                  data-champ="post_title"
-                  data-cpt="chasse"
-                  data-post-id="<?= esc_attr($chasse_id); ?>"
-                  data-no-edit="1">
-
-                  <label for="champ-titre-chasse">Titre <span class="champ-obligatoire">*</span></label>
-                  <input type="text" class="champ-input champ-texte-edit" maxlength="70"
-                    value="<?= esc_attr($titre); ?>"
-                    id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>
-                    placeholder="renseigner le titre de la chasse" />
-                  <div class="champ-feedback"></div>
-                </li>
+                <?php
+                get_template_part(
+                    'template-parts/common/edition-row',
+                    null,
+                    [
+                        'class' => 'champ-chasse champ-titre ' . ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli') . ($peut_editer_titre ? '' : ' champ-desactive'),
+                        'attributes' => [
+                            'data-champ'   => 'post_title',
+                            'data-cpt'     => 'chasse',
+                            'data-post-id' => $chasse_id,
+                            'data-no-edit' => '1',
+                        ],
+                        'label' => function () {
+                            ?>
+                            <label for="champ-titre-chasse">Titre <span class="champ-obligatoire">*</span></label>
+                            <?php
+                        },
+                        'content' => function () use ($titre, $peut_editer_titre) {
+                            ?>
+                            <input type="text" class="champ-input champ-texte-edit" maxlength="70"
+                                value="<?= esc_attr($titre); ?>"
+                                id="champ-titre-chasse" <?= $peut_editer_titre ? '' : 'disabled'; ?>
+                                placeholder="renseigner le titre de la chasse" />
+                            <div class="champ-feedback"></div>
+                            <?php
+                        },
+                    ]
+                );
+                ?>
                 
                 <!-- Image -->
                 <li class="champ-chasse champ-img <?= empty($image_id) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"

--- a/wp-content/themes/chassesautresor/template-parts/common/edition-row.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/edition-row.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Template Part: Edition row with icon, label and content.
+ *
+ * Expected args:
+ * - string $icon       FontAwesome classes for the icon (optional).
+ * - string|callable $label   Label HTML or callback printing it.
+ * - string|callable $content Content HTML or callback printing it.
+ * - string $class      Additional CSS classes for <li>.
+ * - array  $attributes Additional HTML attributes for <li> (key => value).
+ * - bool   $no_icon    True to remove icon placeholder.
+ *
+ * @package chassesautresor
+ */
+
+$icon       = $args['icon'] ?? '';
+$label      = $args['label'] ?? '';
+$content    = $args['content'] ?? '';
+$class      = $args['class'] ?? '';
+$attributes = $args['attributes'] ?? [];
+$no_icon    = !empty($args['no_icon']);
+
+$attr_strings = [];
+foreach ($attributes as $key => $value) {
+    $attr_strings[] = sprintf('%s="%s"', esc_attr($key), esc_attr($value));
+}
+?>
+<li class="edition-row <?php echo esc_attr($class); ?>" <?php echo implode(' ', $attr_strings); ?><?php echo $no_icon ? ' data-no-icon="1"' : ''; ?>>
+  <?php if (!$no_icon) : ?>
+    <span class="edition-row-icon">
+      <?php if (!empty($icon)) : ?>
+        <i class="<?php echo esc_attr($icon); ?>" aria-hidden="true"></i>
+      <?php endif; ?>
+    </span>
+  <?php endif; ?>
+  <div class="edition-row-label">
+    <?php
+    if (is_callable($label)) {
+        $label();
+    } else {
+        echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+    ?>
+  </div>
+  <div class="edition-row-content">
+    <?php
+    if (is_callable($content)) {
+        $content();
+    } else {
+        echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+    ?>
+  </div>
+</li>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -106,21 +106,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
                 <h3>Informations</h3>
                 <ul class="resume-infos">
-                  <li class="champ-enigme champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
-                    data-champ="post_title"
-                    data-cpt="enigme"
-                    data-post-id="<?= esc_attr($enigme_id); ?>"
-                    data-no-edit="1">
-
-                    <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span></label>
-                    <input type="text"
-                      class="champ-input champ-texte-edit"
-                      maxlength="80"
-                      value="<?= esc_attr($titre); ?>"
-                      id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?>
-                      placeholder="renseigner le titre de l’énigme" />
-                    <div class="champ-feedback"></div>
-                  </li>
+                  <?php
+                  get_template_part(
+                      'template-parts/common/edition-row',
+                      null,
+                      [
+                          'class' => 'champ-enigme champ-titre ' . ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli') . ($peut_editer_titre ? '' : ' champ-desactive'),
+                          'attributes' => [
+                              'data-champ'   => 'post_title',
+                              'data-cpt'     => 'enigme',
+                              'data-post-id' => $enigme_id,
+                              'data-no-edit' => '1',
+                          ],
+                          'label' => function () {
+                              ?>
+                              <label for="champ-titre-enigme">Titre <span class="champ-obligatoire">*</span></label>
+                              <?php
+                          },
+                          'content' => function () use ($titre, $peut_editer_titre) {
+                              ?>
+                              <input type="text"
+                                class="champ-input champ-texte-edit"
+                                maxlength="80"
+                                value="<?= esc_attr($titre); ?>"
+                                id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?>
+                                placeholder="renseigner le titre de l’énigme" />
+                              <div class="champ-feedback"></div>
+                              <?php
+                          },
+                      ]
+                  );
+                  ?>
 
                   <?php
                   $has_images_utiles = enigme_a_une_image($enigme_id);

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -88,21 +88,37 @@ $is_complete = (
               <div class="resume-bloc resume-obligatoire">
                 <h3>Informations</h3>
                 <ul class="resume-infos">
-                  <li class="champ-organisateur champ-titre ligne-titre <?= empty($titre) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
-                    data-champ="post_title"
-                    data-cpt="organisateur"
-                    data-post-id="<?= esc_attr($organisateur_id); ?>"
-                    data-no-edit="1">
-
-                    <label for="champ-titre-organisateur">Titre <span class="champ-obligatoire">*</span></label>
-                    <input type="text"
-                      class="champ-input champ-texte-edit"
-                      maxlength="50"
-                      value="<?= esc_attr($titre); ?>"
-                      id="champ-titre-organisateur" <?= $peut_editer_titre ? '' : 'disabled'; ?>
-                      placeholder="renseigner le titre de l’organisateur" />
-                    <div class="champ-feedback"></div>
-                  </li>
+                  <?php
+                  get_template_part(
+                      'template-parts/common/edition-row',
+                      null,
+                      [
+                          'class' => 'champ-organisateur champ-titre ligne-titre ' . (empty($titre) ? 'champ-vide' : 'champ-rempli') . ($peut_editer_titre ? '' : ' champ-desactive'),
+                          'attributes' => [
+                              'data-champ'   => 'post_title',
+                              'data-cpt'     => 'organisateur',
+                              'data-post-id' => $organisateur_id,
+                              'data-no-edit' => '1',
+                          ],
+                          'label' => function () {
+                              ?>
+                              <label for="champ-titre-organisateur">Titre <span class="champ-obligatoire">*</span></label>
+                              <?php
+                          },
+                          'content' => function () use ($titre, $peut_editer_titre) {
+                              ?>
+                              <input type="text"
+                                class="champ-input champ-texte-edit"
+                                maxlength="50"
+                                value="<?= esc_attr($titre); ?>"
+                                id="champ-titre-organisateur" <?= $peut_editer_titre ? '' : 'disabled'; ?>
+                                placeholder="renseigner le titre de l’organisateur" />
+                              <div class="champ-feedback"></div>
+                              <?php
+                          },
+                      ]
+                  );
+                  ?>
 
                 <li class="champ-organisateur champ-img champ-logo ligne-logo <?= empty($logo_id) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="<?= esc_attr($organisateur_id); ?>">
                   <div class="champ-affichage">


### PR DESCRIPTION
## Résumé
- introduction d'un composant réutilisable pour les lignes d'édition
- refactorisation des panneaux chasse, organisateur et énigme pour utiliser ce composant
- mutualisation des règles de mise en page CSS

## Changelog
- création du partial `edition-row`
- intégration dans les panneaux d'édition principaux
- ajout des styles `.edition-row`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a48bf4158883329fbc61f84c141ac4