### PR TITLE
Fix topbar visibility on enigma page

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/enigme.css
+++ b/wp-content/themes/chassesautresor/assets/css/enigme.css
@@ -588,7 +588,7 @@ body.single-enigme.topbar-visible header.site-header {
   transform: translateY(0);
 }
 
-@media (max-width: 1023px) {
+@media (hover: none) {
   body.single-enigme header.site-header {
     display: none;
   }

--- a/wp-content/themes/chassesautresor/assets/js/enigme-topbar.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-topbar.js
@@ -4,13 +4,15 @@
       return;
     }
 
-    if (window.matchMedia('(max-width: 1023px)').matches) {
+    if (!window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
       return;
     }
 
     const body = document.body;
     const desktopHeader = document.querySelector('header.site-header');
     let hideTimer;
+
+    body.classList.remove('topbar-visible');
 
     function showTopbar() {
       clearTimeout(hideTimer);


### PR DESCRIPTION
Résumé : correction de l'affichage de la topbar sur la page énigme.

- Cache la topbar sur les appareils sans support du hover
- Affiche la topbar au survol sur desktop avec un léger délai de disparition

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a6da13501483329676c5cd8c9a73d1