### PR TITLE
Élargir le bloc de participation sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/enigme.css
+++ b/wp-content/themes/chassesautresor/assets/css/enigme.css
@@ -342,9 +342,16 @@ li.active .enigme-menu__edit {
   padding: var(--space-xl);
   border-radius: 6px;
   justify-content: center;
-  width: 70%;
+  width: 100%;
+  max-width: 700px;
   margin: auto;
   text-align: center;
+}
+
+@media (min-width: 768px) {
+  .participation {
+    width: 70%;
+  }
 }
 
 .participation-header {


### PR DESCRIPTION
## Résumé
- Ajuste la largeur du bloc de participation

## Changements notables
- `width` à 100 % par défaut et ajout d’un `max-width`
- Application d’un `width` à 70 % dès 768px de largeur d’écran

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a688066ca88332a4ae7c175548b8cc