### PR TITLE
docs: documenter la gestion des fichiers de traduction

### DIFF
--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -53,6 +53,8 @@ extensions actives :
 - Réponses courtes et fonctionnelles : éviter les formules, les paraphrases, les répétitions.
 - Historique de développement : le développement initial a largement été modifié. Quasiment tout a été revu, mais il se peut qu’on rencontre des résidus dans le code, il faut en avoir conscience.
 
+- Traductions : ne jamais fournir les fichiers `.mo` (binaires). Seuls les fichiers `.po` doivent être versionnés.
+
 ### 🚫 Suppressions obligatoires
 Toute évolution ou migration de logique (ex. déplacement d’un champ vers champ-init.js) doit impérativement inclure l’identification et la suppression des doublons ou fonctions redondantes (dans les fichiers JS ou PHP concernés).
 Le code ancien ne doit jamais rester actif ou latent, même s’il n’est “plus appelé”.


### PR DESCRIPTION
## Résumé
- ajout d'une règle interdisant l'ajout des fichiers `.mo`

## Changements notables
- avertissement sur l'exclusion des fichiers binaires `.mo`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a72341b6748332b90de3059bd3435d