### PR TITLE
Actualisation du solde après réponses automatiques

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
@@ -11,21 +11,31 @@ function timeUntilMidnight() {
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('.formulaire-reponse-auto');
   if (!form) return;
-  const feedback = document.querySelector('.reponse-feedback');
+  const feedback = form.querySelector('.reponse-feedback');
   const compteur = document.querySelector('.tentatives-counter');
   const compteurValeur = compteur ? compteur.querySelector('.valeur') : null;
+  const soldeFooter = document.querySelector('.participation-infos .solde');
+  const tentativesFooter = document.querySelector('.participation-infos .tentatives');
+  const soldeInfo = form.querySelector('.points-sousligne');
   const input = form.querySelector('input[name="reponse"]');
   const limiteMsg = document.querySelector('.message-limite');
   const headerPoints = document.querySelector('.zone-points .points-value');
   const cout = parseInt(form.dataset.cout || '0', 10);
-  const soldeApres = parseInt(form.dataset.soldeApres || '0', 10);
+  let soldeAvant = parseInt(form.dataset.soldeAvant || '0', 10);
+  let soldeApres = parseInt(form.dataset.soldeApres || '0', 10);
   const seuil = parseInt(form.dataset.seuil || '300', 10);
+  const __ = window.wp?.i18n?.__ || (s => s);
+  const sprintf = window.wp?.i18n?.sprintf;
   let hideTimer = null;
 
   form.addEventListener('submit', e => {
     e.preventDefault();
     if (cout >= seuil) {
-      const ok = confirm(`Confirmer l'envoi ? Cette tentative coûtera ${cout} pts. Solde après : ${soldeApres} pts.`);
+      const ok = confirm(
+        __("Confirmer l'envoi ? Cette tentative coûtera %1$d pts. Solde après : %2$d pts.", 'chassesautresor-com')
+          .replace('%1$d', cout)
+          .replace('%2$d', soldeApres)
+      );
       if (!ok) return;
     }
     const data = new URLSearchParams(new FormData(form));
@@ -42,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return JSON.parse(text);
         } catch (e) {
           if (feedback) {
-            feedback.textContent = 'Erreur serveur';
+            feedback.textContent = __('Erreur serveur', 'chassesautresor-com');
             feedback.style.display = 'block';
             hideTimer = setTimeout(() => { feedback.style.display = 'none'; }, 5000);
           }
@@ -62,6 +72,31 @@ document.addEventListener('DOMContentLoaded', () => {
           if (headerPoints && typeof res.data.points !== 'undefined') {
             headerPoints.textContent = res.data.points;
           }
+          if (soldeFooter && typeof res.data.points !== 'undefined') {
+            soldeFooter.textContent = `${__('Solde', 'chassesautresor-com')} : ${res.data.points} ${__('pts', 'chassesautresor-com')}`;
+          }
+          if (tentativesFooter && typeof res.data.compteur !== 'undefined') {
+            let maxFooter = tentativesFooter.dataset.max;
+            if (!maxFooter) {
+              const split = tentativesFooter.textContent.split('/');
+              maxFooter = split[1] ? split[1].trim() : '∞';
+              tentativesFooter.dataset.max = maxFooter;
+            }
+            const baseText = __('Tentatives quotidiennes : %1$s/%2$s', 'chassesautresor-com');
+            tentativesFooter.textContent = sprintf
+              ? sprintf(baseText, res.data.compteur, maxFooter)
+              : `${__('Tentatives quotidiennes :', 'chassesautresor-com')} ${res.data.compteur}/${maxFooter}`;
+          }
+          if (soldeInfo && typeof res.data.points !== 'undefined') {
+            soldeAvant = parseInt(res.data.points, 10);
+            soldeApres = soldeAvant - cout;
+            form.dataset.soldeAvant = soldeAvant;
+            form.dataset.soldeApres = soldeApres;
+            const baseSolde = __('Solde : %1$d → %2$d pts', 'chassesautresor-com');
+            soldeInfo.textContent = sprintf
+              ? sprintf(baseSolde, soldeAvant, soldeApres)
+              : `${__('Solde', 'chassesautresor-com')} : ${soldeAvant} → ${soldeApres} ${__('pts', 'chassesautresor-com')}`;
+          }
 
           if (res.data.resultat === 'variante') {
             if (res.data.message) {
@@ -69,11 +104,12 @@ document.addEventListener('DOMContentLoaded', () => {
               feedback.style.display = 'block';
             }
           } else if (res.data.resultat === 'bon') {
-            feedback.textContent = 'Bonne réponse !';
+            feedback.innerHTML = `<i class="fa-solid fa-circle-check" style="color:var(--color-success);"></i> ${__('Bonne réponse', 'chassesautresor-com')}`;
             feedback.style.display = 'block';
-            form.remove();
+            const titre = form.querySelector('h3');
+            form.replaceChildren(titre, feedback);
             if (compteur) {
-                compteur.remove();
+              compteur.remove();
             }
             const currentMenuItem = document.querySelector('.enigme-menu li.active');
             if (currentMenuItem) {
@@ -106,7 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             }
           } else {
-            feedback.textContent = 'Mauvaise réponse';
+            feedback.innerHTML = `<i class="fa-solid fa-circle-xmark" style="color:var(--color-gris-3);"></i> ${__('Mauvaise réponse', 'chassesautresor-com')}`;
             feedback.style.display = 'block';
             hideTimer = setTimeout(() => { feedback.style.display = 'none'; }, 5000);
           }
@@ -116,7 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (compteurValeur) {
               compteurValeur.textContent = `${res.data.compteur}/${max}`;
             } else {
-              compteur.textContent = `Tentatives quotidiennes ${res.data.compteur}/${max}`;
+              compteur.textContent = `${__('Tentatives quotidiennes', 'chassesautresor-com')} ${res.data.compteur}/${max}`;
             }
             if (max && res.data.compteur >= max) {
               if (input) input.remove();
@@ -126,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const p = document.createElement('p');
                 p.className = 'message-limite';
                 p.dataset.tentatives = 'epuisees';
-                p.textContent = 'tentatives quotidiennes épuisées';
+                p.textContent = __('tentatives quotidiennes épuisées', 'chassesautresor-com');
                 form.insertBefore(p, form.querySelector('input[name="enigme_id"]'));
               }
               const btn = form.querySelector('button[type="submit"]');
@@ -148,7 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
               const p = document.createElement('p');
               p.className = 'message-limite';
               p.dataset.tentatives = 'epuisees';
-              p.textContent = 'tentatives quotidiennes épuisées';
+              p.textContent = __('tentatives quotidiennes épuisées', 'chassesautresor-com');
               form.insertBefore(p, form.querySelector('input[name="enigme_id"]'));
             }
             const btn = form.querySelector('button[type="submit"]');

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -104,6 +104,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
             <?= esc_html($cout); ?> <?= esc_html__('pts', 'chassesautresor-com'); ?>
         </span>
     <?php endif; ?>
+    <div class="reponse-feedback" style="display:none"></div>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>
   <?php elseif ($points_manquants > 0) : ?>
@@ -142,5 +143,4 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
     </p>
   <?php endif; ?>
 </form>
-<div class="reponse-feedback" style="display:none"></div>
 


### PR DESCRIPTION
## Résumé
- Rafraîchissement dynamique du solde et des tentatives après chaque tentative automatique
- Affichage des messages de résultat sous le titre "Votre réponse" avec icônes de succès ou d'échec

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57d922bf483328b2a15ecde4ccc49