### PR TITLE
Corrige l’aside de la page énigme sur desktop

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-aside.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-aside.js
@@ -2,6 +2,7 @@
   function init() {
     const aside = document.querySelector('.menu-lateral');
     if (!aside) return;
+    const layout = aside.closest('.enigme-layout');
     const bp = getComputedStyle(document.documentElement)
       .getPropertyValue('--breakpoint-desktop')
       .trim() || '1280px';
@@ -16,6 +17,7 @@
     let timer = null;
     function hideAside() {
       aside.classList.add('is-hidden');
+      layout?.classList.add('enigme-layout--aside-hidden');
       opener.style.display = 'flex';
       if (timer) {
         clearTimeout(timer);
@@ -24,6 +26,7 @@
     }
     function showAside() {
       aside.classList.remove('is-hidden');
+      layout?.classList.remove('enigme-layout--aside-hidden');
       opener.style.display = 'none';
       if (timer) clearTimeout(timer);
       timer = setTimeout(hideAside, 5000);

--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -13,11 +13,11 @@
   max-height: calc(100vh - var(--space-md));
   color: rgba(var(--color-white-rgb, 255, 255, 255), 0.4);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  overflow-y: auto;
 }
 
 .menu-lateral__content {
   flex: 1 1 auto;
-  overflow-y: auto;
   overflow-x: hidden;
   /*background-color: inherit;*/
 }
@@ -25,8 +25,6 @@
 .menu-lateral__accordeons {
   margin-top: auto;
   flex-shrink: 0;
-  position: sticky;
-  bottom: 0;
   /*background-color: inherit;*/
   width: calc(100% + 2 * var(--space-md));
   margin-left: calc(-1 * var(--space-md));
@@ -275,12 +273,12 @@
     top: 50%;
     left: 0;
     transform: translateY(-50%);
-    transition: transform var(--transition-medium);
+    transition: transform var(--transition-slow);
   }
   .menu-lateral.is-hidden {
     transform: translate(calc(-100% - var(--space-2xl)), -50%);
     box-shadow: none;
-    display: none;
+    pointer-events: none;
   }
   .menu-lateral__reveal {
     position: fixed;

--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -278,7 +278,7 @@
     transition: transform var(--transition-medium);
   }
   .menu-lateral.is-hidden {
-    transform: translate(calc(-100% - 1rem), -50%);
+    transform: translate(calc(-100% - var(--space-2xl)), -50%);
     box-shadow: none;
   }
   .menu-lateral__reveal {

--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -280,6 +280,7 @@
   .menu-lateral.is-hidden {
     transform: translate(calc(-100% - var(--space-2xl)), -50%);
     box-shadow: none;
+    display: none;
   }
   .menu-lateral__reveal {
     position: fixed;

--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -271,19 +271,20 @@
   .menu-lateral {
     position: fixed;
     top: 50%;
-    left: 0;
+    left: var(--space-md);
+    width: 320px;
     transform: translateY(-50%);
     transition: transform var(--transition-slow);
   }
   .menu-lateral.is-hidden {
-    transform: translate(calc(-100% - var(--space-2xl)), -50%);
+    transform: translate(calc(-100% - var(--space-2xl) - var(--space-md)), -50%);
     box-shadow: none;
     pointer-events: none;
   }
   .menu-lateral__reveal {
     position: fixed;
     top: 50%;
-    left: 0;
+    left: var(--space-md);
     transform: translateY(-50%);
     background-color: var(--color-primary-dark);
     color: var(--color-white);

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -1,7 +1,7 @@
 /* Layout for enigma pages */
 .enigme-layout {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: 320px 1fr;
   gap: var(--space-xl);
   transition: grid-template-columns var(--transition-slow);
 }
@@ -39,7 +39,7 @@
     gap: 0;
   }
   .enigme-layout > .page-enigme {
-    margin-left: calc(280px + var(--space-md));
+    margin-left: calc(320px + 2 * var(--space-md));
   }
   .enigme-layout--aside-hidden > .page-enigme {
     margin-left: 0;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -6,10 +6,25 @@
   transition: grid-template-columns var(--transition-medium);
 }
 
+.enigme-layout > .menu-lateral {
+  grid-column: 1;
+}
+
+.enigme-layout > .page-enigme {
+  grid-column: 2;
+}
+
+.enigme-layout--aside-hidden > .page-enigme {
+  grid-column: 1;
+}
+
 @media not all and (--bp-lg) {
   .enigme-layout .menu-lateral {
     position: sticky;
     top: var(--space-md);
+  }
+  .enigme-layout > .page-enigme {
+    grid-column: 1;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -12,6 +12,7 @@
 
 .enigme-layout > .page-enigme {
   grid-column: 2;
+  transition: margin-left var(--transition-slow);
 }
 
 .enigme-layout--aside-hidden > .page-enigme {
@@ -30,6 +31,19 @@
 
 .enigme-layout--aside-hidden {
   grid-template-columns: 1fr;
+}
+
+@media (min-width: 1280px) {
+  .enigme-layout {
+    display: block;
+    gap: 0;
+  }
+  .enigme-layout > .page-enigme {
+    margin-left: calc(280px + var(--space-md));
+  }
+  .enigme-layout--aside-hidden > .page-enigme {
+    margin-left: 0;
+  }
 }
 
 /* Display images stacked with full width */

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -3,17 +3,18 @@
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: var(--space-xl);
+  transition: grid-template-columns var(--transition-medium);
 }
 
-.enigme-layout .menu-lateral {
-  position: sticky;
-  top: var(--space-md);
-}
-
-@media (--bp-lg) and (hover: hover) {
-  body.single-enigme .enigme-layout .menu-lateral {
-    top: calc(var(--space-4xl) + var(--space-md));
+@media not all and (--bp-lg) {
+  .enigme-layout .menu-lateral {
+    position: sticky;
+    top: var(--space-md);
   }
+}
+
+.enigme-layout--aside-hidden {
+  grid-template-columns: 1fr;
 }
 
 /* Display images stacked with full width */

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: var(--space-xl);
-  transition: grid-template-columns var(--transition-medium);
+  transition: grid-template-columns var(--transition-slow);
 }
 
 .enigme-layout > .menu-lateral {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1622,7 +1622,7 @@ a[aria-disabled=true] {
     transition: transform var(--transition-medium);
   }
   .menu-lateral.is-hidden {
-    transform: translate(calc(-100% - 1rem), -50%);
+    transform: translate(calc(-100% - var(--space-2xl)), -50%);
     box-shadow: none;
   }
   .menu-lateral__reveal {
@@ -3593,18 +3593,19 @@ body.panneau-ouvert::before {
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: var(--space-xl);
+  transition: grid-template-columns var(--transition-medium);
 }
 
-.enigme-layout .menu-lateral {
-  position: sticky;
-  top: var(--space-md);
-}
-
-@media (min-width: 1024px) and (hover: hover) {
-  body.single-enigme .enigme-layout .menu-lateral {
-    top: calc(var(--space-4xl) + var(--space-md));
+@media not all and (min-width: 1024px) {
+  .enigme-layout .menu-lateral {
+    position: sticky;
+    top: var(--space-md);
   }
 }
+.enigme-layout--aside-hidden {
+  grid-template-columns: 1fr;
+}
+
 /* Display images stacked with full width */
 .enigme-images {
   display: flex;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1615,19 +1615,20 @@ a[aria-disabled=true] {
   .menu-lateral {
     position: fixed;
     top: 50%;
-    left: 0;
+    left: var(--space-md);
+    width: 320px;
     transform: translateY(-50%);
     transition: transform var(--transition-slow);
   }
   .menu-lateral.is-hidden {
-    transform: translate(calc(-100% - var(--space-2xl)), -50%);
+    transform: translate(calc(-100% - var(--space-2xl) - var(--space-md)), -50%);
     box-shadow: none;
     pointer-events: none;
   }
   .menu-lateral__reveal {
     position: fixed;
     top: 50%;
-    left: 0;
+    left: var(--space-md);
     transform: translateY(-50%);
     background-color: var(--color-primary-dark);
     color: var(--color-white);
@@ -3590,7 +3591,7 @@ body.panneau-ouvert::before {
 /* Layout for enigma pages */
 .enigme-layout {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: 320px 1fr;
   gap: var(--space-xl);
   transition: grid-template-columns var(--transition-slow);
 }
@@ -3627,7 +3628,7 @@ body.panneau-ouvert::before {
     gap: 0;
   }
   .enigme-layout > .page-enigme {
-    margin-left: calc(280px + var(--space-md));
+    margin-left: calc(320px + 2 * var(--space-md));
   }
   .enigme-layout--aside-hidden > .page-enigme {
     margin-left: 0;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1347,11 +1347,11 @@ a[aria-disabled=true] {
   max-height: calc(100vh - var(--space-md));
   color: rgba(var(--color-white-rgb, 255, 255, 255), 0.4);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  overflow-y: auto;
 }
 
 .menu-lateral__content {
   flex: 1 1 auto;
-  overflow-y: auto;
   overflow-x: hidden;
   /*background-color: inherit;*/
 }
@@ -1359,8 +1359,6 @@ a[aria-disabled=true] {
 .menu-lateral__accordeons {
   margin-top: auto;
   flex-shrink: 0;
-  position: sticky;
-  bottom: 0;
   /*background-color: inherit;*/
   width: calc(100% + 2 * var(--space-md));
   margin-left: calc(-1 * var(--space-md));
@@ -1619,12 +1617,12 @@ a[aria-disabled=true] {
     top: 50%;
     left: 0;
     transform: translateY(-50%);
-    transition: transform var(--transition-medium);
+    transition: transform var(--transition-slow);
   }
   .menu-lateral.is-hidden {
     transform: translate(calc(-100% - var(--space-2xl)), -50%);
     box-shadow: none;
-    display: none;
+    pointer-events: none;
   }
   .menu-lateral__reveal {
     position: fixed;
@@ -3594,7 +3592,7 @@ body.panneau-ouvert::before {
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: var(--space-xl);
-  transition: grid-template-columns var(--transition-medium);
+  transition: grid-template-columns var(--transition-slow);
 }
 
 .enigme-layout > .menu-lateral {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3601,6 +3601,7 @@ body.panneau-ouvert::before {
 
 .enigme-layout > .page-enigme {
   grid-column: 2;
+  transition: margin-left var(--transition-slow);
 }
 
 .enigme-layout--aside-hidden > .page-enigme {
@@ -3620,6 +3621,18 @@ body.panneau-ouvert::before {
   grid-template-columns: 1fr;
 }
 
+@media (min-width: 1280px) {
+  .enigme-layout {
+    display: block;
+    gap: 0;
+  }
+  .enigme-layout > .page-enigme {
+    margin-left: calc(280px + var(--space-md));
+  }
+  .enigme-layout--aside-hidden > .page-enigme {
+    margin-left: 0;
+  }
+}
 /* Display images stacked with full width */
 .enigme-images {
   display: flex;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1624,6 +1624,7 @@ a[aria-disabled=true] {
   .menu-lateral.is-hidden {
     transform: translate(calc(-100% - var(--space-2xl)), -50%);
     box-shadow: none;
+    display: none;
   }
   .menu-lateral__reveal {
     position: fixed;
@@ -3596,10 +3597,25 @@ body.panneau-ouvert::before {
   transition: grid-template-columns var(--transition-medium);
 }
 
+.enigme-layout > .menu-lateral {
+  grid-column: 1;
+}
+
+.enigme-layout > .page-enigme {
+  grid-column: 2;
+}
+
+.enigme-layout--aside-hidden > .page-enigme {
+  grid-column: 1;
+}
+
 @media not all and (min-width: 1024px) {
   .enigme-layout .menu-lateral {
     position: sticky;
     top: var(--space-md);
+  }
+  .enigme-layout > .page-enigme {
+    grid-column: 1;
   }
 }
 .enigme-layout--aside-hidden {


### PR DESCRIPTION
## Résumé
- centre le panneau latéral de l’énigme sur les grands écrans
- masque complètement l’aside replié et ajuste la grille
- étend le contenu principal lorsque l’aside est caché

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a7f2edd2048332baa48970d6e81450