### PR TITLE
Masquer le compteur de tentatives en validation manuelle

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -74,7 +74,7 @@ function initEnigmeEdit() {
   // ==============================
   initChampConditionnel('acf[enigme_mode_validation]', {
     'aucune': [],
-    'manuelle': ['.champ-cout-points', '.champ-nb-tentatives'],
+    'manuelle': ['.champ-cout-points'],
     'automatique': ['.champ-groupe-reponse-automatique', '.champ-cout-points', '.champ-nb-tentatives']
   });
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -610,19 +610,25 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
         }
 
         $mode_validation = get_field('enigme_mode_validation', $enigme_id);
-        if ($mode_validation !== 'aucune') {
-            if (!function_exists('compter_tentatives_du_jour')) {
-                require_once __DIR__ . '/tentatives.php';
-            }
+        $cout            = (int) get_field('enigme_tentative_cout_points', $enigme_id);
+        $solde_actuel    = function_exists('get_user_points')
+            ? get_user_points($user_id)
+            : 0;
 
+        $afficher_tentatives = $mode_validation === 'automatique';
+        $afficher_infos = $cout > 0 || $afficher_tentatives;
+
+        if ($afficher_tentatives && !function_exists('compter_tentatives_du_jour')) {
+            require_once __DIR__ . '/tentatives.php';
+        }
+
+        if ($afficher_tentatives) {
             $tentatives_utilisees = compter_tentatives_du_jour($user_id, $enigme_id);
             $tentatives_max       = (int) get_field('enigme_tentative_max', $enigme_id);
             $tentatives_max_aff   = $tentatives_max > 0 ? $tentatives_max : '∞';
-            $cout                 = (int) get_field('enigme_tentative_cout_points', $enigme_id);
-            $solde_actuel         = function_exists('get_user_points')
-                ? get_user_points($user_id)
-                : 0;
+        }
 
+        if ($afficher_infos) {
             $content .= '<div class="participation-infos txt-small" ';
             $content .= 'style="color:var(--color-text-primary);display:flex;justify-content:space-between;">';
 
@@ -634,13 +640,19 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
                 $content .= '<span></span>';
             }
 
-            $content .= '<span class="tentatives">'
-                . sprintf(
-                    esc_html__('Tentatives quotidiennes : %1$d/%2$s', 'chassesautresor-com'),
-                    $tentatives_utilisees,
-                    $tentatives_max_aff
-                )
-                . '</span></div>';
+            if ($afficher_tentatives) {
+                $content .= '<span class="tentatives">'
+                    . sprintf(
+                        esc_html__('Tentatives quotidiennes : %1$d/%2$s', 'chassesautresor-com'),
+                        $tentatives_utilisees,
+                        $tentatives_max_aff
+                    )
+                    . '</span>';
+            } elseif ($cout > 0) {
+                $content .= '<span></span>';
+            }
+
+            $content .= '</div>';
         }
 
         if ($content !== '') {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -365,7 +365,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
               <div class="champ-feedback"></div>
             </li>
 
-            <li class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" data-no-icon="1">
+            <li class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?><?= $mode_validation === 'automatique' ? '' : ' cache'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" data-no-icon="1">
               <div class="champ-edition">
                 <label for="enigme-nb-tentatives">Nb tentatives
                   <?php


### PR DESCRIPTION
## Résumé
- masque le champ "Nb tentatives" lorsque la validation est manuelle
- supprime l'affichage du compteur de tentatives dans la participation en mode manuel

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a581f7bf648332858b5bb63e842f12