### PR TITLE
Actualiser l'aside d'une énigme après validation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
@@ -117,12 +117,20 @@ document.addEventListener('DOMContentLoaded', () => {
               currentMenuItem.classList.add('succes');
             }
             const sectionGagnants = document.querySelector('.enigme-gagnants');
+            const sectionProgression = document.querySelector('.enigme-progression');
             const enigmeIdInput = form.querySelector('input[name="enigme_id"]');
+            const navigation = document.querySelector('.enigme-navigation');
+            const chasseId = navigation ? navigation.dataset.chasseId : null;
+            const bloc = document.querySelector('.menu-lateral__accordeons .accordeon-bloc');
+            const toggle = bloc ? bloc.querySelector('.accordeon-toggle') : null;
+            const contenu = bloc ? bloc.querySelector('.accordeon-contenu') : null;
+            const requests = [];
+
             if (sectionGagnants && enigmeIdInput) {
               const dataW = new URLSearchParams();
               dataW.append('action', 'enigme_recuperer_gagnants');
               dataW.append('enigme_id', enigmeIdInput.value);
-              fetch('/wp-admin/admin-ajax.php', {
+              const req = fetch('/wp-admin/admin-ajax.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: dataW
@@ -131,16 +139,35 @@ document.addEventListener('DOMContentLoaded', () => {
                 .then(r => {
                   if (r.success) {
                     sectionGagnants.innerHTML = r.data.html;
-                    const bloc = document.querySelector('.menu-lateral__accordeons .accordeon-bloc');
-                    const toggle = bloc ? bloc.querySelector('.accordeon-toggle') : null;
-                    const contenu = bloc ? bloc.querySelector('.accordeon-contenu') : null;
-                    if (toggle && contenu) {
-                      toggle.setAttribute('aria-expanded', 'true');
-                      contenu.classList.remove('accordeon-ferme');
-                    }
                   }
                 });
+              requests.push(req);
             }
+
+            if (sectionProgression && chasseId) {
+              const dataP = new URLSearchParams();
+              dataP.append('action', 'enigme_recuperer_progression');
+              dataP.append('chasse_id', chasseId);
+              const req = fetch('/wp-admin/admin-ajax.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: dataP
+              })
+                .then(r => r.json())
+                .then(r => {
+                  if (r.success) {
+                    sectionProgression.innerHTML = r.data.html;
+                  }
+                });
+              requests.push(req);
+            }
+
+            Promise.all(requests).finally(() => {
+              if (toggle && contenu) {
+                toggle.setAttribute('aria-expanded', 'true');
+                contenu.classList.remove('accordeon-ferme');
+              }
+            });
           } else {
             feedback.innerHTML = `<i class="fa-solid fa-circle-xmark" style="color:var(--color-gris-3);"></i> ${__('Mauvaise réponse', 'chassesautresor-com')}`;
             feedback.style.display = 'block';

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -53,7 +53,34 @@ defined('ABSPATH') || exit;
     add_action('deleted_user', 'enigme_bump_permissions_cache_version', 10, 1);
     add_action('added_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
     add_action('updated_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
-add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
+    add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
+    /**
+     * Clear sidebar caches for a given hunt and user.
+     *
+     * @param int $chasse_id Hunt identifier.
+     * @param int $user_id   User identifier.
+     */
+    function enigme_clear_sidebar_cache(int $chasse_id, int $user_id): void
+    {
+        wp_cache_delete('enigme_sidebar_engagement_' . $chasse_id . '_' . $user_id, 'chassesautresor');
+        wp_cache_delete('enigme_sidebar_progression_' . $chasse_id . '_' . $user_id, 'chassesautresor');
+    }
+
+    /**
+     * Clear sidebar caches when an enigma is solved.
+     *
+     * @param int $user_id   User identifier.
+     * @param int $enigme_id Enigma identifier.
+     */
+    function enigme_clear_sidebar_cache_on_solve(int $user_id, int $enigme_id): void
+    {
+        $chasse_id = recuperer_id_chasse_associee($enigme_id);
+        if ($chasse_id) {
+            enigme_clear_sidebar_cache($chasse_id, $user_id);
+        }
+    }
+
+    add_action('enigme_resolue', 'enigme_clear_sidebar_cache_on_solve', 10, 2);
 
     /**
      * Determine if the enigma menu should be displayed for a user.
@@ -978,6 +1005,31 @@ add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
 
     add_action('wp_ajax_enigme_recuperer_gagnants', 'ajax_enigme_recuperer_gagnants');
     add_action('wp_ajax_nopriv_enigme_recuperer_gagnants', 'ajax_enigme_recuperer_gagnants');
+
+    /**
+     * AJAX handler to refresh the progression section.
+     */
+    function ajax_enigme_recuperer_progression(): void
+    {
+        if (!is_user_logged_in()) {
+            wp_send_json_error('non_connecte', 403);
+        }
+
+        $chasse_id = isset($_POST['chasse_id']) ? (int) $_POST['chasse_id'] : 0;
+        if ($chasse_id <= 0) {
+            wp_send_json_error('missing_chasse', 400);
+        }
+
+        $user_id = get_current_user_id();
+        $html    = '<h3>' . esc_html__('Progression', 'chassesautresor-com') . '</h3>';
+        $html   .= enigme_sidebar_engagement_html($chasse_id, $user_id);
+        $html   .= enigme_sidebar_progression_html($chasse_id, $user_id);
+
+        wp_send_json_success(['html' => $html]);
+    }
+
+    add_action('wp_ajax_enigme_recuperer_progression', 'ajax_enigme_recuperer_progression');
+    add_action('wp_ajax_nopriv_enigme_recuperer_progression', 'ajax_enigme_recuperer_progression');
 
     /**
      * Enqueue scripts for the winners pager.


### PR DESCRIPTION
## Résumé
- Rafraîchit automatiquement la progression et les gagnants après une bonne réponse
- Ouvre l'accordéon de l'aside une fois les données rechargées
- Purge les caches de l'aside à la résolution d'une énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a588e67b6083329d465221704b8e81