### PR TITLE
fix: improve english translations

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -259,8 +259,10 @@ function initChasseEdit() {
       bouton.dataset.champ = 'chasse_infos_recompense_valeur';
       bouton.dataset.cpt = 'chasse';
       bouton.dataset.postId = ligne.dataset.postId || '';
-      bouton.setAttribute('aria-label', 'Modifier la récompense');
-      bouton.textContent = wp.i18n.__('modifier', 'chassesautresor-com');
+      const action = complet ? 'modifier' : 'ajouter';
+      const aria = complet ? 'Modifier la récompense' : 'Ajouter la récompense';
+      bouton.setAttribute('aria-label', wp.i18n.__(aria, 'chassesautresor-com'));
+      bouton.textContent = wp.i18n.__(action, 'chassesautresor-com');
       champTexte.appendChild(bouton);
       if (typeof initZoneClicEdition === 'function') initZoneClicEdition(bouton);
     }

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -224,7 +224,7 @@ msgstr "Riddles"
 #: template-parts/chasse/chasse-edition-main.php:650
 #: template-parts/chasse/chasse-edition-main.php:662
 msgid "Indices"
-msgstr "Indices"
+msgstr "Hints"
 
 #: inc/enigme/affichage.php:447
 msgid "Voir la solution"
@@ -518,7 +518,7 @@ msgstr "Modifying the description"
 #: assets/js/core/helpers.js:240 assets/js/core/helpers.js:262
 #: assets/js/core/resume.js:373 assets/js/enigme-edit.js:891
 msgid "modifier"
-msgstr "modify"
+msgstr "edit"
 
 #: template-parts/chasse/chasse-edition-main.php:171
 msgid "Récompense"
@@ -610,7 +610,7 @@ msgstr "Close the panel."
 #: template-parts/chasse/panneaux/chasse-edition-description.php:28
 #: template-parts/enigme/panneaux/enigme-edition-description.php:27
 #: template-parts/enigme/panneaux/enigme-edition-images.php:20
-msgid "💾 Enregistrer"
+msgid "Enregistrer"
 msgstr "Save"
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:33
@@ -1191,7 +1191,7 @@ msgstr "Month"
 
 #: template-parts/enigme/enigme-edition-main.php
 msgid "Participants"
-msgstr "Participants"
+msgstr "Players"
 
 #: template-parts/enigme/enigme-edition-main.php
 msgid "Points collectés"
@@ -1381,3 +1381,33 @@ msgstr "Animation"
 
 msgid "Taux d'engagement"
 msgstr "Engagement rate"
+
+#: inc/user-functions.php:233 templates/myaccount/layout.php:156
+msgid "Vos commandes"
+msgstr "Your orders"
+
+#: templates/myaccount/content-chasses.php:119
+msgid "Énigme"
+msgstr "Riddle"
+
+#: template-parts/chasse/chasse-edition-main.php:217 assets/js/chasse-edit.js:264
+msgid "Ajouter la récompense"
+msgstr "Add reward"
+
+#: templates/myaccount/content-chasses.php:112
+msgid "%d tentative en attente"
+msgid_plural "%d tentatives en attente"
+msgstr[0] "%d pending attempt"
+msgstr[1] "%d pending attempts"
+
+#: templates/myaccount/content-chasses.php:114
+msgid "%d tentative"
+msgid_plural "%d tentatives"
+msgstr[0] "%d attempt"
+msgstr[1] "%d attempts"
+
+#: templates/myaccount/content-chasses.php:116
+msgid "%d bonne réponse"
+msgid_plural "%d bonnes réponses"
+msgstr[0] "%d correct answer"
+msgstr[1] "%d correct answers"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -101,7 +101,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         ],
                         'label' => function () {
                             ?>
-                            <label for="champ-titre-chasse">Titre <span class="champ-obligatoire">*</span></label>
+                            <label for="champ-titre-chasse"><?php esc_html_e('Titre', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
                             <?php
                         },
                         'content' => function () use ($titre, $peut_editer_titre) {
@@ -212,8 +212,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                 data-champ="chasse_infos_recompense_valeur"
                                 data-cpt="chasse"
                                 data-post-id="<?= esc_attr($chasse_id); ?>"
-                                aria-label="<?= esc_attr__('Modifier la récompense', 'chassesautresor-com'); ?>">
-                                <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                aria-label="<?= esc_attr__($recompense_remplie ? 'Modifier la récompense' : 'Ajouter la récompense', 'chassesautresor-com'); ?>">
+                                <?= esc_html__($recompense_remplie ? 'modifier' : 'ajouter', 'chassesautresor-com'); ?>
                             </button>
                         <?php endif; ?>
                     </div>

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
@@ -144,7 +144,7 @@ $pages = (int) ceil($total / $per_page);
                     ?>
                     <td>
                         <span class="etiquette <?php echo esc_attr($class); ?>">
-                            <?php echo esc_html($result); ?>
+                            <?php echo esc_html__($result, 'chassesautresor-com'); ?>
                         </span>
                     </td>
                 </tr>


### PR DESCRIPTION
## Résumé
- Correction des libellés non traduits
- Amélioration des traductions anglaises manquantes

## Changements notables
- Traduction du champ titre et logique du bouton récompense
- Internationalisation du tableau des tentatives
- Ajout de nombreuses entrées de traduction en_US

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a724dc5a9c8332894969bf13e5c2d6