### PR TITLE
fix: remove duplicate enigmeId declaration

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
+++ b/wp-content/themes/chassesautresor/assets/js/reponse-automatique.js
@@ -108,8 +108,6 @@ document.addEventListener('DOMContentLoaded', () => {
             feedback.style.display = 'block';
             const enigmeId = form.querySelector('input[name="enigme_id"]')?.value;
             const titre = form.querySelector('h3');
-            const enigmeIdInput = form.querySelector('input[name="enigme_id"]');
-            const enigmeId = enigmeIdInput ? enigmeIdInput.value : null;
             form.replaceChildren(titre, feedback);
             if (compteur) {
               compteur.remove();


### PR DESCRIPTION
## Résumé
- corrige une erreur console liée à une double déclaration de `enigmeId`

## Changements notables
- supprime la seconde déclaration d'`enigmeId` dans `reponse-automatique.js`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a72cb5446c8332aa83bdde12a9b54c