### PR TITLE
Indice: remplace le bouton Paramètres par l'icône de bascule

### DIFF
--- a/wp-content/themes/chassesautresor/single-indice.php
+++ b/wp-content/themes/chassesautresor/single-indice.php
@@ -20,8 +20,13 @@ get_header();
 <div id="primary" class="content-area">
     <main id="main" class="site-main">
         <?php if ($edition_active) : ?>
-            <button id="toggle-mode-edition-indice" type="button" class="toggle-mode-edition-indice">
-                <?= esc_html__('Paramètres', 'chassesautresor-com'); ?>
+            <button
+                id="toggle-mode-edition-indice"
+                type="button"
+                class="toggle-mode-edition-indice bouton-edition-toggle btn-icon bouton-tertiaire"
+                aria-label="<?= esc_attr__('Paramètres', 'chassesautresor-com'); ?>"
+            >
+                <i class="fa-solid fa-gear"></i>
             </button>
         <?php endif; ?>
 


### PR DESCRIPTION
## Résumé
- Remplacement du bouton "Paramètres" par l'icône de bascule sur la page d'un indice.

## Changements notables
- Harmonisation du bouton d'ouverture du panneau d'édition avec les autres CPT.
- Utilisation des classes `bouton-edition-toggle`, `btn-icon` et `bouton-tertiaire` avec une icône engrenage.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a91a6a09708332b30bf484b03a5601