### PR TITLE
Ajout du panneau d’édition pour les indices

### DIFF
--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -105,7 +105,7 @@ class CreerIndicePermissionsTest extends TestCase
         $this->assertSame(42, $updated_fields['indice_chasse_linked']);
         $expected_date = wp_date('Y-m-d H:i:s', (int) current_time('timestamp') + DAY_IN_SECONDS);
         $this->assertSame($expected_date, $updated_fields['indice_date_disponibilite']);
-        $this->assertArrayNotHasKey('indice_cache_etat_systeme', $updated_fields);
+        $this->assertSame('desactive', $updated_fields['indice_cache_etat_systeme']);
         $this->assertFalse($updated_fields['indice_cache_complet']);
         $titre_objet = get_the_title(42);
         $this->assertSame("Indice #123 - {$titre_objet}", $updated_post['post_title']);

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -12,7 +12,8 @@ function modifierChampSimple(champ, valeur, postId, cpt = 'enigme') {
 
   const action = (cpt === 'enigme') ? 'modifier_champ_enigme' :
     (cpt === 'organisateur') ? 'modifier_champ_organisateur' :
-      'modifier_champ_chasse';
+      (cpt === 'indice') ? 'modifier_champ_indice' :
+        'modifier_champ_chasse';
 
   return fetch(ajaxurl, {
     method: 'POST',
@@ -66,7 +67,8 @@ function initChampTexte(bloc) {
 
   const action = (cpt === 'chasse') ? 'modifier_champ_chasse'
     : (cpt === 'enigme') ? 'modifier_champ_enigme'
-      : 'modifier_champ_organisateur';
+      : (cpt === 'indice') ? 'modifier_champ_indice'
+        : 'modifier_champ_organisateur';
 
   if (!champ || !cpt || !postId || !input) return;
 

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -59,7 +59,8 @@ function initChampImage(bloc) {
         body: new URLSearchParams({
           action: (cpt === 'chasse') ? 'modifier_champ_chasse' :
             (cpt === 'enigme') ? 'modifier_champ_enigme' :
-              'modifier_champ_organisateur',
+              (cpt === 'indice') ? 'modifier_champ_indice' :
+                'modifier_champ_organisateur',
           champ,
           valeur: id,
           post_id: postId

--- a/wp-content/themes/chassesautresor/assets/js/indice-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/indice-edit.js
@@ -34,6 +34,58 @@ function initIndiceEdit() {
     boutonsToggle[0].click();
     DEBUG && console.log('🔧 Ouverture auto du panneau édition indice via ?edition=open');
   }
+
+  // ==============================
+  // 🟢 Initialisation des champs
+  // ==============================
+  document.querySelectorAll('.champ-indice[data-champ]').forEach((bloc) => {
+    if (bloc.classList.contains('champ-img')) {
+      if (typeof initChampImage === 'function') initChampImage(bloc);
+    } else {
+      if (typeof initChampTexte === 'function') initChampTexte(bloc);
+    }
+  });
+
+  initChampConditionnel('acf[indice_cible]', {
+    chasse: [],
+    enigme: ['#champ-indice-cible-enigmes']
+  });
+  initChampRadioAjax('acf[indice_cible]', 'indice');
+
+  initChampConditionnel('acf[indice_disponibilite]', {
+    immediate: [],
+    differe: ['#champ-indice-date']
+  });
+  initChampRadioAjax('acf[indice_disponibilite]', 'indice');
+
+  document
+    .querySelectorAll('#champ-indice-cible-enigmes input[type="checkbox"]')
+    .forEach((checkbox) => {
+      checkbox.addEventListener('change', () => {
+        const bloc = document.getElementById('champ-indice-cible-enigmes');
+        const champ = bloc.dataset.champ;
+        const postId = bloc.dataset.postId;
+        const valeurs = [...bloc.querySelectorAll('input[type="checkbox"]')]
+          .filter((el) => el.checked)
+          .map((el) => el.value);
+        modifierChampSimple(champ, valeurs, postId, 'indice');
+      });
+    });
+
+  document
+    .querySelectorAll('input[name="acf[indice_cible]"]')
+    .forEach((radio) => {
+      radio.addEventListener('change', () => {
+        if (radio.value === 'chasse') {
+          const bloc = document.getElementById('champ-indice-cible-enigmes');
+          const chasseId = bloc?.dataset.chasseId;
+          const postId = bloc?.dataset.postId;
+          if (chasseId && postId) {
+            modifierChampSimple('indice_cible_objet', [chasseId], postId, 'indice');
+          }
+        }
+      });
+    });
 }
 
 document.addEventListener('DOMContentLoaded', initIndiceEdit);

--- a/wp-content/themes/chassesautresor/assets/js/indice-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/indice-edit.js
@@ -86,6 +86,24 @@ function initIndiceEdit() {
         }
       });
     });
+
+  // ==============================
+  // 📜 Panneau description (wysiwyg)
+  // ==============================
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.ouvrir-panneau-description');
+    if (!btn || btn.dataset.cpt !== 'indice') return;
+    if (typeof window.openPanel === 'function') {
+      window.openPanel('panneau-description-indice');
+    }
+  });
+  document
+    .querySelector('#panneau-description-indice .panneau-fermer')
+    ?.addEventListener('click', () => {
+      if (typeof window.closePanel === 'function') {
+        window.closePanel('panneau-description-indice');
+      }
+    });
 }
 
 document.addEventListener('DOMContentLoaded', initIndiceEdit);

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -765,10 +765,10 @@ function utilisateur_peut_editer_champs(int $post_id): bool
                 && $etat === 'bloquee_chasse';
 
         case 'indice':
