### PR TITLE
Améliore affichage des tentatives d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -212,6 +212,7 @@ require_once $inc_path . 'utils/liens.php';
 require_once $inc_path . 'chasse/stats.php';
 require_once $inc_path . 'organisateur/stats.php';
 require_once $inc_path . 'pager.php';
+require_once $inc_path . 'table.php';
 
 require_once $inc_path . 'edition/edition-core.php';
 require_once $inc_path . 'edition/edition-organisateur.php';

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -32,7 +32,7 @@ function enqueue_script_enigme_edit()
   if (!utilisateur_peut_modifier_post($enigme_id)) return;
 
   // 📦 Modules JS partagés + scripts spécifiques
-  enqueue_core_edit_scripts(['organisateur-edit', 'enigme-edit', 'enigme-stats', 'table-etiquette']);
+  enqueue_core_edit_scripts(['organisateur-edit', 'enigme-edit', 'enigme-stats', 'table-etiquette', 'tentatives-toggle']);
 
   wp_localize_script(
     'enigme-stats',

--- a/wp-content/themes/chassesautresor/inc/table.php
+++ b/wp-content/themes/chassesautresor/inc/table.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Helper functions for table rendering.
+ */
+
+declare(strict_types=1);
+
+defined('ABSPATH') || exit;
+
+/**
+ * Render a table cell with excerpt and toggle for long propositions.
+ *
+ * @param string $text     Full text to display.
+ * @param bool   $expanded Whether the cell should be expanded by default.
+ * @param int    $limit    Number of characters before truncation.
+ *
+ * @return string HTML for the table cell.
+ */
+function cta_render_proposition_cell(string $text, bool $expanded = false, int $limit = 39): string
+{
+    $needs_toggle = mb_strlen($text) > $limit;
+    $excerpt      = $needs_toggle ? mb_substr($text, 0, $limit) . '…' : $text;
+
+    $excerpt_html = '<span class="proposition-excerpt"' . ($expanded ? ' hidden' : '') . '>' . esc_html($excerpt) . '</span>';
+    $full_html    = '';
+    $button_html  = '';
+    $class        = 'proposition-cell';
+
+    if ($needs_toggle) {
+        $full_html = '<span class="proposition-full"' . ($expanded ? '' : ' hidden') . '>' . esc_html($text) . '</span>';
+
+        $label_more = esc_attr__('Voir plus', 'chassesautresor-com');
+        $label_less = esc_attr__('Voir moins', 'chassesautresor-com');
+        $aria_label = $expanded ? $label_less : $label_more;
+        $icon       = $expanded ? 'fa-minus' : 'fa-ellipsis';
+
+        $button_html = '<button type="button" class="toggle-proposition" aria-expanded="' . ($expanded ? 'true' : 'false') . '" aria-label="' . $aria_label . '" data-more="' . $label_more . '" data-less="' . $label_less . '"><i class="fa-solid ' . $icon . '" aria-hidden="true"></i></button>';
+    }
+
+    if ($expanded && $needs_toggle) {
+        $class .= ' expanded';
+    }
+
+    return '<td class="' . $class . '">' . $excerpt_html . $full_html . $button_html . '</td>';
+}

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
@@ -24,23 +24,34 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
       <tr>
         <th><?= esc_html__('Date', 'chassesautresor-com'); ?></th>
         <th><?= esc_html__('Utilisateur', 'chassesautresor-com'); ?></th>
-        <th><?= esc_html__('Réponse', 'chassesautresor-com'); ?></th>
-        <th><?= esc_html__('Actions', 'chassesautresor-com'); ?></th>
+        <th><?= esc_html__('Proposition', 'chassesautresor-com'); ?></th>
+        <th><?= esc_html__('Résultat', 'chassesautresor-com'); ?></th>
       </tr>
   </thead>
   <tbody>
   <?php foreach ($tentatives as $tent) :
-    $user  = get_userdata($tent->user_id);
-    $login = ($user && isset($user->user_login)) ? $user->user_login : esc_html__('Inconnu', 'chassesautresor-com');
-    $date  = mysql2date('d/m/y H:i', $tent->date_tentative);
-    $pending = ($tent->resultat === 'attente' && (int) $tent->traitee === 0) ? ' tentative-pending' : '';
+    $user       = get_userdata($tent->user_id);
+    $login      = ($user && isset($user->user_login)) ? $user->user_login : esc_html__('Inconnu', 'chassesautresor-com');
+    $date       = mysql2date('d/m/y H:i', $tent->date_tentative);
+    $is_pending = ($tent->resultat === 'attente' && (int) $tent->traitee === 0);
+    $pending    = $is_pending ? ' tentative-pending' : '';
   ?>
     <tr class="<?= $pending ?>">
       <td><?= esc_html($date); ?></td>
       <td><?= esc_html($login); ?></td>
-      <td><?= esc_html($tent->reponse_saisie); ?></td>
+      <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? '', $is_pending); ?>
       <td>
