### PR TITLE
Hide hunt description label and fix Save translation

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -608,10 +608,14 @@ msgstr "Edit Hunt Description"
 msgid "Fermer le panneau"
 msgstr "Close the panel."
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:28
-#: template-parts/enigme/panneaux/enigme-edition-description.php:27
-#: template-parts/enigme/panneaux/enigme-edition-images.php:20
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:37
 msgid "Enregistrer"
+msgstr "Save"
+
+#: template-parts/chasse/panneaux/chasse-edition-description.php:41
+#: template-parts/enigme/panneaux/enigme-edition-description.php:27
+#: template-parts/enigme/panneaux/enigme-edition-images.php:31
+msgid "💾 Enregistrer"
 msgstr "Save"
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:33

--- a/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/panneaux/chasse-edition-description.php
@@ -9,33 +9,43 @@
 defined('ABSPATH') || exit;
 
 $chasse_id = $args['chasse_id'] ?? null;
-if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
+if (! $chasse_id || get_post_type($chasse_id) !== 'chasse') {
+    return;
+}
+
+$hide_label = static function (array $field): array {
+    $field['wrapper']['class'] = trim(($field['wrapper']['class'] ?? '') . ' acf-hide-label');
+
+    return $field;
+};
+add_filter('acf/prepare_field/name=chasse_principale_description', $hide_label);
 ?>
 
-  <div id="panneau-description-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
-    <div class="panneau-lateral__contenu">
+<div id="panneau-description-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
+  <div class="panneau-lateral__contenu">
 
-      <header class="panneau-lateral__header">
-        <h2><?php echo esc_html__( 'Modifier la description de la chasse', 'chassesautresor-com' ); ?></h2>
-        <button type="button" class="panneau-fermer" aria-label="<?php echo esc_attr__( 'Fermer le panneau', 'chassesautresor-com' ); ?>">✖</button>
-      </header>
+    <header class="panneau-lateral__header">
+      <h2><?php echo esc_html__( 'Modifier la description de la chasse', 'chassesautresor-com' ); ?></h2>
+      <button type="button" class="panneau-fermer" aria-label="<?php echo esc_attr__( 'Fermer le panneau', 'chassesautresor-com' ); ?>">✖</button>
+    </header>
 
-    <?php
-    acf_form([
-      'post_id'             => $chasse_id,
-      'fields'              => ['chasse_principale_description'],
-      'form'                => true,
-        'submit_value'        => __( '💾 Enregistrer', 'chassesautresor-com' ),
-      'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
-      'html_before_fields'  => '<div class="champ-wrapper">',
-      'html_after_fields'   => '</div>',
-      'return'              => add_query_arg(
-        ['edition' => 'open', 'tab' => 'param'],
-        get_permalink()
+  <?php
+  acf_form([
+      'post_id'            => $chasse_id,
+      'fields'             => ['chasse_principale_description'],
+      'form'               => true,
+      'submit_value'       => __( '💾 Enregistrer', 'chassesautresor-com' ),
+      'html_submit_button' => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
+      'html_before_fields' => '<div class="champ-wrapper">',
+      'html_after_fields'  => '</div>',
+      'return'             => add_query_arg(
+          ['edition' => 'open', 'tab' => 'param'],
+          get_permalink()
       ) . '#chasse-description',
-        'updated_message'     => __( 'Description mise à jour.', 'chassesautresor-com' )
-      ]);
-    ?>
+      'updated_message'    => __( 'Description mise à jour.', 'chassesautresor-com' ),
+  ]);
+  remove_filter('acf/prepare_field/name=chasse_principale_description', $hide_label);
+  ?>
 
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Masquer l'étiquette inutile dans le panneau d'édition de la chasse
- Ajouter la traduction anglaise du bouton « 💾 Enregistrer »

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a828fbc250833291ae6db822686374