### PR TITLE
Alignement des champs de réglages de l’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -72,6 +72,14 @@
   display: none;
 }
 
+/* Placeholder pour les lignes sans icône afin d'aligner le contenu */
+.resume-infos > li[data-no-icon]::before {
+  content: '';
+  display: block;
+  flex: 0 0 var(--editor-icon-width);
+  margin-right: 0.3rem;
+}
+
 /* Hauteur et alignement par défaut des lignes de paramètres */
 .resume-infos > li {
   min-height: 40px;

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -80,6 +80,23 @@
   margin-right: 0.3rem;
 }
 
+/* Correction spécifique pour les champs de tentatives */
+.resume-infos .champ-cout-points[data-no-icon],
+.resume-infos .champ-nb-tentatives[data-no-icon] {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.resume-infos .champ-cout-points[data-no-icon]::before,
+.resume-infos .champ-nb-tentatives[data-no-icon]::before {
+  content: '';
+  display: block;
+  flex: 0 0 var(--editor-icon-width);
+  margin-right: 0.3rem;
+}
+
 /* Hauteur et alignement par défaut des lignes de paramètres */
 .resume-infos > li {
   min-height: 40px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1768,6 +1768,14 @@ a[aria-disabled=true] {
   display: none;
 }
 
+/* Placeholder pour les lignes sans icône afin d'aligner le contenu */
+.resume-infos > li[data-no-icon]::before {
+  content: "";
+  display: block;
+  flex: 0 0 var(--editor-icon-width);
+  margin-right: 0.3rem;
+}
+
 /* Hauteur et alignement par défaut des lignes de paramètres */
 .resume-infos > li {
   min-height: 40px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1776,6 +1776,23 @@ a[aria-disabled=true] {
   margin-right: 0.3rem;
 }
 
+/* Correction spécifique pour les champs de tentatives */
+.resume-infos .champ-cout-points[data-no-icon],
+.resume-infos .champ-nb-tentatives[data-no-icon] {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.resume-infos .champ-cout-points[data-no-icon]::before,
+.resume-infos .champ-nb-tentatives[data-no-icon]::before {
+  content: "";
+  display: block;
+  flex: 0 0 var(--editor-icon-width);
+  margin-right: 0.3rem;
+}
+
 /* Hauteur et alignement par défaut des lignes de paramètres */
 .resume-infos > li {
   min-height: 40px;


### PR DESCRIPTION
## Résumé
- Aligne les lignes de l’onglet Paramètres avec celles des Informations dans le panneau d’édition.
- Recompile la feuille de style du thème.

## Testing
- `npm run build:css`
- `npm test`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a810ec95a883329b7942e9682f67aa