### PR TITLE
Supprimer le forçage de l'état système des indices à leur création

### DIFF
--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -108,6 +108,7 @@ class CreerIndicePermissionsTest extends TestCase
         $this->assertSame(10, $updated_fields['indice_organisateur_linked']);
         $expected_date = wp_date('Y-m-d H:i:s', (int) current_time('timestamp') + DAY_IN_SECONDS);
         $this->assertSame($expected_date, $updated_fields['indice_date_disponibilite']);
+        $this->assertArrayNotHasKey('indice_cache_etat_systeme', $updated_fields);
         $this->assertFalse($updated_fields['indice_cache_complet']);
         $titre_objet = get_the_title(42);
         $this->assertSame("Indice #123 - {$titre_objet}", $updated_post['post_title']);

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -97,7 +97,6 @@ function creer_indice_pour_objet(int $objet_id, string $objet_type, ?int $user_i
     update_field('indice_date_disponibilite', $date_disponibilite, $indice_id);
 
     update_field('indice_cout_points', 0, $indice_id);
-    update_field('indice_cache_etat_systeme', 'accessible', $indice_id);
     update_field('indice_cache_complet', false, $indice_id);
 
     return $indice_id;


### PR DESCRIPTION
## Résumé
- ne plus définir `indice_cache_etat_systeme` lors de la création d'un indice
- vérifier par test que le champ n'est pas forcé

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a86e0b3f88833282e84a93fa293740