### PR TITLE
Add English translations for organizer account notifications

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1184,3 +1184,23 @@ msgstr ""
 msgid "Définition du taux de résolution"
 msgstr ""
 
+#: inc/admin-functions.php:1849
+msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
+msgstr ""
+
+#: inc/admin-functions.php:1886
+msgid "Votre demande de validation pour la chasse « %s » nécessite des corrections."
+msgstr ""
+
+#: inc/admin-functions.php:1895
+msgid "Une copie de ce message vous a été envoyée par email."
+msgstr ""
+
+#: inc/admin-functions.php:1891
+msgid "Message de l’administrateur : %s"
+msgstr ""
+
+#: inc/admin-functions.php:1918
+msgid "Votre chasse « %s » a été bannie."
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1685,3 +1685,23 @@ msgstr "Remove"
 msgid "Ex : soleil"
 msgstr "E.g. sun"
 
+#: inc/admin-functions.php:1849
+msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
+msgstr "Your validation request for the hunt “%s” was accepted."
+
+#: inc/admin-functions.php:1886
+msgid "Votre demande de validation pour la chasse « %s » nécessite des corrections."
+msgstr "Your validation request for the hunt “%s” requires corrections."
+
+#: inc/admin-functions.php:1895
+msgid "Une copie de ce message vous a été envoyée par email."
+msgstr "A copy of this message has been sent to you by email."
+
+#: inc/admin-functions.php:1891
+msgid "Message de l’administrateur : %s"
+msgstr "Administrator's message: %s"
+
+#: inc/admin-functions.php:1918
+msgid "Votre chasse « %s » a été bannie."
+msgstr "Your hunt “%s” was banned."
+


### PR DESCRIPTION
## Résumé
- Ajout des traductions anglaises manquantes pour les notifications de l’espace organisateur
- Mise à jour du modèle de traductions `chassesautresor-com.pot`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a821684dcc8332a66ce6ef436acc4c