### PR TITLE
feat: display placeholder for missing enigma visuals

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -113,20 +113,42 @@ function afficher_visuels_enigme(int $enigme_id): void
     }
 
     $images = get_field('enigme_visuel_image', $enigme_id);
-    if (!$images || !is_array($images)) return;
-
-    echo '<div class="galerie-enigme-wrapper">';
-
-    $image_id_active = $images[0]['ID'] ?? null;
-    if ($image_id_active) {
-        echo '<div class="image-principale">';
-        echo build_picture_enigme($image_id_active, __('Visuel énigme', 'chassesautresor-com'), ['full'], [
-            'id'    => 'image-enigme-active',
-            'class' => 'image-active',
-        ]);
-        echo '</div>';
+    $valid_images = [];
+    if (is_array($images)) {
+        foreach ($images as $img) {
+            $id = (int) ($img['ID'] ?? 0);
+            if ($id && $id !== ID_IMAGE_PLACEHOLDER_ENIGME) {
+                $valid_images[] = $id;
+            }
+        }
     }
 
+    if (!$valid_images) {
+        $valid_images[] = ID_IMAGE_PLACEHOLDER_ENIGME;
+    }
+
+    $caption = (string) get_field('enigme_visuel_legende', $enigme_id);
+
+    echo '<div class="galerie-enigme-wrapper">';
+    foreach ($valid_images as $index => $image_id) {
+        $alt = trim((string) get_post_meta($image_id, '_wp_attachment_image_alt', true));
+        if (!$alt) {
+            $alt = $image_id === ID_IMAGE_PLACEHOLDER_ENIGME
+                ? __('Image par défaut de l’énigme', 'chassesautresor-com')
+                : ($caption ?: __('Visuel énigme', 'chassesautresor-com'));
+        }
+
+        $attrs = [
+            'class' => $index === 0 ? 'image-active' : '',
+        ];
+
+        echo '<figure class="image-principale">';
+        echo build_picture_enigme($image_id, $alt, ['full'], $attrs);
+        if ($caption) {
+            echo '<figcaption>' . esc_html($caption) . '</figcaption>';
+        }
+        echo '</figure>';
+    }
     echo '</div>';
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
@@ -11,66 +11,65 @@ if (!$post_id) {
 $images = get_field('enigme_visuel_image', $post_id);
 cat_debug('[images] 🔍 Énigme #' . $post_id . ' → images récupérées : ' . print_r($images, true));
 
-// Test : au moins une image != placeholder
-$has_valid_images = is_array($images) && array_filter($images, function ($img) {
-    return isset($img['ID']) && (int) $img['ID'] !== ID_IMAGE_PLACEHOLDER_ENIGME;
-});
+// Filtrage des images valides (hors placeholder)
+$valid_images = [];
+if (is_array($images)) {
+    foreach ($images as $img) {
+        $id = (int) ($img['ID'] ?? 0);
+        if ($id && $id !== ID_IMAGE_PLACEHOLDER_ENIGME) {
+            $valid_images[] = $id;
+        }
+    }
+}
+if (!$valid_images) {
+    $valid_images[] = ID_IMAGE_PLACEHOLDER_ENIGME;
+}
 
-// ID de l'image principale (réelle ou placeholder)
-$image_id = $has_valid_images ? (int) ($images[0]['ID'] ?? 0) : ID_IMAGE_PLACEHOLDER_ENIGME;
-$meta      = wp_get_attachment_metadata($image_id);
-$width     = (int) ($meta['width'] ?? 0);
 $threshold_full = 1024;
+$caption        = (string) get_field('enigme_visuel_legende', $post_id);
 
 if (function_exists('utilisateur_peut_voir_enigme') && !utilisateur_peut_voir_enigme($post_id)) {
     echo '<div class="visuels-proteges">🔒 Les visuels de cette énigme sont protégés.</div>';
     return;
 }
 
-if ($has_valid_images) {
-    cat_debug('[images] ✅ Galerie active pour #' . $post_id);
+cat_debug('[images] ✅ Galerie active pour #' . $post_id);
 
-    echo '<div class="galerie-enigme-wrapper">';
+echo '<div class="galerie-enigme-wrapper">';
+foreach ($valid_images as $index => $image_id) {
+    $meta  = wp_get_attachment_metadata($image_id);
+    $width = (int) ($meta['width'] ?? 0);
 
-    // Image principale
-    $img_attrs = [
-        'id'      => 'image-enigme-active',
-        'class'   => 'image-active',
+    $attrs = [
         'loading' => 'lazy',
         'srcset'  => wp_get_attachment_image_srcset($image_id, 'large'),
         'sizes'   => wp_get_attachment_image_sizes($image_id, 'large'),
     ];
-    if ($width && $width <= $threshold_full) {
-        $img_attrs['class'] .= ' enigme-image--limited';
-        $img_attrs['style']  = 'width:auto;max-width:100%;';
-    } elseif ($width) {
-        $img_attrs['style'] = 'width:100%;';
+    if ($index === 0) {
+        $attrs['id']    = 'image-enigme-active';
+        $attrs['class'] = 'image-active';
     }
-
-    $img_html = wp_get_attachment_image($image_id, 'large', false, $img_attrs);
-    echo '<div class="image-principale">';
-    echo $img_html;
-    echo '</div>';
-
-    echo '</div>';
-} else {
-    cat_debug('[images] 🟡 Aucune image valide → fallback picture');
-    $attrs = [
-        'srcset' => wp_get_attachment_image_srcset(ID_IMAGE_PLACEHOLDER_ENIGME, 'large'),
-        'sizes'   => wp_get_attachment_image_sizes(ID_IMAGE_PLACEHOLDER_ENIGME, 'large'),
-        'loading' => 'lazy',
-        'alt'     => esc_attr__('Image par défaut de l’énigme', 'chassesautresor-com'),
-    ];
-
     if ($width && $width <= $threshold_full) {
-        $attrs['class'] = 'enigme-image--limited';
+        $attrs['class'] = ($attrs['class'] ?? '') . ' enigme-image--limited';
         $attrs['style'] = 'width:auto;max-width:100%;';
     } elseif ($width) {
         $attrs['style'] = 'width:100%;';
     }
 
-    echo '<div class="image-principale">';
-    echo wp_get_attachment_image(ID_IMAGE_PLACEHOLDER_ENIGME, 'large', false, $attrs);
-    echo '</div>';
+    $alt = trim((string) get_post_meta($image_id, '_wp_attachment_image_alt', true));
+    if (!$alt) {
+        $alt = $image_id === ID_IMAGE_PLACEHOLDER_ENIGME
+            ? __('Image par défaut de l’énigme', 'chassesautresor-com')
+            : ($caption ?: __('Image de l’énigme', 'chassesautresor-com'));
+    }
+    $attrs['alt'] = esc_attr($alt);
+
+    echo '<figure class="image-principale">';
+    echo wp_get_attachment_image($image_id, 'large', false, $attrs);
+    if ($caption) {
+        echo '<figcaption>' . esc_html($caption) . '</figcaption>';
+    }
+    echo '</figure>';
 }
+echo '</div>';
 


### PR DESCRIPTION
## Résumé
- Améliore l’affichage des visuels d’énigme en gérant les images manquantes.

## Changements
- Parcourt les images d’une énigme avec repli sur un placeholder si nécessaire.
- Ajoute texte alternatif et légende optionnelle pour chaque visuel.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a77676404083329de98b3bbbb513ec