### PR TITLE
Masquer les énigmes programmées pour les utilisateurs non privilégiés

### DIFF
--- a/tests/EnigmeMenuRenderingTest.php
+++ b/tests/EnigmeMenuRenderingTest.php
@@ -408,7 +408,7 @@ class EnigmeMenuRenderingTest extends TestCase
         $this->assertStringNotContainsString('data-enigme-id="102"', $output);
     }
 
-    public function test_menu_disables_link_for_date_locked_enigme(): void
+    public function test_menu_excludes_date_locked_enigme_for_user(): void
     {
         $GLOBALS['is_admin']      = false;
         $GLOBALS['is_associated'] = false;
@@ -437,8 +437,7 @@ class EnigmeMenuRenderingTest extends TestCase
         ob_start();
         afficher_enigme_stylisee(101);
         $output = ob_get_clean();
-        $this->assertStringContainsString('data-enigme-id="102"><a', $output);
-        $this->assertStringNotContainsString('data-enigme-id="102"><a href', $output);
+        $this->assertStringNotContainsString('data-enigme-id="102"', $output);
     }
 
     public function test_traiter_statut_enigme_blocks_access_without_prerequisites(): void

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -653,6 +653,10 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                     $etat_sys = 'accessible';
                 }
 
+                if (!$is_privileged && $etat_sys === 'bloquee_date') {
+                    continue;
+                }
+
                 if ($etat_sys === 'bloquee_chasse' && in_array($validation_status, ['creation', 'correction'], true)) {
                     if (!get_field('enigme_cache_complet', $post->ID)) {
                         $classes[] = 'incomplete';
@@ -707,11 +711,7 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
             }
 
             $title = esc_html(get_the_title($post->ID));
-            if (!$is_privileged && $etat_sys === 'bloquee_date') {
-                $link = '<a class="no-link" tabindex="-1">' . $title . '</a>';
-            } else {
-                $link = '<a href="' . esc_url(get_permalink($post->ID)) . '">' . $title . '</a>';
-            }
+            $link  = '<a href="' . esc_url(get_permalink($post->ID)) . '">' . $title . '</a>';
 
             $submenu_items[] = sprintf(
                 '<li class="%s" data-enigme-id="%d">%s%s%s</li>',


### PR DESCRIPTION
## Résumé
- retire du menu les énigmes dont l'ouverture est programmée pour les joueurs sans droits
- simplifie le lien du menu pour les organisateurs et administrateurs

## Changements notables
- exclusion des énigmes `bloquee_date` pour les utilisateurs non organisateurs
- ajustement du test de rendu du menu des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a55258c060833298ee3a75afe0deeb