### PR TITLE
Afficher la proposition des tentatives dans Mon Compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/mon-compte.css
+++ b/wp-content/themes/chassesautresor/assets/css/mon-compte.css
@@ -721,5 +721,20 @@ body.woocommerce h2 {
 }
 
 
+/* Tentatives - Proposition toggle */
+.proposition-cell {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.proposition-cell .toggle-proposition {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+
 
 

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-toggle.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-toggle.js
@@ -1,0 +1,28 @@
+(function () {
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest('.toggle-proposition');
+    if (!btn) {
+      return;
+    }
+    var cell = btn.closest('.proposition-cell');
+    if (!cell) {
+      return;
+    }
+    var excerpt = cell.querySelector('.proposition-excerpt');
+    var full = cell.querySelector('.proposition-full');
+    var expanded = btn.getAttribute('aria-expanded') === 'true';
+    if (expanded) {
+      if (full) full.hidden = true;
+      if (excerpt) excerpt.hidden = false;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-label', btn.dataset.more || 'Voir plus');
+      btn.innerHTML = '<i class="fa-solid fa-ellipsis" aria-hidden="true"></i>';
+    } else {
+      if (full) full.hidden = false;
+      if (excerpt) excerpt.hidden = true;
+      btn.setAttribute('aria-expanded', 'true');
+      btn.setAttribute('aria-label', btn.dataset.less || 'Voir moins');
+      btn.innerHTML = '<i class="fa-solid fa-minus" aria-hidden="true"></i>';
+    }
+  });
+})();

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
@@ -31,6 +31,14 @@ wp_enqueue_script(
     true
 );
 
+wp_enqueue_script(
+    'tentatives-toggle',
+    $uri . '/assets/js/tentatives-toggle.js',
+    [],
+    filemtime($dir . '/assets/js/tentatives-toggle.js'),
+    true
+);
+
 // Retrieve last 4 engaged hunts and their latest enigme
 $chasse_ids  = [];
 $enigme_map = [];
@@ -122,6 +130,7 @@ $pages = (int) ceil($total / $per_page);
                 <tr>
                     <th><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
                     <th><?php esc_html_e('Énigme', 'chassesautresor-com'); ?></th>
+                    <th><?php esc_html_e('Proposition', 'chassesautresor-com'); ?></th>
                     <th><?php esc_html_e('Résultat', 'chassesautresor-com'); ?></th>
                 </tr>
             </thead>
@@ -130,6 +139,27 @@ $pages = (int) ceil($total / $per_page);
                 <tr>
                     <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
                     <td><?php echo esc_html($tent->post_title); ?></td>
+                    <?php
+                    $proposition   = $tent->reponse_saisie ?? '';
+                    $excerpt_limit = 30;
+                    $needs_toggle  = mb_strlen($proposition) > $excerpt_limit;
+                    $excerpt       = $needs_toggle ? mb_substr($proposition, 0, $excerpt_limit) . '…' : $proposition;
+                    ?>
+                    <td class="proposition-cell">
+                        <span class="proposition-excerpt"><?php echo esc_html($excerpt); ?></span>
+                        <?php if ($needs_toggle) : ?>
+                        <span class="proposition-full" hidden><?php echo esc_html($proposition); ?></span>
+                        <button
+                            class="toggle-proposition"
+                            aria-expanded="false"
+                            aria-label="<?php esc_attr_e('Voir plus', 'chassesautresor-com'); ?>"
+                            data-more="<?php esc_attr_e('Voir plus', 'chassesautresor-com'); ?>"
+                            data-less="<?php esc_attr_e('Voir moins', 'chassesautresor-com'); ?>"
+                        >
+                            <i class="fa-solid fa-ellipsis" aria-hidden="true"></i>
+                        </button>
+                        <?php endif; ?>
+                    </td>
                     <?php
                     $result = $tent->resultat;
                     $class  = 'etiquette-error';


### PR DESCRIPTION
## Résumé
- Ajoute une colonne "Proposition" aux tentatives dans l’espace Mon Compte avec texte réduit et bascule voir plus/moins.
- Introduit un script pour afficher ou masquer la proposition complète.
- Ajoute les styles nécessaires pour les icônes de bascule.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a5f41d660c8332b755232a46a4622e