-            $etat = get_field('indice_cache_etat_systeme', $post_id);
+            $etat = get_field('indice_cache_etat_systeme', $post_id) ?: '';
 
             return $status === 'pending'
-                && $etat === 'desactive';
+                && ($etat === 'desactive' || $etat === '');
     }
 
     return false;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -95,6 +95,7 @@ function creer_indice_pour_objet(int $objet_id, string $objet_type, ?int $user_i
 
     update_field('indice_cout_points', 0, $indice_id);
     update_field('indice_cache_complet', false, $indice_id);
+    update_field('indice_cache_etat_systeme', 'desactive', $indice_id);
 
     return $indice_id;
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -8,6 +8,7 @@ defined('ABSPATH') || exit;
 // 🔹 register_endpoint_creer_indice() → Enregistre /creer-indice
 // 🔹 creer_indice_pour_objet() → Crée un indice lié à une chasse ou une énigme
 // 🔹 creer_indice_et_rediriger_si_appel() → Crée un indice et redirige
+// 🔹 modifier_champ_indice() → Mise à jour AJAX (champ ACF ou natif)
 
 /**
  * Charge les scripts nécessaires à l’édition d’un indice.
@@ -235,6 +236,82 @@ function ajax_chasse_lister_indices(): void
     wp_send_json_success(['html' => $html]);
 }
 add_action('wp_ajax_chasse_lister_indices', 'ajax_chasse_lister_indices');
+
+/**
+ * Gère l’enregistrement AJAX des champs ACF ou natifs du CPT indice.
+ *
+ * @hook wp_ajax_modifier_champ_indice
+ * @return void
+ */
+function modifier_champ_indice(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $champ   = sanitize_text_field($_POST['champ'] ?? '');
+    $valeur  = $_POST['valeur'] ?? '';
+    $post_id = isset($_POST['post_id']) ? (int) $_POST['post_id'] : 0;
+
+    if (!$champ || !$post_id || get_post_type($post_id) !== 'indice') {
+        wp_send_json_error('⚠️ donnees_invalides');
+    }
+
+    if (!utilisateur_peut_modifier_post($post_id) || !utilisateur_peut_editer_champs($post_id)) {
+        wp_send_json_error('⚠️ acces_refuse');
+    }
+
+    $champ_valide = false;
+    $reponse      = ['champ' => $champ, 'valeur' => $valeur];
+
+    if ($champ === 'post_title') {
+        $ok = wp_update_post(['ID' => $post_id, 'post_title' => sanitize_text_field($valeur)], true);
+        if (is_wp_error($ok)) {
+            wp_send_json_error('⚠️ echec_update_post_title');
+        }
+        wp_send_json_success($reponse);
+    }
+
+    switch ($champ) {
+        case 'indice_image':
+            $champ_valide = update_field('indice_image', (int) $valeur, $post_id) !== false;
+            break;
+        case 'indice_contenu':
+            $champ_valide = update_field('indice_contenu', wp_kses_post($valeur), $post_id) !== false;
+            break;
+        case 'indice_cible':
+            $val = $valeur === 'enigme' ? 'enigme' : 'chasse';
+            $champ_valide = update_field('indice_cible', $val, $post_id) !== false;
+            break;
+        case 'indice_cible_objet':
+            $ids = array_filter(array_map('intval', explode(',', (string) $valeur)));
+            $champ_valide = update_field('indice_cible_objet', $ids, $post_id) !== false;
+            break;
+        case 'indice_disponibilite':
+            $val = $valeur === 'differe' ? 'differe' : 'immediate';
+            $champ_valide = update_field('indice_disponibilite', $val, $post_id) !== false;
+            break;
+        case 'indice_date_disponibilite':
+            $dt = convertir_en_datetime(sanitize_text_field($valeur), ['Y-m-d\TH:i', 'Y-m-d H:i:s', 'Y-m-d H:i']);
+            if (!$dt) {
+                wp_send_json_error('⚠️ format_date_invalide');
+            }
+            $champ_valide = update_field('indice_date_disponibilite', $dt->format('Y-m-d H:i:s'), $post_id) !== false;
+            break;
+        case 'indice_cout_points':
+            $champ_valide = update_field('indice_cout_points', (int) $valeur, $post_id) !== false;
+            break;
+        default:
+            wp_send_json_error('⚠️ champ_inconnu');
+    }
+
+    if ($champ_valide) {
+        wp_send_json_success($reponse);
+    }
+
+    wp_send_json_error('⚠️ echec_mise_a_jour');
+}
+add_action('wp_ajax_modifier_champ_indice', 'modifier_champ_indice');
 
 /**
  * Pré-remplit automatiquement la chasse liée d'un indice lors de sa création.

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1736,3 +1736,47 @@ msgstr "Clue edit panel"
 #: template-parts/indice/indice-edition-main.php:33
 msgid "Contenu d'édition à venir..."
 msgstr "Editing content coming soon..."
+
+#: template-parts/indice/indice-edition-main.php:104
+msgid "Image"
+msgstr "Image"
+
+#: template-parts/indice/indice-edition-main.php:123
+msgid "Texte"
+msgstr "Text"
+
+#: template-parts/indice/indice-edition-main.php:134
+msgid "Aide pour"
+msgstr "Help for"
+
+#: template-parts/indice/indice-edition-main.php:136
+msgid "Chasse"
+msgstr "Hunt"
+
+#: template-parts/indice/indice-edition-main.php:141
+msgid "Aucune énigme disponible."
+msgstr "No puzzle available."
+
+#: template-parts/indice/indice-edition-main.php:167
+msgid "Publication"
+msgstr "Publishing"
+
+#: template-parts/indice/indice-edition-main.php:169
+msgid "Immédiate"
+msgstr "Immediate"
+
+#: template-parts/indice/indice-edition-main.php:170
+msgid "Différée"
+msgstr "Delayed"
+
+#: template-parts/indice/indice-edition-main.php:181
+msgid "(points)"
+msgstr "(points)"
+
+#: template-parts/indice/indice-edition-main.php:94
+msgid "renseigner le titre de l’indice"
+msgstr "enter the clue title"
+
+#: template-parts/indice/indice-edition-main.php:124
+msgid "renseigner le texte de l’indice"
+msgstr "enter the clue text"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1780,3 +1780,11 @@ msgstr "enter the clue title"
 #: template-parts/indice/indice-edition-main.php:124
 msgid "renseigner le texte de l’indice"
 msgstr "enter the clue text"
+
+#: template-parts/indice/panneaux/indice-edition-description.php:17
+msgid "Modifier le texte de l’indice"
+msgstr "Edit the clue text"
+
+#: template-parts/indice/panneaux/indice-edition-description.php:28
+msgid "Texte de l’indice mis à jour."
+msgstr "Clue text updated."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1224,3 +1224,11 @@ msgstr "renseigner le titre de l’indice"
 #: template-parts/indice/indice-edition-main.php:124
 msgid "renseigner le texte de l’indice"
 msgstr "renseigner le texte de l’indice"
+
+#: template-parts/indice/panneaux/indice-edition-description.php:17
+msgid "Modifier le texte de l’indice"
+msgstr "Modifier le texte de l’indice"
+
+#: template-parts/indice/panneaux/indice-edition-description.php:28
+msgid "Texte de l’indice mis à jour."
+msgstr "Texte de l’indice mis à jour."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1180,3 +1180,47 @@ msgstr "Panneau d'édition indice"
 #: template-parts/indice/indice-edition-main.php:33
 msgid "Contenu d'édition à venir..."
 msgstr "Contenu d'édition à venir..."
+
+#: template-parts/indice/indice-edition-main.php:104
+msgid "Image"
+msgstr "Image"
+
+#: template-parts/indice/indice-edition-main.php:123
+msgid "Texte"
+msgstr "Texte"
+
+#: template-parts/indice/indice-edition-main.php:134
+msgid "Aide pour"
+msgstr "Aide pour"
+
+#: template-parts/indice/indice-edition-main.php:136
+msgid "Chasse"
+msgstr "Chasse"
+
+#: template-parts/indice/indice-edition-main.php:141
+msgid "Aucune énigme disponible."
+msgstr "Aucune énigme disponible."
+
+#: template-parts/indice/indice-edition-main.php:167
+msgid "Publication"
+msgstr "Publication"
+
+#: template-parts/indice/indice-edition-main.php:169
+msgid "Immédiate"
+msgstr "Immédiate"
+
+#: template-parts/indice/indice-edition-main.php:170
+msgid "Différée"
+msgstr "Différée"
+
+#: template-parts/indice/indice-edition-main.php:181
+msgid "(points)"
+msgstr "(points)"
+
+#: template-parts/indice/indice-edition-main.php:94
+msgid "renseigner le titre de l’indice"
+msgstr "renseigner le titre de l’indice"
+
+#: template-parts/indice/indice-edition-main.php:124
+msgid "renseigner le texte de l’indice"
+msgstr "renseigner le texte de l’indice"

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
@@ -119,10 +119,26 @@ $selection = array_map('intval', $cible_objet);
                                     <div class="champ-feedback"></div>
                                 </li>
 
-                                <li class="champ-indice champ-texte <?= empty($texte) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_contenu" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                <li class="champ-indice champ-description <?= empty($texte) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_modifier ? '' : ' champ-desactive'; ?>" data-champ="indice_contenu" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
                                     <label><?= esc_html__('Texte', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
-                                    <textarea class="champ-input champ-texte-edit" maxlength="1000" placeholder="<?= esc_attr__('renseigner le texte de l’indice', 'chassesautresor-com'); ?>"><?= esc_textarea($texte); ?></textarea>
-                                    <div class="champ-feedback"></div>
+                                    <div class="champ-texte">
+                                        <?php if (empty(trim($texte))) : ?>
+                                            <?php if ($peut_modifier) : ?>
+                                                <a href="#" class="champ-ajouter ouvrir-panneau-description" data-cpt="indice" data-champ="indice_contenu" data-post-id="<?= esc_attr($indice_id); ?>">
+                                                    <?= esc_html__('ajouter', 'chassesautresor-com'); ?>
+                                                </a>
+                                            <?php endif; ?>
+                                        <?php else : ?>
+                                            <span class="champ-texte-contenu">
+                                                <?= esc_html(wp_trim_words(wp_strip_all_tags($texte), 25)); ?>
+                                                <?php if ($peut_modifier) : ?>
+                                                    <button type="button" class="champ-modifier ouvrir-panneau-description" data-cpt="indice" data-champ="indice_contenu" data-post-id="<?= esc_attr($indice_id); ?>" aria-label="<?= esc_attr__('Modifier le texte de l’indice', 'chassesautresor-com'); ?>">
+                                                        <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                                    </button>
+                                                <?php endif; ?>
+                                            </span>
+                                        <?php endif; ?>
+                                    </div>
                                 </li>
                             </ul>
                         </div>
@@ -195,3 +211,10 @@ $selection = array_map('intval', $cible_objet);
         </div>
     </div>
 </section>
+
+<?php
+// 📎 Panneau latéral d'édition du texte
+get_template_part('template-parts/indice/panneaux/indice-edition-description', null, [
+    'indice_id' => $indice_id,
+]);
+?>

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
@@ -16,20 +16,182 @@ if (!$peut_modifier) {
     return;
 }
 
-$titre = get_the_title($indice_id);
+$titre          = get_the_title($indice_id);
+$image_id       = get_field('indice_image', $indice_id);
+$image_url      = $image_id ? wp_get_attachment_image_url($image_id, 'thumbnail') : '';
+$texte          = get_field('indice_contenu', $indice_id);
+$cible          = get_field('indice_cible', $indice_id) ?: 'chasse';
+$cible_objet    = (array) get_field('indice_cible_objet', $indice_id, false);
+$chasse_liee    = get_field('indice_chasse_linked', $indice_id, false);
+$disponibilite  = get_field('indice_disponibilite', $indice_id) ?: 'immediate';
+$date_dispo     = get_field('indice_date_disponibilite', $indice_id);
+$cout           = (int) get_field('indice_cout_points', $indice_id);
+
+$enigmes_eligibles = [];
+$enigmes_posts     = get_posts([
+    'post_type'      => 'enigme',
+    'posts_per_page' => -1,
+    'post_status'    => 'publish',
+    'orderby'        => 'title',
+    'order'          => 'ASC',
+]);
+foreach ($enigmes_posts as $enigma) {
+    $chasse = get_field('enigme_chasse_associee', $enigma->ID, false);
+    $chasse_id = is_object($chasse) ? $chasse->ID : (int) $chasse;
+    if ($chasse_id && get_post_status($chasse_id) === 'publish') {
+        $enigmes_eligibles[$enigma->ID] = get_the_title($enigma->ID);
+    }
+}
+$selection = array_map('intval', $cible_objet);
 ?>
 
 <section class="edition-panel edition-panel-indice edition-panel-modal" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
     <div class="edition-panel-header">
-        <h2>
-            <i class="fa-solid fa-gear"></i>
-            <?= esc_html__('Panneau d\'édition indice', 'chassesautresor-com'); ?> :
-            <span class="titre-objet" data-cpt="indice"><?= esc_html($titre); ?></span>
-        </h2>
-        <button type="button" class="panneau-fermer" aria-label="<?= esc_attr__('Fermer les paramètres', 'chassesautresor-com'); ?>">✖</button>
+        <div class="edition-panel-header-top">
+            <h2>
+                <i class="fa-solid fa-gear"></i>
+                <?= esc_html__("Panneau d'édition indice", 'chassesautresor-com'); ?> :
+                <span class="titre-objet" data-cpt="indice"><?= esc_html($titre); ?></span>
+            </h2>
+            <button type="button" class="panneau-fermer" aria-label="<?= esc_attr__('Fermer les paramètres', 'chassesautresor-com'); ?>">✖</button>
+        </div>
+        <div class="edition-tabs">
+            <button class="edition-tab active" data-target="indice-tab-param"><?= esc_html__('Paramètres', 'chassesautresor-com'); ?></button>
+        </div>
     </div>
 
-    <div class="edition-panel-body">
-        <p><?= esc_html__('Contenu d\'édition à venir...', 'chassesautresor-com'); ?></p>
+    <div id="indice-tab-param" class="edition-tab-content active">
+        <i class="fa-solid fa-sliders tab-watermark" aria-hidden="true"></i>
+        <div class="edition-panel-header">
+            <h2><i class="fa-solid fa-sliders"></i> <?= esc_html__('Paramètres', 'chassesautresor-com'); ?></h2>
+        </div>
+        <div class="edition-panel-body">
+            <div class="edition-panel-section edition-panel-section-ligne">
+                <div class="section-content">
+                    <div class="resume-blocs-grid">
+                        <div class="resume-bloc resume-obligatoire">
+                            <h3><?= esc_html__('Informations', 'chassesautresor-com'); ?></h3>
+                            <ul class="resume-infos">
+                                <?php
+                                get_template_part(
+                                    'template-parts/common/edition-row',
+                                    null,
+                                    [
+                                        'class' => 'champ-indice champ-titre ' . (empty($titre) ? 'champ-vide' : 'champ-rempli'),
+                                        'attributes' => [
+                                            'data-champ'   => 'post_title',
+                                            'data-cpt'     => 'indice',
+                                            'data-post-id' => $indice_id,
+                                            'data-no-edit' => '1',
+                                        ],
+                                        'label' => function () {
+                                            ?>
+                                            <label for="champ-titre-indice"><?= esc_html__('Titre', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
+                                            <?php
+                                        },
+                                        'content' => function () use ($titre) {
+                                            ?>
+                                            <input type="text" class="champ-input champ-texte-edit" maxlength="80" value="<?= esc_attr($titre); ?>" id="champ-titre-indice" placeholder="<?= esc_attr__('renseigner le titre de l’indice', 'chassesautresor-com'); ?>" />
+                                            <div class="champ-feedback"></div>
+                                            <?php
+                                        },
+                                    ]
+                                );
+                                ?>
+
+                                <li class="champ-indice champ-img <?= empty($image_id) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_image" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                    <div class="champ-affichage">
+                                        <label><?= esc_html__('Image', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
+                                        <?php if ($peut_modifier) : ?>
+                                            <button type="button" class="champ-modifier" data-champ="indice_image" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>" aria-label="<?= esc_attr__('Modifier l’image', 'chassesautresor-com'); ?>">
+                                                <img src="<?= esc_url($image_url ?: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='); ?>" alt="" />
+                                                <span class="champ-ajout-image"><?= esc_html__('ajouter une image', 'chassesautresor-com'); ?></span>
+                                            </button>
+                                        <?php else : ?>
+                                            <?php if ($image_url) : ?>
+                                                <img src="<?= esc_url($image_url); ?>" alt="" />
+                                            <?php else : ?>
+                                                <span class="champ-ajout-image"><?= esc_html__('ajouter une image', 'chassesautresor-com'); ?></span>
+                                            <?php endif; ?>
+                                        <?php endif; ?>
+                                    </div>
+                                    <input type="hidden" class="champ-input" value="<?= esc_attr($image_id ?? ''); ?>">
+                                    <div class="champ-feedback"></div>
+                                </li>
+
+                                <li class="champ-indice champ-texte <?= empty($texte) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_contenu" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                    <label><?= esc_html__('Texte', 'chassesautresor-com'); ?> <span class="champ-obligatoire">*</span></label>
+                                    <textarea class="champ-input champ-texte-edit" maxlength="1000" placeholder="<?= esc_attr__('renseigner le texte de l’indice', 'chassesautresor-com'); ?>"><?= esc_textarea($texte); ?></textarea>
+                                    <div class="champ-feedback"></div>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div class="resume-bloc resume-reglages">
+                            <h3><?= esc_html__('Réglages', 'chassesautresor-com'); ?></h3>
+                            <ul class="resume-infos">
+                                <li class="champ-indice champ-cible <?= ($cible === 'enigme' && empty($selection)) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_cible" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                    <label><?= esc_html__('Aide pour', 'chassesautresor-com'); ?></label>
+                                    <div class="champ-radio">
+                                        <label><input type="radio" name="acf[indice_cible]" value="chasse" <?= $cible === 'chasse' ? 'checked' : ''; ?>> <?= esc_html__('Chasse', 'chassesautresor-com'); ?></label>
+                                        <label><input type="radio" name="acf[indice_cible]" value="enigme" <?= $cible === 'enigme' ? 'checked' : ''; ?>> <?= esc_html__('Énigmes', 'chassesautresor-com'); ?></label>
+                                    </div>
+                                    <div id="champ-indice-cible-enigmes" class="champ-indice champ-pre-requis<?= $cible === 'enigme' ? '' : ' cache'; ?><?= empty($enigmes_eligibles) ? ' champ-vide' : ''; ?>" data-champ="indice_cible_objet" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>" data-no-edit="1" data-chasse-id="<?= esc_attr($chasse_liee); ?>">
+                                        <?php if (empty($enigmes_eligibles)) : ?>
+                                            <em><?= esc_html__('Aucune énigme disponible.', 'chassesautresor-com'); ?></em>
+                                        <?php else : ?>
+                                            <div class="liste-pre-requis">
+                                                <?php foreach ($enigmes_eligibles as $id => $titre_enigme) :
+                                                    $img = get_image_enigme($id, 'thumbnail');
+                                                    $checked = in_array($id, $selection, true);
+                                                    ?>
+                                                    <label class="prerequis-item">
+                                                        <input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?>>
+                                                        <span class="prerequis-mini">
+                                                            <?php if ($img) : ?>
+                                                                <img src="<?= esc_url($img); ?>" alt="" />
+                                                            <?php endif; ?>
+                                                            <span class="prerequis-titre"><?= esc_html($titre_enigme); ?></span>
+                                                            <span class="prerequis-check"><i class="fa-solid fa-check" aria-hidden="true"></i></span>
+                                                        </span>
+                                                    </label>
+                                                <?php endforeach; ?>
+                                            </div>
+                                        <?php endif; ?>
+                                        <div class="champ-feedback"></div>
+                                    </div>
+                                    <div class="champ-feedback"></div>
+                                </li>
+
+                                <li class="champ-indice champ-publication <?= ($disponibilite === 'differe' && empty($date_dispo)) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_disponibilite" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                    <label><?= esc_html__('Publication', 'chassesautresor-com'); ?></label>
+                                    <div class="champ-radio">
+                                        <label><input type="radio" name="acf[indice_disponibilite]" value="immediate" <?= $disponibilite === 'immediate' ? 'checked' : ''; ?>> <?= esc_html__('Immédiate', 'chassesautresor-com'); ?></label>
+                                        <label><input type="radio" name="acf[indice_disponibilite]" value="differe" <?= $disponibilite === 'differe' ? 'checked' : ''; ?>> <?= esc_html__('Différée', 'chassesautresor-com'); ?></label>
+                                    </div>
+                                    <div id="champ-indice-date" class="<?= $disponibilite === 'differe' ? '' : 'cache'; ?>" data-champ="indice_date_disponibilite" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>" data-date="<?= esc_attr($date_dispo ?: ''); ?>">
+                                        <input type="datetime-local" class="champ-input champ-date-edit" value="<?= esc_attr($date_dispo ?: ''); ?>">
+                                        <div class="champ-feedback"></div>
+                                    </div>
+                                    <div class="champ-feedback"></div>
+                                </li>
+
+                                <li class="champ-indice champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_cout_points" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                    <div class="champ-edition" style="display:flex;align-items:center;">
+                                        <label><?= esc_html__('Coût', 'chassesautresor-com'); ?> <span class="txt-small"><?= esc_html__('(points)', 'chassesautresor-com'); ?></span></label>
+                                        <input type="number" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" />
+                                        <div class="champ-option-gratuit" style="margin-left:15px;">
+                                            <input type="checkbox" <?= $cout === 0 ? 'checked' : ''; ?>>
+                                            <label><?= esc_html__('Gratuit', 'chassesautresor-com'); ?></label>
+                                        </div>
+                                    </div>
+                                    <div class="champ-feedback"></div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </section>

--- a/wp-content/themes/chassesautresor/template-parts/indice/panneaux/indice-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/panneaux/indice-edition-description.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Panneau latéral pour éditer le texte d'un indice (champ ACF wysiwyg)
+ * Requiert : $args['indice_id']
+ */
+
+defined('ABSPATH') || exit;
+
+$indice_id = $args['indice_id'] ?? null;
+if (!$indice_id || get_post_type($indice_id) !== 'indice') {
+    return;
+}
+?>
+
+<div id="panneau-description-indice" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
+    <div class="panneau-lateral__contenu">
+        <header class="panneau-lateral__header">
+            <h2><?php echo esc_html__( 'Modifier le texte de l’indice', 'chassesautresor-com' ); ?></h2>
+            <button type="button" class="panneau-fermer" aria-label="<?php echo esc_attr__( 'Fermer le panneau', 'chassesautresor-com' ); ?>">✖</button>
+        </header>
+        <?php
+        acf_form([
+            'post_id'            => $indice_id,
+            'fields'             => ['indice_contenu'],
+            'form'               => true,
+            'submit_value'       => __( '💾 Enregistrer', 'chassesautresor-com' ),
+            'html_submit_button' => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
+            'html_before_fields' => '<div class="champ-wrapper">',
+            'html_after_fields'  => '</div>',
+            'return'             => add_query_arg('panneau', 'description-indice', get_permalink()),
+            'updated_message'    => __( 'Texte de l’indice mis à jour.', 'chassesautresor-com' ),
+        ]);
+        ?>
+    </div>
+</div>


### PR DESCRIPTION
## Résumé
- implémente le panneau d’édition des indices avec onglet Paramètres
- permet la gestion des cibles, de la publication et du coût en points

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a8883bacf88332b0e755a5c2493238