### PR TITLE
Supprime le badge de points en doublon

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -97,14 +97,6 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
 >
     <h3><?= esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
 
-    <?php if ($cout > 0) : ?>
-        <span
-            class="badge-cout"
-            aria-label="<?= esc_attr(sprintf(__('Coût par tentative : %d points.', 'chassesautresor-com'), $cout)); ?>"
-        >
-            <?= esc_html($cout); ?> <?= esc_html__('pts', 'chassesautresor-com'); ?>
-        </span>
-    <?php endif; ?>
     <div class="reponse-feedback" style="display:none"></div>
   <?php if ($message_tentatives) : ?>
     <p class="message-limite" data-tentatives="epuisees"><?= esc_html($message_tentatives); ?></p>


### PR DESCRIPTION
## Résumé
- Suppression de l'affichage redondant du badge de coût dans le formulaire de réponse

## Changements
- Retrait du badge de points affiché entre le titre et le champ de réponse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a584784ee08332af951af1798aee9e