### PR TITLE
Add missing translations for winners messages

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -20,6 +20,14 @@ msgstr ""
 msgid "chassesautresor.com"
 msgstr ""
 
+#: template-parts/enigme/partials/enigme-sidebar-section.php:42
+msgid "Aucune énigme disponible"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
+msgid "Aucun gagnant pour le moment."
+msgstr ""
+
 #. Description of the theme
 #: style.css
 msgid "sites dédiés aux amoureux de chasses au trésor chassesautresor.com"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1654,3 +1654,11 @@ msgstr "Administration"
 msgid "Organisateurs"
 msgstr "Organizers"
 
+#: template-parts/enigme/partials/enigme-sidebar-section.php:42
+msgid "Aucune énigme disponible"
+msgstr "No puzzles available"
+
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
+msgid "Aucun gagnant pour le moment."
+msgstr "No winners yet."
+


### PR DESCRIPTION
## Résumé
Ajoute les traductions anglaises manquantes pour la page d'énigme.

## Modifications
- Ajout des chaînes d'absence d'énigme et de gagnants au fichier modèle
- Traductions anglaises correspondantes dans le fichier `en_US.po`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a738f84dcc8332b526e6e05c580a11