### PR TITLE
Masquer le libellé de description de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1241,6 +1241,10 @@ body.panneau-ouvert::before {
   color: var(--color-editor-text-muted);
 }
 
+.acf-hide-label > .acf-label {
+  display: none;
+}
+
 .ligne-lien-formulaire label {
   display: flex;
   align-items: center;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2893,6 +2893,10 @@ body.panneau-ouvert::before {
   color: var(--color-editor-text-muted);
 }
 
+.acf-hide-label > .acf-label {
+  display: none;
+}
+
 .ligne-lien-formulaire label {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Résumé
- masque le texte du libellé au-dessus du champ de description dans le panneau d’édition d’une chasse
- compile les styles mis à jour

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a8306f31b48332b4a6bf5c2a36dde3