### PR TITLE
Open organizer hunts in same window

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1718,7 +1718,9 @@ function afficher_tableau_organisateurs_pending(?array $liste = null, int $page 
                         break;
                 }
 
-                echo '<td class="col-chasse"><a href="' . esc_url($row['chasse_permalink']) . '" target="_blank">' . esc_html($row['chasse_titre']) . '</a></td>';
+                echo '<td class="col-chasse"><a href="' . esc_url($row['chasse_permalink']) . '">'
+                    . esc_html($row['chasse_titre'])
+                    . '</a></td>';
                 echo '<td class="col-enigmes"><span class="etiquette">' . intval($row['nb_enigmes']) . '</span></td>';
 
                 $warning   = $row['pending_validation'] || $row['pending_attempts'];


### PR DESCRIPTION
## Résumé
- Corrige l'ouverture des liens de chasse dans l'onglet Organisateurs afin qu'ils ne s'ouvrent plus dans un nouvel onglet.

## Changements notables
- Mise à jour du tableau des organisateurs pour ouvrir les chasses dans la même fenêtre.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a77a9331c08332b8d25c9e65d91184