### PR TITLE
docs: add translation instructions

### DIFF
--- a/wp-content/themes/chassesautresor/docs/README.md
+++ b/wp-content/themes/chassesautresor/docs/README.md
@@ -5,6 +5,7 @@ Ce répertoire rassemble des documents complémentaires au thème.
 - [Workflow organisateur](organisateur-workflow.md)
 - [Charte Orgy](orgy-charte.md)
 - [Pager par défaut](pager.md)
+- [Traductions du thème](traductions.md)
 
 Toutes les nouvelles chaînes de texte doivent utiliser les fonctions d'internationalisation de WordPress avec le domaine `chassesautresor-com`.
 

--- a/wp-content/themes/chassesautresor/docs/traductions.md
+++ b/wp-content/themes/chassesautresor/docs/traductions.md
@@ -1,0 +1,33 @@
+# Traductions
+
+Ce document regroupe les instructions de développement concernant les fichiers de langue du thème.
+
+## Chargement des traductions
+
+Ajouter dans `functions.php` :
+
+```php
+add_action( 'after_setup_theme', function () {
+    load_child_theme_textdomain( 'chassesautresor-com', get_stylesheet_directory() . '/languages' );
+} );
+```
+
+Pour un thème autonome, utiliser `load_theme_textdomain` à la place.
+
+## Compilation des fichiers .po
+
+Compiler un fichier unique :
+
+```bash
+msgfmt languages/fr_FR.po -o languages/fr_FR.mo
+```
+
+Compiler toutes les traductions :
+
+```bash
+for po in languages/*.po; do
+  msgfmt "$po" -o "${po%.po}.mo"
+done
+```
+
+Ne pas versionner les fichiers `.mo` compilés.


### PR DESCRIPTION
## Résumé
- documente les commandes de compilation des fichiers de langue
- référence la nouvelle documentation dans l’index des docs

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a81b61b2308332b941cab92530d585