### PR TITLE
Corrige l'association automatique de l'organisateur pour les indices

### DIFF
--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -24,6 +24,10 @@ namespace {
         function utilisateur_peut_modifier_post($id) { global $can_edit; return $can_edit; }
     }
 
+    if (!function_exists('get_organisateur_chasse')) {
+        function get_organisateur_chasse($chasse_id) { return 10; }
+    }
+
     if (!function_exists('get_organisateur_from_chasse')) {
         function get_organisateur_from_chasse($chasse_id) { return 7; }
     }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -57,11 +57,20 @@ function creer_indice_pour_objet(int $objet_id, string $objet_type, ?int $user_i
     }
 
     $organisateur_id = null;
+
     if ($objet_type === 'chasse') {
-        $organisateur_id = get_organisateur_from_chasse($objet_id);
+        $organisateur_id = get_organisateur_chasse($objet_id);
+        if (!$organisateur_id) {
+            $organisateur_id = get_organisateur_from_chasse($objet_id);
+        }
     } else {
-        $chasse_id       = recuperer_id_chasse_associee($objet_id);
-        $organisateur_id = $chasse_id ? get_organisateur_from_chasse($chasse_id) : null;
+        $chasse_id = recuperer_id_chasse_associee($objet_id);
+        if ($chasse_id) {
+            $organisateur_id = get_organisateur_chasse($chasse_id);
+            if (!$organisateur_id) {
+                $organisateur_id = get_organisateur_from_chasse($chasse_id);
+            }
+        }
     }
 
     if (!$organisateur_id || !utilisateur_peut_modifier_post($organisateur_id)) {


### PR DESCRIPTION
## Résumé
- corrige la récupération de l'organisateur lors de la création d'un indice
- ajuste le test pour valider l'ID organisateur retourné

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a8674dfcc48332aa79913cde397c8e