### PR TITLE
Agrandir le titre de la page énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -329,12 +329,13 @@ li.active .enigme-menu__edit {
 .page-enigme .enigme-header .enigme-titre {
   word-break: break-word;
   overflow-wrap: anywhere;
+  font-size: 64px;
 }
 
 .page-enigme .enigme-header .enigme-soustitre {
   margin-top: var(--space-xs);
   color: var(--color-text-secondary);
-  font-size: 1.25rem;
+  font-size: 32px;
 }
 
 @media not all and (--bp-md) {
@@ -343,7 +344,7 @@ li.active .enigme-menu__edit {
   }
 
   .page-enigme .enigme-header {
-    text-align: left;
+    text-align: center;
     padding-bottom: var(--space-sm);
   }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3907,12 +3907,13 @@ li.active .enigme-menu__edit {
 .page-enigme .enigme-header .enigme-titre {
   word-break: break-word;
   overflow-wrap: anywhere;
+  font-size: 64px;
 }
 
 .page-enigme .enigme-header .enigme-soustitre {
   margin-top: var(--space-xs);
   color: var(--color-text-secondary);
-  font-size: 1.25rem;
+  font-size: 32px;
 }
 
 @media not all and (min-width: 768px) {
@@ -3920,7 +3921,7 @@ li.active .enigme-menu__edit {
     gap: var(--space-xl);
   }
   .page-enigme .enigme-header {
-    text-align: left;
+    text-align: center;
     padding-bottom: var(--space-sm);
   }
   .page-enigme .enigme-header .enigme-soustitre {


### PR DESCRIPTION
## Résumé
Augmente la taille du titre et du sous-titre sur les pages d'énigme et corrige l'alignement du titre sur mobile.

## Changements notables
- Amplifie la police du titre d'énigme et de son sous-titre pour les écrans larges
- Centre le bloc de titre sur les affichages mobiles

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a80b173fa48332bb11eefc672814fd