### PR TITLE
Masquer le footer sur les pages d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/footer-enigme.php
+++ b/wp-content/themes/chassesautresor/footer-enigme.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Footer template for enigme pages without site footer.
+ *
+ * @package chassesautresor
+ */
+
+wp_footer();
+

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -141,4 +141,4 @@ if (is_singular('enigme')) {
     </main>
   </div>
 
-<?php get_footer(); ?>
+<?php get_footer('enigme'); ?>


### PR DESCRIPTION
Supprime l'affichage du footer sur les pages d'énigme.

- Ajout d'un template de footer minimal pour les énigmes
- Utilisation de ce template dans le gabarit single-enigme

### Testing
- `source ./setup-env.sh && echo 'setup done'`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a552d18974833283ae6c56db62d1dd