### PR TITLE
Externalise le script de galerie d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-gallery.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-gallery.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const vignettes = document.querySelectorAll('.vignette');
+    const principale = document.getElementById('image-enigme-active');
+    const lien = principale?.closest('a');
+    const container = principale?.closest('.image-principale');
+    const picture = principale?.parentElement;
+
+    vignettes.forEach(v => {
+        v.addEventListener('click', () => {
+            const id = v.getAttribute('data-image-id');
+            if (!id || !principale || !lien || !picture) return;
+
+            const base = '/voir-image-enigme?id=' + id;
+
+            const offsetBefore = container ? container.getBoundingClientRect().top : 0;
+            if (container) {
+                container.style.minHeight = container.offsetHeight + 'px';
+            }
+
+            const preload = new Image();
+            preload.onload = () => {
+                picture.querySelectorAll('source').forEach(source => {
+                    const size = source.getAttribute('data-size');
+                    source.srcset = base + '&taille=' + size;
+                });
+
+                principale.src = base + '&taille=thumbnail';
+                lien.href = base + '&taille=full';
+
+                if (container) {
+                    container.style.minHeight = '';
+                    const offsetAfter = container.getBoundingClientRect().top;
+                    window.scrollBy(0, offsetBefore - offsetAfter);
+                }
+
+                vignettes.forEach(x => x.classList.remove('active'));
+                v.classList.add('active');
+            };
+
+            preload.src = base + '&taille=thumbnail';
+        });
+    });
+});

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -150,6 +150,13 @@ add_action('wp_enqueue_scripts', function () {
             filemtime($theme_path . '/assets/js/accordeon.js'),
             true
         );
+        wp_enqueue_script(
+            'enigme-gallery',
+            $script_dir . 'enigme-gallery.js',
+            [],
+            filemtime($theme_path . '/assets/js/enigme-gallery.js'),
+            true
+        );
     }
 });
 

--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -156,55 +156,6 @@ function afficher_visuels_enigme(int $enigme_id): void
         }
         echo '</div>';
     }
-
-    // 🔁 JS interaction
-?>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const vignettes = document.querySelectorAll('.vignette');
-            const principale = document.getElementById('image-enigme-active');
-            const lien = principale?.closest('a');
-            const container = principale?.closest('.image-principale');
-            const picture = principale?.parentElement;
-
-            vignettes.forEach(v => {
-                v.addEventListener('click', () => {
-                    const id = v.getAttribute('data-image-id');
-                    if (!id || !principale || !lien || !picture) return;
-
-                    const base = '/voir-image-enigme?id=' + id;
-
-                    const offsetBefore = container ? container.getBoundingClientRect().top : 0;
-                    if (container) {
-                        container.style.minHeight = container.offsetHeight + 'px';
-                    }
-
-                    const preload = new Image();
-                    preload.onload = () => {
-                        picture.querySelectorAll('source').forEach(source => {
-                            const size = source.getAttribute('data-size');
-                            source.srcset = base + '&taille=' + size;
-                        });
-
-                        principale.src = base + '&taille=thumbnail';
-                        lien.href = base + '&taille=full';
-
-                        if (container) {
-                            container.style.minHeight = '';
-                            const offsetAfter = container.getBoundingClientRect().top;
-                            window.scrollBy(0, offsetBefore - offsetAfter);
-                        }
-
-                        vignettes.forEach(x => x.classList.remove('active'));
-                        v.classList.add('active');
-                    };
-
-                    preload.src = base + '&taille=thumbnail';
-                });
-            });
-        });
-    </script>
-<?php
 }
 
 


### PR DESCRIPTION
## Résumé
- Déplace le script de la galerie d’énigme vers un fichier dédié et le charge uniquement sur les pages d’énigme.
- Supprime le script inline de `afficher_visuels_enigme()` pour respecter les bonnes pratiques.

## Modifications notables
- Ajout du fichier `enigme-gallery.js` pour gérer l’interaction des vignettes.
- Enqueue conditionnel du script `enigme-gallery` via `functions.php` avec chargement en pied de page.
- Nettoyage de `visuels.php` en retirant le bloc `<script>` intégré.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a5fcc4addc83329bc3a1c992403bf9