### PR TITLE
Corrige l'alignement des labels des réglages d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -825,6 +825,15 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
   min-width: var(--editor-label-width);
 }
 
+/* Les lignes de réglages n'ont pas d'icône de complétion.
+   On élargit donc leurs labels pour compenser l'absence de marge
+   laissée par cette icône et aligner le contenu avec la section
+   « Informations ». */
+.resume-reglages .resume-infos > li > label,
+.resume-reglages .resume-infos > li > .champ-edition > label {
+  width: calc(var(--editor-label-width) + var(--editor-icon-width) + var(--space-xs) + 0.3rem);
+}
+
 .resume-infos .champ-valeur {
   display: inline-block;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2487,6 +2487,15 @@ body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
   min-width: var(--editor-label-width);
 }
 
+/* Les lignes de réglages n'ont pas d'icône de complétion.
+   On élargit donc leurs labels pour compenser l'absence de marge
+   laissée par cette icône et aligner le contenu avec la section
+   « Informations ». */
+.resume-reglages .resume-infos > li > label,
+.resume-reglages .resume-infos > li > .champ-edition > label {
+  width: calc(var(--editor-label-width) + var(--editor-icon-width) + var(--space-xs) + 0.3rem);
+}
+
 .resume-infos .champ-valeur {
   display: inline-block;
 }


### PR DESCRIPTION
## Résumé
- aligne le contenu des réglages d'énigme avec la section informations

## Changements notables
- élargissement des labels des lignes sans icône de complétion
- recompilation du style CSS du thème

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a83c446bcc83329a9d754b07eab825