### PR TITLE
Responsive enigma title font size

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -329,7 +329,7 @@ li.active .enigme-menu__edit {
 .page-enigme .enigme-header .enigme-titre {
   word-break: break-word;
   overflow-wrap: anywhere;
-  font-size: 64px;
+  font-size: clamp(26px, 8vw, 64px);
 }
 
 .page-enigme .enigme-header .enigme-soustitre {
@@ -360,10 +360,6 @@ li.active .enigme-menu__edit {
 
   .page-enigme .enigme-header {
     padding-bottom: var(--space-xs);
-  }
-
-  .page-enigme .enigme-header .enigme-titre {
-    font-size: 26px;
   }
 
   .page-enigme .enigme-header .enigme-soustitre {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3966,7 +3966,7 @@ li.active .enigme-menu__edit {
 .page-enigme .enigme-header .enigme-titre {
   word-break: break-word;
   overflow-wrap: anywhere;
-  font-size: 64px;
+  font-size: clamp(26px, 8vw, 64px);
 }
 
 .page-enigme .enigme-header .enigme-soustitre {
@@ -3993,9 +3993,6 @@ li.active .enigme-menu__edit {
   }
   .page-enigme .enigme-header {
     padding-bottom: var(--space-xs);
-  }
-  .page-enigme .enigme-header .enigme-titre {
-    font-size: 26px;
   }
   .page-enigme .enigme-header .enigme-soustitre {
     font-size: 0.9rem;


### PR DESCRIPTION
## Résumé
Ajuste la taille du titre des énigmes pour qu'il diminue progressivement sur les petits écrans.

## Changements
- Dimensionnement fluide du titre d'énigme via `clamp()`.
- Nettoyage de la règle spécifique aux mobiles.

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8400ec7088332b11e74678f3ad061