### PR TITLE
feat: improve mobile enigma panel

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/enigme.css
+++ b/wp-content/themes/chassesautresor/assets/css/enigme.css
@@ -444,7 +444,10 @@ li.active .enigme-menu__edit {
     align-items: center;
     position: sticky;
     top: 0;
-    padding: var(--space-sm) var(--space-md);
+    padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
+    padding-bottom: var(--space-sm);
+    padding-left: calc(var(--space-md) + env(safe-area-inset-left));
+    padding-right: calc(var(--space-md) + env(safe-area-inset-right));
     background-color: var(--color-background);
     z-index: 10;
   }
@@ -482,15 +485,29 @@ li.active .enigme-menu__edit {
     bottom: 0;
     background-color: var(--color-background);
     border-radius: var(--space-sm) var(--space-sm) 0 0;
-    padding: var(--space-md);
+    padding-top: var(--space-md);
+    padding-bottom: calc(var(--space-md) + env(safe-area-inset-bottom));
+    padding-left: calc(var(--space-md) + env(safe-area-inset-left));
+    padding-right: calc(var(--space-md) + env(safe-area-inset-right));
     max-height: 80vh;
     overflow-y: auto;
+  }
+
+  .enigme-mobile-panel.full .enigme-mobile-panel__sheet {
+    top: 0;
+    bottom: 0;
+    border-radius: 0;
+    max-height: 100vh;
   }
 
   .enigme-mobile-panel__tabs {
     display: flex;
     gap: var(--space-xs);
     margin-bottom: var(--space-md);
+    position: sticky;
+    top: 0;
+    background-color: var(--color-background);
+    z-index: 1;
   }
 
   .panel-tab {
@@ -513,6 +530,10 @@ li.active .enigme-menu__edit {
   .enigme-mobile-panel__content {
     max-height: calc(80vh - var(--space-xl));
     overflow-y: auto;
+  }
+
+  .enigme-mobile-panel.full .enigme-mobile-panel__content {
+    max-height: calc(100vh - var(--space-xl));
   }
 
   .enigme-mobile-header + .page-enigme {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-panel.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-panel.js
@@ -8,6 +8,12 @@
     const tabs = panel.querySelectorAll('.panel-tab');
     const tabContents = panel.querySelectorAll('.panel-tab-content');
     let lastFocused = null;
+    let startY = null;
+
+    function updateMode() {
+      const full = sheet.scrollHeight > window.innerHeight * 0.75;
+      panel.classList.toggle('full', full);
+    }
 
     function openPanel() {
       lastFocused = document.activeElement;
@@ -15,6 +21,7 @@
       panel.classList.add('open');
       toggle.setAttribute('aria-expanded', 'true');
       document.body.classList.add('no-scroll');
+      updateMode();
       const focusable = sheet.querySelectorAll('a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
       if (focusable.length) {
         focusable[0].focus();
@@ -60,6 +67,30 @@
         closePanel();
       } else if (e.key === 'Tab' && !panel.hidden) {
         trapFocus(e);
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (!panel.hidden) {
+        updateMode();
+      }
+    });
+
+    sheet.addEventListener('touchstart', (e) => {
+      if (sheet.scrollTop === 0) {
+        startY = e.touches[0].clientY;
+      } else {
+        startY = null;
+      }
+    });
+
+    sheet.addEventListener('touchmove', (e) => {
+      if (startY !== null) {
+        const diff = e.touches[0].clientY - startY;
+        if (diff > 50) {
+          closePanel();
+          startY = null;
+        }
       }
     });
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -992,7 +992,8 @@ defined('ABSPATH') || exit;
 
         echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
         echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';
-        echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true">';
+        echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true" aria-labelledby="enigme-mobile-panel-title">';
+        echo '<h2 id="enigme-mobile-panel-title" class="screen-reader-text">' . esc_html__('Panneau d\'énigme', 'chassesautresor-com') . '</h2>';
         echo '<nav class="enigme-mobile-panel__tabs" role="tablist">';
         echo '<button type="button" role="tab" aria-selected="true" class="panel-tab panel-tab--active" data-target="panel-enigmes">' . esc_html__('Énigmes', 'chassesautresor-com') . '</button>';
         echo '<button type="button" role="tab" aria-selected="false" class="panel-tab" data-target="panel-stats">' . esc_html__('Statistiques', 'chassesautresor-com') . '</button>';


### PR DESCRIPTION
## Summary
- améliore l’accessibilité et l’ergonomie du panneau mobile
- gère le plein écran et la fermeture par glisser
- ajoute prise en compte des safe areas et onglets sticky

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a6a66fd6f08332a7a506fda4d527a7