### PR TITLE
Gérer l’erreur de création d’indice avec redirection

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -171,7 +171,11 @@ function creer_indice_et_rediriger_si_appel(): void
 
     $indice_id = creer_indice_pour_objet($cible_id, $cible_type);
     if (is_wp_error($indice_id)) {
-        wp_die($indice_id->get_error_message(), 'Erreur', ['response' => 400]);
+        $error_message = sanitize_text_field($indice_id->get_error_message());
+        $referer       = wp_get_referer() ?: get_permalink($cible_id);
+        $redirect_url  = add_query_arg('erreur', $error_message, $referer);
+        wp_safe_redirect($redirect_url);
+        exit;
     }
 
     $preview_url = add_query_arg('edition', 'open', get_preview_post_link($indice_id));

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -160,11 +160,18 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     }
     ?>
 
-    <?php if (!empty($_GET['erreur']) && $_GET['erreur'] === 'points_insuffisants') : ?>
-      <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
-        ❌ Vous n’avez pas assez de points pour engager cette énigme.
-        <a href="<?= esc_url(home_url('/boutique')); ?>">Accéder à la boutique</a>
-      </div>
+    <?php if (!empty($_GET['erreur'])) : ?>
+        <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
+        <?php if ($error_message === 'points_insuffisants') : ?>
+            <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+                ❌ <?= esc_html__('Vous n’avez pas assez de points pour engager cette énigme.', 'chassesautresor-com'); ?>
+                <a href="<?= esc_url(home_url('/boutique')); ?>"><?= esc_html__('Accéder à la boutique', 'chassesautresor-com'); ?></a>
+            </div>
+        <?php else : ?>
+            <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+                <?= esc_html($error_message); ?>
+            </div>
+        <?php endif; ?>
     <?php endif; ?>
 
     <!-- 📦 Fiche complète (images + méta + actions) -->

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -36,28 +36,35 @@ if (is_singular('enigme')) {
 <div id="primary" class="content-area">
     <main id="main" class="site-main single-enigme-main statut-<?= esc_attr($statut_enigme); ?>">
 
-      <?php if (enigme_est_visible_pour($user_id, $enigme_id)) : ?>
-        <section class="enigme-wrapper">
-          <!-- 🧩 Affichage de l'énigme -->
-          <?php afficher_enigme_stylisee($enigme_id, $statut_data); ?>
-        </section>
-      <?php endif; ?>
+        <?php if (!empty($_GET['erreur'])) : ?>
+            <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
+            <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+                <?= esc_html($error_message); ?>
+            </div>
+        <?php endif; ?>
 
-      <!-- 🛠 Panneau principal d’édition -->
-      <?php get_template_part('template-parts/enigme/enigme-edition-main', null, [
-        'enigme_id' => $enigme_id,
-        'user_id'   => $user_id,
-      ]); ?>
+        <?php if (enigme_est_visible_pour($user_id, $enigme_id)) : ?>
+            <section class="enigme-wrapper">
+                <!-- 🧩 Affichage de l'énigme -->
+                <?php afficher_enigme_stylisee($enigme_id, $statut_data); ?>
+            </section>
+        <?php endif; ?>
 
-      <?php if ($edition_active) : ?>
-        <!-- ✏️ Panneaux complémentaires -->
-        <?php
-        get_template_part('template-parts/enigme/panneaux/enigme-edition-description', null, ['enigme_id' => $enigme_id]);
-        get_template_part('template-parts/enigme/panneaux/enigme-edition-images', null, ['enigme_id' => $enigme_id]);
-        get_template_part('template-parts/enigme/panneaux/enigme-edition-variantes', null, ['enigme_id' => $enigme_id]);
-        get_template_part('template-parts/enigme/panneaux/enigme-edition-solution', null, ['enigme_id' => $enigme_id]);
-        ?>
-      <?php endif; ?>
+        <!-- 🛠 Panneau principal d’édition -->
+        <?php get_template_part('template-parts/enigme/enigme-edition-main', null, [
+            'enigme_id' => $enigme_id,
+            'user_id'   => $user_id,
+        ]); ?>
+
+        <?php if ($edition_active) : ?>
+            <!-- ✏️ Panneaux complémentaires -->
+            <?php
+            get_template_part('template-parts/enigme/panneaux/enigme-edition-description', null, ['enigme_id' => $enigme_id]);
+            get_template_part('template-parts/enigme/panneaux/enigme-edition-images', null, ['enigme_id' => $enigme_id]);
+            get_template_part('template-parts/enigme/panneaux/enigme-edition-variantes', null, ['enigme_id' => $enigme_id]);
+            get_template_part('template-parts/enigme/panneaux/enigme-edition-solution', null, ['enigme_id' => $enigme_id]);
+            ?>
+        <?php endif; ?>
 
     </main>
   </div>


### PR DESCRIPTION
## Résumé
- gère les erreurs de création d’indice en redirigeant avec un message localisé
- affiche ce message sur les pages chasse et énigme

## Détails
- interception des `WP_Error` lors de la création d’un indice et redirection vers la page précédente
- ajout d’un bloc d’affichage d’erreur générique sur les vues chasse et énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a873cc0fa08332b9608f1d9e32e95a