### PR TITLE
Réduire l'espacement du titre de participation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -398,6 +398,10 @@ li.active .enigme-menu__edit {
   max-width: 700px;
   margin: auto;
   text-align: center;
+
+  h3 {
+    margin-top: 0;
+  }
 }
 
 @media (min-width: 768px) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3968,6 +3968,9 @@ li.active .enigme-menu__edit {
   margin: auto;
   text-align: center;
 }
+.participation h3 {
+  margin-top: 0;
+}
 
 @media (min-width: 768px) {
   .participation {


### PR DESCRIPTION
## Résumé
- Ajuste l'espacement avant le titre h3 de la section de participation des énigmes.

## Changements notables
- Supprime la marge supérieure des titres h3 dans `.participation`.
- Reconstruit la feuille de styles compilée.

## Testing
- `npm ci`
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a80da94a908332b41a169bffa9f1c4