### PR TITLE
feat: prise en charge de plusieurs bonnes réponses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -82,11 +82,11 @@ function initChampTexte(bloc) {
     let timer;
     input.addEventListener('input', () => {
       clearTimeout(timer);
-      const valeur = input.value.trim();
+      const brute = input.value.trim();
 
       timer = setTimeout(() => {
         if (champ === 'email_contact') {
-          const isValide = valeur === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(valeur);
+          const isValide = brute === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(brute);
           if (!isValide) {
             feedback.textContent = '⛔ Adresse email invalide';
             feedback.className = 'champ-feedback champ-error';
@@ -94,7 +94,7 @@ function initChampTexte(bloc) {
           }
         }
 
-        if (champ === 'post_title' && !valeur) {
+        if (champ === 'post_title' && !brute) {
           feedback.textContent = '❌ Le titre est obligatoire.';
           feedback.className = 'champ-feedback champ-error';
           return;
@@ -105,7 +105,7 @@ function initChampTexte(bloc) {
             document.querySelector('.enigme-soustitre') ||
             document.querySelector('.enigme-legende');
           if (legendeDOM) {
-            legendeDOM.textContent = valeur;
+            legendeDOM.textContent = brute;
             legendeDOM.classList.add('modifiee');
           }
         }
@@ -113,9 +113,18 @@ function initChampTexte(bloc) {
         feedback.textContent = 'Enregistrement en cours...';
         feedback.className = 'champ-feedback champ-loading';
 
-        modifierChampSimple(champ, valeur, postId, cpt).then(success => {
+        let valeurEnvoyee = brute;
+        let estVide = !brute;
+
+        if (champ === 'enigme_reponse_bonne') {
+          const parts = brute.split(',').map(v => v.trim()).filter(v => v);
+          valeurEnvoyee = JSON.stringify(parts);
+          estVide = parts.length === 0;
+        }
+
+        modifierChampSimple(champ, valeurEnvoyee, postId, cpt).then(success => {
           if (success) {
-            bloc.classList.toggle('champ-vide', !valeur);
+            bloc.classList.toggle('champ-vide', estVide);
             feedback.textContent = '';
             feedback.className = 'champ-feedback champ-success';
             if (typeof window.mettreAJourResumeInfos === 'function') {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -198,7 +198,7 @@ function modifier_champ_enigme()
 
   $user_id = get_current_user_id();
   $champ = sanitize_text_field($_POST['champ'] ?? '');
-  $valeur = wp_kses_post($_POST['valeur'] ?? '');
+  $valeur = $_POST['valeur'] ?? '';
   $post_id = isset($_POST['post_id']) ? (int) $_POST['post_id'] : 0;
 
   if (!$champ || !$post_id || get_post_type($post_id) !== 'enigme') {
@@ -223,7 +223,7 @@ function modifier_champ_enigme()
 
   // 🔹 Titre natif
   if ($champ === 'post_title') {
-    $ok = wp_update_post(['ID' => $post_id, 'post_title' => $valeur], true);
+    $ok = wp_update_post(['ID' => $post_id, 'post_title' => sanitize_text_field($valeur)], true);
     if (is_wp_error($ok)) {
       wp_send_json_error('⚠️ echec_update_post_title');
     }
@@ -237,13 +237,36 @@ function modifier_champ_enigme()
     enigme_mettre_a_jour_etat_systeme($post_id);
   }
 
-  // 🔹 Réponse attendue
+  // 🔹 Réponse attendue (liste JSON)
   if ($champ === 'enigme_reponse_bonne') {
-    if (strlen($valeur) > 75) {
-      wp_send_json_error('⚠️ La réponse ne peut dépasser 75 caractères.');
+    $liste = json_decode(wp_unslash($valeur), true);
+    if (!is_array($liste)) {
+      wp_send_json_error('⚠️ format_invalide');
     }
-    $ok = update_field($champ, sanitize_text_field($valeur), $post_id);
-    if ($ok) $champ_valide = true;
+
+    $liste = array_values(array_filter(array_map(function ($r) {
+      $clean = sanitize_text_field($r);
+      return $clean !== '' ? $clean : null;
+    }, $liste)));
+
+    if (empty($liste)) {
+      wp_send_json_error('⚠️ reponse_vide');
+    }
+
+    if (count($liste) > 5) {
+      wp_send_json_error('⚠️ trop_de_reponses');
+    }
+
+    foreach ($liste as $r) {
+      if (mb_strlen($r) > 75) {
+        wp_send_json_error('⚠️ longueur_max');
+      }
+    }
+
+    $ok = update_field($champ, wp_json_encode($liste), $post_id);
+    if ($ok) {
+      $champ_valide = true;
+    }
     enigme_mettre_a_jour_etat_systeme($post_id);
   }
 
@@ -264,14 +287,14 @@ function modifier_champ_enigme()
   }
 
   // 🔹 Accès : condition (immédiat, date_programmee uniquement)
-  if ($champ === 'enigme_acces_condition' && in_array($valeur, ['immediat', 'date_programmee'])) {
-    $ok = update_field($champ, $valeur, $post_id);
+  if ($champ === 'enigme_acces_condition' && in_array(sanitize_text_field($valeur), ['immediat', 'date_programmee'])) {
+    $ok = update_field($champ, sanitize_text_field($valeur), $post_id);
     if ($ok) $champ_valide = true;
   }
 
   // 🔹 Accès : date
   if ($champ === 'enigme_acces_date') {
-    $dt = convertir_en_datetime($valeur, [
+    $dt = convertir_en_datetime(sanitize_text_field($valeur), [
       'Y-m-d\TH:i',
       'Y-m-d H:i:s',
       'Y-m-d H:i'
@@ -305,9 +328,10 @@ function modifier_champ_enigme()
 
   // 🔹 Fallback
   if (!$champ_valide) {
-    $ok = update_field($champ, is_numeric($valeur) ? (int) $valeur : $valeur, $post_id);
+    $valeur_saine = is_numeric($valeur) ? (int) $valeur : sanitize_text_field($valeur);
+    $ok = update_field($champ, $valeur_saine, $post_id);
     $valeur_meta = get_post_meta($post_id, $champ, true);
-    if ($ok || trim((string) $valeur_meta) === trim((string) $valeur)) {
+    if ($ok || trim((string) $valeur_meta) === trim((string) $valeur_saine)) {
       $champ_valide = true;
     } else {
       wp_send_json_error('⚠️ echec_mise_a_jour_final');

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -5,6 +5,27 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!function_exists('enigme_get_bonnes_reponses')) {
+    function enigme_get_bonnes_reponses(int $enigme_id): array
+    {
+        $raw = function_exists('get_field') ? get_field('enigme_reponse_bonne', $enigme_id) : '';
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return array_values(array_filter(array_map('strval', $decoded)));
+            }
+
+            return [$raw];
+        }
+
+        if (is_array($raw)) {
+            return array_values(array_filter(array_map('strval', $raw)));
+        }
+
+        return [];
+    }
+}
+
 //
 // 🧩 GESTION DES STATUTS ET DE L’ACCESSIBILITÉ DES ÉNIGMES
 // 🧠 GESTION DES STATUTS DES CHASSES
@@ -514,8 +535,8 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
 
     // ❓ Vérifie si la réponse attendue est bien définie si validation = automatique
     $mode = get_field('enigme_mode_validation', $enigme_id);
-    $reponse = get_field('enigme_reponse_bonne', $enigme_id);
-    if ($etat === 'accessible' && $mode === 'automatique' && !$reponse) {
+    $reponses = enigme_get_bonnes_reponses($enigme_id);
+    if ($etat === 'accessible' && $mode === 'automatique' && empty($reponses)) {
         $etat = 'invalide';
         cat_debug("🧩 #$enigme_id → invalide (automatique sans réponse)");
     }
@@ -703,8 +724,8 @@ function enigme_est_complet(int $enigme_id): bool
 
     // 🔄 [NOVELTY] Require an expected answer if validation is automatic
     $mode = get_field('enigme_mode_validation', $enigme_id);
-    $reponse = trim((string) get_field('enigme_reponse_bonne', $enigme_id));
-    $reponse_ok = $mode !== 'automatique' || $reponse !== '';
+    $reponses = enigme_get_bonnes_reponses($enigme_id);
+    $reponse_ok = $mode !== 'automatique' || !empty($reponses);
 
     // ✅ Ensure prerequisite list is filled when required
     $condition_acces = get_field('enigme_acces_condition', $enigme_id) ?? 'immediat';

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -887,6 +887,9 @@ msgstr "Result"
 msgid "Réponse"
 msgstr "Answer"
 
+msgid "Bonne(s) réponse(s)"
+msgstr "Correct answer(s)"
+
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:28
 msgid "Actions"
 msgstr "Actions"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -877,6 +877,9 @@ msgstr "Aucune tentative de soumission."
 msgid "Réponse"
 msgstr "Réponse"
 
+msgid "Bonne(s) réponse(s)"
+msgstr "Bonne(s) réponse(s)"
+
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:28
 msgid "Actions"
 msgstr "Actions"

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -24,7 +24,8 @@ $visuel = get_field('enigme_visuel_image', $enigme_id); // champ "gallery" → t
 $has_images = is_array($visuel) && count($visuel) > 0;
 $legende = (string) get_field('enigme_visuel_legende', $enigme_id);
 $texte_enigme = (string) get_field('enigme_visuel_texte', $enigme_id);
-$reponse = get_field('enigme_reponse_bonne', $enigme_id);
+$reponses = enigme_get_bonnes_reponses($enigme_id);
+$reponse = implode(', ', $reponses);
 $casse = get_field('enigme_reponse_casse', $enigme_id);
 $max = (int) get_field('enigme_tentative_max', $enigme_id);
 $cout = get_field('enigme_tentative_cout_points', $enigme_id);
@@ -283,7 +284,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             </li>
 
             <li class="champ-enigme champ-bonne-reponse champ-groupe-reponse-automatique cache<?= empty($reponse) ? ' champ-vide' : ' champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_bonne" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" data-no-icon="1">
-                <label for="champ-bonne-reponse"><?= esc_html__('Réponse', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
+                <label for="champ-bonne-reponse"><?= esc_html__('Bonne(s) réponse(s)', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
                 <input type="text" id="champ-bonne-reponse" name="champ-bonne-reponse" class="champ-input champ-texte-edit<?= empty($reponse) ? ' champ-vide-obligatoire' : ''; ?>" value="<?= esc_attr($reponse); ?>" placeholder="<?= esc_attr__('Ex : soleil', 'chassesautresor-com'); ?>" <?= $peut_editer ? '' : 'disabled'; ?> />
                 <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" style="display: inline-flex; align-items: center;">
                   <label style="display: flex; align-items: center; gap: 4px;"><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> <?= esc_html__('Respecter la casse', 'chassesautresor-com'); ?></label>


### PR DESCRIPTION
## Résumé
- sérialise les réponses attendues en JSON pour permettre plusieurs entrées
- adapte la validation côté serveur et client
- met à jour les fichiers de langue

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a80d3140708332bb0ab992e63fd05b