### PR TITLE
Supprime la légende en double des visuels d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -144,9 +144,6 @@ function afficher_visuels_enigme(int $enigme_id): void
 
         echo '<figure class="image-principale">';
         echo build_picture_enigme($image_id, $alt, ['full'], $attrs);
-        if ($caption) {
-            echo '<figcaption>' . esc_html($caption) . '</figcaption>';
-        }
         echo '</figure>';
     }
     echo '</div>';

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
@@ -66,9 +66,6 @@ foreach ($valid_images as $index => $image_id) {
 
     echo '<figure class="image-principale">';
     echo wp_get_attachment_image($image_id, 'large', false, $attrs);
-    if ($caption) {
-        echo '<figcaption>' . esc_html($caption) . '</figcaption>';
-    }
     echo '</figure>';
 }
 echo '</div>';


### PR DESCRIPTION
## Résumé
- Retire l'affichage de la légende sous les visuels lorsqu'elle duplique le sous-titre.

## Changements notables
- Supprime l'élément `<figcaption>` dans les templates des images d'énigme.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a77e74e61483328e26ceb0f6f7b1bc