### PR TITLE
Pré-remplissage et panneau d'édition pour les indices

### DIFF
--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -1,66 +1,73 @@
 <?php
-namespace CreerIndice { 
+namespace {
     if (!defined('TITRE_DEFAUT_INDICE')) {
         define('TITRE_DEFAUT_INDICE', 'indice');
     }
 
+    if (!function_exists('__')) {
+        function __($text, $domain = null) { return $text; }
+    }
+
+    if (!function_exists('get_post_type')) {
+        function get_post_type($id) { return 'chasse'; }
+    }
+
+    if (!function_exists('is_user_logged_in')) {
+        function is_user_logged_in() { global $is_logged_in; return $is_logged_in; }
+    }
+
+    if (!function_exists('get_current_user_id')) {
+        function get_current_user_id() { return 1; }
+    }
+
+    if (!function_exists('utilisateur_peut_modifier_post')) {
+        function utilisateur_peut_modifier_post($id) { global $can_edit; return $can_edit; }
+    }
+
+    if (!function_exists('wp_insert_post')) {
+        function wp_insert_post($args) { return 123; }
+    }
+
+    if (!function_exists('wp_update_post')) {
+        function wp_update_post($args) { global $updated_post; $updated_post = $args; return 123; }
+    }
+
+    if (!function_exists('update_field')) {
+        function update_field($field, $value, $post_id) { global $updated_fields; $updated_fields[$field] = $value; }
+    }
+
+    if (!function_exists('current_time')) {
+        function current_time($format) {
+            if ($format === 'timestamp') return 1704067200;
+            return '2024-01-01 00:00:00';
+        }
+    }
+
+    if (!function_exists('wp_date')) {
+        function wp_date($format, $timestamp) { return gmdate($format, $timestamp); }
+    }
+
+    if (!function_exists('get_the_title')) {
+        function get_the_title($id) { return 'Chasse de Test'; }
+    }
+
+    if (!defined('DAY_IN_SECONDS')) {
+        define('DAY_IN_SECONDS', 86400);
+    }
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error {
+            private $message;
+            public function __construct($code = '', $message = '') { $this->message = $message; }
+            public function get_error_message() { return $this->message; }
+        }
+    }
+
+    if (!function_exists('is_wp_error')) {
+        function is_wp_error($thing) { return $thing instanceof WP_Error; }
+    }
+
     require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
-
-    class WP_Error
-    {
-        private $message;
-        public function __construct($code = '', $message = '')
-        {
-            $this->message = $message;
-        }
-        public function get_error_message()
-        {
-            return $this->message;
-        }
-    }
-
-    function get_post_type($id)
-    {
-        return 'chasse';
-    }
-
-    function is_user_logged_in()
-    {
-        global $is_logged_in;
-        return $is_logged_in;
-    }
-
-    function get_current_user_id()
-    {
-        return 1;
-    }
-
-    function utilisateur_peut_modifier_post($id)
-    {
-        global $can_edit;
-        return $can_edit;
-    }
-
-    function wp_insert_post($args)
-    {
-        return 123;
-    }
-
-    function update_field($field, $value, $post_id)
-    {
-        global $updated_fields;
-        $updated_fields[$field] = $value;
-    }
-
-    function current_time($format)
-    {
-        return '2024-01-01 00:00:00';
-    }
-
-    function is_wp_error($thing)
-    {
-        return $thing instanceof WP_Error;
-    }
 }
 
 namespace CreerIndice {
@@ -85,13 +92,20 @@ class CreerIndicePermissionsTest extends TestCase
 
     public function test_creates_indice_when_authorised(): void
     {
-        global $can_edit, $updated_fields;
+        global $can_edit, $updated_fields, $updated_post;
         $can_edit = true;
         $updated_fields = [];
+        $updated_post = [];
 
-        $result = creer_indice_pour_objet(42, 'chasse');
+        $result = \creer_indice_pour_objet(42, 'chasse');
         $this->assertSame(123, $result);
         $this->assertSame('chasse', $updated_fields['indice_cible']);
+        $this->assertSame(42, $updated_fields['indice_cible_objet']);
+        $expected_date = wp_date('Y-m-d H:i:s', (int) current_time('timestamp') + DAY_IN_SECONDS);
+        $this->assertSame($expected_date, $updated_fields['indice_date_disponibilite']);
+        $this->assertFalse($updated_fields['indice_cache_complet']);
+        $titre_objet = get_the_title(42);
+        $this->assertSame("Indice #123 - {$titre_objet}", $updated_post['post_title']);
     }
 }
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -97,10 +97,33 @@ function creer_indice_pour_objet(int $objet_id, string $objet_type, ?int $user_i
  */
 function register_endpoint_creer_indice(): void
 {
-    add_rewrite_rule('^creer-indice/?', 'index.php?creer_indice=1', 'top');
+    add_rewrite_rule('^creer-indice/?$', 'index.php?creer_indice=1', 'top');
     add_rewrite_tag('%creer_indice%', '1');
 }
 add_action('init', 'register_endpoint_creer_indice');
+
+/**
+ * S'assure que les règles de réécriture prennent en compte /creer-indice/.
+ *
+ * Cette fonction est exécutée lors de l'activation du thème ou
+ * automatiquement une fois si les règles n'ont pas encore été mises à jour.
+ *
+ * @return void
+ */
+function flush_rewrite_rules_creer_indice(): void
+{
+    register_endpoint_creer_indice();
+    flush_rewrite_rules();
+    update_option('creer_indice_rewrite_flushed', 1);
+}
+
+add_action('after_switch_theme', 'flush_rewrite_rules_creer_indice');
+
+add_action('init', function (): void {
+    if (!get_option('creer_indice_rewrite_flushed')) {
+        flush_rewrite_rules_creer_indice();
+    }
+}, 20);
 
 /**
  * Détecte l’appel à /creer-indice/ et redirige vers l’indice créé.

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1222,3 +1222,14 @@ msgid "Votre chasse « %s » a été bannie."
 
 msgstr ""
 
+#: inc/edition/edition-indice.php:73
+msgid "Indice #%d - %s"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:26
+msgid "Panneau d'édition indice"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:33
+msgid "Contenu d'édition à venir..."
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1725,3 +1725,14 @@ msgid "Votre chasse « %s » a été bannie."
 msgstr "Your hunt “%s” was banned."
 
 
+#: inc/edition/edition-indice.php:73
+msgid "Indice #%d - %s"
+msgstr "Clue #%d - %s"
+
+#: template-parts/indice/indice-edition-main.php:26
+msgid "Panneau d'édition indice"
+msgstr "Clue edit panel"
+
+#: template-parts/indice/indice-edition-main.php:33
+msgid "Contenu d'édition à venir..."
+msgstr "Editing content coming soon..."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1169,3 +1169,14 @@ msgstr "Respecter la casse"
 msgid "Enregistrer les variantes"
 msgstr "Enregistrer les variantes"
 
+#: inc/edition/edition-indice.php:73
+msgid "Indice #%d - %s"
+msgstr "Indice #%d - %s"
+
+#: template-parts/indice/indice-edition-main.php:26
+msgid "Panneau d'édition indice"
+msgstr "Panneau d'édition indice"
+
+#: template-parts/indice/indice-edition-main.php:33
+msgid "Contenu d'édition à venir..."
+msgstr "Contenu d'édition à venir..."

--- a/wp-content/themes/chassesautresor/single-indice.php
+++ b/wp-content/themes/chassesautresor/single-indice.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Template : single-indice.php
+ * Affiche le panneau d'édition d'un indice.
+ */
+
+defined('ABSPATH') || exit;
+
+$indice_id = get_the_ID();
+$edition_active = utilisateur_peut_modifier_post($indice_id);
+
+if ($edition_active) {
+    acf_form_head();
+}
+
+get_header();
+?>
+
+<div id="primary" class="content-area">
+    <main id="main" class="site-main">
+        <?php
+        get_template_part('template-parts/indice/indice-edition-main', null, [
+            'indice_id' => $indice_id,
+        ]);
+        ?>
+    </main>
+</div>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Template Part: Panneau d'édition frontale d'un indice
+ * Requiert : $args['indice_id']
+ */
+
+defined('ABSPATH') || exit;
+
+$indice_id = $args['indice_id'] ?? null;
+if (!$indice_id || get_post_type($indice_id) !== 'indice') {
+    return;
+}
+
+$peut_modifier = utilisateur_peut_voir_panneau($indice_id);
+if (!$peut_modifier) {
+    return;
+}
+
+$titre = get_the_title($indice_id);
+?>
+
+<section class="edition-panel edition-panel-indice edition-panel-modal" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+    <div class="edition-panel-header">
+        <h2>
+            <i class="fa-solid fa-gear"></i>
+            <?= esc_html__('Panneau d\'édition indice', 'chassesautresor-com'); ?> :
+            <span class="titre-objet" data-cpt="indice"><?= esc_html($titre); ?></span>
+        </h2>
+        <button type="button" class="panneau-fermer" aria-label="<?= esc_attr__('Fermer les paramètres', 'chassesautresor-com'); ?>">✖</button>
+    </div>
+
+    <div class="edition-panel-body">
+        <p><?= esc_html__('Contenu d\'édition à venir...', 'chassesautresor-com'); ?></p>
+    </div>
+</section>


### PR DESCRIPTION
## Résumé
- initialise le titre et les champs ACF lors de la création d'un indice
- ajoute un template single et un panneau d'édition placeholder pour le CPT indice
- met à jour les traductions et les tests associés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a83f60aaf8833283bed95bfe9a2209