### PR TITLE
Restore edit button for puzzle text

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -364,7 +364,9 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
 
   // Ajouter bouton édition ✏️ si besoin
   const dejaBouton = ligne.querySelector('.champ-modifier');
-  const pasDEdition = ligne.dataset.noEdit !== undefined;
+  const pasDEdition =
+    ligne.dataset.noEdit !== undefined ||
+    (champ === 'enigme_visuel_texte' && !estRempli);
 
   if (pasDEdition) {
     ligne.style.cursor = '';

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -364,7 +364,7 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
 
   // Ajouter bouton édition ✏️ si besoin
   const dejaBouton = ligne.querySelector('.champ-modifier');
-  const pasDEdition = ligne.dataset.noEdit !== undefined || champ === 'enigme_visuel_texte';
+  const pasDEdition = ligne.dataset.noEdit !== undefined;
 
   if (pasDEdition) {
     ligne.style.cursor = '';


### PR DESCRIPTION
## Résumé
- Corrige la disparition du bouton d’édition du texte d’énigme

## Changements notables
- Retrait de la suppression automatique du bouton "modifier" pour le champ texte d’énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a4a7d71af483328682bfedb1b35c0f