### PR TITLE
Affichage et édition frontale pour les indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indice-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/indice-edit.js
@@ -1,0 +1,36 @@
+function initIndiceEdit() {
+  if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
+
+  const boutonsToggle = document.querySelectorAll(
+    '#toggle-mode-edition-indice, .toggle-mode-edition-indice'
+  );
+  const panneauEdition = document.querySelector('.edition-panel-indice');
+
+  const toggleEdition = () => {
+    document.body.classList.toggle('edition-active-indice');
+    document.body.classList.toggle('panneau-ouvert');
+    document.body.classList.toggle('mode-edition');
+  };
+
+  boutonsToggle.forEach((btn) => {
+    btn.addEventListener('click', toggleEdition);
+  });
+
+  panneauEdition?.querySelector('.panneau-fermer')?.addEventListener('click', () => {
+    document.body.classList.remove('edition-active-indice');
+    document.body.classList.remove('panneau-ouvert');
+    document.body.classList.remove('mode-edition');
+    document.activeElement?.blur();
+  });
+
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('edition') === 'open' && boutonsToggle.length > 0) {
+    boutonsToggle[0].click();
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initIndiceEdit);
+} else {
+  initIndiceEdit();
+}

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -349,6 +349,10 @@ function utilisateur_peut_modifier_post($post_id)
             $organisateur_id = $chasse_id ? get_organisateur_from_chasse($chasse_id) : null;
             return $organisateur_id ? utilisateur_peut_modifier_post($organisateur_id) : false;
 
+        case 'indice':
+            $cible_id = (int) get_field('indice_cible_objet', $post_id);
+            return $cible_id ? utilisateur_peut_modifier_post($cible_id) : false;
+
         default:
             cat_debug("❌ utilisateur_peut_modifier_post: post_type inconnu ($post_type)");
             return false;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -25,7 +25,7 @@ function enqueue_script_indice_edit(): void
         return;
     }
 
-    enqueue_core_edit_scripts(['organisateur-edit']);
+    enqueue_core_edit_scripts(['organisateur-edit', 'indice-edit']);
     wp_enqueue_media();
 }
 add_action('wp_enqueue_scripts', 'enqueue_script_indice_edit');

--- a/wp-content/themes/chassesautresor/single-indice.php
+++ b/wp-content/themes/chassesautresor/single-indice.php
@@ -19,10 +19,18 @@ get_header();
 <div id="primary" class="content-area">
     <main id="main" class="site-main">
         <?php
-        get_template_part('template-parts/indice/indice-edition-main', null, [
+        get_template_part('template-parts/indice/indice-affichage', null, [
             'indice_id' => $indice_id,
         ]);
         ?>
+
+        <?php if ($edition_active) : ?>
+            <?php
+            get_template_part('template-parts/indice/indice-edition-main', null, [
+                'indice_id' => $indice_id,
+            ]);
+            ?>
+        <?php endif; ?>
     </main>
 </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-affichage.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-affichage.php
@@ -19,7 +19,7 @@ $edition_active = utilisateur_peut_modifier_post($indice_id);
 
 <section class="indice-affichage" data-post-id="<?= esc_attr($indice_id); ?>">
     <?php if ($edition_active) : ?>
-        <button id="toggle-mode-edition-indice" type="button" class="bouton-edition-toggle" data-cpt="indice" aria-label="<?= esc_attr__('Activer Orgy', 'chassesautresor-com'); ?>">
+        <button id="toggle-mode-edition-indice" type="button" class="bouton-edition-toggle" data-cpt="indice" aria-label="<?= esc_attr__('Activer l\'édition', 'chassesautresor-com'); ?>">
             <i class="fa-solid fa-gear"></i>
         </button>
     <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-affichage.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-affichage.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Template Part: Indice - Affichage
+ * Displays the title, image and content of an indice.
+ */
+
+defined('ABSPATH') || exit;
+
+$indice_id = $args['indice_id'] ?? null;
+if (! $indice_id || get_post_type($indice_id) !== 'indice') {
+    return;
+}
+
+$titre = get_the_title($indice_id);
+$image_url = get_the_post_thumbnail_url($indice_id, 'large');
+$contenu = apply_filters('the_content', get_post_field('post_content', $indice_id));
+$edition_active = utilisateur_peut_modifier_post($indice_id);
+?>
+
+<section class="indice-affichage" data-post-id="<?= esc_attr($indice_id); ?>">
+    <?php if ($edition_active) : ?>
+        <button id="toggle-mode-edition-indice" type="button" class="bouton-edition-toggle" data-cpt="indice" aria-label="<?= esc_attr__('Activer Orgy', 'chassesautresor-com'); ?>">
+            <i class="fa-solid fa-gear"></i>
+        </button>
+    <?php endif; ?>
+
+    <h1 class="titre-indice" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+        <?= esc_html($titre); ?>
+    </h1>
+
+    <?php if ($image_url) : ?>
+        <div class="indice-image">
+            <img src="<?= esc_url($image_url); ?>" alt="<?= esc_attr__('Image de l\'indice', 'chassesautresor-com'); ?>" />
+        </div>
+    <?php endif; ?>
+
+    <div class="indice-contenu">
+        <?= $contenu; ?>
+    </div>
+</section>


### PR DESCRIPTION
## Résumé
- ajoute un template d’affichage pour les indices avec titre, image et contenu
- permet l’édition frontale via un panneau dédié et un bouton de bascule
- enfile un script JS pour gérer l’ouverture/fermeture du panneau

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a85f1303148332b3080d53a2ce440b