### PR TITLE
Ajout d'une icône d'édition sur les pages énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -2,23 +2,29 @@
 var DEBUG = window.DEBUG || false;
 DEBUG && console.log('✅ enigme-edit.js chargé');
 
-let boutonToggle;
+let boutonsToggle;
 let panneauEdition;
 
 
 
 function initEnigmeEdit() {
   if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
-  boutonToggle = document.getElementById('toggle-mode-edition-enigme');
+  boutonsToggle = document.querySelectorAll(
+    '#toggle-mode-edition-enigme, .toggle-mode-edition-enigme'
+  );
   panneauEdition = document.querySelector('.edition-panel-enigme');
 
   // ==============================
   // 🛠️ Contrôles panneau principal
   // ==============================
-  boutonToggle?.addEventListener('click', () => {
+  const toggleEdition = () => {
     document.body.classList.toggle('edition-active-enigme');
     document.body.classList.toggle('panneau-ouvert');
     document.body.classList.toggle('mode-edition');
+  };
+
+  boutonsToggle.forEach((btn) => {
+    btn.addEventListener('click', toggleEdition);
   });
 
 
@@ -36,10 +42,12 @@ function initEnigmeEdit() {
   const params = new URLSearchParams(window.location.search);
   const doitOuvrir = params.get('edition') === 'open';
   const tab = params.get('tab');
-  if (doitOuvrir && boutonToggle) {
-    boutonToggle.click();
+  if (doitOuvrir && boutonsToggle.length > 0) {
+    boutonsToggle[0].click();
     if (tab) {
-      const btn = panneauEdition?.querySelector(`.edition-tab[data-target="enigme-tab-${tab}"]`);
+      const btn = panneauEdition?.querySelector(
+        `.edition-tab[data-target="enigme-tab-${tab}"]`
+      );
       btn?.click();
     }
     DEBUG && console.log('🔧 Ouverture auto du panneau édition énigme via ?edition=open');

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -484,6 +484,32 @@ li.active .enigme-menu__edit {
   display: none;
 }
 
+.enigme-edit-toggle--desktop {
+  position: fixed;
+  top: var(--space-md);
+  right: var(--space-md);
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: var(--space-xs);
+  color: var(--color-primary);
+  background: none;
+  border: 1px solid rgba(255, 215, 0, 0.5);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.enigme-edit-toggle--desktop svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+body.topbar-visible .enigme-edit-toggle--desktop {
+  top: calc(var(--space-md) + var(--space-4xl));
+}
+
 @media not all and (--bp-lg) {
   .enigme-layout .menu-lateral {
     display: none;
@@ -505,6 +531,11 @@ li.active .enigme-menu__edit {
     z-index: 10;
   }
 
+  .enigme-mobile-actions {
+    display: flex;
+    gap: var(--space-md);
+  }
+
   .enigme-mobile-header a,
   .enigme-mobile-header button {
     width: 2.5rem;
@@ -523,6 +554,10 @@ li.active .enigme-menu__edit {
   .enigme-mobile-header svg {
     width: 1rem;
     height: 1rem;
+  }
+
+  .enigme-edit-toggle--desktop {
+    display: none;
   }
 
   .enigme-mobile-panel {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4051,6 +4051,32 @@ li.active .enigme-menu__edit {
   display: none;
 }
 
+.enigme-edit-toggle--desktop {
+  position: fixed;
+  top: var(--space-md);
+  right: var(--space-md);
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: var(--space-xs);
+  color: var(--color-primary);
+  background: none;
+  border: 1px solid rgba(255, 215, 0, 0.5);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.enigme-edit-toggle--desktop svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+body.topbar-visible .enigme-edit-toggle--desktop {
+  top: calc(var(--space-md) + var(--space-4xl));
+}
+
 @media not all and (min-width: 1024px) {
   .enigme-layout .menu-lateral {
     display: none;
@@ -4070,6 +4096,10 @@ li.active .enigme-menu__edit {
     background-color: var(--color-background);
     z-index: 10;
   }
+  .enigme-mobile-actions {
+    display: flex;
+    gap: var(--space-md);
+  }
   .enigme-mobile-header a,
   .enigme-mobile-header button {
     width: 2.5rem;
@@ -4087,6 +4117,9 @@ li.active .enigme-menu__edit {
   .enigme-mobile-header svg {
     width: 1rem;
     height: 1rem;
+  }
+  .enigme-edit-toggle--desktop {
+    display: none;
   }
   .enigme-mobile-panel {
     position: fixed;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -986,17 +986,48 @@ defined('ABSPATH') || exit;
             $has_incomplete_enigme
         );
 
-        $retour_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+        $retour_url   = $chasse_id ? get_permalink($chasse_id) : home_url('/');
+        $settings_icon = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none"'
+            . ' stroke="currentColor" stroke-width="2" stroke-linecap="round"'
+            . ' stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path'
+            . ' d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83'
+            . ' 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1'
+            . ' 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65'
+            . ' 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65'
+            . ' 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09'
+            . ' a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2'
+            . ' 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65'
+            . ' 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1'
+            . ' 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06'
+            . ' a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2'
+            . ' 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>';
         echo '<header class="enigme-mobile-header">';
         echo '<a class="enigme-mobile-back" href="' . esc_url($retour_url) . '">';
         echo '<span class="screen-reader-text">' . esc_html__('Retour', 'chassesautresor-com') . '</span>';
         echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>';
         echo '</a>';
+        echo '<div class="enigme-mobile-actions">';
+        if (function_exists('utilisateur_peut_modifier_enigme') && utilisateur_peut_modifier_enigme($enigme_id)) {
+            echo '<button type="button" class="toggle-mode-edition-enigme enigme-mobile-edit" aria-label="'
+                . esc_attr__('Paramètres', 'chassesautresor-com') . '">';
+            echo '<span class="screen-reader-text">' . esc_html__('Paramètres', 'chassesautresor-com') . '</span>';
+            echo $settings_icon;
+            echo '</button>';
+        }
         echo '<button type="button" class="enigme-mobile-panel-toggle" aria-controls="enigme-mobile-panel" aria-expanded="false" aria-label="' . esc_attr__('Menu énigme', 'chassesautresor-com') . '">';
         echo '<span class="screen-reader-text">' . esc_html__('Menu énigme', 'chassesautresor-com') . '</span>';
         echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
         echo '</button>';
+        echo '</div>';
         echo '</header>';
+
+        if (function_exists('utilisateur_peut_modifier_enigme') && utilisateur_peut_modifier_enigme($enigme_id)) {
+            echo '<button type="button" class="enigme-edit-toggle--desktop toggle-mode-edition-enigme" aria-label="'
+                . esc_attr__('Paramètres', 'chassesautresor-com') . '">';
+            echo '<span class="screen-reader-text">' . esc_html__('Paramètres', 'chassesautresor-com') . '</span>';
+            echo $settings_icon;
+            echo '</button>';
+        }
 
         echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
         echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';


### PR DESCRIPTION
## Résumé
- ajout d'un bouton de paramétrage en haut des pages énigme
- support des doubles déclencheurs d'ouverture du panneau d'édition
- styles adaptés pour mobile et desktop

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8004e14ac83329fd80e69d4f54b56