### PR TITLE
Corrige l'affichage du bouton des variantes d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -370,7 +370,10 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
 
   if (pasDEdition) {
     ligne.style.cursor = '';
-    dejaBouton?.remove();
+    // Ne supprimer le bouton existant que s'il a été ajouté automatiquement
+    if (ligne.dataset.noEdit === undefined) {
+      dejaBouton?.remove();
+    }
     return;
   }
 


### PR DESCRIPTION
## Résumé
- évite la suppression du bouton *modifier* des variantes lors des mises à jour du résumé

## Modifications notables
- préserve les boutons personnalisés des champs marqués `data-no-edit`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5aef713308332ae86c30574bb8b3d