### PR TITLE
fix: translate attempts tooltip

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1521,7 +1521,7 @@ msgid ""
 "illimitées\\n\\nMode gratuit : 24 tentatives par jour"
 msgstr ""
 "Maximum number of daily attempts per player:\\n\\nPaid mode: "
-"unlimited\\n\\nFree mode: 24 attempts per day"
+"unlimited attempts\n\nFree mode: 24 attempts per day"
 
 #: template-parts/enigme/enigme-edition-main.php:711
 msgid "Délai de parution des solutions"


### PR DESCRIPTION
## Résumé
- Ajout de la traduction anglaise manquante pour le message d'aide sur le plafond quotidien des tentatives.

## Changements notables
- Met à jour `en_US.po` avec la traduction du message d'information.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a8230fc4bc8332bdaa6208a0a4605b