### PR TITLE
Charge la feuille de style énigme uniquement sur les énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -81,7 +81,6 @@ add_action('wp_enqueue_scripts', function () {
             'modal-bienvenue',
             'general-style',
             'chasse-style',
-            'enigme-style',
             'gamification-style',
             'cartes-style',
             'organisateurs',
@@ -91,6 +90,10 @@ add_action('wp_enqueue_scripts', function () {
 
         foreach ($common_styles as $handle) {
             wp_enqueue_style($handle);
+        }
+
+        if (is_singular('enigme')) {
+            wp_enqueue_style('enigme-style');
         }
 
         // 📌 Styles conditionnels


### PR DESCRIPTION
## Résumé
- Charge "enigme-style" seulement sur les contenus "énigme"
- Nettoie la liste des styles communs

## Détails
- Retire `enigme-style` des styles communs
- Ajoute un chargement conditionnel du style pour les énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5d2486ac48332931c1a9b8ec4f613