### PR TITLE
Désactiver le drag & drop sur les chasses non éditables

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1504,42 +1504,43 @@ function initPagerTentatives() {
 // ==============================
 // ➕ Affichage dynamique du bouton d'ajout d'énigme
 // ==============================
-window.mettreAJourBoutonAjoutEnigme = function () {
-  const nav = document.querySelector('.enigme-navigation');
-  if (!nav) return;
+  window.mettreAJourBoutonAjoutEnigme = function () {
+    const nav = document.querySelector('.enigme-navigation');
+    if (!nav) return;
+    const menu = nav.querySelector('.enigme-menu');
+    if (!menu || !menu.classList.contains('enigme-menu--editable')) return;
 
-  nav.querySelectorAll('#carte-ajout-enigme').forEach((btn) => btn.remove());
+    nav.querySelectorAll('#carte-ajout-enigme').forEach((btn) => btn.remove());
 
-  const chasseId = nav.dataset.chasseId;
-  if (!chasseId) return;
+    const chasseId = nav.dataset.chasseId;
+    if (!chasseId) return;
 
-  const data = new FormData();
-  data.append('action', 'verifier_enigmes_completes');
-  data.append('chasse_id', chasseId);
+    const data = new FormData();
+    data.append('action', 'verifier_enigmes_completes');
+    data.append('chasse_id', chasseId);
 
-  fetch(window.ajaxurl, {
-    method: 'POST',
-    credentials: 'same-origin',
-    body: data
-  })
-    .then(r => r.json())
-    .then(res => {
-      if (!res.success || res.data.has_incomplete || nav.querySelector('#carte-ajout-enigme')) {
-        return;
-      }
-
-      const link = document.createElement('a');
-      link.id = 'carte-ajout-enigme';
-      link.dataset.postId = '0';
-      link.href = `${window.location.origin}/creer-enigme/?chasse_id=${chasseId}`;
-      link.innerHTML =
-        '<i class="fa-solid fa-circle-plus fa-lg" aria-hidden="true"></i>' +
-        `<span>${wp.i18n.__('Ajouter une énigme', 'chassesautresor-com')}</span>`;
-      const menu = nav.querySelector('.enigme-menu');
-      nav.insertBefore(link, menu);
+    fetch(window.ajaxurl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: data
     })
-    .catch(() => {});
-};
+      .then((r) => r.json())
+      .then((res) => {
+        if (!res.success || res.data.has_incomplete || nav.querySelector('#carte-ajout-enigme')) {
+          return;
+        }
+
+        const link = document.createElement('a');
+        link.id = 'carte-ajout-enigme';
+        link.dataset.postId = '0';
+        link.href = `${window.location.origin}/creer-enigme/?chasse_id=${chasseId}`;
+        link.innerHTML =
+          '<i class="fa-solid fa-circle-plus fa-lg" aria-hidden="true"></i>' +
+          `<span>${wp.i18n.__('Ajouter une énigme', 'chassesautresor-com')}</span>`;
+        nav.insertBefore(link, menu);
+      })
+      .catch(() => {});
+  };
 
 // ==============================
 // 🔀 Réordonnancement des énigmes
@@ -1547,7 +1548,7 @@ window.mettreAJourBoutonAjoutEnigme = function () {
 function initEnigmeReorder() {
   const nav = document.querySelector('.enigme-navigation');
   const menu = nav?.querySelector('.enigme-menu');
-  if (!nav || !menu) return;
+  if (!nav || !menu || !menu.classList.contains('enigme-menu--editable')) return;
 
   menu.querySelectorAll('li').forEach((li) => {
     li.draggable = true;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -581,6 +581,9 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
         $liste             = [];
         $chasse_stat       = $chasse_id ? get_field('chasse_cache_statut', $chasse_id) : '';
         $validation_status = $chasse_id ? get_field('chasse_cache_statut_validation', $chasse_id) : '';
+        if ($edition_active && !in_array($validation_status, ['creation', 'correction'], true)) {
+            $edition_active = false;
+        }
         $show_menu         = enigme_user_can_see_menu($user_id, $chasse_id, $chasse_stat);
         $skip_checks       = $chasse_stat === 'termine';
         $is_privileged = current_user_can('administrator')


### PR DESCRIPTION
## Résumé
Désactive l'ajout d'énigme et le réordonnancement par glisser-déposer lorsque la chasse n'est plus en création ou en correction.

## Changements
- Bloque l'édition des énigmes si la chasse n'est pas en phase de création ou de correction.
- Ignore l'insertion du bouton « Ajouter une énigme » lorsque le menu n'est pas éditable.
- N'initialise plus le drag & drop pour les menus non éditables.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4977a95248332b21b19b93f48a84a