### PR TITLE
feat: traductions anglais interface édition chasse

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1139,7 +1139,7 @@ msgstr "Illustrations"
 
 #: template-parts/enigme/enigme-edition-main.php
 msgid "Réglages"
-msgstr "Options"
+msgstr "Settings"
 
 #: template-parts/enigme/enigme-edition-main.php
 msgid "Respecter la casse"
@@ -1324,3 +1324,60 @@ msgstr "pending"
 #: template-parts/enigme/enigme-edition-main.php
 msgid "votre fichier %s"
 msgstr "your %s file"
+
+msgid "Image chasse"
+msgstr "Hunt image"
+
+msgid "Modifier l’image"
+msgstr "Edit image"
+
+msgid "ajouter une image"
+msgstr "add an image"
+
+msgid "Configurer la récompense"
+msgstr "Configure the reward"
+
+msgid "Titre de la récompense"
+msgstr "Reward title"
+
+msgid "Ex : Un papillon en cristal..."
+msgstr "E.g.: A crystal butterfly..."
+
+msgid "Descripton de la récompense"
+msgstr "Reward description"
+
+msgid "Ex : Un coffret cadeau comprenant..."
+msgstr "E.g.: A gift box including..."
+
+msgid "Valeur en euros (€)"
+msgstr "Value in euros (€)"
+
+msgid "Ex : 50"
+msgstr "E.g.: 50"
+
+msgid "Supprimer la récompense"
+msgstr "Delete the reward"
+
+msgid "Nb gagnants"
+msgstr "Number of winners"
+
+msgid "Illimité"
+msgstr "Unlimited"
+
+msgid "Début"
+msgstr "Start"
+
+msgid "Date de fin"
+msgstr "End date"
+
+msgid "Durée illimitée"
+msgstr "Unlimited duration"
+
+msgid "Coût"
+msgstr "Cost"
+
+msgid "Animation"
+msgstr "Animation"
+
+msgid "Taux d'engagement"
+msgstr "Engagement rate"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -64,16 +64,16 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
         </div>
         <div class="edition-tabs">
-          <button class="edition-tab active" data-target="chasse-tab-param">Paramètres</button>
-          <button class="edition-tab" data-target="chasse-tab-stats">Statistiques</button>
-          <button class="edition-tab" data-target="chasse-tab-animation">Animation</button>
+          <button class="edition-tab active" data-target="chasse-tab-param"><?= esc_html__('Paramètres', 'chassesautresor-com'); ?></button>
+          <button class="edition-tab" data-target="chasse-tab-stats"><?= esc_html__('Statistiques', 'chassesautresor-com'); ?></button>
+          <button class="edition-tab" data-target="chasse-tab-animation"><?= esc_html__('Animation', 'chassesautresor-com'); ?></button>
         </div>
     </div>
 
     <div id="chasse-tab-param" class="edition-tab-content active">
       <i class="fa-solid fa-sliders tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+        <h2><i class="fa-solid fa-sliders"></i> <?= esc_html__('Paramètres', 'chassesautresor-com'); ?></h2>
       </div>
       <div class="edition-panel-body">
 
@@ -123,22 +123,22 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
                   <div class="champ-affichage">
