### PR TITLE
Masquer les énigmes verrouillées dans le menu

### DIFF
--- a/tests/EnigmeMenuRenderingTest.php
+++ b/tests/EnigmeMenuRenderingTest.php
@@ -41,6 +41,18 @@ if (!function_exists('get_field')) {
     }
 }
 
+if (!function_exists('update_field')) {
+    function update_field($key, $value, $post_id = null)
+    {
+        if ($post_id !== null) {
+            $GLOBALS['fields'][$post_id][$key] = $value;
+        } else {
+            $GLOBALS['fields'][$key] = $value;
+        }
+        return true;
+    }
+}
+
 if (!function_exists('current_user_can')) {
     function current_user_can($role)
     {
@@ -223,24 +235,24 @@ if (!function_exists('get_the_title')) {
     }
 }
 
+if (!function_exists('titre_est_valide')) {
+    function titre_est_valide($id)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+    function utilisateur_est_engage_dans_chasse($user_id, $chasse_id)
+    {
+        return $GLOBALS['engage_chasse'] ?? true;
+    }
+}
+
 if (!function_exists('utilisateur_est_engage_dans_enigme')) {
     function utilisateur_est_engage_dans_enigme($user_id, $post_id)
     {
-        return false;
-    }
-}
-
-if (!function_exists('enigme_get_statut_utilisateur')) {
-    function enigme_get_statut_utilisateur($post_id, $user_id)
-    {
-        return 'non_commencee';
-    }
-}
-
-if (!function_exists('enigme_pre_requis_remplis')) {
-    function enigme_pre_requis_remplis($enigme_id, $user_id)
-    {
-        return $GLOBALS['prereq_ok'] ?? true;
+        return $GLOBALS['engage_enigme'] ?? false;
     }
 }
 
@@ -278,6 +290,7 @@ if (!function_exists('cat_debug')) {
 }
 
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/layout-functions.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/statut-functions.php';
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/affichage.php';
 
 /**
@@ -310,6 +323,8 @@ class EnigmeMenuRenderingTest extends TestCase
         $GLOBALS['is_admin'] = false;
         $GLOBALS['is_associated'] = true;
         $GLOBALS['is_organizer'] = true;
+        $GLOBALS['engage_chasse'] = true;
+        $GLOBALS['engage_enigme'] = false;
 
         global $wpdb;
         $wpdb = new class {
@@ -344,17 +359,19 @@ class EnigmeMenuRenderingTest extends TestCase
 
         $GLOBALS['fields'][101]['enigme_cache_complet']       = true;
         $GLOBALS['fields'][101]['enigme_cache_etat_systeme']  = 'accessible';
+        $GLOBALS['fields'][101]['enigme_acces_condition']     = 'immediat';
         $GLOBALS['post_status'][101] = 'publish';
 
         $GLOBALS['fields'][102] = [
-            'enigme_cache_complet' => true,
-            'enigme_cache_etat_systeme' => 'bloquee_pre_requis',
+            'enigme_cache_complet'       => true,
+            'enigme_cache_etat_systeme'  => 'bloquee_pre_requis',
+            'enigme_acces_condition'     => 'pre_requis',
+            'enigme_acces_pre_requis'    => [201],
         ];
         $GLOBALS['post_types'][102]  = 'enigme';
         $GLOBALS['post_status'][102] = 'publish';
         $GLOBALS['titles'][102]      = 'Enigme Bloquee';
         $GLOBALS['enigma_list']      = [(object) ['ID' => 101], (object) ['ID' => 102]];
-        $GLOBALS['prereq_ok']        = false;
 
         ob_start();
         afficher_enigme_stylisee(101);
@@ -370,16 +387,18 @@ class EnigmeMenuRenderingTest extends TestCase
         $GLOBALS['fields'][2]['chasse_cache_statut'] = 'ouverte';
 
         $GLOBALS['fields'][101] = [
-            'enigme_cache_complet' => true,
-            'enigme_cache_etat_systeme' => 'accessible',
+            'enigme_cache_complet'       => true,
+            'enigme_cache_etat_systeme'  => 'accessible',
+            'enigme_acces_condition'     => 'immediat',
         ];
         $GLOBALS['post_types'][101]  = 'enigme';
         $GLOBALS['post_status'][101] = 'publish';
         $GLOBALS['titles'][101]      = 'Enigme Accessible';
 
         $GLOBALS['fields'][102] = [
-            'enigme_cache_complet' => true,
-            'enigme_cache_etat_systeme' => 'bloquee_date',
+            'enigme_cache_complet'       => true,
+            'enigme_cache_etat_systeme'  => 'bloquee_date',
+            'enigme_acces_condition'     => 'date_programmee',
         ];
         $GLOBALS['post_types'][102]  = 'enigme';
         $GLOBALS['post_status'][102] = 'publish';
@@ -391,5 +410,27 @@ class EnigmeMenuRenderingTest extends TestCase
         $output = ob_get_clean();
         $this->assertStringContainsString('data-enigme-id="102"><a', $output);
         $this->assertStringNotContainsString('data-enigme-id="102"><a href', $output);
+    }
+
+    public function test_traiter_statut_enigme_blocks_access_without_prerequisites(): void
+    {
+        $GLOBALS['is_admin']      = false;
+        $GLOBALS['is_associated'] = false;
+        $GLOBALS['is_organizer']  = false;
+        $GLOBALS['fields'][2]['chasse_cache_statut'] = 'ouverte';
+        $GLOBALS['fields'][102] = [
+            'enigme_cache_complet'       => true,
+            'enigme_cache_etat_systeme'  => 'bloquee_pre_requis',
+            'enigme_acces_condition'     => 'pre_requis',
+            'enigme_acces_pre_requis'    => [201],
+        ];
+        $GLOBALS['post_types'][102]  = 'enigme';
+        $GLOBALS['post_status'][102] = 'publish';
+        $GLOBALS['engage_chasse']    = true;
+        $GLOBALS['engage_enigme']    = true;
+
+        $result = traiter_statut_enigme(102, 1);
+        $this->assertTrue($result['rediriger']);
+        $this->assertSame('bloquee_pre_requis', $result['etat']);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -630,13 +630,15 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
             $classes = [];
 
             if (!$skip_checks) {
-                $etat_sys = get_field('enigme_cache_etat_systeme', $post->ID) ?? 'accessible';
+                $etat_sys       = get_field('enigme_cache_etat_systeme', $post->ID) ?? 'accessible';
+                $condition_acces = get_field('enigme_acces_condition', $post->ID) ?? 'immediat';
+
                 if (in_array($etat_sys, ['invalide', 'cache_invalide'], true)) {
                     continue;
                 }
 
                 if (
-                    $etat_sys === 'bloquee_pre_requis'
+                    $condition_acces === 'pre_requis'
                     && !$is_privileged
                     && (!function_exists('enigme_pre_requis_remplis')
                         || !enigme_pre_requis_remplis($post->ID, $user_id))
@@ -644,7 +646,10 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                     continue;
                 }
 
-                if ($etat_sys === 'bloquee_pre_requis') {
+                if (
+                    $condition_acces === 'pre_requis'
+                    && $etat_sys === 'bloquee_pre_requis'
+                ) {
                     $etat_sys = 'accessible';
                 }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -635,13 +635,26 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                     continue;
                 }
 
+                if (
+                    $etat_sys === 'bloquee_pre_requis'
+                    && !$is_privileged
+                    && (!function_exists('enigme_pre_requis_remplis')
+                        || !enigme_pre_requis_remplis($post->ID, $user_id))
+                ) {
+                    continue;
+                }
+
+                if ($etat_sys === 'bloquee_pre_requis') {
+                    $etat_sys = 'accessible';
+                }
+
                 if ($etat_sys === 'bloquee_chasse' && in_array($validation_status, ['creation', 'correction'], true)) {
                     if (!get_field('enigme_cache_complet', $post->ID)) {
                         $classes[] = 'incomplete';
                     } else {
                         $classes[] = 'bloquee';
                     }
-                } elseif (in_array($etat_sys, ['bloquee_date', 'bloquee_chasse', 'bloquee_pre_requis'], true)) {
+                } elseif (in_array($etat_sys, ['bloquee_date', 'bloquee_chasse'], true)) {
                     $classes[] = 'bloquee';
                 } else {
                     $statut_user = enigme_get_statut_utilisateur($post->ID, $user_id);
@@ -688,13 +701,19 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                 }
             }
 
+            $title = esc_html(get_the_title($post->ID));
+            if (!$is_privileged && $etat_sys === 'bloquee_date') {
+                $link = '<a class="no-link" tabindex="-1">' . $title . '</a>';
+            } else {
+                $link = '<a href="' . esc_url(get_permalink($post->ID)) . '">' . $title . '</a>';
+            }
+
             $submenu_items[] = sprintf(
-                '<li class="%s" data-enigme-id="%d">%s<a href="%s">%s</a>%s</li>',
+                '<li class="%s" data-enigme-id="%d">%s%s%s</li>',
                 esc_attr(implode(' ', $classes)),
                 $post->ID,
                 $handle,
-                esc_url(get_permalink($post->ID)),
-                esc_html(get_the_title($post->ID)),
+                $link,
                 $edit
             );
         }

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -350,6 +350,18 @@ function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
         ];
     }
 
+    $condition_acces = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
+    if ($condition_acces === 'pre_requis' && !enigme_pre_requis_remplis($enigme_id, $user_id)) {
+        return [
+            'etat' => 'bloquee_pre_requis',
+            'rediriger' => true,
+            'url' => $chasse_id ? get_permalink($chasse_id) : home_url('/'),
+            'afficher_formulaire' => false,
+            'afficher_message' => false,
+            'message_html' => '',
+        ];
+    }
+
     // 🔁 Cas interdits : accès refusé
     if ($statut === 'abandonnee') {
         return [
@@ -584,6 +596,14 @@ function utilisateur_peut_engager_enigme(int $enigme_id, ?int $user_id = null): 
     $user_id = $user_id ?? get_current_user_id();
 
     $etat_systeme = enigme_get_etat_systeme($enigme_id);
+    if (
+        $etat_systeme === 'bloquee_pre_requis'
+        && function_exists('enigme_pre_requis_remplis')
+        && enigme_pre_requis_remplis($enigme_id, $user_id)
+    ) {
+        $etat_systeme = 'accessible';
+    }
+
     $statut = enigme_get_statut_utilisateur($enigme_id, $user_id);
 
     $statuts_autorises = ['non_commencee', 'abandonnee', 'echouee'];

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -45,8 +45,21 @@ if (!enigme_est_visible_pour($user_id, $enigme_id)) {
 }
 
 // 🔒 Énigme inaccessible : redirection vers la chasse liée
-$etat_systeme = get_field('enigme_cache_etat_systeme', $enigme_id) ?? 'accessible';
-if ($etat_systeme !== 'accessible' && !utilisateur_peut_modifier_enigme($enigme_id)) {
+$etat_systeme   = get_field('enigme_cache_etat_systeme', $enigme_id) ?? 'accessible';
+$condition_acces = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
+
+if (
+    $condition_acces === 'pre_requis'
+    && $etat_systeme === 'bloquee_pre_requis'
+    && !enigme_pre_requis_remplis($enigme_id, $user_id)
+    && !utilisateur_peut_modifier_enigme($enigme_id)
+) {
+    $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+    wp_safe_redirect($url);
+    exit;
+}
+
+if ($etat_systeme !== 'accessible' && $etat_systeme !== 'bloquee_pre_requis' && !utilisateur_peut_modifier_enigme($enigme_id)) {
     $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
     wp_safe_redirect($url);
     exit;


### PR DESCRIPTION
## Résumé
- masque les énigmes soumises à des prérequis non remplis
- désactive les liens des énigmes bloquées par date

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a4a1a448e083329d80bf0ccc17884d