### PR TITLE
Add English translations for My Account menu

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1616,3 +1616,35 @@ msgstr "Average share of puzzles each player has participated in, relative to th
 msgid "Définition du taux de résolution"
 msgstr "Definition of the resolution rate"
 
+#: templates/myaccount/layout.php:34
+msgid "Accueil"
+msgstr "Dashboard"
+
+#: templates/myaccount/layout.php:41
+msgid "Commandes"
+msgstr "Orders"
+
+#: templates/myaccount/layout.php:48
+msgid "Chasses"
+msgstr "Hunts"
+
+#: templates/myaccount/layout.php:49
+msgid "Vos chasses"
+msgstr "Your hunts"
+
+#: templates/myaccount/layout.php:66
+msgid "Profil"
+msgstr "Profile"
+
+#: templates/myaccount/layout.php:95
+msgid "Déconnexion"
+msgstr "Log out"
+
+#: templates/myaccount/layout.php:100
+msgid "Administration"
+msgstr "Administration"
+
+#: templates/myaccount/layout.php:104
+msgid "Organisateurs"
+msgstr "Organizers"
+


### PR DESCRIPTION
Ajout des traductions en anglais pour le menu « Mon Compte ».

- Ajout des chaînes manquantes dans `en_US.po`
- Traduction des éléments de navigation (Accueil, Commandes, Chasses, Profil, etc.)

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a735c851948332a28d06e53464b5c2