### PR TITLE
Conditionally load ACF head for enigma editing

### DIFF
--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -5,11 +5,15 @@
  */
 
 defined('ABSPATH') || exit;
-acf_form_head();
-
 // 🔹 Données de base
-$enigme_id = get_the_ID();
-$user_id   = get_current_user_id();
+$enigme_id      = get_the_ID();
+$edition_active = utilisateur_peut_modifier_post($enigme_id);
+
+if ($edition_active) {
+    acf_form_head();
+}
+
+$user_id = get_current_user_id();
 
 // 🔹 Chasse associée
 $chasse_id = recuperer_id_chasse_associee($enigme_id);
@@ -66,7 +70,6 @@ if ($etat_systeme !== 'accessible' && $etat_systeme !== 'bloquee_pre_requis' && 
 }
 
 // 🔹 Orgy auto
-$edition_active = utilisateur_peut_modifier_post($enigme_id);
 verifier_ou_mettre_a_jour_cache_complet($enigme_id);
 
 $enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);


### PR DESCRIPTION
### Résumé
Conditionne le chargement des scripts ACF aux énigmes éditables.

### Changements notables
- Récupération anticipée de `$enigme_id` et `$edition_active` avant tout rendu
- Appel `acf_form_head()` limité aux utilisateurs pouvant éditer l’énigme

### Testing
- `source ./setup-env.sh && echo "env loaded"`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5d240afdc8332b1322153bf9fd135