### PR TITLE
fix: translate add and validate buttons

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -527,6 +527,7 @@ msgstr ""
 #: template-parts/chasse/chasse-edition-main.php:142
 #: template-parts/enigme/enigme-edition-main.php:177
 #: template-parts/organisateur/organisateur-edition-main.php:141
+#: assets/js/enigme-edit.js:645
 msgid "ajouter"
 msgstr ""
 
@@ -819,6 +820,11 @@ msgstr ""
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:55
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:48
 msgid "Valider"
+msgstr ""
+
+#: assets/js/enigme-edit.js:605
+#: assets/js/enigme-edit.js:657
+msgid "valider"
 msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:61

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -502,6 +502,7 @@ msgstr "Hunting description"
 #: template-parts/chasse/chasse-edition-main.php:142
 #: template-parts/enigme/enigme-edition-main.php:177
 #: template-parts/organisateur/organisateur-edition-main.php:141
+#: assets/js/enigme-edit.js:645
 msgid "ajouter"
 msgstr "Add"
 
@@ -784,6 +785,11 @@ msgstr "You solved this puzzle on %s."
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:55
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:48
 msgid "Valider"
+msgstr "Validate"
+
+#: assets/js/enigme-edit.js:605
+#: assets/js/enigme-edit.js:657
+msgid "valider"
 msgstr "Validate"
 
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:61


### PR DESCRIPTION
## Summary
- ajoute les chaînes manquantes "ajouter" et "valider" dans le modèle de traduction
- traduit ces libellés en anglais pour le panneau d'édition des énigmes

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a821bd485083328358370a6d1e77f0