### PR TITLE
fix: update progression tooltip translation

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -338,9 +338,9 @@ defined('ABSPATH') || exit;
             'enigme-progression',
             esc_html__(
                 'Part moyenne des énigmes auxquelles chaque joueur a participé, '
-                . 'rapportée au nombre total d’énigmes de la chasse.\n\n'
-                . 'Vous\nPart des énigmes auxquelles vous avez accédé.\n\n'
-                . 'Moyenne\nMoyenne sur l’ensemble des joueurs.',
+                . 'rapportée au nombre total d’énigmes de la chasse. '
+                . 'Vous : Part des énigmes auxquelles vous avez accédé '
+                . 'Moyenne : Moyenne sur l’ensemble des joueurs.',
                 'chassesautresor-com'
             ),
             esc_attr__(

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1148,7 +1148,10 @@ msgid "Gagnants :"
 msgstr ""
 
 #: inc/enigme/affichage.php:339
-msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse.\n\nVous\nPart des énigmes auxquelles vous avez accédé.\n\nMoyenne\nMoyenne sur l’ensemble des joueurs."
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
 msgstr ""
 
 #: inc/enigme/affichage.php:347

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1601,8 +1601,14 @@ msgid "Gagnants :"
 msgstr "Winners:"
 
 #: inc/enigme/affichage.php:339
-msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse.\n\nVous\nPart des énigmes auxquelles vous avez accédé.\n\nMoyenne\nMoyenne sur l’ensemble des joueurs."
-msgstr "Average share of puzzles each player has participated in, relative to the total number of puzzles in the hunt.\n\nYou\nShare of puzzles you have accessed.\n\nAverage\nAverage across all players."
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
+msgstr ""
+"Average share of puzzles each player has participated in, relative to the "
+"total number of puzzles in the hunt. You: Share of puzzles you have accessed "
+"Average: Average across all players."
 
 #: inc/enigme/affichage.php:347
 msgid "Définition de la progression"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1117,8 +1117,14 @@ msgid "Gagnants :"
 msgstr "Gagnants :"
 
 #: inc/enigme/affichage.php:339
-msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse.\n\nVous\nPart des énigmes auxquelles vous avez accédé.\n\nMoyenne\nMoyenne sur l’ensemble des joueurs."
-msgstr "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse.\n\nVous\nPart des énigmes auxquelles vous avez accédé.\n\nMoyenne\nMoyenne sur l’ensemble des joueurs."
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
+msgstr ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
 
 #: inc/enigme/affichage.php:347
 msgid "Définition de la progression"


### PR DESCRIPTION
Corrige la traduction du message d'aide sur la progression des énigmes.

- Harmonisation du texte français pour l'info-bulle de progression
- Mise à jour de la traduction anglaise correspondante

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a7358aa3d0833283ac83449ac5e2bf