### PR TITLE
Fix winner list refresh after automatic answer validation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
@@ -106,6 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
           } else if (res.data.resultat === 'bon') {
             feedback.innerHTML = `<i class="fa-solid fa-circle-check" style="color:var(--color-success);"></i> ${__('Bonne réponse', 'chassesautresor-com')}`;
             feedback.style.display = 'block';
+            const enigmeId = form.querySelector('input[name="enigme_id"]')?.value;
             const titre = form.querySelector('h3');
             form.replaceChildren(titre, feedback);
             if (compteur) {
@@ -118,7 +119,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             const sectionGagnants = document.querySelector('.enigme-gagnants');
             const sectionProgression = document.querySelector('.enigme-progression');
-            const enigmeIdInput = form.querySelector('input[name="enigme_id"]');
             const navigation = document.querySelector('.enigme-navigation');
             const chasseId = navigation ? navigation.dataset.chasseId : null;
             const bloc = document.querySelector('.menu-lateral__accordeons .accordeon-bloc');
@@ -126,10 +126,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const contenu = bloc ? bloc.querySelector('.accordeon-contenu') : null;
             const requests = [];
 
-            if (sectionGagnants && enigmeIdInput) {
+            if (sectionGagnants && enigmeId) {
               const dataW = new URLSearchParams();
               dataW.append('action', 'enigme_recuperer_gagnants');
-              dataW.append('enigme_id', enigmeIdInput.value);
+              dataW.append('enigme_id', enigmeId);
               const req = fetch('/wp-admin/admin-ajax.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
Corrige l’actualisation de la liste des gagnants après une réponse automatique validée.

- Sauvegarde l’identifiant de l’énigme avant de nettoyer le formulaire
- Rafraîchit correctement la section des gagnants lorsque l’accordéon s’ouvre

**Testing**
- `source ./setup-env.sh`
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f80dcc10833281b569ec1a6da5be