### PR TITLE
feat: traductions anglaises manquantes

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -667,7 +667,7 @@ msgstr "Edit simple text"
 
 #: template-parts/enigme/enigme-edition-main.php:202
 msgid "Sous-titre"
-msgstr "Sous-titre"
+msgstr "Subtitle"
 
 #: template-parts/enigme/enigme-edition-main.php:204
 msgid "Ajouter un sous-titre (max 100 caractères)"
@@ -823,6 +823,10 @@ msgstr "Statistics will be available once hunting is enabled."
 msgid "Aucun participant engagé."
 msgstr "No participants engaged."
 
+#: template-parts/enigme/partials/enigme-partial-participants.php:47
+msgid "Liste participants"
+msgstr "Participants list"
+
 #: template-parts/enigme/partials/enigme-partial-participants.php:50
 msgid "Nom"
 msgstr "Name"
@@ -845,7 +849,7 @@ msgstr "Attempts"
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:73
 msgid "Trouvé"
-msgstr "trouvé"
+msgstr "Found"
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:91
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:64
@@ -872,8 +876,16 @@ msgid "Aucune tentative de soumission."
 msgstr "No attempt to submit."
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:27
+msgid "Proposition"
+msgstr "Answer"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:27
+msgid "Résultat"
+msgstr "Result"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:27
 msgid "Réponse"
-msgstr "Immediate"
+msgstr "Answer"
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:28
 msgid "Actions"
@@ -1264,3 +1276,51 @@ msgstr "No link can be found or opened."
 #: template-parts/enigme/enigme-edition-main.php
 msgid "Débloquées uniquement au moment choisi."
 msgstr "Unlocked only at the chosen time."
+
+#: assets/js/enigme-edit.js
+msgid "Validation automatique : Le joueur devra saisir une réponse exacte. Celle-ci sera automatiquement vérifiée selon les critères définis (réponse attendue, casse, variantes)."
+msgstr "Automatic validation: The player must enter an exact answer. It will be automatically checked based on the defined criteria (expected answer, case, variants)."
+
+#: assets/js/enigme-edit.js
+msgid "Validation manuelle : Le joueur rédige une réponse libre. Vous validez ou invalidez manuellement sa tentative depuis votre espace personnel. Un email et un message d'alerte vous avertit de chaque nouvelle soumission."
+msgstr "Manual validation: The player enters a free-form answer. You approve or reject their attempt manually from your personal area. An email and alert message notify you of each new submission."
+
+#: template-parts/modals/modal-points.php
+msgid "À quoi servent les points ?"
+msgstr "What are points used for?"
+
+#: template-parts/modals/modal-points.php
+msgid "Les points vous permettent de débloquer :"
+msgstr "Points allow you to unlock:"
+
+#: template-parts/modals/modal-points.php
+msgid "🎯 Des chasses au trésor"
+msgstr "🎯 Treasure hunts"
+
+#: template-parts/modals/modal-points.php
+msgid "❓ Des tentatives de réponse"
+msgstr "❓ Answer attempts"
+
+#: template-parts/modals/modal-points.php
+msgid "💡 Des indices"
+msgstr "💡 Hints"
+
+#: template-parts/modals/modal-points.php
+msgid "La gratuité ou l'accès par points est choisi librement par chaque organisateur."
+msgstr "Free access or point access is chosen freely by each organizer."
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php
+msgid "bon"
+msgstr "correct"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php
+msgid "faux"
+msgstr "wrong"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php
+msgid "attente"
+msgstr "pending"
+
+#: template-parts/enigme/enigme-edition-main.php
+msgid "votre fichier %s"
+msgstr "your %s file"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -564,7 +564,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             $card_class = $stats_locked ? 'disabled' : '';
             get_template_part('template-parts/common/stat-card', null, [
                 'icon'  => 'fa-solid fa-users',
-                'label' => 'Participants',
+                'label' => esc_html__('Participants', 'chassesautresor-com'),
                 'value' => $nb_participants,
                 'stat'  => 'participants',
                 'class' => $card_class,

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-tentatives.php
@@ -49,8 +49,17 @@ $pages = $args['pages'] ?? $pages ?? (int) ceil($total / $par_page);
         } elseif ($result === 'attente') {
             $class = 'etiquette-pending';
         }
+
+        $result_label = $result;
+        if ($result === 'bon') {
+            $result_label = esc_html__('bon', 'chassesautresor-com');
+        } elseif ($result === 'faux') {
+            $result_label = esc_html__('faux', 'chassesautresor-com');
+        } elseif ($result === 'attente') {
+            $result_label = esc_html__('attente', 'chassesautresor-com');
+        }
         ?>
-        <span class="etiquette <?= esc_attr($class); ?>"><?= esc_html($result); ?></span>
+        <span class="etiquette <?= esc_attr($class); ?>"><?= esc_html($result_label); ?></span>
         <?php if ($is_pending) : ?>
           <form method="post" style="display:inline;">
             <?php wp_nonce_field('traiter_tentative_' . $tent->tentative_uid); ?>

--- a/wp-content/themes/chassesautresor/template-parts/modals/modal-points.php
+++ b/wp-content/themes/chassesautresor/template-parts/modals/modal-points.php
@@ -6,15 +6,15 @@ defined('ABSPATH') || exit;
 <div id="points-modal" class="points-modal">
     <div class="points-modal-content">
         <span class="close-modal">&times;</span>
-        <h2>À quoi servent les points ?</h2>
-        <p>Les points vous permettent de débloquer :</p>
+        <h2><?= esc_html__('À quoi servent les points ?', 'chassesautresor-com'); ?></h2>
+        <p><?= esc_html__('Les points vous permettent de débloquer :', 'chassesautresor-com'); ?></p>
         <ul class="points-list">
-            <li>🎯 Des chasses au trésor</li>
-            <li>❓ Des tentatives de réponse</li>
-            <li>💡 Des indices</li>
+            <li><?= esc_html__('🎯 Des chasses au trésor', 'chassesautresor-com'); ?></li>
+            <li><?= esc_html__('❓ Des tentatives de réponse', 'chassesautresor-com'); ?></li>
+            <li><?= esc_html__('💡 Des indices', 'chassesautresor-com'); ?></li>
         </ul>
         <p class="points-info-text">
-            La gratuité ou l'accès par points est choisi librement par chaque organisateur.
+            <?= esc_html__('La gratuité ou l\'accès par points est choisi librement par chaque organisateur.', 'chassesautresor-com'); ?>
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Résumé
- Ajout de traductions anglaises pour plusieurs chaînes de l’interface
- Internationalisation des textes du panneau Points et des statistiques

## Détails
- Traduction du champ de sous-titre et des messages d’aide de validation
- Localisation de la modale Points et des résultats de tentatives
- Ajout de l’étiquette Participants dans les cartes de statistiques

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a6e63ae42483329149a9abc4115d78