### PR TITLE
Refactor resume infos to CSS grid

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -80,7 +80,15 @@
   gap: var(--space-xs);
 }
 
-.resume-infos > li > label {
+.resume-infos > li > .icon-attente,
+.resume-infos > li > .icone-check {
+  grid-column: 1;
+}
+
+.resume-infos > li > label,
+.resume-infos > li > .edition-row-label,
+.resume-infos > li > .champ-affichage > label {
+  grid-column: 2;
   width: 100%;
 }
 
@@ -88,12 +96,17 @@
   display: contents;
 }
 
+.resume-infos > li > .champ-affichage > :not(label),
+.resume-infos > li > .edition-row-content,
+.resume-infos > li > :not(.icon-attente):not(.icone-check):not(label):not(.champ-feedback):not(.edition-row-label):not(.champ-affichage) {
+  grid-column: 3;
+  width: 100%;
+}
+
 .resume-infos > li > .champ-edition {
   display: flex;
   align-items: start;
   gap: var(--space-xs);
-  grid-column: 3;
-  width: 100%;
   margin-top: 0;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1775,7 +1775,15 @@ a[aria-disabled=true] {
   gap: var(--space-xs);
 }
 
-.resume-infos > li > label {
+.resume-infos > li > .icon-attente,
+.resume-infos > li > .icone-check {
+  grid-column: 1;
+}
+
+.resume-infos > li > label,
+.resume-infos > li > .edition-row-label,
+.resume-infos > li > .champ-affichage > label {
+  grid-column: 2;
   width: 100%;
 }
 
@@ -1783,12 +1791,17 @@ a[aria-disabled=true] {
   display: contents;
 }
 
+.resume-infos > li > .champ-affichage > :not(label),
+.resume-infos > li > .edition-row-content,
+.resume-infos > li > :not(.icon-attente):not(.icone-check):not(label):not(.champ-feedback):not(.edition-row-label):not(.champ-affichage) {
+  grid-column: 3;
+  width: 100%;
+}
+
 .resume-infos > li > .champ-edition {
   display: flex;
   align-items: start;
   gap: var(--space-xs);
-  grid-column: 3;
-  width: 100%;
   margin-top: 0;
 }
 


### PR DESCRIPTION
Met en place une grille CSS pour les lignes de paramètres afin d'aligner correctement les libellés et leur contenu.

- Remplace le conteneur flex par une grille CSS pour `.resume-infos > li`
- Ajuste les règles associées et régénère `style.css`

**Testing**
- `node build-css.js`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a81bb3892c8332a72cd93c3f007656