### PR TITLE
Remplacer l'organisateur lié par la chasse liée pour les indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Un endpoint dédié permet de créer rapidement un indice :
 
 - **URL :** `/creer-indice/`
 - **Paramètres :** `chasse_id`, `enigme_id` (optionnel) et `nonce`.
-- **Champs ACF initialisés :** `indice_cible`, `indice_cible_objet`, `indice_organisateur_linked`, `indice_disponibilite`, `indice_date_disponibilite`, `indice_cout_points` et `indice_cache_complet`.
+- **Champs ACF initialisés :** `indice_cible`, `indice_cible_objet`, `indice_chasse_linked`, `indice_disponibilite`, `indice_date_disponibilite`, `indice_cout_points` et `indice_cache_complet`.
 - **Comportement :** après création, l’utilisateur est redirigé vers l’indice et le panneau d’édition s’ouvre automatiquement.

--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -24,9 +24,6 @@ namespace {
         function utilisateur_peut_modifier_post($id) { global $can_edit; return $can_edit; }
     }
 
-    if (!function_exists('get_organisateur_from_chasse')) {
-        function get_organisateur_from_chasse($chasse_id) { return 7; }
-    }
 
     if (!function_exists('wp_insert_post')) {
         function wp_insert_post($args) { return 123; }
@@ -105,7 +102,7 @@ class CreerIndicePermissionsTest extends TestCase
         $this->assertSame(123, $result);
         $this->assertSame('chasse', $updated_fields['indice_cible']);
         $this->assertSame(42, $updated_fields['indice_cible_objet']);
-        $this->assertSame(10, $updated_fields['indice_organisateur_linked']);
+        $this->assertSame(42, $updated_fields['indice_chasse_linked']);
         $expected_date = wp_date('Y-m-d H:i:s', (int) current_time('timestamp') + DAY_IN_SECONDS);
         $this->assertSame($expected_date, $updated_fields['indice_date_disponibilite']);
         $this->assertArrayNotHasKey('indice_cache_etat_systeme', $updated_fields);

--- a/tests/IndiceChasseAutoFillTest.php
+++ b/tests/IndiceChasseAutoFillTest.php
@@ -18,19 +18,16 @@ namespace {
         function update_field($field, $value, $post_id) {
             global $updated_fields; $updated_fields[$field] = $value; }
     }
-    if (!function_exists('get_organisateur_from_chasse')) {
-        function get_organisateur_from_chasse($chasse_id) { return 10; }
-    }
     if (!function_exists('recuperer_id_chasse_associee')) {
         function recuperer_id_chasse_associee($id) { return 99; }
     }
     require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
 }
 
-namespace IndiceOrganisateur {
+namespace IndiceChasse {
     use PHPUnit\Framework\TestCase;
 
-    class IndiceOrganisateurAutoFillTest extends TestCase
+    class IndiceChasseAutoFillTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -44,16 +41,16 @@ namespace IndiceOrganisateur {
          * @runInSeparateProcess
          * @preserveGlobalState disabled
          */
-        public function test_sets_organisateur_on_save(): void
+        public function test_sets_chasse_on_save(): void
         {
             global $fields, $updated_fields;
             $fields = [
-                'indice_organisateur_linked' => null,
+                'indice_chasse_linked' => null,
                 'indice_cible' => 'chasse',
                 'indice_cible_objet' => 42,
             ];
-            \sauvegarder_indice_organisateur_si_manquant(123);
-            $this->assertSame(10, $updated_fields['indice_organisateur_linked']);
+            \sauvegarder_indice_chasse_si_manquant(123);
+            $this->assertSame(42, $updated_fields['indice_chasse_linked']);
         }
     }
 }

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -350,12 +350,12 @@ function utilisateur_peut_modifier_post($post_id)
             return $organisateur_id ? utilisateur_peut_modifier_post($organisateur_id) : false;
 
         case 'indice':
-            $organisateur_id = get_field('indice_organisateur_linked', $post_id);
-            if (is_array($organisateur_id)) {
-                $organisateur_id = $organisateur_id['ID'] ?? $organisateur_id[0] ?? null;
+            $chasse_id = get_field('indice_chasse_linked', $post_id);
+            if (is_array($chasse_id)) {
+                $chasse_id = $chasse_id['ID'] ?? $chasse_id[0] ?? null;
             }
 
-            if (!$organisateur_id) {
+            if (!$chasse_id) {
                 $cible = get_field('indice_cible_objet', $post_id);
                 if (is_array($cible)) {
                     $first    = $cible[0] ?? null;
@@ -367,15 +367,14 @@ function utilisateur_peut_modifier_post($post_id)
                 if ($cible_id) {
                     $cible_type = get_post_type($cible_id);
                     if ($cible_type === 'chasse') {
-                        $organisateur_id = get_organisateur_from_chasse($cible_id);
+                        $chasse_id = $cible_id;
                     } elseif ($cible_type === 'enigme') {
-                        $chasse_id       = recuperer_id_chasse_associee($cible_id);
-                        $organisateur_id = $chasse_id ? get_organisateur_from_chasse($chasse_id) : null;
+                        $chasse_id = recuperer_id_chasse_associee($cible_id);
                     }
                 }
             }
 
-            return $organisateur_id ? utilisateur_peut_modifier_post($organisateur_id) : false;
+            return $chasse_id ? utilisateur_peut_modifier_post($chasse_id) : false;
 
         default:
             cat_debug("❌ utilisateur_peut_modifier_post: post_type inconnu ($post_type)");

--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -483,9 +483,9 @@ Label : cible
 Instructions : (vide)
 Requis : non
 ----------------------------------------
-— indice_organisateur_linked —
+— indice_chasse_linked —
 Type : relationship
-Label : organisateur lié
+Label : chasse liée
 Instructions : (vide)
 Requis : non
 ----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -416,7 +416,7 @@ Groupe : paramètres indices
 * indice_contenu (wysiwyg)
 * indice_cible (radio)
 * indice_cible_objet (relationship)
-* indice_organisateur_linked (relationship)
+* indice_chasse_linked (relationship)
 * indice_disponibilite (radio)
 * indice_date_disponibilite (date_time_picker, retour d/m/Y g:i a)
 * indice_cout_points (number)


### PR DESCRIPTION
## Résumé
- Migration du champ ACF `indice_organisateur_linked` vers `indice_chasse_linked`
- Mise à jour des contrôles et du pré-remplissage des indices
- Actualisation de la documentation et des tests

## Changelog
- 🗃️ Conversion du champ lié aux indices pour stocker la chasse associée
- 🔒 Ajustement des permissions en fonction de la chasse liée
- 📝 MAJ des notices, README et scénarios de tests

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a885a1248c833289ebc157e94d5d91