-                    <label>Image chasse <span class="champ-obligatoire">*</span></label>
+                    <label><?= esc_html__('Image chasse', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
                     <?php if ($peut_editer) : ?>
                       <button type="button"
                         class="champ-modifier"
                         data-champ="chasse_principale_image"
                         data-cpt="chasse"
                         data-post-id="<?= esc_attr($chasse_id); ?>"
-                        aria-label="Modifier l’image">
+                        aria-label="<?= esc_attr__('Modifier l’image', 'chassesautresor-com'); ?>">
                         <img src="<?= esc_url($image_url ?: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='); ?>" alt="Image de la chasse" />
-                        <span class="champ-ajout-image">ajouter une image</span>
+                        <span class="champ-ajout-image"><?= esc_html__('ajouter une image', 'chassesautresor-com'); ?></span>
                       </button>
                     <?php else : ?>
                       <?php if ($image_url) : ?>
                         <img src="<?= esc_url($image_url); ?>" alt="Image de la chasse" />
                       <?php else : ?>
-                        <span class="champ-ajout-image">ajouter une image</span>
+                        <span class="champ-ajout-image"><?= esc_html__('ajouter une image', 'chassesautresor-com'); ?></span>
                       <?php endif; ?>
                     <?php endif; ?>
                   </div>
@@ -224,7 +224,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
               <!-- SECTION 2 : Réglages -->
               <div class="resume-bloc resume-reglages">
-                <h3>Réglages</h3>
+                <h3><?= esc_html__('Réglages', 'chassesautresor-com'); ?></h3>
                 <ul class="resume-infos">
 
                 <!-- Mode de fin de chasse -->
@@ -336,7 +336,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
-                  <label for="chasse-nb-gagnants">Nb gagnants</label>
+                  <label for="chasse-nb-gagnants"><?= esc_html__('Nb gagnants', 'chassesautresor-com'); ?></label>
 
                   <input type="number"
                     id="chasse-nb-gagnants"
@@ -352,7 +352,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       name="nb-gagnants-illimite"
                       <?= ($nb_max == 0 ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>
                       data-champ="chasse_infos_nb_max_gagants">
-                    <label for="nb-gagnants-illimite">Illimité</label>
+                    <label for="nb-gagnants-illimite"><?= esc_html__('Illimité', 'chassesautresor-com'); ?></label>
                   </div>
 
                   <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
@@ -373,7 +373,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
-                  <label for="chasse-date-debut">Début</label>
+                  <label for="chasse-date-debut"><?= esc_html__('Début', 'chassesautresor-com'); ?></label>
                   <input type="datetime-local"
                     id="chasse-date-debut"
                     name="chasse-date-debut"
@@ -389,7 +389,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
-                  <label for="chasse-date-fin">Date de fin</label>
+                  <label for="chasse-date-fin"><?= esc_html__('Date de fin', 'chassesautresor-com'); ?></label>
                   <input type="date"
                     id="chasse-date-fin"
                     name="chasse-date-fin"
@@ -403,7 +403,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       name="duree-illimitee"
                       data-champ="chasse_infos_duree_illimitee"
                       <?= ($illimitee ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                    <label for="duree-illimitee">Durée illimitée</label>
+                    <label for="duree-illimitee"><?= esc_html__('Durée illimitée', 'chassesautresor-com'); ?></label>
                   </div>
 
                 </li>
@@ -416,7 +416,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
                   <div class="champ-edition" style="display: flex; align-items: center;">
-                    <label>Coût <span class="txt-small">(points)</span>
+                    <label><?= esc_html__('Coût', 'chassesautresor-com'); ?> <span class="txt-small">(<?= esc_html__('points', 'chassesautresor-com'); ?>)</span>
                       <?php
                       get_template_part(
                           'template-parts/common/help-icon',
@@ -441,7 +441,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         id="cout-gratuit"
                         name="cout-gratuit"
                         <?= ((int)$cout === 0) ? 'checked' : ''; ?> <?= $peut_editer_cout ? '' : 'disabled'; ?>>
-                      <label for="cout-gratuit">Gratuit</label>
+                      <label for="cout-gratuit"><?= esc_html__('Gratuit', 'chassesautresor-com'); ?></label>
                     </div>
                   </div>
 
@@ -548,9 +548,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       ?>
         <div class="edition-panel-body">
           <div class="stats-header" style="display:flex;align-items:center;justify-content:flex-end;gap:1rem;">
-            <a href="?edition=open&amp;tab=stats" class="stats-reset"><i class="fa-solid fa-rotate-right"></i> Actualiser</a>
+            <a href="?edition=open&amp;tab=stats" class="stats-reset"><i class="fa-solid fa-rotate-right"></i> <?= esc_html__('Actualiser', 'chassesautresor-com'); ?></a>
             <div class="stats-filtres">
-              <label for="chasse-periode">Période&nbsp;:</label>
+              <label for="chasse-periode"><?= esc_html__('Période :', 'chassesautresor-com'); ?></label>
               <select id="chasse-periode">
                 <option value="total">Total</option>
                 <option value="jour">Aujourd’hui</option>
@@ -571,21 +571,21 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             ]);
             get_template_part('template-parts/common/stat-card', null, [
                 'icon'  => 'fa-solid fa-arrow-rotate-right',
-                'label' => 'Tentatives',
+                'label' => esc_html__('Tentatives', 'chassesautresor-com'),
                 'value' => $nb_tentatives,
                 'stat'  => 'tentatives',
                 'class' => $card_class,
             ]);
             get_template_part('template-parts/common/stat-card', null, [
                 'icon'  => 'fa-solid fa-coins',
-                'label' => 'Points collectés',
+                'label' => esc_html__('Points collectés', 'chassesautresor-com'),
                 'value' => $nb_points,
                 'stat'  => 'points',
                 'class' => $card_class,
             ]);
             get_template_part('template-parts/common/stat-card', null, [
                 'icon'  => 'fa-solid fa-percent',
-                'label' => 'Taux d\'engagement',
+                'label' => esc_html__('Taux d\'engagement', 'chassesautresor-com'),
                 'value' => $taux_engagement . '%',
                 'stat'  => 'engagement-rate',
                 'help'  => __(

--- a/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-recompense.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-recompense.php
@@ -12,32 +12,32 @@ $valeur_recompense = get_field('chasse_infos_recompense_valeur', $chasse_id);
   <div class="panneau-lateral__contenu">
 
     <header class="panneau-lateral__header">
-      <h2>Configurer la récompense</h2>
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+      <h2><?= esc_html__('Configurer la récompense', 'chassesautresor-com'); ?></h2>
+      <button type="button" class="panneau-fermer" aria-label="<?= esc_attr__('Fermer le panneau', 'chassesautresor-com'); ?>">✖</button>
     </header>
 
     <div class="champ-wrapper" style="display: flex; flex-direction: column; gap: 20px;">
         
-      <label for="champ-recompense-titre">Titre de la récompense <span class="champ-obligatoire">*</span></label>
-      <input id="champ-recompense-titre" type="text" maxlength="40" placeholder="Ex : Un papillon en cristal..." value="<?= esc_attr(get_field('chasse_infos_recompense_titre', $chasse_id)); ?>">
+      <label for="champ-recompense-titre"><?= esc_html__('Titre de la récompense', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
+      <input id="champ-recompense-titre" type="text" maxlength="40" placeholder="<?= esc_attr__('Ex : Un papillon en cristal...', 'chassesautresor-com'); ?>" value="<?= esc_attr(get_field('chasse_infos_recompense_titre', $chasse_id)); ?>">
 
-      <label for="champ-recompense-texte">Descripton de la récompense <span class="champ-obligatoire">*</span></label>
-      <textarea id="champ-recompense-texte" rows="4" placeholder="Ex : Un coffret cadeau comprenant..."><?= esc_textarea(wp_strip_all_tags($texte_recompense)); ?></textarea>
+      <label for="champ-recompense-texte"><?= esc_html__('Descripton de la récompense', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
+      <textarea id="champ-recompense-texte" rows="4" placeholder="<?= esc_attr__('Ex : Un coffret cadeau comprenant...', 'chassesautresor-com'); ?>"><?= esc_textarea(wp_strip_all_tags($texte_recompense)); ?></textarea>
 
 
-      <label for="champ-recompense-valeur">Valeur en euros (€) <span class="champ-obligatoire">*</span></label>
+      <label for="champ-recompense-valeur"><?= esc_html__('Valeur en euros (€)', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
       <?php
       $valeur_formatee = $valeur_recompense !== '' && $valeur_recompense !== null
         ? number_format((float) $valeur_recompense, 2, ',', ' ')
         : '';
       ?>
-      <input id="champ-recompense-valeur" class="w-175" type="text" inputmode="decimal" placeholder="Ex : 50" value="<?= esc_attr($valeur_formatee); ?>">
+      <input id="champ-recompense-valeur" class="w-175" type="text" inputmode="decimal" placeholder="<?= esc_attr__('Ex : 50', 'chassesautresor-com'); ?>" value="<?= esc_attr($valeur_formatee); ?>">
 
       <div class="panneau-lateral__actions">
-        <button id="bouton-enregistrer-recompense" type="button" class="bouton-enregistrer-description bouton-enregistrer-liens">💾 Enregistrer</button>
+        <button id="bouton-enregistrer-recompense" type="button" class="bouton-enregistrer-description bouton-enregistrer-liens">💾 <?= esc_html__('Enregistrer', 'chassesautresor-com'); ?></button>
       </div>
       <button type="button" id="bouton-supprimer-recompense" class="bouton-texte secondaire">
-      ❌ Supprimer la récompense
+      ❌ <?= esc_html__('Supprimer la récompense', 'chassesautresor-com'); ?>
     </button>
 
     </div>


### PR DESCRIPTION
## Résumé
- internationalisation du panneau d'édition de chasse
- traduction anglaise des champs de récompense et des statistiques

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec1d811083329445e46cf6bec367