### PR TITLE
docs: ignore compiled mo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ wp-config.php
 .env
 *.log
 *.sql
+*.mo
 vendor/
 composer.phar
 tests/.phpunit.result.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
   ```
 - Ensure the test suite passes.
 
+## Internationalisation
+- Ne jamais committer les fichiers compilés `.mo` (seuls les fichiers `.po` doivent être versionnés).
+
 ## Pull Request Messages
 - Begin the PR body with a short summary in French.
 - Provide a bullet list of notable changes.


### PR DESCRIPTION
## Résumé
- documenter l'interdiction de versionner les fichiers `.mo`
- ignorer les fichiers `.mo`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a735995ba88332a478dbe96fc041c3