-        <?php if ($tent->resultat === 'attente'): ?>
+        <?php
+        $result = $tent->resultat;
+        $class  = 'etiquette-error';
+        if ($result === 'bon') {
+            $class = 'etiquette-success';
+        } elseif ($result === 'attente') {
+            $class = 'etiquette-pending';
+        }
+        ?>
+        <span class="etiquette <?= esc_attr($class); ?>"><?= esc_html($result); ?></span>
+        <?php if ($is_pending) : ?>
           <form method="post" style="display:inline;">
             <?php wp_nonce_field('traiter_tentative_' . $tent->tentative_uid); ?>
             <input type="hidden" name="uid" value="<?= esc_attr($tent->tentative_uid); ?>">
@@ -51,8 +62,6 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
               <?= esc_html__('Invalider', 'chassesautresor-com'); ?>
             </button>
           </form>
-        <?php else: ?>
-          <?= esc_html($tent->resultat); ?>
         <?php endif; ?>
       </td>
     </tr>

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
@@ -132,28 +132,7 @@ $pages = (int) ceil($total / $per_page);
                 <tr>
                     <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
                     <td><?php echo esc_html($tent->post_title); ?></td>
-                    <?php
-                    $proposition   = $tent->reponse_saisie ?? '';
-                    $excerpt_limit = 39;
-                    $needs_toggle  = mb_strlen($proposition) > $excerpt_limit;
-                    $excerpt       = $needs_toggle ? mb_substr($proposition, 0, $excerpt_limit) . '…' : $proposition;
-                    ?>
-                    <td class="proposition-cell">
-                        <span class="proposition-excerpt"><?php echo esc_html($excerpt); ?></span>
-                        <?php if ($needs_toggle) : ?>
-                        <span class="proposition-full" hidden><?php echo esc_html($proposition); ?></span>
-                        <button
-                            type="button"
-                            class="toggle-proposition"
-                            aria-expanded="false"
-                            aria-label="<?php esc_attr_e('Voir plus', 'chassesautresor-com'); ?>"
-                            data-more="<?php esc_attr_e('Voir plus', 'chassesautresor-com'); ?>"
-                            data-less="<?php esc_attr_e('Voir moins', 'chassesautresor-com'); ?>"
-                        >
-                            <i class="fa-solid fa-ellipsis" aria-hidden="true"></i>
-                        </button>
-                        <?php endif; ?>
-                    </td>
+                    <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? ''); ?>
                     <?php
                     $result = $tent->resultat;
                     $class  = 'etiquette-error';


### PR DESCRIPTION
## Résumé
- centralise le rendu des propositions avec une fonction dédiée
- harmonise le tableau des tentatives côté édition et ajoute un badge de résultat
- charge le script de bascule des propositions sur les pages d’édition

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a6bc54218c833296c80f779a78407d