### PR TITLE
Corrige la gestion des prérequis vides pour les énigmes

### DIFF
--- a/tests/EnigmeMenuRenderingTest.php
+++ b/tests/EnigmeMenuRenderingTest.php
@@ -379,6 +379,35 @@ class EnigmeMenuRenderingTest extends TestCase
         $this->assertStringNotContainsString('data-enigme-id="102"', $output);
     }
 
+    public function test_menu_excludes_enigme_with_empty_prerequisites(): void
+    {
+        $GLOBALS['is_admin']      = false;
+        $GLOBALS['is_associated'] = false;
+        $GLOBALS['is_organizer']  = false;
+        $GLOBALS['fields'][2]['chasse_cache_statut'] = 'ouverte';
+
+        $GLOBALS['fields'][101]['enigme_cache_complet']       = true;
+        $GLOBALS['fields'][101]['enigme_cache_etat_systeme']  = 'accessible';
+        $GLOBALS['fields'][101]['enigme_acces_condition']     = 'immediat';
+        $GLOBALS['post_status'][101] = 'publish';
+
+        $GLOBALS['fields'][102] = [
+            'enigme_cache_complet'       => true,
+            'enigme_cache_etat_systeme'  => 'bloquee_pre_requis',
+            'enigme_acces_condition'     => 'pre_requis',
+            'enigme_acces_pre_requis'    => [],
+        ];
+        $GLOBALS['post_types'][102]  = 'enigme';
+        $GLOBALS['post_status'][102] = 'publish';
+        $GLOBALS['titles'][102]      = 'Enigme Mal Config';
+        $GLOBALS['enigma_list']      = [(object) ['ID' => 101], (object) ['ID' => 102]];
+
+        ob_start();
+        afficher_enigme_stylisee(101);
+        $output = ob_get_clean();
+        $this->assertStringNotContainsString('data-enigme-id="102"', $output);
+    }
+
     public function test_menu_disables_link_for_date_locked_enigme(): void
     {
         $GLOBALS['is_admin']      = false;

--- a/tests/EnigmePrerequisCompletionTest.php
+++ b/tests/EnigmePrerequisCompletionTest.php
@@ -42,4 +42,17 @@ class EnigmePrerequisCompletionTest extends TestCase
 
         $this->assertFalse(enigme_est_complet(1));
     }
+
+    public function test_prerequis_not_fulfilled_when_list_empty(): void
+    {
+        global $fields;
+        $fields = [
+            1 => [
+                'enigme_acces_condition'  => 'pre_requis',
+                'enigme_acces_pre_requis' => [],
+            ],
+        ];
+
+        $this->assertFalse(enigme_pre_requis_remplis(1, 1));
+    }
 }

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -159,8 +159,10 @@ function enigme_pre_requis_remplis(int $enigme_id, int $user_id): bool
 {
     $pre_requis = get_field('enigme_acces_pre_requis', $enigme_id);
 
+    $condition = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
+
     if (empty($pre_requis) || !is_array($pre_requis)) {
-        return true; // ✅ Aucun prérequis → considéré comme rempli
+        return $condition !== 'pre_requis'; // ❌ Pré-requis exigés mais liste vide
     }
 
     foreach ($pre_requis as $enigme_requise) {


### PR DESCRIPTION
## Résumé
- Bloque une énigme configurée avec des prérequis mais sans liste fournie
- Ajoute des tests unitaires couvrant la complétion et le menu des énigmes

## Changelog
- renforce la vérification de `enigme_pre_requis_remplis`
- couvre le cas des prérequis vides dans les tests de complétion et de rendu du menu

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a54f9217d48332b601f0d784f7109b