### PR TITLE
Affichage dynamique du titre dans les panneaux d'édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -83,14 +83,19 @@ window.renderLiensPublicsJS = renderLiensPublics;
  */
 window.mettreAJourTitreHeader = function (cpt, valeur) {
   const selecteurs = {
-    organisateur: '.header-organisateur__nom',
-    chasse: '.titre-objet[data-cpt="chasse"]',
-    enigme: '.titre-objet[data-cpt="enigme"]'
+    organisateur: ['.header-organisateur__nom', '.titre-objet[data-cpt="organisateur"]'],
+    chasse: ['.titre-objet[data-cpt="chasse"]'],
+    enigme: ['.titre-objet[data-cpt="enigme"]']
   };
 
-  const cible = document.querySelector(selecteurs[cpt]);
-  if (cible) {
-    cible.textContent = valeur;
+  const cibles = selecteurs[cpt]
+    ? selecteurs[cpt].flatMap((sel) => Array.from(document.querySelectorAll(sel)))
+    : [];
+
+  if (cibles.length > 0) {
+    cibles.forEach((el) => {
+      el.textContent = valeur;
+    });
   } else {
     console.warn('❌ Impossible de trouver le header pour le CPT :', cpt);
   }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -56,7 +56,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
     <div class="edition-panel-header">
         <div class="edition-panel-header-top">
-            <h2><i class="fa-solid fa-gear"></i> <?= esc_html__('Panneau d\'édition chasse', 'chassesautresor-com'); ?></h2>
+            <h2>
+                <i class="fa-solid fa-gear"></i>
+                <?= esc_html__('Panneau d\'édition chasse', 'chassesautresor-com'); ?> :
+                <span class="titre-objet" data-cpt="chasse"><?= esc_html($titre); ?></span>
+            </h2>
             <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
         </div>
         <div class="edition-tabs">

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -81,7 +81,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 
       <div class="edition-panel-header">
         <div class="edition-panel-header-top">
-          <h2><i class="fa-solid fa-gear"></i> <?= esc_html__('Panneau d\'édition énigme', 'chassesautresor-com'); ?></h2>
+          <h2>
+            <i class="fa-solid fa-gear"></i>
+            <?= esc_html__('Panneau d\'édition énigme', 'chassesautresor-com'); ?> :
+            <span class="titre-objet" data-cpt="enigme"><?= esc_html($titre); ?></span>
+          </h2>
 
         <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
       </div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -64,7 +64,11 @@ $is_complete = (
 
     <div class="edition-panel-header">
       <div class="edition-panel-header-top">
-        <h2><i class="fa-solid fa-gear"></i> <?= esc_html__('Panneau d\'édition organisateur', 'chassesautresor-com'); ?></h2>
+        <h2>
+          <i class="fa-solid fa-gear"></i>
+          <?= esc_html__('Panneau d\'édition organisateur', 'chassesautresor-com'); ?> :
+          <span class="titre-objet" data-cpt="organisateur"><?= esc_html($titre); ?></span>
+        </h2>
         <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres organisateur">✖</button>
       </div>
       <div class="edition-tabs">


### PR DESCRIPTION
## Résumé
- Ajout de l'affichage du titre du contenu dans les en-têtes des panneaux d'édition
- Mise à jour dynamique du titre lors de la modification depuis l'onglet Paramètres

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a554f32b8883328386d41073f0489c