### PR TITLE
Masquer le label du visuel principal

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-images.php
@@ -13,21 +13,34 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
     </header>
 
     <?php
+    $hide_label = static function (array $field): array {
+        $field['wrapper']['class'] = trim(($field['wrapper']['class'] ?? '') . ' acf-hide-label');
+        return $field;
+    };
+    add_filter('acf/prepare_field/name=enigme_visuel_image', $hide_label);
+
+    $submit_button_html = '<div class="panneau-lateral__actions">'
+        . '<button type="submit" class="bouton-enregistrer-description '
+        . 'bouton-enregistrer-liens">%s</button>'
+        . '</div>';
+
     acf_form([
-      'post_id'             => $enigme_id,
-      'fields'              => ['enigme_visuel_image'],
-      'form'                => true,
-      'submit_value'        => __( '💾 Enregistrer', 'chassesautresor-com' ),
-      'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
-      'html_before_fields'  => '<div class="champ-wrapper">',
-      'html_after_fields'   => '</div>',
-      // Après sauvegarde, on revient sur la même page en ouvrant
-      // automatiquement le panneau principal grâce au paramètre
-      // ?edition=open. L'ancre #images-enigme permet de scroller
-      // directement sur le panneau images.
-      'return'              => add_query_arg('edition', 'open', get_permalink()) . '#images-enigme',
-      'updated_message'     => __( 'Images mises à jour.', 'chassesautresor-com' )
+        'post_id'            => $enigme_id,
+        'fields'             => ['enigme_visuel_image'],
+        'form'               => true,
+        'submit_value'       => __('💾 Enregistrer', 'chassesautresor-com'),
+        'html_submit_button' => $submit_button_html,
+        'html_before_fields' => '<div class="champ-wrapper">',
+        'html_after_fields'  => '</div>',
+        // Après sauvegarde, on revient sur la même page en ouvrant
+        // automatiquement le panneau principal grâce au paramètre
+        // ?edition=open. L'ancre #images-enigme permet de scroller
+        // directement sur le panneau images.
+        'return'             => add_query_arg('edition', 'open', get_permalink()) . '#images-enigme',
+        'updated_message'    => __('Images mises à jour.', 'chassesautresor-com'),
     ]);
+
+    remove_filter('acf/prepare_field/name=enigme_visuel_image', $hide_label);
     ?>
   </div>
 </div>


### PR DESCRIPTION
### Résumé
Supprime l'en-tête du champ "image principale" dans l'édition des images d'énigme.

### Changements
- Masquage du label du champ `enigme_visuel_image` via un filtre ACF
- Extraction du HTML du bouton de sauvegarde pour respecter PSR-12

### Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a7763e45a88332be16fe062ff8388b