### PR TITLE
Add missing English translations for validation and participation info

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1094,3 +1094,43 @@ msgstr ""
 #: assets/js/enigme-edit.js:908
 msgid "❌ Erreur réseau"
 msgstr ""
+
+#: inc/enigme/affichage.php:678
+msgid "Mode de validation de l'énigme : %s"
+msgstr ""
+
+#: inc/enigme/affichage.php:675
+msgid "automatique"
+msgstr ""
+
+#: inc/enigme/affichage.php:676
+msgid "manuelle"
+msgstr ""
+
+#: inc/enigme/affichage.php:710
+msgid "Solde : %d pts"
+msgstr ""
+
+#: inc/enigme/reponses.php:67 assets/js/reponse-automatique.js:95
+msgid "Solde : %1$d → %2$d pts"
+msgstr ""
+
+#: inc/enigme/affichage.php:719
+msgid "Tentatives quotidiennes : %1$d/%2$s"
+msgstr ""
+
+#: inc/enigme/reponses.php:459
+msgid "Tentatives quotidiennes : %1$d / %2$s"
+msgstr ""
+
+#: assets/js/reponse-automatique.js:85
+msgid "Tentatives quotidiennes : %1$s/%2$s"
+msgstr ""
+
+#: assets/js/reponse-automatique.js:88
+msgid "Tentatives quotidiennes :"
+msgstr ""
+
+#: templates/myaccount/content-points.php:103 inc/enigme/reponses.php:59 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
+msgid "Ajouter des points"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1381,3 +1381,43 @@ msgstr "Animation"
 
 msgid "Taux d'engagement"
 msgstr "Engagement rate"
+
+#: inc/enigme/affichage.php:678
+msgid "Mode de validation de l'énigme : %s"
+msgstr "Riddle validation mode: %s"
+
+#: inc/enigme/affichage.php:675
+msgid "automatique"
+msgstr "automatic"
+
+#: inc/enigme/affichage.php:676
+msgid "manuelle"
+msgstr "manual"
+
+#: inc/enigme/affichage.php:710
+msgid "Solde : %d pts"
+msgstr "Balance: %d pts"
+
+#: inc/enigme/reponses.php:67 assets/js/reponse-automatique.js:95
+msgid "Solde : %1$d → %2$d pts"
+msgstr "Balance: %1$d → %2$d pts"
+
+#: inc/enigme/affichage.php:719
+msgid "Tentatives quotidiennes : %1$d/%2$s"
+msgstr "Daily Attempts: %1$d/%2$s"
+
+#: inc/enigme/reponses.php:459
+msgid "Tentatives quotidiennes : %1$d / %2$s"
+msgstr "Daily Attempts: %1$d / %2$s"
+
+#: assets/js/reponse-automatique.js:85
+msgid "Tentatives quotidiennes : %1$s/%2$s"
+msgstr "Daily Attempts: %1$s/%2$s"
+
+#: assets/js/reponse-automatique.js:88
+msgid "Tentatives quotidiennes :"
+msgstr "Daily Attempts:"
+
+#: templates/myaccount/content-points.php:103 inc/enigme/reponses.php:59 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
+msgid "Ajouter des points"
+msgstr "Add points"


### PR DESCRIPTION
## Résumé
Ajout des traductions anglaises manquantes pour le mode de validation des énigmes et les informations de participation.

## Changements
- Traductions pour "Mode de validation de l'énigme" ainsi que "manuelle" et "automatique"
- Traductions du solde et du compteur de tentatives quotidiennes
- Traduction du CTA « Ajouter des points » et mise à jour du fichier modèle

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a726e969408332b5ecedd38502cc87