### PR TITLE
Add language switcher with locale cookie

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -23,6 +23,42 @@ add_action( 'after_setup_theme', 'cta_load_textdomain' );
 
 
 /**
+ * Retrieves the locale from the cookie.
+ *
+ * @return string
+ */
+function cta_get_locale_from_cookie() {
+    $locale = isset( $_COOKIE['cta_lang'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['cta_lang'] ) ) : '';
+
+    return apply_filters( 'locale', $locale );
+}
+
+/**
+ * Handles language switching via query parameter and cookie.
+ *
+ * @return void
+ */
+function cta_handle_language() {
+    $locale = '';
+
+    if ( isset( $_GET['lang'] ) ) {
+        $lang   = sanitize_text_field( wp_unslash( $_GET['lang'] ) );
+        $locale = 'fr' === $lang ? 'fr_FR' : ( 'en' === $lang ? 'en_US' : '' );
+
+        if ( $locale ) {
+            setcookie( 'cta_lang', $locale, time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+        }
+    } else {
+        $locale = cta_get_locale_from_cookie();
+    }
+
+    if ( $locale ) {
+        switch_to_locale( $locale );
+    }
+}
+add_action( 'init', 'cta_handle_language' );
+
+/**
  * Chargement des styles du thème parent et enfant avec prise en charge d'Astra.
  */
 add_action('wp_enqueue_scripts', function () {

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -53,10 +53,29 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
 		<?php echo esc_html( astra_default_strings( 'string-header-skip-link', false ) ); ?>
 </a>
 
+<?php
+$active_locale = cta_get_locale_from_cookie();
+if ( ! $active_locale ) {
+    $active_locale = get_locale();
+}
+?>
+<ul class="lang-switcher">
+    <li class="<?php echo 'fr_FR' === $active_locale ? 'active' : ''; ?>">
+        <a href="<?php echo esc_url( home_url( '?lang=fr' ) ); ?>">
+            <?php echo esc_html__( 'Français', 'chassesautresor-com' ); ?>
+        </a>
+    </li>
+    <li class="<?php echo 'en_US' === $active_locale ? 'active' : ''; ?>">
+        <a href="<?php echo esc_url( home_url( '?lang=en' ) ); ?>">
+            <?php echo esc_html__( 'English', 'chassesautresor-com' ); ?>
+        </a>
+    </li>
+</ul>
+
 <div
 <?php
-	echo wp_kses_post(
-		astra_attr(
+        echo wp_kses_post(
+                astra_attr(
 			'site',
 			array(
 				'id'    => 'page',

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: chassesautresor.com\n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Domain: chassesautresor-com\n"
+
+msgid "Français"
+msgstr "French"
+
+msgid "English"
+msgstr "English"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: chassesautresor.com\n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Domain: chassesautresor-com\n"
+
+msgid "Français"
+msgstr "Français"
+
+msgid "English"
+msgstr "Anglais"
+


### PR DESCRIPTION
## Résumé
Implémente un commutateur de langue avec persistance via cookie et traductions associées.

## Changements notables
- Ajout de `cta_handle_language()` et `cta_get_locale_from_cookie()` pour gérer le locale
- Insertion d'un sélecteur de langue dans l'en-tête
- Création des fichiers de traduction `.po` pour `fr_FR` et `en_US`
- Suppression des fichiers `.mo` binaires pour éviter les erreurs de PR

## Testing
- `source ./setup-env.sh`
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a6b2cdf6b4833296df2ad9ec35ad0d