### PR TITLE
Déplace les vérifications d'accès des énigmes

### DIFF
--- a/tests/EnigmeAccessRedirectTest.php
+++ b/tests/EnigmeAccessRedirectTest.php
@@ -1,0 +1,93 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+// Stubs for WordPress functions used before guest redirect check
+if (!function_exists('is_singular')) {
+    function is_singular($type)
+    {
+        return $GLOBALS['is_singular'] ?? false;
+    }
+}
+if (!function_exists('get_queried_object_id')) {
+    function get_queried_object_id()
+    {
+        return 42;
+    }
+}
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id()
+    {
+        return $GLOBALS['user_id'] ?? 0;
+    }
+}
+if (!function_exists('utilisateur_peut_modifier_post')) {
+    function utilisateur_peut_modifier_post($id)
+    {
+        return false;
+    }
+}
+if (!function_exists('recuperer_id_chasse_associee')) {
+    function recuperer_id_chasse_associee($id)
+    {
+        return 123;
+    }
+}
+if (!function_exists('verifier_et_synchroniser_cache_enigmes_si_autorise')) {
+    function verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id) {}
+}
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in()
+    {
+        return $GLOBALS['logged_in'] ?? false;
+    }
+}
+if (!function_exists('get_permalink')) {
+    function get_permalink($id)
+    {
+        return 'permalink-' . $id;
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '/')
+    {
+        return 'home' . $path;
+    }
+}
+if (!function_exists('wp_redirect')) {
+    function wp_redirect($url)
+    {
+        $GLOBALS['redirect_to'] = $url;
+        throw new Exception('redirect');
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/access.php';
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class EnigmeAccessRedirectTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['is_singular'] = true;
+        $GLOBALS['user_id']     = 0;
+        $GLOBALS['logged_in']   = false;
+        $GLOBALS['redirect_to'] = null;
+    }
+
+    public function test_guest_is_redirected_to_related_chasse(): void
+    {
+        try {
+            handle_single_enigme_access();
+        } catch (Exception $e) {
+            // Intercepts exit triggered by the handler.
+        }
+        $this->assertSame('permalink-123', $GLOBALS['redirect_to']);
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/enigme-functions.php
+++ b/wp-content/themes/chassesautresor/inc/enigme-functions.php
@@ -9,3 +9,4 @@ require_once $base . 'affichage.php';
 require_once $base . 'reponses.php';
 require_once $base . 'tentatives.php';
 require_once $base . 'utils.php';
+require_once $base . 'access.php';

--- a/wp-content/themes/chassesautresor/inc/enigme/access.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/access.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Access control and redirection logic for single enigme pages.
+ *
+ * @package chassesautresor
+ */
+
+defined('ABSPATH') || exit;
+
+/**
+ * Handles access checks and redirects for the single enigme template.
+ *
+ * This function centralizes all redirection logic so that the template
+ * focuses solely on rendering once the user is allowed to view the page.
+ *
+ * @hook template_redirect
+ * @return void
+ */
+function handle_single_enigme_access(): void
+{
+    if (!is_singular('enigme')) {
+        return;
+    }
+
+    $enigme_id      = get_queried_object_id();
+    $user_id        = get_current_user_id();
+    $edition_active = utilisateur_peut_modifier_post($enigme_id);
+    $chasse_id      = recuperer_id_chasse_associee($enigme_id);
+
+    if ($chasse_id) {
+        verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
+    }
+
+    if (!is_user_logged_in()) {
+        $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+        wp_redirect($url);
+        exit;
+    }
+
+    if (
+        utilisateur_est_engage_dans_chasse($user_id, $chasse_id) &&
+        !utilisateur_est_engage_dans_enigme($user_id, $enigme_id) &&
+        utilisateur_peut_engager_enigme($enigme_id, $user_id)
+    ) {
+        marquer_enigme_comme_engagee($user_id, $enigme_id);
+
+        if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
+            verifier_fin_de_chasse($user_id, $enigme_id);
+        }
+    }
+
+    if (!enigme_est_visible_pour($user_id, $enigme_id)) {
+        $fallback_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+        wp_redirect($fallback_url);
+        exit;
+    }
+
+    $etat_systeme    = get_field('enigme_cache_etat_systeme', $enigme_id) ?? 'accessible';
+    $condition_acces = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
+
+    if (
+        $condition_acces === 'pre_requis' &&
+        $etat_systeme === 'bloquee_pre_requis' &&
+        !enigme_pre_requis_remplis($enigme_id, $user_id) &&
+        !utilisateur_peut_modifier_enigme($enigme_id)
+    ) {
+        $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+        wp_safe_redirect($url);
+        exit;
+    }
+
+    if (
+        $etat_systeme !== 'accessible' &&
+        $etat_systeme !== 'bloquee_pre_requis' &&
+        !utilisateur_peut_modifier_enigme($enigme_id)
+    ) {
+        $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+        wp_safe_redirect($url);
+        exit;
+    }
+
+    verifier_ou_mettre_a_jour_cache_complet($enigme_id);
+
+    $enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);
+
+    if (
+        $edition_active &&
+        utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&
+        !$enigme_complete &&
+        !isset($_GET['edition'])
+    ) {
+        wp_redirect(add_query_arg('edition', 'open', get_permalink($enigme_id)));
+        exit;
+    }
+
+    if (
+        $edition_active &&
+        utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&
+        compter_tentatives_en_attente($enigme_id) > 0 &&
+        !isset($_GET['edition'])
+    ) {
+        wp_redirect(
+            add_query_arg(
+                [
+                    'edition' => 'open',
+                    'tab'     => 'soumission',
+                ],
+                get_permalink($enigme_id)
+            )
+        );
+        exit;
+    }
+}
+add_action('template_redirect', 'handle_single_enigme_access');

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -14,91 +14,9 @@ if ($edition_active) {
 }
 
 $user_id = get_current_user_id();
