### PR TITLE
Improve Enigme image fallback handling

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -29,17 +29,10 @@ if (!utilisateur_peut_voir_enigme($parent_id)) {
     exit('Accès refusé');
 }
 
-// 📦 Récupération du chemin de l'image
+// 📦 Récupération du chemin de l'image (gère le fallback vers l'original)
 $info = trouver_chemin_image($image_id, $taille);
 $path = $info['path'] ?? null;
 $mime = $info['mime'] ?? 'application/octet-stream';
-
-// 🔁 Fallback automatique vers full si fichier manquant
-if (!$path && $taille !== 'full') {
-    $info = trouver_chemin_image($image_id, 'full');
-    $path = $info['path'] ?? null;
-    $mime = $info['mime'] ?? 'application/octet-stream';
-}
 
 if (!$path) {
     http_response_code(404);


### PR DESCRIPTION
Assure un fallback correct des visuels d'énigme vers l'image originale.

- Vérifie l'existence des tailles d'images et retombe sur la version originale si nécessaire
- Simplifie le handler `/voir-image-enigme` en s'appuyant sur ce fallback

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6e5e08083328906b17347012d4d