### PR TITLE
Ajout du panneau d'édition pour les indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indice-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/indice-edit.js
@@ -1,0 +1,39 @@
+// ✅ indice-edit.js
+var DEBUG = window.DEBUG || false;
+DEBUG && console.log('✅ indice-edit.js chargé');
+
+let boutonsToggle;
+let panneauEdition;
+
+function initIndiceEdit() {
+  if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
+
+  boutonsToggle = document.querySelectorAll(
+    '#toggle-mode-edition-indice, .toggle-mode-edition-indice'
+  );
+  panneauEdition = document.querySelector('.edition-panel-indice');
+
+  const toggleEdition = () => {
+    document.body.classList.toggle('edition-active-indice');
+    document.body.classList.toggle('panneau-ouvert');
+    document.body.classList.toggle('mode-edition');
+  };
+
+  boutonsToggle.forEach((btn) => {
+    btn.addEventListener('click', toggleEdition);
+  });
+
+  panneauEdition?.querySelector('.panneau-fermer')?.addEventListener('click', () => {
+    document.body.classList.remove('edition-active-indice', 'panneau-ouvert', 'mode-edition');
+    document.activeElement?.blur();
+  });
+
+  const params = new URLSearchParams(window.location.search);
+  const doitOuvrir = params.get('edition') === 'open';
+  if (doitOuvrir && boutonsToggle.length > 0) {
+    boutonsToggle[0].click();
+    DEBUG && console.log('🔧 Ouverture auto du panneau édition indice via ?edition=open');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initIndiceEdit);

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -730,7 +730,8 @@ body[class*="edition-active"] .champ-desactive .champ-modifier,
 
 body.edition-active .panneau-organisateur,
 body.edition-active-chasse .edition-panel-chasse,
-body.edition-active-enigme .edition-panel-enigme {
+body.edition-active-enigme .edition-panel-enigme,
+body.edition-active-indice .edition-panel-indice {
   height: 90vh;
   max-height: 90vh;
   opacity: 1;
@@ -746,7 +747,8 @@ body.edition-active-enigme .edition-panel-enigme {
 
 body.edition-active .panneau-organisateur.edition-panel-modal,
 body.edition-active-chasse .edition-panel-chasse.edition-panel-modal,
-body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
+body.edition-active-enigme .edition-panel-enigme.edition-panel-modal,
+body.edition-active-indice .edition-panel-indice.edition-panel-modal {
   position: fixed;
   top: 50%;
   left: 50%;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2393,7 +2393,8 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 body.edition-active .panneau-organisateur,
 body.edition-active-chasse .edition-panel-chasse,
-body.edition-active-enigme .edition-panel-enigme {
+body.edition-active-enigme .edition-panel-enigme,
+body.edition-active-indice .edition-panel-indice {
   height: 90vh;
   max-height: 90vh;
   opacity: 1;
@@ -2409,7 +2410,8 @@ body.edition-active-enigme .edition-panel-enigme {
 
 body.edition-active .panneau-organisateur.edition-panel-modal,
 body.edition-active-chasse .edition-panel-chasse.edition-panel-modal,
-body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
+body.edition-active-enigme .edition-panel-enigme.edition-panel-modal,
+body.edition-active-indice .edition-panel-indice.edition-panel-modal {
   position: fixed;
   top: 50%;
   left: 50%;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -25,7 +25,7 @@ function enqueue_script_indice_edit(): void
         return;
     }
 
-    enqueue_core_edit_scripts(['organisateur-edit']);
+    enqueue_core_edit_scripts(['organisateur-edit', 'indice-edit']);
     wp_enqueue_media();
 }
 add_action('wp_enqueue_scripts', 'enqueue_script_indice_edit');

--- a/wp-content/themes/chassesautresor/single-indice.php
+++ b/wp-content/themes/chassesautresor/single-indice.php
@@ -6,8 +6,9 @@
 
 defined('ABSPATH') || exit;
 
-$indice_id = get_the_ID();
+$indice_id      = get_the_ID();
 $edition_active = utilisateur_peut_modifier_post($indice_id);
+$contenu        = get_field('indice_contenu', $indice_id);
 
 if ($edition_active) {
     acf_form_head();
@@ -18,6 +19,21 @@ get_header();
 
 <div id="primary" class="content-area">
     <main id="main" class="site-main">
+        <?php if ($edition_active) : ?>
+            <button id="toggle-mode-edition-indice" type="button" class="toggle-mode-edition-indice">
+                <?= esc_html__('Paramètres', 'chassesautresor-com'); ?>
+            </button>
+        <?php endif; ?>
+
+        <article class="indice">
+            <h1><?= esc_html(get_the_title($indice_id)); ?></h1>
+            <?php if (!empty($contenu)) : ?>
+                <div class="indice-contenu">
+                    <?= apply_filters('the_content', $contenu); ?>
+                </div>
+            <?php endif; ?>
+        </article>
+
         <?php
         get_template_part('template-parts/indice/indice-edition-main', null, [
             'indice_id' => $indice_id,


### PR DESCRIPTION
## Résumé
- affiche le titre et le contenu d’un indice avec un bouton d’ouverture du panneau d’édition
- ajoute le script et les styles nécessaires pour activer le mode édition d’un indice
- enfile le script `indice-edit.js` lors du chargement d’une page indice

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87008eec08332a2ea32dc803a4f76