### PR TITLE
Add English translation for attempt limit hint

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1527,8 +1527,8 @@ msgid ""
 "Nombre maximal de tentatives quotidiennes par joueur:\\n\\nMode payant : "
 "illimitées\\n\\nMode gratuit : 24 tentatives par jour"
 msgstr ""
-"Maximum number of daily attempts per player:\\n\\nPaid mode: "
-"unlimited attempts\n\nFree mode: 24 attempts per day"
+"Maximum number of daily attempts per player:\\n\\nPaid mode: unlimited\\n\\n"
+"Free mode: 24 attempts per day"
 
 #: template-parts/enigme/enigme-edition-main.php:711
 msgid "Délai de parution des solutions"


### PR DESCRIPTION
## Summary
- Ajout de la traduction anglaise manquante pour le message d'aide du nombre de tentatives quotidiennes dans l'édition d'énigme

## Changelog
- Mise à jour du fichier `en_US.po` pour le plafond de tentatives

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a827f7618083329a6524012605c0fa