### PR TITLE
Masquer le coût d'une énigme sans validation

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -337,7 +337,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             </li>
 
             <!-- Tentatives -->
-            <li class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_tentative.enigme_tentative_cout_points" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" data-no-icon="1">
+            <li class="champ-enigme champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?><?= $mode_validation === 'aucune' ? ' cache' : ''; ?>"
+                data-champ="enigme_tentative.enigme_tentative_cout_points"
+                data-cpt="enigme"
+                data-post-id="<?= esc_attr($enigme_id); ?>"
+                data-no-edit="1"
+                data-no-icon="1">
               <div class="champ-edition">
                 <label for="enigme-tentative-cout">Coût tentative
                   <?php


### PR DESCRIPTION
## Résumé
- corrige l'affichage des coûts d'énigme lorsque la validation est désactivée

## Changements notables
- masque la ligne de coût si le mode de validation est "aucune"

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5925e36448332b2dff1de6357dccb