-
-// 🔹 Chasse associée
-$chasse_id = recuperer_id_chasse_associee($enigme_id);
-if ($chasse_id) {
-  verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
-}
-
-// 🔹 Accès invité : redirection systématique vers la chasse associée
-if (!is_user_logged_in()) {
-    $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
-    wp_redirect($url);
-    exit;
-}
-
-// 🔹 Engagement automatique si autorisé
-if (
-    utilisateur_est_engage_dans_chasse($user_id, $chasse_id) &&
-    !utilisateur_est_engage_dans_enigme($user_id, $enigme_id) &&
-    utilisateur_peut_engager_enigme($enigme_id, $user_id)
-) {
-    marquer_enigme_comme_engagee($user_id, $enigme_id);
-
-    if (get_field('enigme_mode_validation', $enigme_id) === 'aucune') {
-        verifier_fin_de_chasse($user_id, $enigme_id);
-    }
-}
-
-// 🔹 Redirection si non visible
-if (!enigme_est_visible_pour($user_id, $enigme_id)) {
-    $fallback_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
-    wp_redirect($fallback_url);
-    exit;
-}
-
-// 🔒 Énigme inaccessible : redirection vers la chasse liée
-$etat_systeme   = get_field('enigme_cache_etat_systeme', $enigme_id) ?? 'accessible';
-$condition_acces = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';
-
-if (
-    $condition_acces === 'pre_requis'
-    && $etat_systeme === 'bloquee_pre_requis'
-    && !enigme_pre_requis_remplis($enigme_id, $user_id)
-    && !utilisateur_peut_modifier_enigme($enigme_id)
-) {
-    $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
-    wp_safe_redirect($url);
-    exit;
-}
-
-if ($etat_systeme !== 'accessible' && $etat_systeme !== 'bloquee_pre_requis' && !utilisateur_peut_modifier_enigme($enigme_id)) {
-    $url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
-    wp_safe_redirect($url);
-    exit;
-}
-
-// 🔹 Orgy auto
-verifier_ou_mettre_a_jour_cache_complet($enigme_id);
-
-$enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);
-if (
-  $edition_active &&
-  utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&
-  !$enigme_complete &&
-  !isset($_GET['edition'])
-) {
-  wp_redirect(add_query_arg('edition', 'open', get_permalink()));
-  exit;
-}
-
-// ✅ Ouvre automatiquement l'onglet Tentatives s'il y a des tentatives en attente
-if (
-  $edition_active &&
-  utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&
-  compter_tentatives_en_attente($enigme_id) > 0 &&
-  !isset($_GET['edition'])
-) {
-  wp_redirect(add_query_arg(['edition' => 'open', 'tab' => 'soumission'], get_permalink()));
-  exit;
-}
-
 // 🔹 Statut logique de l’énigme
-$statut_data     = traiter_statut_enigme($enigme_id, $user_id);
-$statut_enigme   = $statut_data['etat'];
-$verrouillage    = enigme_verifier_verrouillage($enigme_id, $user_id);
-$pre_requis_ok   = enigme_pre_requis_remplis($enigme_id, $user_id);
+$statut_data   = traiter_statut_enigme($enigme_id, $user_id);
+$statut_enigme = $statut_data['etat'];
 
 // 🔹 Données affichables
 $titre              = get_the_title($enigme_id);


### PR DESCRIPTION
## Résumé
- externalise la logique d'accès des énigmes dans un hook `template_redirect`
- simplifie le template `single-enigme.php`
- couvre la redirection invité par un test unitaire

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a6882790fc8332bb5a8569dc406445