### PR TITLE
Force lazy loading and CDN caching for enigme images

### DIFF
--- a/tests/EnigmePictureLazyLoadingTest.php
+++ b/tests/EnigmePictureLazyLoadingTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+if (!function_exists('esc_url')) {
+    function esc_url($url) { return $url; }
+}
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) { return $text; }
+}
+if (!function_exists('site_url')) {
+    function site_url($path = '') { return 'https://example.com' . $path; }
+}
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($args, $url) { return $url . '?' . http_build_query($args); }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/visuels.php';
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class EnigmePictureLazyLoadingTest extends TestCase
+{
+    public function test_build_picture_enigme_adds_lazy_loading(): void
+    {
+        $html = build_picture_enigme(42, 'Alt text', ['full']);
+        $this->assertStringContainsString('loading="lazy"', $html);
+        $this->assertSame(1, substr_count($html, 'loading="lazy"'));
+    }
+
+    public function test_loading_attribute_cannot_be_overridden(): void
+    {
+        $html = build_picture_enigme(42, 'Alt text', ['full'], ['loading' => 'eager']);
+        $this->assertStringContainsString('loading="lazy"', $html);
+        $this->assertStringNotContainsString('loading="eager"', $html);
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -84,12 +84,14 @@ function build_picture_enigme(int $image_id, string $alt, array $sizes, array $i
         'taille' => $fallback_size,
     ], $base_url));
 
+    $img_attrs['loading'] = 'lazy';
+
     $attr_str = '';
     foreach ($img_attrs as $key => $value) {
         $attr_str .= ' ' . $key . '="' . esc_attr($value) . '"';
     }
 
-    $html .= '  <img src="' . $src_fallback . '" alt="' . esc_attr($alt) . '" loading="lazy"' . $attr_str . ">\n";
+    $html .= '  <img src="' . $src_fallback . '" alt="' . esc_attr($alt) . '"' . $attr_str . ">\n";
     $html .= "</picture>\n";
 
     return $html;
@@ -230,7 +232,8 @@ function afficher_picture_vignette_enigme(int $enigme_id, string $alt = '', arra
  */
 function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
 {
-    $src = wp_get_attachment_image_src($image_id, $taille);
+    $wp_size = $taille === 'full' ? [1920, 1920] : $taille;
+    $src     = wp_get_attachment_image_src($image_id, $wp_size);
     $url = $src[0] ?? null;
     if (!$url) return null;
 

--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -53,11 +53,11 @@ remove_all_actions('shutdown');
 remove_all_actions('template_redirect');
 
 // ✅ Envoi du fichier
-// 📅 Cache
+// 📅 Cache (compatible CDN)
 $mtime = filemtime($path);
 $etag  = '"' . md5($mtime . filesize($path)) . '"';
 
-header('Cache-Control: private, max-age=86400');
+header('Cache-Control: public, max-age=604800, immutable');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');
 header('ETag: ' . $etag);
 


### PR DESCRIPTION
## Résumé
Assure le lazy loading des visuels d’énigmes et prépare le cache CDN.

## Changements
- impose `loading="lazy"` pour les `<img>` générés
- limite la taille maximale des images « full » à 1920 px
- rend le proxy `/voir-image-enigme` compatible avec un cache CDN
- ajoute des tests vérifiant le lazy loading

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a77106f6e48332b22325379cc5ef1a