### PR TITLE
feat: add hint creation endpoint

### DIFF
--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace CreerIndice { 
+    if (!defined('TITRE_DEFAUT_INDICE')) {
+        define('TITRE_DEFAUT_INDICE', 'indice');
+    }
+
+    require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
+
+    class WP_Error
+    {
+        private $message;
+        public function __construct($code = '', $message = '')
+        {
+            $this->message = $message;
+        }
+        public function get_error_message()
+        {
+            return $this->message;
+        }
+    }
+
+    function get_post_type($id)
+    {
+        return 'chasse';
+    }
+
+    function is_user_logged_in()
+    {
+        global $is_logged_in;
+        return $is_logged_in;
+    }
+
+    function get_current_user_id()
+    {
+        return 1;
+    }
+
+    function utilisateur_peut_modifier_post($id)
+    {
+        global $can_edit;
+        return $can_edit;
+    }
+
+    function wp_insert_post($args)
+    {
+        return 123;
+    }
+
+    function update_field($field, $value, $post_id)
+    {
+        global $updated_fields;
+        $updated_fields[$field] = $value;
+    }
+
+    function current_time($format)
+    {
+        return '2024-01-01 00:00:00';
+    }
+
+    function is_wp_error($thing)
+    {
+        return $thing instanceof WP_Error;
+    }
+}
+
+namespace CreerIndice {
+
+use PHPUnit\Framework\TestCase;
+
+class CreerIndicePermissionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $is_logged_in, $can_edit;
+        $is_logged_in = true;
+        $can_edit = false;
+    }
+
+    protected function tearDown(): void
+    {
+        global $is_logged_in, $can_edit;
+        $is_logged_in = true;
+        $can_edit = false;
+    }
+
+    public function test_creates_indice_when_authorised(): void
+    {
+        global $can_edit, $updated_fields;
+        $can_edit = true;
+        $updated_fields = [];
+
+        $result = creer_indice_pour_objet(42, 'chasse');
+        $this->assertSame(123, $result);
+        $this->assertSame('chasse', $updated_fields['indice_cible']);
+    }
+}
+}

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -276,6 +276,7 @@ require_once $inc_path . 'edition/edition-core.php';
 require_once $inc_path . 'edition/edition-organisateur.php';
 require_once $inc_path . 'edition/edition-chasse.php';
 require_once $inc_path . 'edition/edition-enigme.php';
+require_once $inc_path . 'edition/edition-indice.php';
 require_once $inc_path . 'edition/edition-securite.php';
 
 

--- a/wp-content/themes/chassesautresor/inc/utils/titres.php
+++ b/wp-content/themes/chassesautresor/inc/utils/titres.php
@@ -15,11 +15,12 @@ defined('ABSPATH') || exit;
 define('TITRE_DEFAUT_ORGANISATEUR', 'Votre nom d’organisateur');
 define('TITRE_DEFAUT_CHASSE', 'Nouvelle chasse');
 define('TITRE_DEFAUT_ENIGME', 'en création');
+define('TITRE_DEFAUT_INDICE', 'Nouvel indice');
 
 /**
  * Retourne le titre par défaut associé à un type de post donné.
  *
- * @param string $post_type Type de post (organisateur, chasse, énigme).
+ * @param string $post_type Type de post (organisateur, chasse, énigme, indice).
  * @return string Titre par défaut ou chaîne vide si inconnu.
  */
 function get_titre_defaut(string $post_type): string {
@@ -30,6 +31,8 @@ function get_titre_defaut(string $post_type): string {
             return TITRE_DEFAUT_CHASSE;
         case 'enigme':
             return TITRE_DEFAUT_ENIGME;
+        case 'indice':
+            return TITRE_DEFAUT_INDICE;
         default:
             return '';
     }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -719,7 +719,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <i class="fa-regular fa-circle-question icone-defaut" aria-hidden="true"></i>
                     <h3><?= esc_html__('Indices', 'chassesautresor-com'); ?></h3>
                     <?php if ($peut_ajouter_indice) : ?>
-                      <a href="#" class="stat-value"><?= esc_html__('Ajouter', 'chassesautresor-com'); ?></a>
+                      <?php $ajout_indice_url = wp_nonce_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-indice/')), 'creer_indice', 'nonce'); ?>
+                      <a href="<?= esc_url($ajout_indice_url); ?>" class="stat-value"><?= esc_html__('Ajouter', 'chassesautresor-com'); ?></a>
                     <?php else : ?>
                       <span class="stat-value"><?= esc_html__('Ajouter', 'chassesautresor-com'); ?></span>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- ajout d'un endpoint `/creer-indice` avec vérification des droits et redirection
- préremplissage des champs ACF et titre par défaut pour le CPT indice
- lien de création d'indice sécurisé par nonce dans l'édition de chasse
- couverture de la création d'indice par un test unitaire

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a83b295dc88332869f52ca465d164c