### PR TITLE
Corriger l'aide des statistiques d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -59,16 +59,6 @@ function initEnigmeEdit() {
     }
   });
 
-  document.querySelectorAll('.stat-help').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const message = btn.dataset.message;
-      if (message) {
-        alert(message);
-      }
-    });
-  });
-
-
   // ==============================
   // 🧩 Affichage conditionnel – Champs radio
   // ==============================

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -153,10 +153,11 @@ add_action('wp_enqueue_scripts', function () {
         wp_enqueue_script(
             'accordeon',
             $script_dir . 'accordeon.js',
-            [],
+            ['wp-i18n'],
             filemtime($theme_path . '/assets/js/accordeon.js'),
             true
         );
+        wp_set_script_translations('accordeon', 'chassesautresor-com');
         wp_enqueue_script(
             'enigme-gallery',
             $script_dir . 'enigme-gallery.js',


### PR DESCRIPTION
## Résumé
- assure le chargement de `wp-i18n` pour les icônes d'aide des énigmes
- supprime l'alerte redondante dans le script d'édition des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a6157f7a208332b48991757ddf18c1