### PR TITLE
Harmonize solved puzzle message

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -63,8 +63,25 @@ if ($mode_validation === 'manuelle') {
                 echo '<p class="message-joueur-statut">' . esc_html__('⏳ Votre tentative est en cours de traitement.', 'chassesautresor-com') . '</p>';
             }
         } else {
-            $texte = __('Énigme résolue', 'chassesautresor-com');
-            echo '<p class="message-joueur-statut">' . esc_html($texte) . '</p>';
+            global $wpdb;
+            $table = $wpdb->prefix . 'enigme_statuts_utilisateur';
+            $resolution_date = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT date_mise_a_jour FROM $table WHERE user_id = %d AND enigme_id = %d",
+                    $user_id,
+                    $post_id
+                )
+            );
+            if ($resolution_date) {
+                $formatted_date = wp_date('d/m/y \\à H:i', strtotime($resolution_date));
+                $message = sprintf(
+                    __('Vous avez résolu cette énigme le %s.', 'chassesautresor-com'),
+                    $formatted_date
+                );
+            } else {
+                $message = __('Énigme résolue', 'chassesautresor-com');
+            }
+            echo '<p class="message-joueur-statut">✅ ' . esc_html($message) . '</p>';
         }
         return;
     }


### PR DESCRIPTION
## Résumé
- aligne l'affichage d'une énigme résolue en validation manuelle avec celui de la validation automatique

## Changements notables
- récupère la date de résolution pour une énigme validée manuellement
- affiche un message cohérent avec l'énigme résolue automatiquement

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5c1daad4c83328c46799c2b83a420