### PR TITLE
Harmoniser les onglets d’édition

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -93,8 +93,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
       <div class="edition-tabs">
         <button class="edition-tab active" data-target="enigme-tab-param"><?= esc_html__('Paramètres', 'chassesautresor-com'); ?></button>
         <button class="edition-tab" data-target="enigme-tab-stats"><?= esc_html__('Statistiques', 'chassesautresor-com'); ?></button>
+        <button class="edition-tab" data-target="enigme-tab-animation"><?= esc_html__('Animation', 'chassesautresor-com'); ?></button>
         <button class="edition-tab" data-target="enigme-tab-soumission"<?= $mode_validation === 'aucune' ? ' style="display:none;"' : ''; ?>><?= esc_html__('Tentatives', 'chassesautresor-com'); ?></button>
-        <button class="edition-tab" data-target="enigme-tab-solution"><?= esc_html__('Solution', 'chassesautresor-com'); ?></button>
       </div>
     </div>
 
@@ -649,10 +649,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
   </div>
 </div>
 
-<div id="enigme-tab-solution" class="edition-tab-content" style="display:none;">
-  <i class="fa-solid fa-key tab-watermark" aria-hidden="true"></i>
+<div id="enigme-tab-animation" class="edition-tab-content" style="display:none;">
+  <i class="fa-solid fa-bullhorn tab-watermark" aria-hidden="true"></i>
   <div class="edition-panel-header">
-    <h2><i class="fa-solid fa-key"></i> <?= esc_html__('Solution de cette énigme', 'chassesautresor-com'); ?></h2>
+    <h2><i class="fa-solid fa-bullhorn"></i> <?= esc_html__('Animation de cette énigme', 'chassesautresor-com'); ?></h2>
   </div>
 
             <?php
@@ -774,6 +774,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
         </div>
       </div>
     </div>
-    </div> <!-- #enigme-tab-solution -->
+    </div> <!-- #enigme-tab-animation -->
   </section>
 <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
@@ -57,6 +57,7 @@ $selection = array_map('intval', $cible_objet);
         </div>
         <div class="edition-tabs">
             <button class="edition-tab active" data-target="indice-tab-param"><?= esc_html__('Paramètres', 'chassesautresor-com'); ?></button>
+            <button class="edition-tab" data-target="indice-tab-stats"><?= esc_html__('Statistiques', 'chassesautresor-com'); ?></button>
         </div>
     </div>
 
@@ -208,6 +209,16 @@ $selection = array_map('intval', $cible_objet);
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <div id="indice-tab-stats" class="edition-tab-content" style="display:none;">
+        <i class="fa-solid fa-chart-column tab-watermark" aria-hidden="true"></i>
+        <div class="edition-panel-header">
+            <h2><i class="fa-solid fa-chart-column"></i> <?= esc_html__('Statistiques', 'chassesautresor-com'); ?></h2>
+        </div>
+        <div class="edition-panel-body">
+            <p><?= esc_html__('Statistiques à venir', 'chassesautresor-com'); ?></p>
         </div>
     </div>
 </section>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -74,8 +74,8 @@ $is_complete = (
       <div class="edition-tabs">
         <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
         <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
-        <button class="edition-tab" data-target="organisateur-tab-revenus">Points</button>
         <button class="edition-tab" data-target="organisateur-tab-animation">Animation</button>
+        <button class="edition-tab" data-target="organisateur-tab-revenus">Points</button>
       </div>
     </div>
 


### PR DESCRIPTION
## Résumé
- Harmonisation de l’ordre et des intitulés des onglets dans les panneaux d’édition.

## Changements notables
- Réorganisation des onglets pour les organisateurs.
- Remplacement de l’onglet *Solution* par *Animation* dans l’édition d’énigme.
- Ajout d’un onglet *Statistiques* pour les indices (placeholder).

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a91a068a0883329045a0400b19d020