### PR TITLE
chore(i18n): compléter les traductions des onglets récents

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-21T20:09:12+00:00\n"
+"POT-Creation-Date: 2025-08-23T01:54:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: chassesautresor-com\n"
@@ -18,14 +18,6 @@ msgstr ""
 #. Author of the theme
 #: style.css
 msgid "chassesautresor.com"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-sidebar-section.php:42
-msgid "Aucune énigme disponible"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
-msgid "Aucun gagnant pour le moment."
 msgstr ""
 
 #. Description of the theme
@@ -42,111 +34,225 @@ msgstr ""
 msgid "Accueil Plein Ecran"
 msgstr ""
 
-#: inc/admin-functions.php:39
+#: functions.php:102
+msgid "Français"
+msgstr ""
+
+#: functions.php:107
+msgid "English"
+msgstr ""
+
+#: functions.php:116
+msgid "Change language"
+msgstr ""
+
+#: inc/admin-functions.php:40
 msgid "⛔ Accès refusé."
 msgstr ""
 
-#: inc/admin-functions.php:46
+#: inc/admin-functions.php:47
 msgid "❌ Requête vide."
 msgstr ""
 
-#: inc/admin-functions.php:57
+#: inc/admin-functions.php:58
 msgid "❌ Aucun utilisateur trouvé."
 msgstr ""
 
-#: inc/admin-functions.php:84
-#: inc/admin-functions.php:388
-#: inc/admin-functions.php:577
+#: inc/admin-functions.php:85
+#: inc/admin-functions.php:389
+#: inc/admin-functions.php:578
 msgid "❌ Vérification du nonce échouée."
 msgstr ""
 
-#: inc/admin-functions.php:89
-#: inc/admin-functions.php:393
+#: inc/admin-functions.php:90
+#: inc/admin-functions.php:394
 msgid "❌ Accès refusé."
 msgstr ""
 
-#: inc/admin-functions.php:98
+#: inc/admin-functions.php:99
 msgid "❌ Données invalides."
 msgstr ""
 
-#: inc/admin-functions.php:104
+#: inc/admin-functions.php:105
 msgid "❌ Utilisateur introuvable."
 msgstr ""
 
-#: inc/admin-functions.php:116
+#: inc/admin-functions.php:117
 msgid "❌ Impossible de retirer plus de points que l’utilisateur en possède."
 msgstr ""
 
-#: inc/admin-functions.php:121
+#: inc/admin-functions.php:122
 msgid "❌ Action invalide."
 msgstr ""
 
-#: inc/admin-functions.php:180
+#: inc/admin-functions.php:181
 msgid "Permission refusée."
 msgstr ""
 
-#: inc/admin-functions.php:188
+#: inc/admin-functions.php:189
 msgid "Requête invalide."
 msgstr ""
 
-#: inc/admin-functions.php:230
+#: inc/admin-functions.php:231
 msgid "Action inconnue."
 msgstr ""
 
-#: inc/admin-functions.php:399
+#: inc/admin-functions.php:400
 msgid "❌ Veuillez entrer un taux de conversion valide."
 msgstr ""
 
-#: inc/admin-functions.php:465
+#: inc/admin-functions.php:466
 msgid "Régler"
 msgstr ""
 
-#: inc/admin-functions.php:466
-#: template-parts/chasse/chasse-edition-main.php:291
+#: inc/admin-functions.php:467
+#: template-parts/chasse/chasse-edition-main.php:309
 msgid "Annuler"
 msgstr ""
 
-#: inc/admin-functions.php:467
+#: inc/admin-functions.php:468
 msgid "Refuser"
 msgstr ""
 
-#: inc/admin-functions.php:582
+#: inc/admin-functions.php:583
 msgid "❌ Vous devez être connecté pour effectuer cette action."
 msgstr ""
 
 #. translators: %d: points minimum
-#: inc/admin-functions.php:597
+#: inc/admin-functions.php:598
 #, php-format
 msgid "❌ Le minimum pour une conversion est de %d points."
 msgstr ""
 
-#: inc/admin-functions.php:604
+#: inc/admin-functions.php:605
 msgid "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
 msgstr ""
 
-#: inc/admin-functions.php:894
+#: inc/admin-functions.php:895
 msgid "⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action."
 msgstr ""
 
-#: inc/admin-functions.php:901
+#: inc/admin-functions.php:902
 msgid "⛔ Erreur de sécurité. Veuillez réessayer."
 msgstr ""
 
-#: inc/admin-functions.php:1342
+#: inc/admin-functions.php:1343
+#: inc/admin-functions.php:1368
 msgid "Non autorisé"
 msgstr ""
 
-#: inc/admin-functions.php:1659
-#: template-parts/chasse/chasse-edition-main.php:448
+#: inc/admin-functions.php:1425
+msgid "Confirmez-vous la réinitialisation des statistiques ?"
+msgstr ""
+
+#: inc/admin-functions.php:1426
+msgid "Statistiques effacées."
+msgstr ""
+
+#: inc/admin-functions.php:1647
+#: templates/myaccount/content-organisateurs.php:21
+msgid "Aucun organisateur."
+msgstr ""
+
+#: inc/admin-functions.php:1676
+msgid "Organisateur"
+msgstr ""
+
+#: inc/admin-functions.php:1677
+#: template-parts/indice/indice-edition-main.php:153
+msgid "Chasse"
+msgstr ""
+
+#: inc/admin-functions.php:1678
+msgid "Nb énigmes"
+msgstr ""
+
+#: inc/admin-functions.php:1679
+msgid "État"
+msgstr ""
+
+#: inc/admin-functions.php:1680
+#: inc/organisateur-functions.php:437
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:26
+msgid "Utilisateur"
+msgstr ""
+
+#: inc/admin-functions.php:1681
+msgid "Créé le"
+msgstr ""
+
+#: inc/admin-functions.php:1701
+msgid "valide"
+msgstr ""
+
+#: inc/admin-functions.php:1704
+msgid "correction"
+msgstr ""
+
+#: inc/admin-functions.php:1707
+msgid "en attente"
+msgstr ""
+
+#: inc/admin-functions.php:1710
+msgid "création"
+msgstr ""
+
+#: inc/admin-functions.php:1714
+msgid "banni"
+msgstr ""
+
+#: inc/admin-functions.php:1730
+msgid "Demande de validation et tentatives manuelles en attente"
+msgstr ""
+
+#: inc/admin-functions.php:1732
+msgid "Demande de validation en attente"
+msgstr ""
+
+#: inc/admin-functions.php:1734
+msgid "Tentatives manuelles en attente de réponse"
+msgstr ""
+
+#: inc/admin-functions.php:1785
+#: template-parts/chasse/chasse-edition-main.php:469
 msgid "Accès refusé."
 msgstr ""
 
-#: inc/admin-functions.php:1666
+#: inc/admin-functions.php:1792
 msgid "ID de chasse invalide."
 msgstr ""
 
-#: inc/admin-functions.php:1670
+#: inc/admin-functions.php:1796
 msgid "Nonce invalide."
+msgstr ""
+
+#: inc/admin-functions.php:1849
+#, php-format
+msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
+msgstr ""
+
+#: inc/admin-functions.php:1886
+#, php-format
+msgid "Votre demande de validation pour la chasse « %s » nécessite des corrections."
+msgstr ""
+
+#: inc/admin-functions.php:1891
+#, php-format
+msgid "Message de l’administrateur : %s"
+msgstr ""
+
+#: inc/admin-functions.php:1895
+msgid "Une copie de ce message vous a été envoyée par email."
+msgstr ""
+
+#: inc/admin-functions.php:1918
+#, php-format
+msgid "Votre chasse « %s » a été bannie."
+msgstr ""
+
+#: inc/admin-functions.php:1940
+#, php-format
+msgid "Votre chasse « %s » a été supprimée."
 msgstr ""
 
 #: inc/chasse-functions.php:245
@@ -163,6 +269,8 @@ msgstr ""
 
 #: inc/chasse-functions.php:650
 #: inc/organisateur-functions.php:273
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/enigme/enigme-edition-main.php:387
 msgid "points"
 msgstr ""
 
@@ -176,23 +284,27 @@ msgstr ""
 msgid "Certaines énigmes doivent être complétées :"
 msgstr ""
 
-#: inc/edition/edition-chasse.php:106
+#: inc/edition/edition-chasse.php:48
+msgid "Erreur lors du chargement des indices."
+msgstr ""
+
+#: inc/edition/edition-chasse.php:115
 msgid "Aucun organisateur associé."
 msgstr ""
 
-#: inc/edition/edition-chasse.php:114
+#: inc/edition/edition-chasse.php:123
 msgid "Limite atteinte"
 msgstr ""
 
-#: inc/edition/edition-chasse.php:117
+#: inc/edition/edition-chasse.php:126
 msgid "Accès refusé"
 msgstr ""
 
-#: inc/edition/edition-chasse.php:127
+#: inc/edition/edition-chasse.php:136
 msgid "Une chasse est déjà en attente de validation."
 msgstr ""
 
-#: inc/edition/edition-chasse.php:140
+#: inc/edition/edition-chasse.php:149
 msgid "Erreur lors de la création de la chasse."
 msgstr ""
 
@@ -200,165 +312,419 @@ msgstr ""
 msgid "Chasse non spécifiée ou invalide."
 msgstr ""
 
-#: inc/enigme/affichage.php:132
-#: inc/enigme/affichage.php:147
+#: inc/edition/edition-indice.php:45
+msgid "Type de cible invalide."
+msgstr ""
+
+#: inc/edition/edition-indice.php:49
+msgid "ID cible invalide."
+msgstr ""
+
+#: inc/edition/edition-indice.php:53
+msgid "Utilisateur non connecté."
+msgstr ""
+
+#: inc/edition/edition-indice.php:57
+#: inc/edition/edition-indice.php:65
+msgid "Droits insuffisants."
+msgstr ""
+
+#: inc/edition/edition-indice.php:82
+#, php-format
+msgid "Indice #%d - %s"
+msgstr ""
+
+#: inc/edition/edition-indice.php:151
+msgid "Action non autorisée."
+msgstr ""
+
+#: inc/edition/edition-indice.php:167
+msgid "ID cible manquant."
+msgstr ""
+
+#: inc/enigme/affichage.php:159
+#: inc/enigme/affichage.php:204
 msgid "Vous"
 msgstr ""
 
-#: inc/enigme/affichage.php:133
-#: inc/enigme/affichage.php:148
+#: inc/enigme/affichage.php:160
+#: inc/enigme/affichage.php:208
 msgid "Moyenne"
 msgstr ""
 
-#: inc/enigme/affichage.php:200
+#: inc/enigme/affichage.php:275
+msgid "Nb joueurs :"
+msgstr ""
+
+#: inc/enigme/affichage.php:281
+msgid "Nb tentatives :"
+msgstr ""
+
+#: inc/enigme/affichage.php:335
 msgid "Progression"
 msgstr ""
 
-#: inc/enigme/affichage.php:263
+#: inc/enigme/affichage.php:339
+msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
+msgstr ""
+
+#: inc/enigme/affichage.php:346
+msgid "Définition de la progression"
+msgstr ""
+
+#: inc/enigme/affichage.php:395
 msgid "Résolution"
 msgstr ""
 
-#: inc/enigme/affichage.php:297
-msgid "Statistiques"
+#: inc/enigme/affichage.php:398
+msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse."
 msgstr ""
 
-#: inc/enigme/affichage.php:311
-msgid "Afficher les statistiques"
+#: inc/enigme/affichage.php:403
+msgid "Définition du taux de résolution"
 msgstr ""
 
-#: inc/enigme/affichage.php:317
-msgid "Activer Orgy"
-msgstr ""
-
-#: inc/enigme/affichage.php:325
-#: template-parts/chasse/partials/chasse-partial-participants.php:51
+#: inc/enigme/affichage.php:518
+#: inc/enigme/affichage.php:1037
+#: template-parts/chasse/partials/chasse-partial-participants.php:53
+#: template-parts/enigme/partials/enigme-sidebar-section.php:37
+#: template-parts/indice/indice-edition-main.php:154
 msgid "Énigmes"
 msgstr ""
 
-#: inc/enigme/affichage.php:317
-msgid "Progression"
+#: inc/enigme/affichage.php:546
+msgid "Afficher les statistiques"
 msgstr ""
 
-#: inc/enigme/affichage.php:416
-#: template-parts/chasse/chasse-edition-main.php:650
-#: template-parts/chasse/chasse-edition-main.php:662
+#: inc/enigme/affichage.php:649
+#: template-parts/chasse/chasse-edition-main.php:708
+#: template-parts/chasse/partials/chasse-partial-indices.php:32
 msgid "Indices"
 msgstr ""
 
-#: inc/enigme/affichage.php:447
+#: inc/enigme/affichage.php:677
+msgid "automatique"
+msgstr ""
+
+#: inc/enigme/affichage.php:678
+msgid "manuelle"
+msgstr ""
+
+#: inc/enigme/affichage.php:680
+#, php-format
+msgid "Mode de validation de l'énigme : %s"
+msgstr ""
+
+#: inc/enigme/affichage.php:712
+#, php-format
+msgid "Solde : %d pts"
+msgstr ""
+
+#: inc/enigme/affichage.php:721
+#, php-format
+msgid "Tentatives quotidiennes : %1$d/%2$s"
+msgstr ""
+
+#: inc/enigme/affichage.php:737
+#, php-format
+msgid "Coût par tentative : %d points."
+msgstr ""
+
+#: inc/enigme/affichage.php:741
+#: assets/js/reponse-automatique.js:76
+#: assets/js/reponse-automatique.js:98
+msgid "pts"
+msgstr ""
+
+#: inc/enigme/affichage.php:780
 msgid "Voir la solution"
 msgstr ""
 
-#: inc/enigme/cta.php:215
+#: inc/enigme/affichage.php:945
+#: inc/enigme/affichage.php:956
+#: inc/enigme/affichage.php:1012
+#: inc/enigme/affichage.php:1013
+#: inc/enigme/affichage.php:1026
+#: inc/enigme/affichage.php:1027
+#: single-indice.php:27
+#: template-parts/chasse/chasse-edition-main.php:67
+#: template-parts/chasse/chasse-edition-main.php:76
+#: template-parts/enigme/enigme-edition-main.php:94
+#: template-parts/enigme/enigme-edition-main.php:104
+#: template-parts/indice/indice-edition-main.php:59
+#: template-parts/indice/indice-edition-main.php:67
+#: template-parts/organisateur/organisateur-edition-main.php:75
+#: template-parts/organisateur/organisateur-edition-main.php:85
+msgid "Paramètres"
+msgstr ""
+
+#: inc/enigme/affichage.php:1006
+msgid "Retour"
+msgstr ""
+
+#: inc/enigme/affichage.php:1017
+#: inc/enigme/affichage.php:1018
+msgid "Menu énigme"
+msgstr ""
+
+#: inc/enigme/affichage.php:1035
+msgid "Panneau d'énigme"
+msgstr ""
+
+#: inc/enigme/affichage.php:1038
+#: inc/enigme/affichage.php:1135
+#: template-parts/chasse/chasse-edition-main.php:68
+#: template-parts/enigme/enigme-edition-main.php:95
+#: template-parts/enigme/enigme-edition-main.php:499
+#: template-parts/enigme/partials/enigme-sidebar-section.php:52
+#: template-parts/indice/indice-edition-main.php:60
+#: template-parts/indice/indice-edition-main.php:218
+#: template-parts/organisateur/organisateur-edition-main.php:76
+#: template-parts/organisateur/organisateur-edition-main.php:252
+#: templates/myaccount/layout.php:111
+msgid "Statistiques"
+msgstr ""
+
+#: inc/enigme/cta.php:193
+msgid "À venir"
+msgstr ""
+
+#: inc/enigme/cta.php:194
+msgid "Chasse verrouillée"
+msgstr ""
+
+#: inc/enigme/cta.php:195
+#: template-parts/enigme/enigme-edition-main.php:451
+msgid "Pré-requis"
+msgstr ""
+
+#: inc/enigme/cta.php:196
+msgid "Invalide"
+msgstr ""
+
+#: inc/enigme/cta.php:197
+msgid "Erreur config"
+msgstr ""
+
+#: inc/enigme/cta.php:198
+msgid "Bloquée"
+msgstr ""
+
+#: inc/enigme/cta.php:201
+msgid "Résolvez d'abord les énigmes prérequises."
+msgstr ""
+
+#: inc/enigme/cta.php:202
+msgid "Cette énigme est bloquée ou mal configurée."
+msgstr ""
+
+#: inc/enigme/cta.php:206
+msgid "Indisponible"
+msgstr ""
+
+#: inc/enigme/cta.php:232
 msgid "Commencer"
 msgstr ""
 
-#: inc/enigme/cta.php:219
+#: inc/enigme/cta.php:236
 msgid "À tenter"
 msgstr ""
 
-#: inc/enigme/cta.php:225
+#: inc/enigme/cta.php:242
+#: templates/myaccount/content-chasses.php:70
 msgid "Voir"
 msgstr ""
 
-#: inc/enigme/cta.php:226
+#: inc/enigme/cta.php:243
 msgid "Continuer"
 msgstr ""
 
-#: inc/enigme/cta.php:269
+#: inc/enigme/cta.php:286
 msgid "Réessayer"
 msgstr ""
 
-#: inc/enigme/cta.php:273
+#: inc/enigme/cta.php:290
 msgid "Échouée"
 msgstr ""
 
-#: inc/enigme/cta.php:279
+#: inc/enigme/cta.php:296
 msgid "Recommencer"
 msgstr ""
 
-#: inc/enigme/cta.php:283
+#: inc/enigme/cta.php:300
 msgid "Abandonnée"
 msgstr ""
 
-#: inc/enigme/reponses.php:41
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:92
+#: inc/enigme/reponses.php:74
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:162
+msgid "Votre réponse"
+msgstr ""
+
+#: inc/enigme/reponses.php:77
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:171
 #, php-format
 msgid "Il vous manque %d points pour soumettre votre réponse."
 msgstr ""
 
-#: inc/enigme/reponses.php:508
+#: inc/enigme/reponses.php:86
+#: single-chasse.php:168
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:183
+msgid "Accéder à la boutique"
+msgstr ""
+
+#: inc/enigme/reponses.php:88
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
+msgid "Ajouter des points"
+msgstr ""
+
+#: inc/enigme/reponses.php:96
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:195
+#: assets/js/reponse-automatique.js:95
+#, php-format,js-format
+msgid "Solde : %1$d → %2$d pts"
+msgstr ""
+
+#: inc/enigme/reponses.php:137
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
+msgid "Valider"
+msgstr ""
+
+#: inc/enigme/reponses.php:140
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:147
+#, php-format
+msgid "Valider — %d pts"
+msgstr ""
+
+#: inc/enigme/reponses.php:448
+msgid "Réponse acceptée"
+msgstr ""
+
+#: inc/enigme/reponses.php:449
+msgid "Réponse refusée"
+msgstr ""
+
+#: inc/enigme/reponses.php:451
+msgid "Félicitations ! Votre réponse est correcte."
+msgstr ""
+
+#: inc/enigme/reponses.php:452
+msgid "Votre réponse est incorrecte."
+msgstr ""
+
+#: inc/enigme/reponses.php:454
+msgid "Retour à l’énigme"
+msgstr ""
+
+#: inc/enigme/reponses.php:455
+msgid "Réessayer l’énigme"
+msgstr ""
+
+#: inc/enigme/reponses.php:462
+#, php-format
+msgid "[Chasses au Trésor] %1$s — %2$s"
+msgstr ""
+
+#: inc/enigme/reponses.php:491
+#, php-format
+msgid "Tentatives quotidiennes : %1$d / %2$s"
+msgstr ""
+
+#: inc/enigme/reponses.php:618
 msgid "Tentative bien reçue."
 msgstr ""
 
-#: inc/enigme/reponses.php:588
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:51
+#: inc/enigme/reponses.php:619
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:50
+#, php-format
 msgid "⏳ Votre tentative %1$s a été soumise le %2$s à %3$s.<br>Vous serez immédiatement averti de son traitement par l'organisateur par email et sur votre <a href=\"%4$s\">espace personnel</a>."
 msgstr ""
 
-#: inc/enigme/visuels.php:129
+#: inc/enigme/tentatives.php:129
+#, php-format
+msgid "Votre demande de résolution de l'énigme %1$s%2$s%3$s a été validée. Félicitations !"
+msgstr ""
+
+#: inc/enigme/tentatives.php:133
+#, php-format
+msgid "Votre demande de résolution de l'énigme %1$s%2$s%3$s a été invalidée."
+msgstr ""
+
+#: inc/enigme/visuels.php:137
+#: template-parts/enigme/partials/enigme-partial-images.php:52
+msgid "Image par défaut de l’énigme"
+msgstr ""
+
+#: inc/enigme/visuels.php:138
 msgid "Visuel énigme"
 msgstr ""
 
-#: inc/enigme/visuels.php:425
+#: inc/enigme/visuels.php:377
 msgid "Pré-requis non remplis"
 msgstr ""
 
-#: inc/gamify-functions.php:496
+#: inc/gamify-functions.php:520
 msgid "Historique de vos points"
 msgstr ""
 
-#: inc/gamify-functions.php:500
+#: inc/gamify-functions.php:524
 msgid "ID"
 msgstr ""
 
-#: inc/gamify-functions.php:501
+#: inc/gamify-functions.php:525
+#: template-parts/enigme/enigme-edition-main.php:577
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:35
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:25
+#: templates/myaccount/content-chasses.php:124
 msgid "Date"
 msgstr ""
 
-#: inc/gamify-functions.php:502
+#: inc/gamify-functions.php:526
 msgid "Origine"
 msgstr ""
 
-#: inc/gamify-functions.php:503
+#: inc/gamify-functions.php:527
 msgid "Motif"
 msgstr ""
 
-#: inc/gamify-functions.php:504
+#: inc/gamify-functions.php:528
 msgid "Variation"
 msgstr ""
 
-#: inc/gamify-functions.php:505
+#: inc/gamify-functions.php:529
+#: assets/js/reponse-automatique.js:76
+#: assets/js/reponse-automatique.js:98
 msgid "Solde"
 msgstr ""
 
 #: inc/organisateur-functions.php:227
 #: inc/organisateur-functions.php:233
-#: template-parts/organisateur/organisateur-edition-main.php:290
-#: template-parts/organisateur/organisateur-edition-main.php:303
+#: template-parts/organisateur/organisateur-edition-main.php:308
+#: template-parts/organisateur/organisateur-edition-main.php:321
 msgid "Ajouter des coordonnées bancaires"
 msgstr ""
 
 #: inc/organisateur-functions.php:231
-#: template-parts/chasse/chasse-edition-main.php:615
-#: template-parts/chasse/chasse-edition-main.php:664
-#: template-parts/chasse/chasse-edition-main.php:666
-#: template-parts/organisateur/organisateur-edition-main.php:287
-#: template-parts/organisateur/organisateur-edition-main.php:301
+#: template-parts/chasse/chasse-edition-main.php:673
+#: template-parts/chasse/partials/chasse-partial-indices.php:46
+#: template-parts/chasse/partials/chasse-partial-indices.php:50
+#: template-parts/organisateur/organisateur-edition-main.php:305
+#: template-parts/organisateur/organisateur-edition-main.php:319
+#: template-parts/organisateur/organisateur-edition-main.php:360
 msgid "Ajouter"
 msgstr ""
 
 #: inc/organisateur-functions.php:232
-#: template-parts/chasse/chasse-edition-main.php:616
-#: template-parts/organisateur/organisateur-edition-main.php:288
-#: template-parts/organisateur/organisateur-edition-main.php:302
+#: template-parts/chasse/chasse-edition-main.php:674
+#: template-parts/organisateur/organisateur-edition-main.php:306
+#: template-parts/organisateur/organisateur-edition-main.php:320
+#: template-parts/organisateur/organisateur-edition-main.php:361
 msgid "Éditer"
 msgstr ""
 
 #: inc/organisateur-functions.php:234
-#: template-parts/organisateur/organisateur-edition-main.php:291
-#: template-parts/organisateur/organisateur-edition-main.php:304
+#: template-parts/organisateur/organisateur-edition-main.php:309
+#: template-parts/organisateur/organisateur-edition-main.php:322
 msgid "Modifier les coordonnées bancaires"
 msgstr ""
 
@@ -378,7 +744,7 @@ msgstr ""
 
 #: inc/organisateur-functions.php:262
 #: inc/organisateur-functions.php:282
-#: template-parts/organisateur/organisateur-edition-main.php:262
+#: template-parts/organisateur/organisateur-edition-main.php:281
 msgid "Convertir"
 msgstr ""
 
@@ -412,11 +778,6 @@ msgstr ""
 
 #: inc/organisateur-functions.php:435
 msgid "Date demande"
-msgstr ""
-
-#: inc/organisateur-functions.php:437
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:26
-msgid "Utilisateur"
 msgstr ""
 
 #: inc/organisateur-functions.php:439
@@ -478,26 +839,57 @@ msgstr ""
 msgid "Last page"
 msgstr ""
 
-#: inc/user-functions.php:160
+#: inc/table.php:32
+msgid "Voir plus"
+msgstr ""
+
+#: inc/table.php:33
+msgid "Voir moins"
+msgstr ""
+
+#: inc/user-functions.php:165
 msgid "Statistiques - Chasses au Trésor"
 msgstr ""
 
-#: inc/user-functions.php:161
+#: inc/user-functions.php:166
 msgid "Outils - Chasses au Trésor"
 msgstr ""
 
-#: inc/user-functions.php:162
+#: inc/user-functions.php:167
 msgid "Organisateur - Chasses au Trésor"
 msgstr ""
 
-#: inc/user-functions.php:167
+#: inc/user-functions.php:172
 msgid "Points - Chasses au Trésor"
 msgstr ""
 
+#: inc/user-functions.php:176
+msgid "Chasses - Chasses au Trésor"
+msgstr ""
+
+#: inc/user-functions.php:233
+#: templates/myaccount/layout.php:156
+msgid "Vos commandes"
+msgstr ""
+
+#: inc/user-functions.php:335
+#, php-format
+msgid "Votre demande de résolution de l'énigme %s est en cours de traitement. Vous recevrez une notification dès que votre demande sera traitée."
+msgstr ""
+
+#: inc/user-functions.php:351
+#, php-format
+msgid "Vos demandes de résolution d'énigmes sont en cours de traitement : %s. Vous recevrez une notification dès que vos demandes seront traitées."
+msgstr ""
+
 #. translators: 1: opening anchor tag, 2: closing anchor tag
-#: inc/user-functions.php:292
+#: inc/user-functions.php:456
 #, php-format
 msgid "Vous avez des %1$sdemandes de conversion%2$s en attente."
+msgstr ""
+
+#: inc/user-functions.php:478
+msgid "Important ! Des tentatives attendent votre action :"
 msgstr ""
 
 #: single-chasse.php:13
@@ -508,6 +900,10 @@ msgstr ""
 msgid "Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique."
 msgstr ""
 
+#: single-chasse.php:167
+msgid "Vous n’avez pas assez de points pour engager cette énigme."
+msgstr ""
+
 #: single-organisateur.php:84
 msgid "Chasses au Trésor"
 msgstr ""
@@ -516,131 +912,300 @@ msgstr ""
 msgid "C'est parti !"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:59
+#: template-parts/chasse/chasse-edition-main.php:61
 msgid "Panneau d'édition chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:134
+#: template-parts/chasse/chasse-edition-main.php:69
+#: template-parts/chasse/chasse-edition-main.php:647
+#: template-parts/enigme/enigme-edition-main.php:96
+#: template-parts/organisateur/organisateur-edition-main.php:77
+#: template-parts/organisateur/organisateur-edition-main.php:335
+msgid "Animation"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:104
+#: template-parts/enigme/enigme-edition-main.php:128
+#: template-parts/indice/indice-edition-main.php:90
+msgid "Titre"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:126
+msgid "Image chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:133
+#: template-parts/indice/indice-edition-main.php:107
+msgid "Modifier l’image"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:135
+#: template-parts/chasse/chasse-edition-main.php:141
+#: template-parts/indice/indice-edition-main.php:109
+#: template-parts/indice/indice-edition-main.php:115
+msgid "ajouter une image"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:154
 msgid "Description chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:142
-#: template-parts/enigme/enigme-edition-main.php:177
-#: template-parts/organisateur/organisateur-edition-main.php:141
+#: template-parts/chasse/chasse-edition-main.php:162
+#: template-parts/enigme/enigme-edition-main.php:172
+#: template-parts/enigme/enigme-edition-main.php:185
+#: template-parts/enigme/enigme-edition-main.php:202
+#: template-parts/indice/indice-edition-main.php:129
+#: template-parts/organisateur/organisateur-edition-main.php:161
 #: assets/js/enigme-edit.js:645
 msgid "ajouter"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:174
 msgid "Modifier la description"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:155
-#: template-parts/chasse/chasse-edition-main.php:196
-#: template-parts/enigme/enigme-edition-main.php:189
-#: template-parts/organisateur/organisateur-edition-main.php:153
-#: template-parts/organisateur/organisateur-edition-main.php:201
-#: assets/js/chasse-edit.js:258
-#: assets/js/core/helpers.js:218
-#: assets/js/core/helpers.js:240
-#: assets/js/core/helpers.js:262
-#: assets/js/core/resume.js:373
-#: assets/js/enigme-edit.js:891
+#: template-parts/chasse/chasse-edition-main.php:175
+#: template-parts/indice/indice-edition-main.php:137
+#: template-parts/organisateur/organisateur-edition-main.php:173
+#: template-parts/organisateur/organisateur-edition-main.php:220
+#: assets/js/core/helpers.js:234
+#: assets/js/core/helpers.js:256
+#: assets/js/core/helpers.js:278
+#: assets/js/core/resume.js:384
+#: assets/js/enigme-edit.js:743
+#: assets/js/enigme-edit.js:988
 msgid "modifier"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:171
+#: template-parts/chasse/chasse-edition-main.php:191
 msgid "Récompense"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:195
-msgid "Modifier la récompense"
+#: template-parts/chasse/chasse-edition-main.php:227
+#: template-parts/enigme/enigme-edition-main.php:238
+#: template-parts/indice/indice-edition-main.php:148
+msgid "Réglages"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:219
+#: template-parts/chasse/chasse-edition-main.php:239
 msgid "Mode de fin"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:230
-#: template-parts/enigme/enigme-edition-main.php:221
+#: template-parts/chasse/chasse-edition-main.php:250
+#: template-parts/enigme/enigme-edition-main.php:247
 msgid "Automatique"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:236
-#: template-parts/enigme/enigme-edition-main.php:227
+#: template-parts/chasse/chasse-edition-main.php:256
+#: template-parts/enigme/enigme-edition-main.php:253
 msgid "Explication du mode automatique"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:253
-#: template-parts/enigme/enigme-edition-main.php:238
-msgid "Manuelle"
+#: template-parts/chasse/chasse-edition-main.php:258
+msgid "Fin de chasse automatique"
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:259
-#: template-parts/enigme/enigme-edition-main.php:244
+msgid "Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode automatique, la chasse se termine dès que le nombre de gagnants prévu est atteint."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:272
+#: template-parts/enigme/enigme-edition-main.php:264
+msgid "Manuelle"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:278
+#: template-parts/enigme/enigme-edition-main.php:270
 msgid "Explication du mode manuel"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:277
+#: template-parts/chasse/chasse-edition-main.php:280
+msgid "Fin de chasse manuelle"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:281
+msgid "Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans le panneau d’édition de la chasse, onglet Paramètres."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:295
 msgid "Terminer la chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:279
+#: template-parts/chasse/chasse-edition-main.php:297
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
 msgid "Gagnants"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:287
+#: template-parts/chasse/chasse-edition-main.php:305
 msgid "Valider la fin de chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:301
+#: template-parts/chasse/chasse-edition-main.php:319
 #, php-format
 msgid "Chasse gagnée le %s par %s"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:405
-#: template-parts/enigme/enigme-edition-main.php:314
+#: template-parts/chasse/chasse-edition-main.php:337
+msgid "Nb gagnants"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:353
+msgid "Illimité"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:374
+msgid "Début"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:390
+msgid "Date de fin"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:404
+msgid "Durée illimitée"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/indice/indice-edition-main.php:198
+msgid "Coût"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:423
 msgid "En savoir plus sur les points"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:541
-msgid "Pourcentage moyen d’énigmes auxquelles chaque participant s’est engagé, par rapport à toutes celles proposées."
+#: template-parts/chasse/chasse-edition-main.php:426
+msgid "Coût d’accès à une chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:546
+#: template-parts/chasse/chasse-edition-main.php:427
+msgid "Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou payant. Cet accès est indispensable pour consulter les énigmes, qui restent invisibles tant qu’il n’a pas été débloqué."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:445
+#: template-parts/enigme/enigme-edition-main.php:394
+#: template-parts/indice/indice-edition-main.php:202
+msgid "Gratuit"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:552
+#: template-parts/enigme/enigme-edition-main.php:517
+msgid "Actualiser"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:554
+#: template-parts/enigme/enigme-edition-main.php:519
+msgid "Période :"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:568
+#: template-parts/enigme/enigme-edition-main.php:533
+msgid "Participants"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:575
+#: template-parts/enigme/enigme-edition-main.php:97
+#: template-parts/enigme/enigme-edition-main.php:540
+#: template-parts/enigme/enigme-edition-main.php:578
+#: template-parts/enigme/enigme-edition-main.php:627
+#: template-parts/enigme/partials/enigme-partial-participants.php:69
+#: templates/myaccount/content-chasses.php:108
+msgid "Tentatives"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:582
+#: template-parts/enigme/enigme-edition-main.php:548
+msgid "Points collectés"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:589
+#: template-parts/chasse/chasse-edition-main.php:597
+msgid "Taux d'engagement"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:592
+msgid "Pourcentage moyen d’énigmes auxquelles chaque joueur a participé, par rapport à l’ensemble des énigmes proposées."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:596
 msgid "Explication du taux d’engagement"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:558
+#: template-parts/chasse/chasse-edition-main.php:605
+#: template-parts/enigme/partials/enigme-partial-participants.php:39
+msgid "Les statistiques seront disponibles une fois la chasse activée."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:616
 msgid "Énigmes sans validation"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/chasse/chasse-edition-main.php:655
+#: template-parts/organisateur/organisateur-edition-main.php:342
 msgid "Communiquez"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:604
+#: template-parts/chasse/chasse-edition-main.php:662
 msgid "Sites et réseaux de la chasse"
 msgstr ""
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:19
+#: template-parts/chasse/panneaux/chasse-edition-description.php:28
 msgid "Modifier la description de la chasse"
 msgstr ""
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:20
+#: template-parts/chasse/panneaux/chasse-edition-description.php:29
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:16
 #: template-parts/enigme/panneaux/enigme-edition-description.php:19
 #: template-parts/enigme/panneaux/enigme-edition-images.php:12
+#: template-parts/indice/panneaux/indice-edition-description.php:19
 msgid "Fermer le panneau"
 msgstr ""
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:28
+#: template-parts/chasse/panneaux/chasse-edition-description.php:37
 #: template-parts/enigme/panneaux/enigme-edition-description.php:27
-#: template-parts/enigme/panneaux/enigme-edition-images.php:20
+#: template-parts/enigme/panneaux/enigme-edition-images.php:31
+#: template-parts/indice/panneaux/indice-edition-description.php:26
 msgid "💾 Enregistrer"
 msgstr ""
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:33
+#: template-parts/chasse/panneaux/chasse-edition-description.php:45
 msgid "Description mise à jour."
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:15
+msgid "Configurer la récompense"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:21
+msgid "Titre de la récompense"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:22
+msgid "Ex : Un papillon en cristal..."
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:24
+msgid "Descripton de la récompense"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:25
+msgid "Ex : Un coffret cadeau comprenant..."
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:28
+msgid "Valeur en euros (€)"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:34
+msgid "Ex : 50"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:37
+msgid "Enregistrer"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:40
+msgid "Supprimer la récompense"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:40
@@ -648,6 +1213,8 @@ msgid "Joueurs"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:51
+#: template-parts/enigme/enigme-edition-main.php:576
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:34
 msgid "Joueur"
 msgstr ""
 
@@ -663,7 +1230,7 @@ msgstr ""
 msgid "Tx participation"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:67
+#: template-parts/chasse/partials/chasse-partial-participants.php:68
 msgid "Trier par taux de résolution"
 msgstr ""
 
@@ -675,104 +1242,321 @@ msgstr ""
 msgid "Aucune donnée."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:80
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:28
+#: assets/js/enigme-edit.js:1616
+msgid "Ajouter une énigme"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:87
 msgid "Panneau d'édition énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:88
-msgid "Solution"
+#: template-parts/enigme/enigme-edition-main.php:91
+#: template-parts/indice/indice-edition-main.php:56
+msgid "Fermer les paramètres"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:169
+#: template-parts/enigme/enigme-edition-main.php:112
+#: template-parts/indice/indice-edition-main.php:74
+msgid "Informations"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:138
+msgid "renseigner le titre de l’énigme"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:156
+msgid "Illustrations"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:194
 msgid "Texte énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:192
+#: template-parts/enigme/enigme-edition-main.php:213
 msgid "Éditer le texte"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:202
-msgid "Sous-titre"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:204
-msgid "Ajouter un sous-titre (max 100 caractères)"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:217
-msgid "Validation"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:255
-msgid "Aucune"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:272
-msgid "Variantes"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:278
-msgid "Explication des variantes"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:294
-msgid "Éditer les variantes"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:295
+#: template-parts/enigme/enigme-edition-main.php:214
+#: template-parts/enigme/enigme-edition-main.php:350
+#: template-parts/enigme/enigme-edition-main.php:673
 msgid "éditer"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:299
-#: assets/js/enigme-edit.js:869
+#: template-parts/enigme/enigme-edition-main.php:228
+msgid "Sous-titre"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:230
+msgid "Ajouter un sous-titre (max 100 caractères)"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:243
+msgid "Validation"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:256
+msgid "Validation automatique"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:257
+msgid "Le joueur soumet une tentative de réponse. Celle-ci est automatiquement vérifiée selon les critères définis (réponse attendue, respect de la casse, variantes), et le résultat est immédiatement communiqué au joueur."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:273
+msgid "Validation manuelle"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:274
+msgid "Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa tentative depuis votre espace personnel. À chaque nouvelle soumission, vous recevez une notification par email ainsi qu’un message d’alerte."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:281
+msgid "Aucune"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:288
+msgid "Bonne(s) réponse(s)"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:294
+msgid "La ou les bonnes réponses"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:295
+msgid "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — selon votre réglage de respect de la casse — résout l’énigme."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:307
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
+msgid "Respecter la casse"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:315
+msgid "Variantes"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:321
+msgid "Explication des variantes"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:324
+msgid "Système de variantes"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:325
+msgid "Les variantes sont des réponses alternatives qui ne sont pas validées comme correctes, mais qui déclenchent un message personnalisé en retour (par exemple une aide, un indice, un lien ou tout autre contenu de votre choix)."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:335
+#: assets/js/enigme-edit.js:915
+msgid "Variante"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:336
+#: assets/js/enigme-edit.js:918
+msgid "Message"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:349
+msgid "Éditer les variantes"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:354
+#: assets/js/enigme-edit.js:966
 msgid "Ajouter des variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:300
-#: assets/js/enigme-edit.js:870
+#: template-parts/enigme/enigme-edition-main.php:355
+#: assets/js/enigme-edit.js:967
 msgid "ajouter des variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:342
-msgid "Explication du nombre de tentatives"
+#: template-parts/enigme/enigme-edition-main.php:371
+msgid "Coût tentative"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:393
-msgid "Plafond nb de tentatives quotidiennes"
+#: template-parts/enigme/enigme-edition-main.php:377
+msgid "Informations sur le coût des tentatives"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:394
-msgid ""
-"Nombre maximal de tentatives quotidiennes par joueur:\\n\\nMode payant : "
-"illimitées\\n\\nMode gratuit : 24 tentatives par jour"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:364
-msgid "Accès"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:368
-msgid "Libre"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:372
-msgid "Date programmée"
+#: template-parts/enigme/enigme-edition-main.php:380
+msgid "Tentative gratuite ou payante ?"
 msgstr ""
 
 #: template-parts/enigme/enigme-edition-main.php:381
-msgid "Pré-requis"
+msgid "Vous êtes libre de définir le coût d’une tentative pour votre énigme : gratuite ou payante en points. Lorsqu’un joueur dépense des points pour soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:385
+#: template-parts/enigme/enigme-edition-main.php:402
+msgid "Nb tentatives"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:408
+msgid "Explication du nombre de tentatives"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:411
+msgid "Plafond nb de tentatives quotidiennes"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:412
+msgid ""
+"Nombre maximal de tentatives quotidiennes par joueur:\n"
+"\n"
+"Mode payant : illimitées\n"
+"\n"
+"Mode gratuit : 24 tentatives par jour"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:418
+msgid "max par jour"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:434
+msgid "Accès"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:438
+msgid "Libre"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:442
+msgid "Date programmée"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:455
 msgid "Aucune autre énigme disponible comme prérequis."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:569
-msgid "Solution de cette énigme"
+#: template-parts/enigme/enigme-edition-main.php:491
+msgid "❌ Suppression énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:640
+#: template-parts/enigme/enigme-edition-main.php:521
+msgid "Total"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:522
+msgid "Aujourd’hui"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:523
+msgid "Semaine"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:524
+msgid "Mois"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:556
+msgid "Bonnes réponses"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:570
+#, php-format
+msgid "Résolue par (%s) joueurs"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:575
+msgid "Rang"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:655
+msgid "Animation de cette énigme"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:667
+msgid "Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée terminée. Une fois celle-ci achevée, elles restent conservées dans un coffre-fort numérique pendant le délai que vous définissez ici."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:670
+msgid "Document PDF"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:671
+#: templates/myaccount/content-outils.php:33
+msgid "Modifier"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:671
+msgid "Choisir un fichier"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:673
+msgid "Rédiger"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:675
+msgid "aucune solution ne"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:680
+#, php-format
+msgid "votre fichier %s"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:681
+#, php-format
+msgid " %d jours après la fin de la chasse, à %s"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:683
+msgid " (pdf sélectionné mais pas de fichier chargé)"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:687
+msgid "votre texte d'explication"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:688
+#, php-format
+msgid ", %d jours après la fin de la chasse, à %s"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:690
+msgid " (rédaction libre sélectionnée mais non remplie)"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:702
+#: template-parts/enigme/enigme-edition-main.php:710
+msgid "Vider"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:712
+msgid "Rédaction libre"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:720
+msgid "Délai après fin de chasse"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:726
 msgid "Informations sur la publication de la solution"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:729
+msgid "Délai de parution des solutions"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:745
+msgid "jours, publié à"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:760
+msgid "Vos solutions sont protégées"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:761
+msgid "Stockées dans un espace privé, hors de portée des joueurs."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:762
+msgid "Aucun lien ne peut être trouvé ni ouvert."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:763
+msgid "Débloquées uniquement au moment choisi."
 msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-description.php:18
@@ -787,17 +1571,21 @@ msgstr ""
 msgid "Modifier les images de l’énigme"
 msgstr ""
 
-#: template-parts/enigme/panneaux/enigme-edition-images.php:29
+#: template-parts/enigme/panneaux/enigme-edition-images.php:40
 msgid "Images mises à jour."
 msgstr ""
 
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:21
+msgid "Configurer les variantes de réponse"
+msgstr ""
+
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:50
-#: assets/js/enigme-edit.js:743
+#: assets/js/enigme-edit.js:826
 msgid "réponse déclenchant l'affichage du message"
 msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:51
-#: assets/js/enigme-edit.js:746
+#: assets/js/enigme-edit.js:829
 msgid "Message affiché au joueur"
 msgstr ""
 
@@ -805,107 +1593,89 @@ msgstr ""
 msgid "Ajouter une variante"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:19
-msgid "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:77
+msgid "Enregistrer les variantes"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:36
-msgid "Énigme résolue"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:63
+msgid "⏳ Votre tentative est en cours de traitement."
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:58
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:78
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:106
+#, php-format
 msgid "Vous avez résolu cette énigme le %s."
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:55
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:48
-msgid "Valider"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:110
+msgid "Énigme résolue"
 msgstr ""
 
-#: assets/js/enigme-edit.js:605
-#: assets/js/enigme-edit.js:657
-msgid "valider"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:61
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:125
+#: assets/js/reponse-automatique.js:197
+#: assets/js/reponse-automatique.js:219
 msgid "tentatives quotidiennes épuisées"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:70
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:134
 #, php-format
 msgid "%dh et %dmn avant réactivation"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
-#: inc/enigme/reponses.php:38
-msgid "Votre réponse"
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:25
+msgid "Gagnants :"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:93
-msgid "Accéder à la boutique"
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
+msgid "Aucun gagnant pour le moment."
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:105
-msgid "pts"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:112
-msgid "Tentatives quotidiennes"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-images.php:39
-msgid "Image par défaut de l’énigme"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-participants.php:39
-msgid "Les statistiques seront disponibles une fois la chasse activée."
+#: template-parts/enigme/partials/enigme-partial-images.php:53
+msgid "Image de l’énigme"
 msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:43
 msgid "Aucun participant engagé."
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:50
+#: template-parts/enigme/partials/enigme-partial-participants.php:47
+msgid "Liste participants"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-participants.php:51
 msgid "Nom"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:55
+#: template-parts/enigme/partials/enigme-partial-participants.php:56
 msgid "Trier par engagement"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:57
+#: template-parts/enigme/partials/enigme-partial-participants.php:58
 msgid "Engagement"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:66
+#: template-parts/enigme/partials/enigme-partial-participants.php:67
 msgid "Trier par tentatives"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:68
-msgid "Tentatives"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-participants.php:73
+#: template-parts/enigme/partials/enigme-partial-participants.php:74
 msgid "Trouvé"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:91
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:64
+#: template-parts/enigme/partials/enigme-partial-participants.php:96
 msgid "Première page"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:94
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:67
+#: template-parts/enigme/partials/enigme-partial-participants.php:99
 msgid "Page précédente"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:100
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:73
+#: template-parts/enigme/partials/enigme-partial-participants.php:105
 msgid "Page suivante"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:103
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:76
+#: template-parts/enigme/partials/enigme-partial-participants.php:108
 msgid "Dernière page"
 msgstr ""
 
@@ -914,19 +1684,37 @@ msgid "Aucune tentative de soumission."
 msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:27
-msgid "Réponse"
+#: templates/myaccount/content-chasses.php:126
+msgid "Proposition"
 msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:28
-msgid "Actions"
+#: templates/myaccount/content-chasses.php:127
+msgid "Résultat"
 msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:34
 msgid "Inconnu"
 msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:51
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:55
+msgid "bon"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:57
+msgid "faux"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:59
+msgid "attente"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:71
 msgid "Invalider"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-sidebar-section.php:42
+msgid "Aucune énigme disponible"
 msgstr ""
 
 #: template-parts/enigme/partials/pirate/enigme-partial-images.php:9
@@ -949,50 +1737,202 @@ msgstr ""
 msgid "🏴‍☠️ Titre (pirate)"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:67
+#: template-parts/indice/indice-edition-main.php:53
+msgid "Panneau d'édition indice"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:95
+msgid "renseigner le titre de l’indice"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:105
+msgid "Image"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:124
+msgid "Texte"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:136
+#: template-parts/indice/panneaux/indice-edition-description.php:18
+msgid "Modifier le texte de l’indice"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:151
+msgid "Aide pour"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:158
+msgid "Aucune énigme disponible."
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:184
+msgid "Publication"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:186
+msgid "Immédiate"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:187
+msgid "Différée"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:198
+msgid "(points)"
+msgstr ""
+
+#: template-parts/indice/indice-edition-main.php:221
+msgid "Statistiques à venir"
+msgstr ""
+
+#: template-parts/indice/panneaux/indice-edition-description.php:31
+msgid "Texte de l’indice mis à jour."
+msgstr ""
+
+#: template-parts/modals/modal-points.php:9
+msgid "À quoi servent les points ?"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:10
+msgid "Les points vous permettent de débloquer :"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:12
+msgid "🎯 Des chasses au trésor"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:13
+msgid "❓ Des tentatives de réponse"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:14
+msgid "💡 Des indices"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:17
+msgid "La gratuité ou l'accès par points est choisi librement par chaque organisateur."
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:69
 msgid "Panneau d'édition organisateur"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:133
-msgid "Présentation"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:153
-msgid "Modifier la présentation"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:187
-msgid "Informations sur l’adresse email de contact"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:251
+#: template-parts/organisateur/organisateur-edition-main.php:78
+#: template-parts/organisateur/organisateur-edition-main.php:264
+#: template-parts/organisateur/organisateur-edition-main.php:270
 #: templates/myaccount/content-points.php:75
 #: templates/myaccount/content-points.php:96
+#: templates/myaccount/layout.php:57
+#: templates/myaccount/layout.php:58
+#: templates/myaccount/layout.php:160
 msgid "Points"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:274
+#: template-parts/organisateur/organisateur-edition-main.php:153
+msgid "Présentation"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:173
+msgid "Modifier la présentation"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:207
+msgid "Informations sur l’adresse email de contact"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:209
+msgid "Email de contact organisateur"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:210
+msgid "Si aucune adresse n’est renseignée, votre adresse email utilisateur est utilisée par défaut."
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:293
 msgid "Informations sur les coordonnées bancaires"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:276
+#: template-parts/organisateur/organisateur-edition-main.php:296
+msgid "Coordonnées bancaires"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:297
 msgid "Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d'argent."
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:352
+msgid "Sites et réseaux de l'organisation"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:380
+msgid "QR code de l'organisation"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:381
+msgid "QR code de votre organisation"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:383
+msgid "Télécharger"
+msgstr ""
+
+#: templates/myaccount/content-chasses.php:111
+#, php-format
+msgid "%d tentative en attente"
+msgid_plural "%d tentatives en attente"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/myaccount/content-chasses.php:113
+#, php-format
+msgid "%d tentative"
+msgid_plural "%d tentatives"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/myaccount/content-chasses.php:116
+#, php-format
+msgid "%d bonne réponse"
+msgid_plural "%d bonnes réponses"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/myaccount/content-chasses.php:125
+msgid "Énigme"
 msgstr ""
 
 #: templates/myaccount/content-dashboard-organisateur.php:25
 msgid "Votre demande de conversion a bien été envoyée."
 msgstr ""
 
+#: templates/myaccount/content-organisateurs.php:19
+#: templates/myaccount/layout.php:104
+msgid "Organisateurs"
+msgstr ""
+
+#: templates/myaccount/content-organisateurs.php:37
+#, php-format
+msgid "%d organisateur"
+msgid_plural "%d organisateurs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/myaccount/content-organisateurs.php:44
+msgid "Filtrer par état :"
+msgstr ""
+
+#: templates/myaccount/content-organisateurs.php:46
+msgid "Tous"
+msgstr ""
+
 #: templates/myaccount/content-outils.php:18
+#: templates/myaccount/layout.php:118
 msgid "Outils"
 msgstr ""
 
 #: templates/myaccount/content-outils.php:23
 msgid "Taux Conversion"
-msgstr ""
-
-#: templates/myaccount/content-outils.php:33
-msgid "Modifier"
 msgstr ""
 
 #: templates/myaccount/content-outils.php:37
@@ -1009,6 +1949,14 @@ msgstr ""
 
 #: templates/myaccount/content-outils.php:49
 msgid "Afficher les champs ACF"
+msgstr ""
+
+#: templates/myaccount/content-outils.php:61
+msgid "Reset stats"
+msgstr ""
+
+#: templates/myaccount/content-outils.php:65
+msgid "Effacer"
 msgstr ""
 
 #: templates/myaccount/content-points.php:30
@@ -1029,6 +1977,48 @@ msgstr ""
 
 #: templates/myaccount/content-points.php:85
 msgid "Gérer"
+msgstr ""
+
+#: templates/myaccount/layout.php:34
+msgid "Accueil"
+msgstr ""
+
+#: templates/myaccount/layout.php:41
+msgid "Commandes"
+msgstr ""
+
+#: templates/myaccount/layout.php:48
+msgid "Chasses"
+msgstr ""
+
+#: templates/myaccount/layout.php:49
+#: templates/myaccount/layout.php:158
+msgid "Vos chasses"
+msgstr ""
+
+#: templates/myaccount/layout.php:66
+msgid "Profil"
+msgstr ""
+
+#: templates/myaccount/layout.php:95
+msgid "Déconnexion"
+msgstr ""
+
+#: templates/myaccount/layout.php:100
+msgid "Administration"
+msgstr ""
+
+#: templates/myaccount/layout.php:154
+msgid "Votre profil"
+msgstr ""
+
+#: templates/myaccount/layout.php:162
+#, php-format
+msgid "Bienvenue %s"
+msgstr ""
+
+#: templates/myaccount/layout.php:187
+msgid "Content not found."
 msgstr ""
 
 #. Template Name of the theme
@@ -1088,66 +2078,63 @@ msgstr ""
 msgid "✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande."
 msgstr ""
 
-#: assets/js/chasse-edit.js:414
-msgid "Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse s’achève dès que le nombre de gagnants prévu est atteint."
+#: assets/js/enigme-aside.js:15
+msgid "Afficher le panneau"
 msgstr ""
 
-#: assets/js/chasse-edit.js:418
-msgid "Vous arrêtez la chasse manuellement, grâce au bouton situé dans le panneau d'édition chasse."
+#: assets/js/enigme-edit.js:600
+msgid "Ex : soleil"
 msgstr ""
 
-#: assets/js/enigme-edit.js:139
-msgid ""
-"Nombre maximum de tentatives quotidiennes d'un joueur\n"
-"Mode payant : tentatives illimitées.\n"
-"Mode gratuit : maximum 24 tentatives par jour."
+#: assets/js/enigme-edit.js:605
+#: assets/js/enigme-edit.js:657
+msgid "valider"
 msgstr ""
 
-#: assets/js/enigme-edit.js:795
-msgid "Enregistrement..."
+#: assets/js/enigme-edit.js:629
+msgid "Supprimer"
 msgstr ""
 
-#: assets/js/enigme-edit.js:815
-msgid "✔️ Variantes enregistrées"
+#: assets/js/enigme-edit.js:703
+msgid "Ajouter une illustration"
 msgstr ""
 
-#: assets/js/enigme-edit.js:890
+#: assets/js/enigme-edit.js:742
+#: assets/js/enigme-edit.js:987
 msgid "Modifier les variantes"
 msgstr ""
 
-#: assets/js/enigme-edit.js:908
+#: assets/js/enigme-edit.js:878
+msgid "Enregistrement..."
+msgstr ""
+
+#: assets/js/enigme-edit.js:898
+msgid "✔️ Variantes enregistrées"
+msgstr ""
+
+#: assets/js/enigme-edit.js:1005
 msgid "❌ Erreur réseau"
 msgstr ""
 
-#: inc/enigme/affichage.php:678
-msgid "Mode de validation de l'énigme : %s"
+#: assets/js/enigme-edit.js:1663
+msgid "Erreur lors de l'enregistrement de l'ordre"
 msgstr ""
 
-#: inc/enigme/affichage.php:675
-msgid "automatique"
+#: assets/js/help-modal.js:19
+msgid "Fermer"
 msgstr ""
 
-#: inc/enigme/affichage.php:676
-msgid "manuelle"
+#: assets/js/reponse-automatique.js:35
+#, js-format
+msgid "Confirmer l'envoi ? Cette tentative coûtera %1$d pts. Solde après : %2$d pts."
 msgstr ""
 
-#: inc/enigme/affichage.php:710
-msgid "Solde : %d pts"
-msgstr ""
-
-#: inc/enigme/reponses.php:67 assets/js/reponse-automatique.js:95
-msgid "Solde : %1$d → %2$d pts"
-msgstr ""
-
-#: inc/enigme/affichage.php:719
-msgid "Tentatives quotidiennes : %1$d/%2$s"
-msgstr ""
-
-#: inc/enigme/reponses.php:459
-msgid "Tentatives quotidiennes : %1$d / %2$s"
+#: assets/js/reponse-automatique.js:55
+msgid "Erreur serveur"
 msgstr ""
 
 #: assets/js/reponse-automatique.js:85
+#, js-format
 msgid "Tentatives quotidiennes : %1$s/%2$s"
 msgstr ""
 
@@ -1155,81 +2142,14 @@ msgstr ""
 msgid "Tentatives quotidiennes :"
 msgstr ""
 
-#: templates/myaccount/content-points.php:103 inc/enigme/reponses.php:59 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
-msgid "Ajouter des points"
+#: assets/js/reponse-automatique.js:107
+msgid "Bonne réponse"
 msgstr ""
 
-#: inc/enigme/affichage.php:275
-msgid "Nb joueurs :"
+#: assets/js/reponse-automatique.js:177
+msgid "Mauvaise réponse"
 msgstr ""
 
-#: inc/enigme/affichage.php:281
-msgid "Nb tentatives :"
-msgstr ""
-
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:25
-msgid "Gagnants :"
-msgstr ""
-
-#: inc/enigme/affichage.php:339
-msgid ""
-"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
-"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
-"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
-msgstr ""
-
-#: inc/enigme/affichage.php:347
-msgid "Définition de la progression"
-msgstr ""
-
-#: inc/enigme/affichage.php:398
-msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse."
-msgstr ""
-
-#: inc/enigme/affichage.php:404
-msgid "Définition du taux de résolution"
-msgstr ""
-
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:21
-msgid "Configurer les variantes de réponse"
-msgstr ""
-
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
-msgid "Respecter la casse"
-msgstr ""
-
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:77
-msgid "Enregistrer les variantes"
-
-#: inc/admin-functions.php:1849
-msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
-msgstr ""
-
-#: inc/admin-functions.php:1886
-msgid "Votre demande de validation pour la chasse « %s » nécessite des corrections."
-msgstr ""
-
-#: inc/admin-functions.php:1895
-msgid "Une copie de ce message vous a été envoyée par email."
-msgstr ""
-
-#: inc/admin-functions.php:1891
-msgid "Message de l’administrateur : %s"
-msgstr ""
-
-#: inc/admin-functions.php:1918
-msgid "Votre chasse « %s » a été bannie."
-
-msgstr ""
-
-#: inc/edition/edition-indice.php:73
-msgid "Indice #%d - %s"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:26
-msgid "Panneau d'édition indice"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:33
-msgid "Contenu d'édition à venir..."
+#: assets/js/reponse-automatique.js:187
+msgid "Tentatives quotidiennes"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: chassesautresor.com 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/chassesautresor\n"
-"POT-Creation-Date: 2025-08-21T20:09:12+00:00\n"
+"POT-Creation-Date: 2025-08-23T01:54:31+00:00\n"
 "PO-Revision-Date: 2025-08-21 20:09+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,124 +15,253 @@ msgstr ""
 "X-Domain: chassesautresor-com\n"
 "X-Generator: WP-CLI 2.12.0\n"
 
+#. Theme Name of the theme
+#. Author of the theme
 #: style.css
 msgid "chassesautresor.com"
 msgstr "chassesautresor.com"
 
+#. Description of the theme
 #: style.css
 msgid "sites dédiés aux amoureux de chasses au trésor chassesautresor.com"
 msgstr "sites dedicated to treasure hunt lovers chassesautresor.com"
 
+#. Author URI of the theme
 #: style.css
 msgid "https://chassesautresor.com/"
 msgstr "https://chassesautresor.com/"
 
+#. Template Name of the theme
 msgid "Accueil Plein Ecran"
 msgstr "Full Screen Home"
 
-#: inc/admin-functions.php:39
+#: functions.php:102
+msgid "Français"
+msgstr "French"
+
+#: functions.php:107
+msgid "English"
+msgstr "English"
+
+#: functions.php:116
+msgid "Change language"
+msgstr "Change language"
+
+#: inc/admin-functions.php:40
 msgid "⛔ Accès refusé."
 msgstr "Access denied."
 
-#: inc/admin-functions.php:46
+#: inc/admin-functions.php:47
 msgid "❌ Requête vide."
 msgstr "Empty query."
 
-#: inc/admin-functions.php:57
+#: inc/admin-functions.php:58
 msgid "❌ Aucun utilisateur trouvé."
 msgstr "No users found."
 
-#: inc/admin-functions.php:84 inc/admin-functions.php:388
-#: inc/admin-functions.php:577
+#: inc/admin-functions.php:85 inc/admin-functions.php:389
+#: inc/admin-functions.php:578
 msgid "❌ Vérification du nonce échouée."
 msgstr "❌ Nonce check failed."
 
-#: inc/admin-functions.php:89 inc/admin-functions.php:393
+#: inc/admin-functions.php:90 inc/admin-functions.php:394
 msgid "❌ Accès refusé."
 msgstr "Access denied."
 
-#: inc/admin-functions.php:98
+#: inc/admin-functions.php:99
 msgid "❌ Données invalides."
 msgstr "Invalid data."
 
-#: inc/admin-functions.php:104
+#: inc/admin-functions.php:105
 msgid "❌ Utilisateur introuvable."
 msgstr "User not found"
 
-#: inc/admin-functions.php:116
+#: inc/admin-functions.php:117
 msgid "❌ Impossible de retirer plus de points que l’utilisateur en possède."
 msgstr "❌ Cannot remove more points than the user has."
 
-#: inc/admin-functions.php:121
+#: inc/admin-functions.php:122
 msgid "❌ Action invalide."
 msgstr "Invalid action."
 
-#: inc/admin-functions.php:180
+#: inc/admin-functions.php:181
 msgid "Permission refusée."
 msgstr "Permission denied."
 
-#: inc/admin-functions.php:188
+#: inc/admin-functions.php:189
 msgid "Requête invalide."
 msgstr "Invalid request."
 
-#: inc/admin-functions.php:230
+#: inc/admin-functions.php:231
 msgid "Action inconnue."
 msgstr "Unknown action"
 
-#: inc/admin-functions.php:399
+#: inc/admin-functions.php:400
 msgid "❌ Veuillez entrer un taux de conversion valide."
 msgstr "❌ Please enter a valid conversion rate."
 
-#: inc/admin-functions.php:465
+#: inc/admin-functions.php:466
 msgid "Régler"
 msgstr "Set"
 
-#: inc/admin-functions.php:466
-#: template-parts/chasse/chasse-edition-main.php:291
+#: inc/admin-functions.php:467
+#: template-parts/chasse/chasse-edition-main.php:309
 msgid "Annuler"
 msgstr "Cancel"
 
-#: inc/admin-functions.php:467
+#: inc/admin-functions.php:468
 msgid "Refuser"
 msgstr "Decline"
 
-#: inc/admin-functions.php:582
+#: inc/admin-functions.php:583
 msgid "❌ Vous devez être connecté pour effectuer cette action."
 msgstr "You must be logged in to perform this action."
 
-#: inc/admin-functions.php:597
+#. translators: %d: points minimum
+#: inc/admin-functions.php:598
+#, php-format
 msgid "❌ Le minimum pour une conversion est de %d points."
 msgstr "❌ The minimum for a conversion is %d points."
 
-#: inc/admin-functions.php:604
+#: inc/admin-functions.php:605
 msgid "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
 msgstr "❌ You don't have enough points to complete this conversion."
 
-#: inc/admin-functions.php:894
+#: inc/admin-functions.php:895
 msgid ""
 "⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action."
 msgstr "⛔ Access denied. You do not have permission to perform this action."
 
-#: inc/admin-functions.php:901
+#: inc/admin-functions.php:902
 msgid "⛔ Erreur de sécurité. Veuillez réessayer."
 msgstr "Security ⛔ error. Please try again."
 
-#: inc/admin-functions.php:1342
+#: inc/admin-functions.php:1343 inc/admin-functions.php:1368
 msgid "Non autorisé"
 msgstr "Not allowed"
 
-#: inc/admin-functions.php:1659
-#: template-parts/chasse/chasse-edition-main.php:448
+#: inc/admin-functions.php:1425
+msgid "Confirmez-vous la réinitialisation des statistiques ?"
+msgstr ""
+
+#: inc/admin-functions.php:1426
+#, fuzzy
+msgid "Statistiques effacées."
+msgstr "Statistics"
+
+#: inc/admin-functions.php:1647
+#: templates/myaccount/content-organisateurs.php:21
+#, fuzzy
+msgid "Aucun organisateur."
+msgstr "No associated organizers."
+
+#: inc/admin-functions.php:1676
+#, fuzzy
+msgid "Organisateur"
+msgstr "Organizers"
+
+#: inc/admin-functions.php:1677
+#: template-parts/indice/indice-edition-main.php:153
+msgid "Chasse"
+msgstr "Hunt"
+
+#: inc/admin-functions.php:1678
+#, fuzzy
+msgid "Nb énigmes"
+msgstr "Riddles"
+
+#: inc/admin-functions.php:1679
+msgid "État"
+msgstr ""
+
+#: inc/admin-functions.php:1680 inc/organisateur-functions.php:437
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:26
+msgid "Utilisateur"
+msgstr "User"
+
+#: inc/admin-functions.php:1681
+msgid "Créé le"
+msgstr ""
+
+#: inc/admin-functions.php:1701
+#, fuzzy
+msgid "valide"
+msgstr "Validate"
+
+#: inc/admin-functions.php:1704
+msgid "correction"
+msgstr ""
+
+#: inc/admin-functions.php:1707
+#, fuzzy
+msgid "en attente"
+msgstr "Pending"
+
+#: inc/admin-functions.php:1710
+#, fuzzy
+msgid "création"
+msgstr "Presentation"
+
+#: inc/admin-functions.php:1714
+msgid "banni"
+msgstr ""
+
+#: inc/admin-functions.php:1730
+msgid "Demande de validation et tentatives manuelles en attente"
+msgstr ""
+
+#: inc/admin-functions.php:1732
+#, fuzzy
+msgid "Demande de validation en attente"
+msgstr "%d pending attempt"
+
+#: inc/admin-functions.php:1734
+#, fuzzy
+msgid "Tentatives manuelles en attente de réponse"
+msgstr "Configure answer variants"
+
+#: inc/admin-functions.php:1785
+#: template-parts/chasse/chasse-edition-main.php:469
 msgid "Accès refusé."
 msgstr "Access denied."
 
-#: inc/admin-functions.php:1666
+#: inc/admin-functions.php:1792
 msgid "ID de chasse invalide."
 msgstr "Invalid hunt ID."
 
-#: inc/admin-functions.php:1670
+#: inc/admin-functions.php:1796
 msgid "Nonce invalide."
 msgstr "Invalid nonce."
+
+#: inc/admin-functions.php:1849
+#, php-format
+msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
+msgstr "Your validation request for the hunt “%s” was accepted."
+
+#: inc/admin-functions.php:1886
+#, php-format
+msgid ""
+"Votre demande de validation pour la chasse « %s » nécessite des corrections."
+msgstr "Your validation request for the hunt “%s” requires corrections."
+
+#: inc/admin-functions.php:1891
+#, php-format
+msgid "Message de l’administrateur : %s"
+msgstr "Administrator's message: %s"
+
+#: inc/admin-functions.php:1895
+msgid "Une copie de ce message vous a été envoyée par email."
+msgstr "A copy of this message has been sent to you by email."
+
+#: inc/admin-functions.php:1918
+#, php-format
+msgid "Votre chasse « %s » a été bannie."
+msgstr "Your hunt “%s” was banned."
+
+#: inc/admin-functions.php:1940
+#, fuzzy, php-format
+msgid "Votre chasse « %s » a été supprimée."
+msgstr "Your hunt “%s” was banned."
 
 #: inc/chasse-functions.php:245
 msgid ""
@@ -152,10 +281,13 @@ msgid "Points insuffisants"
 msgstr "Insufficient Points"
 
 #: inc/chasse-functions.php:650 inc/organisateur-functions.php:273
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/enigme/enigme-edition-main.php:387
 msgid "points"
 msgstr "points"
 
 #: inc/chasse-functions.php:653
+#, php-format
 msgid "Il vous manque %1$d %2$s pour participer à cette chasse."
 msgstr "You are %1$d %2$s short to participate in this hunt."
 
@@ -163,23 +295,28 @@ msgstr "You are %1$d %2$s short to participate in this hunt."
 msgid "Certaines énigmes doivent être complétées :"
 msgstr "Some puzzles need to be completed:"
 
-#: inc/edition/edition-chasse.php:106
+#: inc/edition/edition-chasse.php:48
+#, fuzzy
+msgid "Erreur lors du chargement des indices."
+msgstr "Error creating hunt."
+
+#: inc/edition/edition-chasse.php:115
 msgid "Aucun organisateur associé."
 msgstr "No associated organizers."
 
-#: inc/edition/edition-chasse.php:114
+#: inc/edition/edition-chasse.php:123
 msgid "Limite atteinte"
 msgstr "Limit reached"
 
-#: inc/edition/edition-chasse.php:117
+#: inc/edition/edition-chasse.php:126
 msgid "Accès refusé"
 msgstr "Access denied"
 
-#: inc/edition/edition-chasse.php:127
+#: inc/edition/edition-chasse.php:136
 msgid "Une chasse est déjà en attente de validation."
 msgstr "A hunt is already awaiting validation."
 
-#: inc/edition/edition-chasse.php:140
+#: inc/edition/edition-chasse.php:149
 msgid "Erreur lors de la création de la chasse."
 msgstr "Error creating hunt."
 
@@ -187,92 +324,340 @@ msgstr "Error creating hunt."
 msgid "Chasse non spécifiée ou invalide."
 msgstr "Hunting unspecified or invalid."
 
-#: inc/enigme/affichage.php:132 inc/enigme/affichage.php:147
+#: inc/edition/edition-indice.php:45
+#, fuzzy
+msgid "Type de cible invalide."
+msgstr "Invalid hunt ID."
+
+#: inc/edition/edition-indice.php:49
+#, fuzzy
+msgid "ID cible invalide."
+msgstr "Invalid hunt ID."
+
+#: inc/edition/edition-indice.php:53
+msgid "Utilisateur non connecté."
+msgstr ""
+
+#: inc/edition/edition-indice.php:57 inc/edition/edition-indice.php:65
+#, fuzzy
+msgid "Droits insuffisants."
+msgstr "Insufficient Points"
+
+#: inc/edition/edition-indice.php:82
+#, php-format
+msgid "Indice #%d - %s"
+msgstr "Clue #%d - %s"
+
+#: inc/edition/edition-indice.php:151
+#, fuzzy
+msgid "Action non autorisée."
+msgstr "Not allowed"
+
+#: inc/edition/edition-indice.php:167
+msgid "ID cible manquant."
+msgstr ""
+
+#: inc/enigme/affichage.php:159 inc/enigme/affichage.php:204
 msgid "Vous"
 msgstr "You"
 
-#: inc/enigme/affichage.php:133 inc/enigme/affichage.php:148
+#: inc/enigme/affichage.php:160 inc/enigme/affichage.php:208
 msgid "Moyenne"
 msgstr "Average"
 
-#: inc/enigme/affichage.php:200 inc/enigme/affichage.php:317
+#: inc/enigme/affichage.php:275
+msgid "Nb joueurs :"
+msgstr "Players:"
+
+#: inc/enigme/affichage.php:281
+msgid "Nb tentatives :"
+msgstr "Attempts:"
+
+#: inc/enigme/affichage.php:335
 msgid "Progression"
 msgstr "Progress (%)"
 
-#: inc/enigme/affichage.php:263
+#: inc/enigme/affichage.php:339
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
+msgstr ""
+"Average share of puzzles each player has participated in, relative to the "
+"total number of puzzles in the hunt. You: Share of puzzles you have accessed "
+"Average: Average across all players."
+
+#: inc/enigme/affichage.php:346
+msgid "Définition de la progression"
+msgstr "Definition of progression"
+
+#: inc/enigme/affichage.php:395
 msgid "Résolution"
 msgstr "Solution"
 
-#: inc/enigme/affichage.php:297
-msgid "Statistiques"
-msgstr "Statistics"
+#: inc/enigme/affichage.php:398
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse."
+msgstr ""
+"Average share of puzzles each player has participated in, relative to the "
+"total number of puzzles in the hunt."
 
-#: inc/enigme/affichage.php:311
-msgid "Afficher les statistiques"
-msgstr "View Stats"
+#: inc/enigme/affichage.php:403
+msgid "Définition du taux de résolution"
+msgstr "Definition of the resolution rate"
 
-#: inc/enigme/affichage.php:317
-msgid "Activer Orgy"
-msgstr "Enable Orgy"
-
-#: inc/enigme/affichage.php:325
-#: template-parts/chasse/partials/chasse-partial-participants.php:51
+#: inc/enigme/affichage.php:518 inc/enigme/affichage.php:1037
+#: template-parts/chasse/partials/chasse-partial-participants.php:53
+#: template-parts/enigme/partials/enigme-sidebar-section.php:37
+#: template-parts/indice/indice-edition-main.php:154
 msgid "Énigmes"
 msgstr "Riddles"
 
-#: inc/enigme/affichage.php:416
-#: template-parts/chasse/chasse-edition-main.php:650
-#: template-parts/chasse/chasse-edition-main.php:662
+#: inc/enigme/affichage.php:546
+msgid "Afficher les statistiques"
+msgstr "View Stats"
+
+#: inc/enigme/affichage.php:649
+#: template-parts/chasse/chasse-edition-main.php:708
+#: template-parts/chasse/partials/chasse-partial-indices.php:32
 msgid "Indices"
 msgstr "Hints"
 
-#: inc/enigme/affichage.php:447
+#: inc/enigme/affichage.php:677
+msgid "automatique"
+msgstr "automatic"
+
+#: inc/enigme/affichage.php:678
+msgid "manuelle"
+msgstr "manual"
+
+#: inc/enigme/affichage.php:680
+#, php-format
+msgid "Mode de validation de l'énigme : %s"
+msgstr "Riddle validation mode: %s"
+
+#: inc/enigme/affichage.php:712
+#, php-format
+msgid "Solde : %d pts"
+msgstr "Balance: %d pts"
+
+#: inc/enigme/affichage.php:721
+#, php-format
+msgid "Tentatives quotidiennes : %1$d/%2$s"
+msgstr "Daily Attempts: %1$d/%2$s"
+
+#: inc/enigme/affichage.php:737
+#, fuzzy, php-format
+msgid "Coût par tentative : %d points."
+msgstr "Attempt cost"
+
+#: inc/enigme/affichage.php:741 assets/js/reponse-automatique.js:76
+#: assets/js/reponse-automatique.js:98
+msgid "pts"
+msgstr "pts"
+
+#: inc/enigme/affichage.php:780
 msgid "Voir la solution"
 msgstr "View solution"
 
-#: inc/enigme/cta.php:215
+#: inc/enigme/affichage.php:945 inc/enigme/affichage.php:956
+#: inc/enigme/affichage.php:1012 inc/enigme/affichage.php:1013
+#: inc/enigme/affichage.php:1026 inc/enigme/affichage.php:1027
+#: single-indice.php:27 template-parts/chasse/chasse-edition-main.php:67
+#: template-parts/chasse/chasse-edition-main.php:76
+#: template-parts/enigme/enigme-edition-main.php:94
+#: template-parts/enigme/enigme-edition-main.php:104
+#: template-parts/indice/indice-edition-main.php:59
+#: template-parts/indice/indice-edition-main.php:67
+#: template-parts/organisateur/organisateur-edition-main.php:75
+#: template-parts/organisateur/organisateur-edition-main.php:85
+msgid "Paramètres"
+msgstr "Settings"
+
+#: inc/enigme/affichage.php:1006
+msgid "Retour"
+msgstr ""
+
+#: inc/enigme/affichage.php:1017 inc/enigme/affichage.php:1018
+#, fuzzy
+msgid "Menu énigme"
+msgstr "Riddle text"
+
+#: inc/enigme/affichage.php:1035
+#, fuzzy
+msgid "Panneau d'énigme"
+msgstr "Riddle Editing Panel"
+
+#: inc/enigme/affichage.php:1038 inc/enigme/affichage.php:1135
+#: template-parts/chasse/chasse-edition-main.php:68
+#: template-parts/enigme/enigme-edition-main.php:95
+#: template-parts/enigme/enigme-edition-main.php:499
+#: template-parts/enigme/partials/enigme-sidebar-section.php:52
+#: template-parts/indice/indice-edition-main.php:60
+#: template-parts/indice/indice-edition-main.php:218
+#: template-parts/organisateur/organisateur-edition-main.php:76
+#: template-parts/organisateur/organisateur-edition-main.php:252
+#: templates/myaccount/layout.php:111
+msgid "Statistiques"
+msgstr "Statistics"
+
+#: inc/enigme/cta.php:193
+msgid "À venir"
+msgstr ""
+
+#: inc/enigme/cta.php:194
+#, fuzzy
+msgid "Chasse verrouillée"
+msgstr "Hunting not found."
+
+#: inc/enigme/cta.php:195 template-parts/enigme/enigme-edition-main.php:451
+msgid "Pré-requis"
+msgstr "Requirements"
+
+#: inc/enigme/cta.php:196
+#, fuzzy
+msgid "Invalide"
+msgstr "Invalidate"
+
+#: inc/enigme/cta.php:197
+msgid "Erreur config"
+msgstr ""
+
+#: inc/enigme/cta.php:198
+msgid "Bloquée"
+msgstr ""
+
+#: inc/enigme/cta.php:201
+msgid "Résolvez d'abord les énigmes prérequises."
+msgstr ""
+
+#: inc/enigme/cta.php:202
+msgid "Cette énigme est bloquée ou mal configurée."
+msgstr ""
+
+#: inc/enigme/cta.php:206
+msgid "Indisponible"
+msgstr ""
+
+#: inc/enigme/cta.php:232
 msgid "Commencer"
 msgstr "Get started"
 
-#: inc/enigme/cta.php:219
+#: inc/enigme/cta.php:236
 msgid "À tenter"
 msgstr "To try"
 
-#: inc/enigme/cta.php:225
+#: inc/enigme/cta.php:242 templates/myaccount/content-chasses.php:70
 msgid "Voir"
 msgstr "See"
 
-#: inc/enigme/cta.php:226
+#: inc/enigme/cta.php:243
 msgid "Continuer"
 msgstr "Continue"
 
-#: inc/enigme/cta.php:269
+#: inc/enigme/cta.php:286
 msgid "Réessayer"
 msgstr "Try again"
 
-#: inc/enigme/cta.php:273
+#: inc/enigme/cta.php:290
 msgid "Échouée"
 msgstr "Failed"
 
-#: inc/enigme/cta.php:279
+#: inc/enigme/cta.php:296
 msgid "Recommencer"
 msgstr "Try again"
 
-#: inc/enigme/cta.php:283
+#: inc/enigme/cta.php:300
 msgid "Abandonnée"
 msgstr "Aborted"
 
-#: inc/enigme/reponses.php:41
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:92
+#: inc/enigme/reponses.php:74
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:162
+msgid "Votre réponse"
+msgstr "Your answer"
+
+#: inc/enigme/reponses.php:77
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:171
+#, php-format
 msgid "Il vous manque %d points pour soumettre votre réponse."
 msgstr "You are %d points short of submitting your answer."
 
-#: inc/enigme/reponses.php:508
+#: inc/enigme/reponses.php:86 single-chasse.php:168
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:183
+msgid "Accéder à la boutique"
+msgstr "Truy cập cửa hàng"
+
+#: inc/enigme/reponses.php:88
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
+msgid "Ajouter des points"
+msgstr "Add points"
+
+#: inc/enigme/reponses.php:96
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:195
+#: assets/js/reponse-automatique.js:95
+#, php-format
+msgid "Solde : %1$d → %2$d pts"
+msgstr "Balance: %1$d → %2$d pts"
+
+#: inc/enigme/reponses.php:137
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
+msgid "Valider"
+msgstr "Validate"
+
+#: inc/enigme/reponses.php:140
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:147
+#, fuzzy, php-format
+msgid "Valider — %d pts"
+msgstr "Balance: %d pts"
+
+#: inc/enigme/reponses.php:448
+#, fuzzy
+msgid "Réponse acceptée"
+msgstr "Answer"
+
+#: inc/enigme/reponses.php:449
+#, fuzzy
+msgid "Réponse refusée"
+msgstr "Access denied"
+
+#: inc/enigme/reponses.php:451
+msgid "Félicitations ! Votre réponse est correcte."
+msgstr ""
+
+#: inc/enigme/reponses.php:452
+#, fuzzy
+msgid "Votre réponse est incorrecte."
+msgstr "Your answer"
+
+#: inc/enigme/reponses.php:454
+#, fuzzy
+msgid "Retour à l’énigme"
+msgstr "Default riddle image"
+
+#: inc/enigme/reponses.php:455
+#, fuzzy
+msgid "Réessayer l’énigme"
+msgstr "Try again"
+
+#: inc/enigme/reponses.php:462
+#, fuzzy, php-format
+msgid "[Chasses au Trésor] %1$s — %2$s"
+msgstr "Treasure hunts"
+
+#: inc/enigme/reponses.php:491
+#, php-format
+msgid "Tentatives quotidiennes : %1$d / %2$s"
+msgstr "Daily Attempts: %1$d / %2$s"
+
+#: inc/enigme/reponses.php:618
 msgid "Tentative bien reçue."
 msgstr "Attempt received."
 
-#: inc/enigme/reponses.php:588
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:51
+#: inc/enigme/reponses.php:619
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:50
+#, php-format
 msgid ""
 "⏳ Votre tentative %1$s a été soumise le %2$s à %3$s.<br>Vous serez "
 "immédiatement averti de son traitement par l'organisateur par email et sur "
@@ -282,72 +667,96 @@ msgstr ""
 "notified of its processing by the organizer by email and on your <a "
 "href=\"%4$s\">personal space</a>."
 
-#: inc/enigme/visuels.php:129
+#: inc/enigme/tentatives.php:129
+#, php-format
+msgid ""
+"Votre demande de résolution de l'énigme %1$s%2$s%3$s a été validée. "
+"Félicitations !"
+msgstr ""
+
+#: inc/enigme/tentatives.php:133
+#, fuzzy, php-format
+msgid "Votre demande de résolution de l'énigme %1$s%2$s%3$s a été invalidée."
+msgstr "Your conversion request has been sent."
+
+#: inc/enigme/visuels.php:137
+#: template-parts/enigme/partials/enigme-partial-images.php:52
+msgid "Image par défaut de l’énigme"
+msgstr "Default riddle image"
+
+#: inc/enigme/visuels.php:138
 msgid "Visuel énigme"
 msgstr "Visual enigma"
 
-#: inc/enigme/visuels.php:425
+#: inc/enigme/visuels.php:377
 msgid "Pré-requis non remplis"
 msgstr "Prerequisites not met"
 
-#: inc/gamify-functions.php:496
+#: inc/gamify-functions.php:520
 msgid "Historique de vos points"
 msgstr "History of your points"
 
-#: inc/gamify-functions.php:500
+#: inc/gamify-functions.php:524
 msgid "ID"
 msgstr "ID"
 
-#: inc/gamify-functions.php:501
+#: inc/gamify-functions.php:525
+#: template-parts/enigme/enigme-edition-main.php:577
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:35
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:25
+#: templates/myaccount/content-chasses.php:124
 msgid "Date"
 msgstr "Date"
 
-#: inc/gamify-functions.php:502
+#: inc/gamify-functions.php:526
 msgid "Origine"
 msgstr "Origin"
 
-#: inc/gamify-functions.php:503
+#: inc/gamify-functions.php:527
 msgid "Motif"
 msgstr "Reason"
 
-#: inc/gamify-functions.php:504
+#: inc/gamify-functions.php:528
 msgid "Variation"
 msgstr "Variation"
 
-#: inc/gamify-functions.php:505
+#: inc/gamify-functions.php:529 assets/js/reponse-automatique.js:76
+#: assets/js/reponse-automatique.js:98
 msgid "Solde"
 msgstr "Balance"
 
 #: inc/organisateur-functions.php:227 inc/organisateur-functions.php:233
-#: template-parts/organisateur/organisateur-edition-main.php:290
-#: template-parts/organisateur/organisateur-edition-main.php:303
+#: template-parts/organisateur/organisateur-edition-main.php:308
+#: template-parts/organisateur/organisateur-edition-main.php:321
 msgid "Ajouter des coordonnées bancaires"
 msgstr "Add bank details"
 
 #: inc/organisateur-functions.php:231
-#: template-parts/chasse/chasse-edition-main.php:615
-#: template-parts/chasse/chasse-edition-main.php:664
-#: template-parts/chasse/chasse-edition-main.php:666
-#: template-parts/organisateur/organisateur-edition-main.php:287
-#: template-parts/organisateur/organisateur-edition-main.php:301
+#: template-parts/chasse/chasse-edition-main.php:673
+#: template-parts/chasse/partials/chasse-partial-indices.php:46
+#: template-parts/chasse/partials/chasse-partial-indices.php:50
+#: template-parts/organisateur/organisateur-edition-main.php:305
+#: template-parts/organisateur/organisateur-edition-main.php:319
+#: template-parts/organisateur/organisateur-edition-main.php:360
 msgid "Ajouter"
 msgstr "Add"
 
 #: inc/organisateur-functions.php:232
-#: template-parts/chasse/chasse-edition-main.php:616
-#: template-parts/organisateur/organisateur-edition-main.php:288
-#: template-parts/organisateur/organisateur-edition-main.php:302
+#: template-parts/chasse/chasse-edition-main.php:674
+#: template-parts/organisateur/organisateur-edition-main.php:306
+#: template-parts/organisateur/organisateur-edition-main.php:320
+#: template-parts/organisateur/organisateur-edition-main.php:361
 msgid "Éditer"
 msgstr "Edit"
 
 #: inc/organisateur-functions.php:234
-#: template-parts/organisateur/organisateur-edition-main.php:291
-#: template-parts/organisateur/organisateur-edition-main.php:304
+#: template-parts/organisateur/organisateur-edition-main.php:309
+#: template-parts/organisateur/organisateur-edition-main.php:322
 msgid "Modifier les coordonnées bancaires"
 msgstr "Edit Bank Details"
 
 #: inc/organisateur-functions.php:253
+#, php-format
 msgid "1 000 points = %s €"
 msgstr "1,000 points = € %s"
 
@@ -356,11 +765,12 @@ msgid "Demande de conversion"
 msgstr "Conversion Request"
 
 #: inc/organisateur-functions.php:258
+#, php-format
 msgid "Transformez vos %d points en euros."
 msgstr "Turn your %d points into euros."
 
 #: inc/organisateur-functions.php:262 inc/organisateur-functions.php:282
-#: template-parts/organisateur/organisateur-edition-main.php:262
+#: template-parts/organisateur/organisateur-edition-main.php:281
 msgid "Convertir"
 msgstr "Convert"
 
@@ -394,11 +804,6 @@ msgstr "View Table"
 msgid "Date demande"
 msgstr "Request date"
 
-#: inc/organisateur-functions.php:437
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:26
-msgid "Utilisateur"
-msgstr "User"
-
 #: inc/organisateur-functions.php:439
 msgid "Montant (€)"
 msgstr "Amount (€)"
@@ -428,6 +833,7 @@ msgid "En attente"
 msgstr "Pending"
 
 #: inc/organisateur-functions.php:464 inc/organisateur-functions.php:565
+#, php-format
 msgid "ID %d"
 msgstr "ID %d"
 
@@ -451,25 +857,64 @@ msgstr "Page suivante"
 msgid "Last page"
 msgstr "Dernière page"
 
-#: inc/user-functions.php:160
+#: inc/table.php:32
+#, fuzzy
+msgid "Voir plus"
+msgstr "See"
+
+#: inc/table.php:33
+#, fuzzy
+msgid "Voir moins"
+msgstr "View solution"
+
+#: inc/user-functions.php:165
 msgid "Statistiques - Chasses au Trésor"
 msgstr "Statistics - Scavenger Hunt"
 
-#: inc/user-functions.php:161
+#: inc/user-functions.php:166
 msgid "Outils - Chasses au Trésor"
 msgstr "Tools - Scavenger Hunt"
 
-#: inc/user-functions.php:162
+#: inc/user-functions.php:167
 msgid "Organisateur - Chasses au Trésor"
 msgstr "Organizer - Scavenger Hunt"
 
-#: inc/user-functions.php:167
+#: inc/user-functions.php:172
 msgid "Points - Chasses au Trésor"
 msgstr "Points - Scavenger Hunt"
 
-#: inc/user-functions.php:292
+#: inc/user-functions.php:176
+#, fuzzy
+msgid "Chasses - Chasses au Trésor"
+msgstr "Statistics - Scavenger Hunt"
+
+#: inc/user-functions.php:233 templates/myaccount/layout.php:156
+msgid "Vos commandes"
+msgstr "Your orders"
+
+#: inc/user-functions.php:335
+#, php-format
+msgid ""
+"Votre demande de résolution de l'énigme %s est en cours de traitement. Vous "
+"recevrez une notification dès que votre demande sera traitée."
+msgstr ""
+
+#: inc/user-functions.php:351
+#, php-format
+msgid ""
+"Vos demandes de résolution d'énigmes sont en cours de traitement : %s. Vous "
+"recevrez une notification dès que vos demandes seront traitées."
+msgstr ""
+
+#. translators: 1: opening anchor tag, 2: closing anchor tag
+#: inc/user-functions.php:456
+#, php-format
 msgid "Vous avez des %1$sdemandes de conversion%2$s en attente."
 msgstr "You have %1$ sconversion requests %2$s pending."
+
+#: inc/user-functions.php:478
+msgid "Important ! Des tentatives attendent votre action :"
+msgstr ""
 
 #: single-chasse.php:13
 msgid "Chasse introuvable."
@@ -483,6 +928,11 @@ msgstr ""
 "Your hunt ends automatically; add a manually or automatically validated "
 "puzzle."
 
+#: single-chasse.php:167
+#, fuzzy
+msgid "Vous n’avez pas assez de points pour engager cette énigme."
+msgstr "❌ You don't have enough points to complete this conversion."
+
 #: single-organisateur.php:84
 msgid "Chasses au Trésor"
 msgstr "Treasure hunts"
@@ -491,90 +941,231 @@ msgstr "Treasure hunts"
 msgid "C'est parti !"
 msgstr "Here we go!"
 
-#: template-parts/chasse/chasse-edition-main.php:59
+#: template-parts/chasse/chasse-edition-main.php:61
 msgid "Panneau d'édition chasse"
 msgstr "Hunt Edit Panel"
 
-#: template-parts/chasse/chasse-edition-main.php:134
+#: template-parts/chasse/chasse-edition-main.php:69
+#: template-parts/chasse/chasse-edition-main.php:647
+#: template-parts/enigme/enigme-edition-main.php:96
+#: template-parts/organisateur/organisateur-edition-main.php:77
+#: template-parts/organisateur/organisateur-edition-main.php:335
+msgid "Animation"
+msgstr "Animation"
+
+#: template-parts/chasse/chasse-edition-main.php:104
+#: template-parts/enigme/enigme-edition-main.php:128
+#: template-parts/indice/indice-edition-main.php:90
+msgid "Titre"
+msgstr "Title"
+
+#: template-parts/chasse/chasse-edition-main.php:126
+msgid "Image chasse"
+msgstr "Hunt image"
+
+#: template-parts/chasse/chasse-edition-main.php:133
+#: template-parts/indice/indice-edition-main.php:107
+msgid "Modifier l’image"
+msgstr "Edit image"
+
+#: template-parts/chasse/chasse-edition-main.php:135
+#: template-parts/chasse/chasse-edition-main.php:141
+#: template-parts/indice/indice-edition-main.php:109
+#: template-parts/indice/indice-edition-main.php:115
+msgid "ajouter une image"
+msgstr "add an image"
+
+#: template-parts/chasse/chasse-edition-main.php:154
 msgid "Description chasse"
 msgstr "Hunting description"
 
-#: template-parts/chasse/chasse-edition-main.php:142
-#: template-parts/enigme/enigme-edition-main.php:177
-#: template-parts/organisateur/organisateur-edition-main.php:141
+#: template-parts/chasse/chasse-edition-main.php:162
+#: template-parts/enigme/enigme-edition-main.php:172
+#: template-parts/enigme/enigme-edition-main.php:185
+#: template-parts/enigme/enigme-edition-main.php:202
+#: template-parts/indice/indice-edition-main.php:129
+#: template-parts/organisateur/organisateur-edition-main.php:161
 #: assets/js/enigme-edit.js:645
 msgid "ajouter"
 msgstr "Add"
 
-#: template-parts/chasse/chasse-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:174
 msgid "Modifier la description"
 msgstr "Modifying the description"
 
-#: template-parts/chasse/chasse-edition-main.php:155
-#: template-parts/chasse/chasse-edition-main.php:196
-#: template-parts/enigme/enigme-edition-main.php:189
-#: template-parts/organisateur/organisateur-edition-main.php:153
-#: template-parts/organisateur/organisateur-edition-main.php:201
-#: assets/js/chasse-edit.js:258 assets/js/core/helpers.js:218
-#: assets/js/core/helpers.js:240 assets/js/core/helpers.js:262
-#: assets/js/core/resume.js:373 assets/js/enigme-edit.js:891
+#: template-parts/chasse/chasse-edition-main.php:175
+#: template-parts/indice/indice-edition-main.php:137
+#: template-parts/organisateur/organisateur-edition-main.php:173
+#: template-parts/organisateur/organisateur-edition-main.php:220
+#: assets/js/core/helpers.js:234 assets/js/core/helpers.js:256
+#: assets/js/core/helpers.js:278 assets/js/core/resume.js:384
+#: assets/js/enigme-edit.js:743 assets/js/enigme-edit.js:988
 msgid "modifier"
 msgstr "edit"
 
-#: template-parts/chasse/chasse-edition-main.php:171
+#: template-parts/chasse/chasse-edition-main.php:191
 msgid "Récompense"
 msgstr "Award"
 
-#: template-parts/chasse/chasse-edition-main.php:195
-msgid "Modifier la récompense"
-msgstr "Edit Reward"
+#: template-parts/chasse/chasse-edition-main.php:227
+#: template-parts/enigme/enigme-edition-main.php:238
+#: template-parts/indice/indice-edition-main.php:148
+msgid "Réglages"
+msgstr "Settings"
 
-#: template-parts/chasse/chasse-edition-main.php:219
+#: template-parts/chasse/chasse-edition-main.php:239
 msgid "Mode de fin"
 msgstr "End Mode"
 
-#: template-parts/chasse/chasse-edition-main.php:230
-#: template-parts/enigme/enigme-edition-main.php:221
+#: template-parts/chasse/chasse-edition-main.php:250
+#: template-parts/enigme/enigme-edition-main.php:247
 msgid "Automatique"
 msgstr "Automatic"
 
-#: template-parts/chasse/chasse-edition-main.php:236
-#: template-parts/enigme/enigme-edition-main.php:227
+#: template-parts/chasse/chasse-edition-main.php:256
+#: template-parts/enigme/enigme-edition-main.php:253
 msgid "Explication du mode automatique"
 msgstr "Explanation of automatic mode"
 
-#: template-parts/chasse/chasse-edition-main.php:253
-#: template-parts/enigme/enigme-edition-main.php:238
+#: template-parts/chasse/chasse-edition-main.php:258
+msgid "Fin de chasse automatique"
+msgstr "Automatic hunt end"
+
+#: template-parts/chasse/chasse-edition-main.php:259
+msgid ""
+"Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode "
+"automatique, la chasse se termine dès que le nombre de gagnants prévu est "
+"atteint."
+msgstr ""
+"A player is declared the winner when they have solved all the riddles. In "
+"automatic mode, the hunt ends as soon as the planned number of winners is "
+"reached."
+
+#: template-parts/chasse/chasse-edition-main.php:272
+#: template-parts/enigme/enigme-edition-main.php:264
 msgid "Manuelle"
 msgstr "Manual"
 
-#: template-parts/chasse/chasse-edition-main.php:259
-#: template-parts/enigme/enigme-edition-main.php:244
+#: template-parts/chasse/chasse-edition-main.php:278
+#: template-parts/enigme/enigme-edition-main.php:270
 msgid "Explication du mode manuel"
 msgstr "Explanation of manual mode"
 
-#: template-parts/chasse/chasse-edition-main.php:277
+#: template-parts/chasse/chasse-edition-main.php:280
+msgid "Fin de chasse manuelle"
+msgstr "Manual hunt end"
+
+#: template-parts/chasse/chasse-edition-main.php:281
+msgid ""
+"Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans "
+"le panneau d’édition de la chasse, onglet Paramètres."
+msgstr ""
+"You can stop the hunt at any time using the button available in the hunt "
+"editing panel, Settings tab."
+
+#: template-parts/chasse/chasse-edition-main.php:295
 msgid "Terminer la chasse"
 msgstr "End Hunt"
 
-#: template-parts/chasse/chasse-edition-main.php:279
+#: template-parts/chasse/chasse-edition-main.php:297
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
 msgid "Gagnants"
 msgstr "Winners"
 
-#: template-parts/chasse/chasse-edition-main.php:287
+#: template-parts/chasse/chasse-edition-main.php:305
 msgid "Valider la fin de chasse"
 msgstr "Validate the end of hunting"
 
-#: template-parts/chasse/chasse-edition-main.php:301
+#: template-parts/chasse/chasse-edition-main.php:319
+#, php-format
 msgid "Chasse gagnée le %s par %s"
 msgstr "Hunting won on %s by %s"
 
-#: template-parts/chasse/chasse-edition-main.php:405
-#: template-parts/enigme/enigme-edition-main.php:314
+#: template-parts/chasse/chasse-edition-main.php:337
+msgid "Nb gagnants"
+msgstr "Number of winners"
+
+#: template-parts/chasse/chasse-edition-main.php:353
+msgid "Illimité"
+msgstr "Unlimited"
+
+#: template-parts/chasse/chasse-edition-main.php:374
+msgid "Début"
+msgstr "Start"
+
+#: template-parts/chasse/chasse-edition-main.php:390
+msgid "Date de fin"
+msgstr "End date"
+
+#: template-parts/chasse/chasse-edition-main.php:404
+msgid "Durée illimitée"
+msgstr "Unlimited duration"
+
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/indice/indice-edition-main.php:198
+msgid "Coût"
+msgstr "Cost"
+
+#: template-parts/chasse/chasse-edition-main.php:423
 msgid "En savoir plus sur les points"
 msgstr "Learn more about loyalty points"
 
-#: template-parts/chasse/chasse-edition-main.php:593
+#: template-parts/chasse/chasse-edition-main.php:426
+msgid "Coût d’accès à une chasse"
+msgstr "Hunt access cost"
+
+#: template-parts/chasse/chasse-edition-main.php:427
+msgid ""
+"Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou "
+"payant. Cet accès est indispensable pour consulter les énigmes, qui restent "
+"invisibles tant qu’il n’a pas été débloqué."
+msgstr ""
+"You are free to set the access cost to your hunt: free or paid. This access "
+"is necessary to view the riddles, which remain hidden until it has been "
+"unlocked."
+
+#: template-parts/chasse/chasse-edition-main.php:445
+#: template-parts/enigme/enigme-edition-main.php:394
+#: template-parts/indice/indice-edition-main.php:202
+msgid "Gratuit"
+msgstr "Free"
+
+#: template-parts/chasse/chasse-edition-main.php:552
+#: template-parts/enigme/enigme-edition-main.php:517
+msgid "Actualiser"
+msgstr "Refresh"
+
+#: template-parts/chasse/chasse-edition-main.php:554
+#: template-parts/enigme/enigme-edition-main.php:519
+msgid "Période :"
+msgstr "Period:"
+
+#: template-parts/chasse/chasse-edition-main.php:568
+#: template-parts/enigme/enigme-edition-main.php:533
+msgid "Participants"
+msgstr "Players"
+
+#: template-parts/chasse/chasse-edition-main.php:575
+#: template-parts/enigme/enigme-edition-main.php:97
+#: template-parts/enigme/enigme-edition-main.php:540
+#: template-parts/enigme/enigme-edition-main.php:578
+#: template-parts/enigme/enigme-edition-main.php:627
+#: template-parts/enigme/partials/enigme-partial-participants.php:69
+#: templates/myaccount/content-chasses.php:108
+msgid "Tentatives"
+msgstr "Attempts"
+
+#: template-parts/chasse/chasse-edition-main.php:582
+#: template-parts/enigme/enigme-edition-main.php:548
+msgid "Points collectés"
+msgstr "Points collected"
+
+#: template-parts/chasse/chasse-edition-main.php:589
+#: template-parts/chasse/chasse-edition-main.php:597
+msgid "Taux d'engagement"
+msgstr "Engagement rate"
+
+#: template-parts/chasse/chasse-edition-main.php:592
 msgid ""
 "Pourcentage moyen d’énigmes auxquelles chaque joueur a participé, par "
 "rapport à l’ensemble des énigmes proposées."
@@ -582,51 +1173,94 @@ msgstr ""
 "Average percentage of puzzles each player has participated in compared to "
 "all the puzzles offered."
 
-#: template-parts/chasse/chasse-edition-main.php:546
+#: template-parts/chasse/chasse-edition-main.php:596
 msgid "Explication du taux d’engagement"
 msgstr "Engagement Rate Explanation"
 
-#: template-parts/chasse/chasse-edition-main.php:558
+#: template-parts/chasse/chasse-edition-main.php:605
+#: template-parts/enigme/partials/enigme-partial-participants.php:39
+msgid "Les statistiques seront disponibles une fois la chasse activée."
+msgstr "Statistics will be available once hunting is enabled."
+
+#: template-parts/chasse/chasse-edition-main.php:616
 msgid "Énigmes sans validation"
 msgstr "Puzzles without validation"
 
-#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/chasse/chasse-edition-main.php:655
+#: template-parts/organisateur/organisateur-edition-main.php:342
 msgid "Communiquez"
 msgstr "Make contact"
 
-#: template-parts/chasse/chasse-edition-main.php:604
+#: template-parts/chasse/chasse-edition-main.php:662
 msgid "Sites et réseaux de la chasse"
 msgstr "website and social networks"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:19
+#: template-parts/chasse/panneaux/chasse-edition-description.php:28
 msgid "Modifier la description de la chasse"
 msgstr "Edit Hunt Description"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:20
+#: template-parts/chasse/panneaux/chasse-edition-description.php:29
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:16
 #: template-parts/enigme/panneaux/enigme-edition-description.php:19
 #: template-parts/enigme/panneaux/enigme-edition-images.php:12
+#: template-parts/indice/panneaux/indice-edition-description.php:19
 msgid "Fermer le panneau"
 msgstr "Close the panel."
+
+#: template-parts/chasse/panneaux/chasse-edition-description.php:37
+#: template-parts/enigme/panneaux/enigme-edition-description.php:27
+#: template-parts/enigme/panneaux/enigme-edition-images.php:31
+#: template-parts/indice/panneaux/indice-edition-description.php:26
+msgid "💾 Enregistrer"
+msgstr "Save"
+
+#: template-parts/chasse/panneaux/chasse-edition-description.php:45
+msgid "Description mise à jour."
+msgstr "Updated description"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:15
+msgid "Configurer la récompense"
+msgstr "Configure the reward"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:21
+msgid "Titre de la récompense"
+msgstr "Reward title"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:22
+msgid "Ex : Un papillon en cristal..."
+msgstr "E.g.: A crystal butterfly..."
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:24
+msgid "Descripton de la récompense"
+msgstr "Reward description"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:25
+msgid "Ex : Un coffret cadeau comprenant..."
+msgstr "E.g.: A gift box including..."
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:28
+msgid "Valeur en euros (€)"
+msgstr "Value in euros (€)"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:34
+msgid "Ex : 50"
+msgstr "E.g.: 50"
 
 #: template-parts/chasse/panneaux/chasse-edition-recompense.php:37
 msgid "Enregistrer"
 msgstr "Save"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:41
-#: template-parts/enigme/panneaux/enigme-edition-description.php:27
-#: template-parts/enigme/panneaux/enigme-edition-images.php:31
-msgid "💾 Enregistrer"
-msgstr "Save"
-
-#: template-parts/chasse/panneaux/chasse-edition-description.php:33
-msgid "Description mise à jour."
-msgstr "Updated description"
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:40
+msgid "Supprimer la récompense"
+msgstr "Delete the reward"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:40
 msgid "Joueurs"
 msgstr "Players"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:51
+#: template-parts/enigme/enigme-edition-main.php:576
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:34
 msgid "Joueur"
 msgstr "Player"
 
@@ -642,7 +1276,7 @@ msgstr "Sort by participation rate"
 msgid "Tx participation"
 msgstr "Tx participation"
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:67
+#: template-parts/chasse/partials/chasse-partial-participants.php:68
 msgid "Trier par taux de résolution"
 msgstr "Sort by resolution rate"
 
@@ -654,95 +1288,361 @@ msgstr "Tx resolution"
 msgid "Aucune donnée."
 msgstr "No data."
 
-#: template-parts/enigme/enigme-edition-main.php:80
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:28
+#: assets/js/enigme-edit.js:1616
+#, fuzzy
+msgid "Ajouter une énigme"
+msgstr "add an image"
+
+#: template-parts/enigme/enigme-edition-main.php:87
 msgid "Panneau d'édition énigme"
 msgstr "Riddle Editing Panel"
 
-#: template-parts/enigme/enigme-edition-main.php:88
-msgid "Solution"
-msgstr "Solution"
+#: template-parts/enigme/enigme-edition-main.php:91
+#: template-parts/indice/indice-edition-main.php:56
+msgid "Fermer les paramètres"
+msgstr "Close settings"
 
-#: template-parts/enigme/enigme-edition-main.php:169
+#: template-parts/enigme/enigme-edition-main.php:112
+#: template-parts/indice/indice-edition-main.php:74
+msgid "Informations"
+msgstr "Information"
+
+#: template-parts/enigme/enigme-edition-main.php:138
+msgid "renseigner le titre de l’énigme"
+msgstr "enter the riddle title"
+
+#: template-parts/enigme/enigme-edition-main.php:156
+msgid "Illustrations"
+msgstr "Illustrations"
+
+#: template-parts/enigme/enigme-edition-main.php:194
 msgid "Texte énigme"
 msgstr "Riddle text"
 
-#: template-parts/enigme/enigme-edition-main.php:192
+#: template-parts/enigme/enigme-edition-main.php:213
 msgid "Éditer le texte"
 msgstr "Edit simple text"
 
-#: template-parts/enigme/enigme-edition-main.php:202
-msgid "Sous-titre"
-msgstr "Subtitle"
-
-#: template-parts/enigme/enigme-edition-main.php:204
-msgid "Ajouter un sous-titre (max 100 caractères)"
-msgstr "Add a subtitle (max 100 characters)"
-
-#: template-parts/enigme/enigme-edition-main.php:217
-msgid "Validation"
-msgstr "Validation"
-
-#: template-parts/enigme/enigme-edition-main.php:255
-msgid "Aucune"
-msgstr "None"
-
-#: template-parts/enigme/enigme-edition-main.php:272
-msgid "Variantes"
-msgstr "Variants"
-
-#: template-parts/enigme/enigme-edition-main.php:278
-msgid "Explication des variantes"
-msgstr "Explanation of variants"
-
-#: template-parts/enigme/enigme-edition-main.php:294
-msgid "Éditer les variantes"
-msgstr "Edit Variants"
-
-#: template-parts/enigme/enigme-edition-main.php:295
+#: template-parts/enigme/enigme-edition-main.php:214
+#: template-parts/enigme/enigme-edition-main.php:350
+#: template-parts/enigme/enigme-edition-main.php:673
 msgid "éditer"
 msgstr "edit"
 
-#: template-parts/enigme/enigme-edition-main.php:299
-#: assets/js/enigme-edit.js:869
+#: template-parts/enigme/enigme-edition-main.php:228
+msgid "Sous-titre"
+msgstr "Subtitle"
+
+#: template-parts/enigme/enigme-edition-main.php:230
+msgid "Ajouter un sous-titre (max 100 caractères)"
+msgstr "Add a subtitle (max 100 characters)"
+
+#: template-parts/enigme/enigme-edition-main.php:243
+msgid "Validation"
+msgstr "Validation"
+
+#: template-parts/enigme/enigme-edition-main.php:256
+msgid "Validation automatique"
+msgstr "Automatic validation"
+
+#: template-parts/enigme/enigme-edition-main.php:257
+msgid ""
+"Le joueur soumet une tentative de réponse. Celle-ci est automatiquement "
+"vérifiée selon les critères définis (réponse attendue, respect de la casse, "
+"variantes), et le résultat est immédiatement communiqué au joueur."
+msgstr ""
+"The player submits an answer attempt. It is automatically checked against "
+"the defined criteria (expected answer, case sensitivity, variants), and the "
+"result is immediately communicated to the player."
+
+#: template-parts/enigme/enigme-edition-main.php:273
+msgid "Validation manuelle"
+msgstr "Manual validation"
+
+#: template-parts/enigme/enigme-edition-main.php:274
+msgid ""
+"Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa "
+"tentative depuis votre espace personnel. À chaque nouvelle soumission, vous "
+"recevez une notification par email ainsi qu’un message d’alerte."
+msgstr ""
+"The player writes a free-form answer. You then approve or reject their "
+"attempt from your personal area. Each new submission triggers an email "
+"notification and an alert message."
+
+#: template-parts/enigme/enigme-edition-main.php:281
+msgid "Aucune"
+msgstr "None"
+
+#: template-parts/enigme/enigme-edition-main.php:288
+msgid "Bonne(s) réponse(s)"
+msgstr "Correct answer(s)"
+
+#: template-parts/enigme/enigme-edition-main.php:294
+msgid "La ou les bonnes réponses"
+msgstr "The correct answer(s)"
+
+#: template-parts/enigme/enigme-edition-main.php:295
+msgid ""
+"Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — "
+"selon votre réglage de respect de la casse — résout l’énigme."
+msgstr ""
+"You may enter between 1 and 5 correct answers. Any player submitting one—"
+"depending on your case sensitivity setting—solves the puzzle."
+
+#: template-parts/enigme/enigme-edition-main.php:307
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
+msgid "Respecter la casse"
+msgstr "Case sensitive"
+
+#: template-parts/enigme/enigme-edition-main.php:315
+msgid "Variantes"
+msgstr "Variants"
+
+#: template-parts/enigme/enigme-edition-main.php:321
+msgid "Explication des variantes"
+msgstr "Explanation of variants"
+
+#: template-parts/enigme/enigme-edition-main.php:324
+msgid "Système de variantes"
+msgstr "Variants system"
+
+#: template-parts/enigme/enigme-edition-main.php:325
+msgid ""
+"Les variantes sont des réponses alternatives qui ne sont pas validées comme "
+"correctes, mais qui déclenchent un message personnalisé en retour (par "
+"exemple une aide, un indice, un lien ou tout autre contenu de votre choix)."
+msgstr ""
+"Variants are alternative answers that are not validated as correct but "
+"trigger a personalized message in return (for example a help message, a "
+"hint, a link or any other content of your choice)."
+
+#: template-parts/enigme/enigme-edition-main.php:335
+#: assets/js/enigme-edit.js:915
+#, fuzzy
+msgid "Variante"
+msgstr "Variants"
+
+#: template-parts/enigme/enigme-edition-main.php:336
+#: assets/js/enigme-edit.js:918
+msgid "Message"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:349
+msgid "Éditer les variantes"
+msgstr "Edit Variants"
+
+#: template-parts/enigme/enigme-edition-main.php:354
+#: assets/js/enigme-edit.js:966
 msgid "Ajouter des variantes"
 msgstr "Add variations"
 
-#: template-parts/enigme/enigme-edition-main.php:300
-#: assets/js/enigme-edit.js:870
+#: template-parts/enigme/enigme-edition-main.php:355
+#: assets/js/enigme-edit.js:967
 msgid "ajouter des variantes"
 msgstr "Add variations"
 
-#: template-parts/enigme/enigme-edition-main.php:342
+#: template-parts/enigme/enigme-edition-main.php:371
+msgid "Coût tentative"
+msgstr "Attempt cost"
+
+#: template-parts/enigme/enigme-edition-main.php:377
+#, fuzzy
+msgid "Informations sur le coût des tentatives"
+msgstr "Bank details information"
+
+#: template-parts/enigme/enigme-edition-main.php:380
+msgid "Tentative gratuite ou payante ?"
+msgstr "Free or paid attempt?"
+
+#: template-parts/enigme/enigme-edition-main.php:381
+msgid ""
+"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
+"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
+"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
+msgstr ""
+"You are free to set the cost of an attempt for your riddle: free or paid in "
+"points. When a player spends points to submit an answer, those points are "
+"immediately credited to your account."
+
+#: template-parts/enigme/enigme-edition-main.php:402
+msgid "Nb tentatives"
+msgstr "Attempts"
+
+#: template-parts/enigme/enigme-edition-main.php:408
 msgid "Explication du nombre de tentatives"
 msgstr "Explanation of the number of attempts"
 
-#: template-parts/enigme/enigme-edition-main.php:364
+#: template-parts/enigme/enigme-edition-main.php:411
+msgid "Plafond nb de tentatives quotidiennes"
+msgstr "Daily attempt limit"
+
+#: template-parts/enigme/enigme-edition-main.php:412
+#, fuzzy
+msgid ""
+"Nombre maximal de tentatives quotidiennes par joueur:\n"
+"\n"
+"Mode payant : illimitées\n"
+"\n"
+"Mode gratuit : 24 tentatives par jour"
+msgstr ""
+"Maximum number of daily attempts per player:\\n\\nPaid mode: "
+"unlimited\\n\\nFree mode: 24 attempts per day"
+
+#: template-parts/enigme/enigme-edition-main.php:418
+msgid "max par jour"
+msgstr "max per day"
+
+#: template-parts/enigme/enigme-edition-main.php:434
 msgid "Accès"
 msgstr "Access"
 
-#: template-parts/enigme/enigme-edition-main.php:368
+#: template-parts/enigme/enigme-edition-main.php:438
 msgid "Libre"
 msgstr "Free"
 
-#: template-parts/enigme/enigme-edition-main.php:372
+#: template-parts/enigme/enigme-edition-main.php:442
 msgid "Date programmée"
 msgstr "Schedule Date "
 
-#: template-parts/enigme/enigme-edition-main.php:381
-msgid "Pré-requis"
-msgstr "Requirements"
-
-#: template-parts/enigme/enigme-edition-main.php:385
+#: template-parts/enigme/enigme-edition-main.php:455
 msgid "Aucune autre énigme disponible comme prérequis."
 msgstr "No other puzzles available as prerequisites."
 
-#: template-parts/enigme/enigme-edition-main.php:569
-msgid "Solution de cette énigme"
-msgstr "Solving this riddle"
+#: template-parts/enigme/enigme-edition-main.php:491
+msgid "❌ Suppression énigme"
+msgstr "❌ Delete riddle"
 
-#: template-parts/enigme/enigme-edition-main.php:640
+#: template-parts/enigme/enigme-edition-main.php:521
+msgid "Total"
+msgstr "Total"
+
+#: template-parts/enigme/enigme-edition-main.php:522
+msgid "Aujourd’hui"
+msgstr "Today"
+
+#: template-parts/enigme/enigme-edition-main.php:523
+msgid "Semaine"
+msgstr "Week"
+
+#: template-parts/enigme/enigme-edition-main.php:524
+msgid "Mois"
+msgstr "Month"
+
+#: template-parts/enigme/enigme-edition-main.php:556
+msgid "Bonnes réponses"
+msgstr "Correct answers"
+
+#: template-parts/enigme/enigme-edition-main.php:570
+#, php-format
+msgid "Résolue par (%s) joueurs"
+msgstr "Solved by (%s) players"
+
+#: template-parts/enigme/enigme-edition-main.php:575
+msgid "Rang"
+msgstr "Rank"
+
+#: template-parts/enigme/enigme-edition-main.php:655
+msgid "Animation de cette énigme"
+msgstr "Animation of this riddle"
+
+#: template-parts/enigme/enigme-edition-main.php:667
+msgid ""
+"Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée "
+"terminée. Une fois celle-ci achevée, elles restent conservées dans un coffre-"
+"fort numérique pendant le délai que vous définissez ici."
+msgstr ""
+"Solutions can only be published once a hunt is declared over. After that, "
+"they are stored in a digital safe for the delay you set here."
+
+#: template-parts/enigme/enigme-edition-main.php:670
+msgid "Document PDF"
+msgstr "PDF document"
+
+#: template-parts/enigme/enigme-edition-main.php:671
+#: templates/myaccount/content-outils.php:33
+msgid "Modifier"
+msgstr "Edit"
+
+#: template-parts/enigme/enigme-edition-main.php:671
+msgid "Choisir un fichier"
+msgstr "Choose a file"
+
+#: template-parts/enigme/enigme-edition-main.php:673
+msgid "Rédiger"
+msgstr "Write"
+
+#: template-parts/enigme/enigme-edition-main.php:675
+msgid "aucune solution ne"
+msgstr "no solution"
+
+#: template-parts/enigme/enigme-edition-main.php:680
+#, php-format
+msgid "votre fichier %s"
+msgstr "your %s file"
+
+#: template-parts/enigme/enigme-edition-main.php:681
+#, php-format
+msgid " %d jours après la fin de la chasse, à %s"
+msgstr " %d days after the end of the hunt, at %s"
+
+#: template-parts/enigme/enigme-edition-main.php:683
+msgid " (pdf sélectionné mais pas de fichier chargé)"
+msgstr " (pdf selected but no file uploaded)"
+
+#: template-parts/enigme/enigme-edition-main.php:687
+msgid "votre texte d'explication"
+msgstr "your explanation text"
+
+#: template-parts/enigme/enigme-edition-main.php:688
+#, php-format
+msgid ", %d jours après la fin de la chasse, à %s"
+msgstr ", %d days after the end of the hunt, at %s"
+
+#: template-parts/enigme/enigme-edition-main.php:690
+msgid " (rédaction libre sélectionnée mais non remplie)"
+msgstr " (free writing selected but not filled)"
+
+#: template-parts/enigme/enigme-edition-main.php:702
+#: template-parts/enigme/enigme-edition-main.php:710
+msgid "Vider"
+msgstr "Clear"
+
+#: template-parts/enigme/enigme-edition-main.php:712
+msgid "Rédaction libre"
+msgstr "Free writing"
+
+#: template-parts/enigme/enigme-edition-main.php:720
+msgid "Délai après fin de chasse"
+msgstr "Delay after hunt end"
+
+#: template-parts/enigme/enigme-edition-main.php:726
 msgid "Informations sur la publication de la solution"
 msgstr "Solution Release Information"
+
+#: template-parts/enigme/enigme-edition-main.php:729
+msgid "Délai de parution des solutions"
+msgstr "Solutions release delay"
+
+#: template-parts/enigme/enigme-edition-main.php:745
+msgid "jours, publié à"
+msgstr "days, published at"
+
+#: template-parts/enigme/enigme-edition-main.php:760
+msgid "Vos solutions sont protégées"
+msgstr "Your solutions are protected"
+
+#: template-parts/enigme/enigme-edition-main.php:761
+msgid "Stockées dans un espace privé, hors de portée des joueurs."
+msgstr "Stored in a private area, out of players' reach."
+
+#: template-parts/enigme/enigme-edition-main.php:762
+msgid "Aucun lien ne peut être trouvé ni ouvert."
+msgstr "No link can be found or opened."
+
+#: template-parts/enigme/enigme-edition-main.php:763
+msgid "Débloquées uniquement au moment choisi."
+msgstr "Unlocked only at the chosen time."
 
 #: template-parts/enigme/panneaux/enigme-edition-description.php:18
 msgid "Modifier le texte de l’énigme"
@@ -756,17 +1656,21 @@ msgstr "Enigma text updated."
 msgid "Modifier les images de l’énigme"
 msgstr "Edit Puzzle Images"
 
-#: template-parts/enigme/panneaux/enigme-edition-images.php:29
+#: template-parts/enigme/panneaux/enigme-edition-images.php:40
 msgid "Images mises à jour."
 msgstr "Images updated."
 
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:21
+msgid "Configurer les variantes de réponse"
+msgstr "Configure answer variants"
+
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:50
-#: assets/js/enigme-edit.js:743
+#: assets/js/enigme-edit.js:826
 msgid "réponse déclenchant l'affichage du message"
 msgstr "response triggering the display of the message"
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:51
-#: assets/js/enigme-edit.js:746
+#: assets/js/enigme-edit.js:829
 msgid "Message affiché au joueur"
 msgstr "Message displayed to player"
 
@@ -774,60 +1678,47 @@ msgstr "Message displayed to player"
 msgid "Ajouter une variante"
 msgstr "Add variation"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:19
-msgid "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
-msgstr "🛠️ This riddle is yours. No forms are displayed."
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:77
+msgid "Enregistrer les variantes"
+msgstr "Save variants"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:36
-msgid "Énigme résolue"
-msgstr "Puzzle solved!"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:63
+msgid "⏳ Votre tentative est en cours de traitement."
+msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:58
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:78
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:106
+#, php-format
 msgid "Vous avez résolu cette énigme le %s."
 msgstr "You solved this puzzle on %s."
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:55
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:48
-msgid "Valider"
-msgstr "Validate"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:110
+msgid "Énigme résolue"
+msgstr "Puzzle solved!"
 
-#: assets/js/enigme-edit.js:605
-#: assets/js/enigme-edit.js:657
-msgid "valider"
-msgstr "Validate"
-
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:61
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:125
+#: assets/js/reponse-automatique.js:197 assets/js/reponse-automatique.js:219
 msgid "tentatives quotidiennes épuisées"
 msgstr "exhausted daily attempts"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:70
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:134
+#, php-format
 msgid "%dh et %dmn avant réactivation"
 msgstr "%dh and %dmn before reactivation"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
-#: inc/enigme/reponses.php:38
-msgid "Votre réponse"
-msgstr "Your answer"
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:25
+msgid "Gagnants :"
+msgstr "Winners:"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:93
-msgid "Accéder à la boutique"
-msgstr "Truy cập cửa hàng"
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
+msgid "Aucun gagnant pour le moment."
+msgstr "No winners yet."
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:105
-msgid "pts"
-msgstr "pts"
-
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:112
-msgid "Tentatives quotidiennes"
-msgstr "Daily Attempts"
-
-#: template-parts/enigme/partials/enigme-partial-images.php:39
-msgid "Image par défaut de l’énigme"
+#: template-parts/enigme/partials/enigme-partial-images.php:53
+#, fuzzy
+msgid "Image de l’énigme"
 msgstr "Default riddle image"
-
-#: template-parts/enigme/partials/enigme-partial-participants.php:39
-msgid "Les statistiques seront disponibles une fois la chasse activée."
-msgstr "Statistics will be available once hunting is enabled."
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:43
 msgid "Aucun participant engagé."
@@ -837,47 +1728,39 @@ msgstr "No participants engaged."
 msgid "Liste participants"
 msgstr "Participants list"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:50
+#: template-parts/enigme/partials/enigme-partial-participants.php:51
 msgid "Nom"
 msgstr "Name"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:55
+#: template-parts/enigme/partials/enigme-partial-participants.php:56
 msgid "Trier par engagement"
 msgstr "Sort by commitment"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:57
+#: template-parts/enigme/partials/enigme-partial-participants.php:58
 msgid "Engagement"
 msgstr "Commitment"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:66
+#: template-parts/enigme/partials/enigme-partial-participants.php:67
 msgid "Trier par tentatives"
 msgstr "Sort by Attempts"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:68
-msgid "Tentatives"
-msgstr "Attempts"
-
-#: template-parts/enigme/partials/enigme-partial-participants.php:73
+#: template-parts/enigme/partials/enigme-partial-participants.php:74
 msgid "Trouvé"
 msgstr "Found"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:91
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:64
+#: template-parts/enigme/partials/enigme-partial-participants.php:96
 msgid "Première page"
 msgstr "First page"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:94
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:67
+#: template-parts/enigme/partials/enigme-partial-participants.php:99
 msgid "Page précédente"
 msgstr "Previous page"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:100
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:73
+#: template-parts/enigme/partials/enigme-partial-participants.php:105
 msgid "Page suivante"
 msgstr "Next page"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:103
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:76
+#: template-parts/enigme/partials/enigme-partial-participants.php:108
 msgid "Dernière page"
 msgstr "Last page"
 
@@ -886,31 +1769,38 @@ msgid "Aucune tentative de soumission."
 msgstr "No attempt to submit."
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:27
+#: templates/myaccount/content-chasses.php:126
 msgid "Proposition"
 msgstr "Answer"
 
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:27
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:28
+#: templates/myaccount/content-chasses.php:127
 msgid "Résultat"
 msgstr "Result"
-
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:27
-msgid "Réponse"
-msgstr "Answer"
-
-msgid "Bonne(s) réponse(s)"
-msgstr "Correct answer(s)"
-
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:28
-msgid "Actions"
-msgstr "Actions"
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:34
 msgid "Inconnu"
 msgstr "Unknown"
 
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:51
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:55
+msgid "bon"
+msgstr "correct"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:57
+msgid "faux"
+msgstr "wrong"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:59
+msgid "attente"
+msgstr "pending"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:71
 msgid "Invalider"
 msgstr "Invalidate"
+
+#: template-parts/enigme/partials/enigme-sidebar-section.php:42
+msgid "Aucune énigme disponible"
+msgstr "No puzzles available"
 
 #: template-parts/enigme/partials/pirate/enigme-partial-images.php:9
 msgid ""
@@ -934,33 +1824,130 @@ msgstr "🏴‍☠️ Text (pirate)"
 msgid "🏴‍☠️ Titre (pirate)"
 msgstr "🏴‍☠️ Title (pirate)"
 
-#: template-parts/organisateur/organisateur-edition-main.php:67
+#: template-parts/indice/indice-edition-main.php:53
+msgid "Panneau d'édition indice"
+msgstr "Clue edit panel"
+
+#: template-parts/indice/indice-edition-main.php:95
+msgid "renseigner le titre de l’indice"
+msgstr "enter the clue title"
+
+#: template-parts/indice/indice-edition-main.php:105
+msgid "Image"
+msgstr "Image"
+
+#: template-parts/indice/indice-edition-main.php:124
+msgid "Texte"
+msgstr "Text"
+
+#: template-parts/indice/indice-edition-main.php:136
+#: template-parts/indice/panneaux/indice-edition-description.php:18
+msgid "Modifier le texte de l’indice"
+msgstr "Edit the clue text"
+
+#: template-parts/indice/indice-edition-main.php:151
+msgid "Aide pour"
+msgstr "Help for"
+
+#: template-parts/indice/indice-edition-main.php:158
+msgid "Aucune énigme disponible."
+msgstr "No puzzle available."
+
+#: template-parts/indice/indice-edition-main.php:184
+msgid "Publication"
+msgstr "Publishing"
+
+#: template-parts/indice/indice-edition-main.php:186
+msgid "Immédiate"
+msgstr "Immediate"
+
+#: template-parts/indice/indice-edition-main.php:187
+msgid "Différée"
+msgstr "Delayed"
+
+#: template-parts/indice/indice-edition-main.php:198
+msgid "(points)"
+msgstr "(points)"
+
+#: template-parts/indice/indice-edition-main.php:221
+#, fuzzy
+msgid "Statistiques à venir"
+msgstr "Statistics"
+
+#: template-parts/indice/panneaux/indice-edition-description.php:31
+msgid "Texte de l’indice mis à jour."
+msgstr "Clue text updated."
+
+#: template-parts/modals/modal-points.php:9
+msgid "À quoi servent les points ?"
+msgstr "What are points used for?"
+
+#: template-parts/modals/modal-points.php:10
+msgid "Les points vous permettent de débloquer :"
+msgstr "Points allow you to unlock:"
+
+#: template-parts/modals/modal-points.php:12
+msgid "🎯 Des chasses au trésor"
+msgstr "🎯 Treasure hunts"
+
+#: template-parts/modals/modal-points.php:13
+msgid "❓ Des tentatives de réponse"
+msgstr "❓ Answer attempts"
+
+#: template-parts/modals/modal-points.php:14
+msgid "💡 Des indices"
+msgstr "💡 Hints"
+
+#: template-parts/modals/modal-points.php:17
+msgid ""
+"La gratuité ou l'accès par points est choisi librement par chaque "
+"organisateur."
+msgstr "Free access or point access is chosen freely by each organizer."
+
+#: template-parts/organisateur/organisateur-edition-main.php:69
 msgid "Panneau d'édition organisateur"
 msgstr "Organizer Edit Panel"
 
-#: template-parts/organisateur/organisateur-edition-main.php:133
-msgid "Présentation"
-msgstr "Presentation"
-
-#: template-parts/organisateur/organisateur-edition-main.php:153
-msgid "Modifier la présentation"
-msgstr "Edit showcase"
-
-#: template-parts/organisateur/organisateur-edition-main.php:187
-msgid "Informations sur l’adresse email de contact"
-msgstr "Contact Email Address Information"
-
-#: template-parts/organisateur/organisateur-edition-main.php:251
+#: template-parts/organisateur/organisateur-edition-main.php:78
+#: template-parts/organisateur/organisateur-edition-main.php:264
+#: template-parts/organisateur/organisateur-edition-main.php:270
 #: templates/myaccount/content-points.php:75
-#: templates/myaccount/content-points.php:96
+#: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
+#: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
 msgid "Points"
 msgstr "Points"
 
-#: template-parts/organisateur/organisateur-edition-main.php:274
+#: template-parts/organisateur/organisateur-edition-main.php:153
+msgid "Présentation"
+msgstr "Presentation"
+
+#: template-parts/organisateur/organisateur-edition-main.php:173
+msgid "Modifier la présentation"
+msgstr "Edit showcase"
+
+#: template-parts/organisateur/organisateur-edition-main.php:207
+msgid "Informations sur l’adresse email de contact"
+msgstr "Contact Email Address Information"
+
+#: template-parts/organisateur/organisateur-edition-main.php:209
+msgid "Email de contact organisateur"
+msgstr "Organizer contact email"
+
+#: template-parts/organisateur/organisateur-edition-main.php:210
+msgid ""
+"Si aucune adresse n’est renseignée, votre adresse email utilisateur est "
+"utilisée par défaut."
+msgstr "If no address is provided, your user email is used by default."
+
+#: template-parts/organisateur/organisateur-edition-main.php:293
 msgid "Informations sur les coordonnées bancaires"
 msgstr "Bank details information"
 
-#: template-parts/organisateur/organisateur-edition-main.php:276
+#: template-parts/organisateur/organisateur-edition-main.php:296
+msgid "Coordonnées bancaires"
+msgstr "Bank details"
+
+#: template-parts/organisateur/organisateur-edition-main.php:297
 msgid ""
 "Ces informations sont nécessaires uniquement pour vous verser les gains "
 "issus de la conversion de vos points en euros. Nous ne prélevons jamais "
@@ -969,21 +1956,79 @@ msgstr ""
 "This information is only necessary to pay you the winnings from the "
 "conversion of your points into euros. We never take money."
 
+#: template-parts/organisateur/organisateur-edition-main.php:352
+#, fuzzy
+msgid "Sites et réseaux de l'organisation"
+msgstr "Organization's websites and social networks"
+
+#: template-parts/organisateur/organisateur-edition-main.php:380
+msgid "QR code de l'organisation"
+msgstr "Organization QR code"
+
+#: template-parts/organisateur/organisateur-edition-main.php:381
+msgid "QR code de votre organisation"
+msgstr "Your organization's QR code"
+
+#: template-parts/organisateur/organisateur-edition-main.php:383
+msgid "Télécharger"
+msgstr "Download"
+
+#: templates/myaccount/content-chasses.php:111
+#, php-format
+msgid "%d tentative en attente"
+msgid_plural "%d tentatives en attente"
+msgstr[0] "%d pending attempt"
+msgstr[1] "%d pending attempts"
+
+#: templates/myaccount/content-chasses.php:113
+#, php-format
+msgid "%d tentative"
+msgid_plural "%d tentatives"
+msgstr[0] "%d attempt"
+msgstr[1] "%d attempts"
+
+#: templates/myaccount/content-chasses.php:116
+#, php-format
+msgid "%d bonne réponse"
+msgid_plural "%d bonnes réponses"
+msgstr[0] "%d correct answer"
+msgstr[1] "%d correct answers"
+
+#: templates/myaccount/content-chasses.php:125
+msgid "Énigme"
+msgstr "Riddle"
+
 #: templates/myaccount/content-dashboard-organisateur.php:25
 msgid "Votre demande de conversion a bien été envoyée."
 msgstr "Your conversion request has been sent."
 
-#: templates/myaccount/content-outils.php:18
+#: templates/myaccount/content-organisateurs.php:19
+#: templates/myaccount/layout.php:104
+msgid "Organisateurs"
+msgstr "Organizers"
+
+#: templates/myaccount/content-organisateurs.php:37
+#, fuzzy, php-format
+msgid "%d organisateur"
+msgid_plural "%d organisateurs"
+msgstr[0] "Organizers"
+msgstr[1] "Organizers"
+
+#: templates/myaccount/content-organisateurs.php:44
+msgid "Filtrer par état :"
+msgstr ""
+
+#: templates/myaccount/content-organisateurs.php:46
+msgid "Tous"
+msgstr ""
+
+#: templates/myaccount/content-outils.php:18 templates/myaccount/layout.php:118
 msgid "Outils"
 msgstr "Tools"
 
 #: templates/myaccount/content-outils.php:23
 msgid "Taux Conversion"
 msgstr "Currency Exchange"
-
-#: templates/myaccount/content-outils.php:33
-msgid "Modifier"
-msgstr "Edit"
 
 #: templates/myaccount/content-outils.php:37
 msgid "Définir un nouveau taux :"
@@ -1000,6 +2045,14 @@ msgstr "ACF"
 #: templates/myaccount/content-outils.php:49
 msgid "Afficher les champs ACF"
 msgstr "Show Fields"
+
+#: templates/myaccount/content-outils.php:61
+msgid "Reset stats"
+msgstr ""
+
+#: templates/myaccount/content-outils.php:65
+msgid "Effacer"
+msgstr ""
 
 #: templates/myaccount/content-points.php:30
 msgid "Points achetés"
@@ -1021,15 +2074,60 @@ msgstr "Points in my organization"
 msgid "Gérer"
 msgstr "Manage"
 
+#: templates/myaccount/layout.php:34
+msgid "Accueil"
+msgstr "Dashboard"
+
+#: templates/myaccount/layout.php:41
+msgid "Commandes"
+msgstr "Orders"
+
+#: templates/myaccount/layout.php:48
+msgid "Chasses"
+msgstr "Hunts"
+
+#: templates/myaccount/layout.php:49 templates/myaccount/layout.php:158
+msgid "Vos chasses"
+msgstr "Your hunts"
+
+#: templates/myaccount/layout.php:66
+msgid "Profil"
+msgstr "Profile"
+
+#: templates/myaccount/layout.php:95
+msgid "Déconnexion"
+msgstr "Log out"
+
+#: templates/myaccount/layout.php:100
+msgid "Administration"
+msgstr "Administration"
+
+#: templates/myaccount/layout.php:154
+msgid "Votre profil"
+msgstr "Your profile"
+
+#: templates/myaccount/layout.php:162
+#, php-format
+msgid "Bienvenue %s"
+msgstr ""
+
+#: templates/myaccount/layout.php:187
+msgid "Content not found."
+msgstr ""
+
+#. Template Name of the theme
 msgid "Confirmation Organisateur"
 msgstr "Organizer Confirmation"
 
+#. Template Name of the theme
 msgid "Créer mon profil"
 msgstr "Create my profile"
 
+#. Template Name of the theme
 msgid "Devenir Organisateur"
 msgstr "Become an Organizer"
 
+#. Template Name of the theme
 msgid "Traitement Engagement"
 msgstr "Engagement Processing"
 
@@ -1038,9 +2136,11 @@ msgid "Échec de vérification de sécurité"
 msgstr "Security check failure"
 
 #: templates/page-traitement-engagement.php:49
+#, php-format
 msgid "Déblocage de la chasse #%d"
 msgstr "Unlocking Hunt #%d"
 
+#. Template Name of the theme
 msgid "Traitement Tentative (Confirmation explicite)"
 msgstr "Attempt Treatment (Explicit Confirmation)"
 
@@ -1056,6 +2156,7 @@ msgstr "Attemp not found"
 msgid "⛔️ Accès refusé."
 msgstr "Access denied."
 
+#. Template Name of the theme
 msgid "Traitement Validation Chasse"
 msgstr "Hunting Validation Processing"
 
@@ -1075,354 +2176,63 @@ msgstr ""
 "✉️ A verification email has been sent to you. Please click on the link to "
 "confirm your request."
 
-#: assets/js/chasse-edit.js:414
-msgid ""
-"Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse "
-"s’achève dès que le nombre de gagnants prévu est atteint."
-msgstr ""
-"A player becomes a winner when they solve all the puzzles. The hunt ends as "
-"soon as the expected number of winners is reached."
+#: assets/js/enigme-aside.js:15
+#, fuzzy
+msgid "Afficher le panneau"
+msgstr "Close the panel."
 
-#: assets/js/chasse-edit.js:418
-msgid ""
-"Vous arrêtez la chasse manuellement, grâce au bouton situé dans le panneau "
-"d'édition chasse."
-msgstr ""
-"You stop the hunt manually, thanks to the button located in the hunt edit "
-"panel."
+#: assets/js/enigme-edit.js:600
+msgid "Ex : soleil"
+msgstr "E.g. sun"
 
-#: assets/js/enigme-edit.js:139
-msgid ""
-"Nombre maximum de tentatives quotidiennes d'un joueur\n"
-"Mode payant : tentatives illimitées.\n"
-"Mode gratuit : maximum 24 tentatives par jour."
-msgstr ""
-"Maximum number of daily attempts by a player\n"
-"Paid mode: unlimited attempts.\n"
-"Free mode: maximum 24 attempts per day."
+#: assets/js/enigme-edit.js:605 assets/js/enigme-edit.js:657
+msgid "valider"
+msgstr "Validate"
 
-#: assets/js/enigme-edit.js:795
-msgid "Enregistrement..."
-msgstr "Registration"
+#: assets/js/enigme-edit.js:629
+msgid "Supprimer"
+msgstr "Remove"
 
-#: assets/js/enigme-edit.js:815
-msgid "✔️ Variantes enregistrées"
-msgstr "Saved ✔️ Variants"
+#: assets/js/enigme-edit.js:703
+#, fuzzy
+msgid "Ajouter une illustration"
+msgstr "Add variation"
 
-#: assets/js/enigme-edit.js:890
+#: assets/js/enigme-edit.js:742 assets/js/enigme-edit.js:987
 msgid "Modifier les variantes"
 msgstr "Change Variants"
 
-#: assets/js/enigme-edit.js:908
+#: assets/js/enigme-edit.js:878
+msgid "Enregistrement..."
+msgstr "Registration"
+
+#: assets/js/enigme-edit.js:898
+msgid "✔️ Variantes enregistrées"
+msgstr "Saved ✔️ Variants"
+
+#: assets/js/enigme-edit.js:1005
 msgid "❌ Erreur réseau"
 msgstr "Network error"
 
-msgid "Français"
-msgstr "French"
-
-msgid "English"
-msgstr "English"
-
-msgid "Change language"
-msgstr "Change language"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Fermer les paramètres"
-msgstr "Close settings"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Paramètres"
-msgstr "Settings"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Informations"
-msgstr "Information"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Titre"
-msgstr "Title"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "renseigner le titre de l’énigme"
-msgstr "enter the riddle title"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Illustrations"
-msgstr "Illustrations"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Réglages"
-msgstr "Settings"
-
-#: template-parts/enigme/enigme-edition-main.php
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
-msgid "Respecter la casse"
-msgstr "Case sensitive"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Coût tentative"
-msgstr "Attempt cost"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Gratuit"
-msgstr "Free"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Nb tentatives"
-msgstr "Attempts"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "max par jour"
-msgstr "max per day"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "❌ Suppression énigme"
-msgstr "❌ Delete riddle"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Actualiser"
-msgstr "Refresh"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Période :"
-msgstr "Period:"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Total"
-msgstr "Total"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Aujourd’hui"
-msgstr "Today"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Semaine"
-msgstr "Week"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Mois"
-msgstr "Month"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Participants"
-msgstr "Players"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Points collectés"
-msgstr "Points collected"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Bonnes réponses"
-msgstr "Correct answers"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Résolue par (%s) joueurs"
-msgstr "Solved by (%s) players"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Rang"
-msgstr "Rank"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Document PDF"
-msgstr "PDF document"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Choisir un fichier"
-msgstr "Choose a file"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Rédiger"
-msgstr "Write"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "aucune solution ne"
-msgstr "no solution"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid " %d jours après la fin de la chasse, à %s"
-msgstr " %d days after the end of the hunt, at %s"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid " (pdf sélectionné mais pas de fichier chargé)"
-msgstr " (pdf selected but no file uploaded)"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "votre texte d'explication"
-msgstr "your explanation text"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid ", %d jours après la fin de la chasse, à %s"
-msgstr ", %d days after the end of the hunt, at %s"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid " (rédaction libre sélectionnée mais non remplie)"
-msgstr " (free writing selected but not filled)"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Vider"
-msgstr "Clear"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Rédaction libre"
-msgstr "Free writing"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Délai après fin de chasse"
-msgstr "Delay after hunt end"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "jours, publié à"
-msgstr "days, published at"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Vos solutions sont protégées"
-msgstr "Your solutions are protected"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Stockées dans un espace privé, hors de portée des joueurs."
-msgstr "Stored in a private area, out of players' reach."
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Aucun lien ne peut être trouvé ni ouvert."
-msgstr "No link can be found or opened."
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Débloquées uniquement au moment choisi."
-msgstr "Unlocked only at the chosen time."
-
-#: assets/js/enigme-edit.js
-msgid "Validation automatique : Le joueur devra saisir une réponse exacte. Celle-ci sera automatiquement vérifiée selon les critères définis (réponse attendue, casse, variantes)."
-msgstr "Automatic validation: The player must enter an exact answer. It will be automatically checked based on the defined criteria (expected answer, case, variants)."
-
-#: assets/js/enigme-edit.js
-msgid "Validation manuelle : Le joueur rédige une réponse libre. Vous validez ou invalidez manuellement sa tentative depuis votre espace personnel. Un email et un message d'alerte vous avertit de chaque nouvelle soumission."
-msgstr "Manual validation: The player enters a free-form answer. You approve or reject their attempt manually from your personal area. An email and alert message notify you of each new submission."
-
-#: template-parts/modals/modal-points.php
-msgid "À quoi servent les points ?"
-msgstr "What are points used for?"
-
-#: template-parts/modals/modal-points.php
-msgid "Les points vous permettent de débloquer :"
-msgstr "Points allow you to unlock:"
-
-#: template-parts/modals/modal-points.php
-msgid "🎯 Des chasses au trésor"
-msgstr "🎯 Treasure hunts"
-
-#: template-parts/modals/modal-points.php
-msgid "❓ Des tentatives de réponse"
-msgstr "❓ Answer attempts"
-
-#: template-parts/modals/modal-points.php
-msgid "💡 Des indices"
-msgstr "💡 Hints"
-
-#: template-parts/modals/modal-points.php
-msgid "La gratuité ou l'accès par points est choisi librement par chaque organisateur."
-msgstr "Free access or point access is chosen freely by each organizer."
-
-#: template-parts/enigme/partials/enigme-partial-tentatives.php
-msgid "bon"
-msgstr "correct"
-
-#: template-parts/enigme/partials/enigme-partial-tentatives.php
-msgid "faux"
-msgstr "wrong"
-
-#: template-parts/enigme/partials/enigme-partial-tentatives.php
-msgid "attente"
-msgstr "pending"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "votre fichier %s"
-msgstr "your %s file"
-
-msgid "Image chasse"
-msgstr "Hunt image"
-
-msgid "Modifier l’image"
-msgstr "Edit image"
-
-msgid "ajouter une image"
-msgstr "add an image"
-
-msgid "Configurer la récompense"
-msgstr "Configure the reward"
-
-msgid "Titre de la récompense"
-msgstr "Reward title"
-
-msgid "Ex : Un papillon en cristal..."
-msgstr "E.g.: A crystal butterfly..."
-
-msgid "Descripton de la récompense"
-msgstr "Reward description"
-
-msgid "Ex : Un coffret cadeau comprenant..."
-msgstr "E.g.: A gift box including..."
-
-msgid "Valeur en euros (€)"
-msgstr "Value in euros (€)"
-
-msgid "Ex : 50"
-msgstr "E.g.: 50"
-
-msgid "Supprimer la récompense"
-msgstr "Delete the reward"
-
-msgid "Nb gagnants"
-msgstr "Number of winners"
-
-msgid "Illimité"
-msgstr "Unlimited"
-
-msgid "Début"
-msgstr "Start"
-
-msgid "Date de fin"
-msgstr "End date"
-
-msgid "Durée illimitée"
-msgstr "Unlimited duration"
-
-msgid "Coût"
-msgstr "Cost"
-
-msgid "Animation"
-msgstr "Animation"
-
-msgid "Taux d'engagement"
-msgstr "Engagement rate"
-
-#: inc/enigme/affichage.php:678
-msgid "Mode de validation de l'énigme : %s"
-msgstr "Riddle validation mode: %s"
-
-#: inc/enigme/affichage.php:675
-msgid "automatique"
-msgstr "automatic"
-
-#: inc/enigme/affichage.php:676
-msgid "manuelle"
-msgstr "manual"
-
-#: inc/enigme/affichage.php:710
-msgid "Solde : %d pts"
-msgstr "Balance: %d pts"
-
-#: inc/enigme/reponses.php:67 assets/js/reponse-automatique.js:95
-msgid "Solde : %1$d → %2$d pts"
-msgstr "Balance: %1$d → %2$d pts"
-
-#: inc/enigme/affichage.php:719
-msgid "Tentatives quotidiennes : %1$d/%2$s"
-msgstr "Daily Attempts: %1$d/%2$s"
-
-#: inc/enigme/reponses.php:459
-msgid "Tentatives quotidiennes : %1$d / %2$s"
-msgstr "Daily Attempts: %1$d / %2$s"
+#: assets/js/enigme-edit.js:1663
+#, fuzzy
+msgid "Erreur lors de l'enregistrement de l'ordre"
+msgstr "Error creating hunt."
+
+#: assets/js/help-modal.js:19
+#, fuzzy
+msgid "Fermer"
+msgstr "<g x=1 id=\"40\">Close Chart</g>"
+
+#: assets/js/reponse-automatique.js:35
+msgid ""
+"Confirmer l'envoi ? Cette tentative coûtera %1$d pts. Solde après : %2$d pts."
+msgstr ""
+
+#: assets/js/reponse-automatique.js:55
+#, fuzzy
+msgid "Erreur serveur"
+msgstr "Network error"
 
 #: assets/js/reponse-automatique.js:85
 msgid "Tentatives quotidiennes : %1$s/%2$s"
@@ -1432,359 +2242,81 @@ msgstr "Daily Attempts: %1$s/%2$s"
 msgid "Tentatives quotidiennes :"
 msgstr "Daily Attempts:"
 
-#: templates/myaccount/content-points.php:103 inc/enigme/reponses.php:59 template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
-msgid "Ajouter des points"
-msgstr "Add points"
-
-#: inc/user-functions.php:233 templates/myaccount/layout.php:156
-msgid "Vos commandes"
-msgstr "Your orders"
-
-#: templates/myaccount/content-chasses.php:119
-msgid "Énigme"
-msgstr "Riddle"
-
-#: template-parts/chasse/chasse-edition-main.php:217 assets/js/chasse-edit.js:264
-msgid "Ajouter la récompense"
-msgstr "Add reward"
-
-#: templates/myaccount/content-chasses.php:112
-msgid "%d tentative en attente"
-msgid_plural "%d tentatives en attente"
-msgstr[0] "%d pending attempt"
-msgstr[1] "%d pending attempts"
-
-#: templates/myaccount/content-chasses.php:114
-msgid "%d tentative"
-msgid_plural "%d tentatives"
-msgstr[0] "%d attempt"
-msgstr[1] "%d attempts"
-
-#: templates/myaccount/content-chasses.php:116
-msgid "%d bonne réponse"
-msgid_plural "%d bonnes réponses"
-msgstr[0] "%d correct answer"
-msgstr[1] "%d correct answers"
-
-#: template-parts/enigme/enigme-edition-main.php:255
-msgid "Validation automatique"
-msgstr "Automatic validation"
-
-#: template-parts/enigme/enigme-edition-main.php:256
-msgid ""
-"Le joueur soumet une tentative de réponse. Celle-ci est automatiquement "
-"vérifiée selon les critères définis (réponse attendue, respect de la casse, "
-"variantes), et le résultat est immédiatement communiqué au joueur."
-msgstr ""
-"The player submits an answer attempt. It is automatically checked against "
-"the defined criteria (expected answer, case sensitivity, variants), and the "
-"result is immediately communicated to the player."
-
-#: template-parts/enigme/enigme-edition-main.php:272
-msgid "Validation manuelle"
-msgstr "Manual validation"
-
-#: template-parts/enigme/enigme-edition-main.php:273
-msgid ""
-"Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa "
-"tentative depuis votre espace personnel. À chaque nouvelle soumission, vous "
-"recevez une notification par email ainsi qu’un message d’alerte."
-msgstr ""
-"The player writes a free-form answer. You then approve or reject their "
-"attempt from your personal area. Each new submission triggers an email "
-"notification and an alert message."
-
-#: template-parts/enigme/enigme-edition-main.php:306
-msgid "Système de variantes"
-msgstr "Variants system"
-
-#: template-parts/enigme/enigme-edition-main.php:307
-msgid ""
-"Les variantes sont des réponses alternatives qui ne sont pas validées comme "
-"correctes, mais qui déclenchent un message personnalisé en retour (par "
-"exemple une aide, un indice, un lien ou tout autre contenu de votre choix)."
-msgstr ""
-"Variants are alternative answers that are not validated as correct but "
-"trigger a personalized message in return (for example a help message, a "
-"hint, a link or any other content of your choice)."
-
-#: template-parts/enigme/enigme-edition-main.php:362
-msgid "Tentative gratuite ou payante ?"
-msgstr "Free or paid attempt?"
-
-#: template-parts/enigme/enigme-edition-main.php:363
-msgid ""
-"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
-"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
-"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
-msgstr ""
-"You are free to set the cost of an attempt for your riddle: free or paid in "
-"points. When a player spends points to submit an answer, those points are "
-"immediately credited to your account."
-
-#: template-parts/enigme/enigme-edition-main.php:393
-msgid "Plafond nb de tentatives quotidiennes"
-msgstr "Daily attempt limit"
-
-#: template-parts/enigme/enigme-edition-main.php:394
-msgid ""
-"Nombre maximal de tentatives quotidiennes par joueur:\\n\\nMode payant : "
-"illimitées\\n\\nMode gratuit : 24 tentatives par jour"
-msgstr ""
-"Maximum number of daily attempts per player:\\n\\nPaid mode: unlimited\\n\\n"
-"Free mode: 24 attempts per day"
-
-#: template-parts/enigme/enigme-edition-main.php:711
-msgid "Délai de parution des solutions"
-msgstr "Solutions release delay"
-
-#: template-parts/enigme/enigme-edition-main.php:649
-msgid ""
-"Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée "
-"terminée. Une fois celle-ci achevée, elles restent conservées dans un "
-"coffre-fort numérique pendant le délai que vous définissez ici."
-msgstr ""
-"Solutions can only be published once a hunt is declared over. After that, "
-"they are stored in a digital safe for the delay you set here."
-
-#: template-parts/chasse/chasse-edition-main.php:258
-msgid "Fin de chasse automatique"
-msgstr "Automatic hunt end"
-
-#: template-parts/chasse/chasse-edition-main.php:259
-msgid ""
-"Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode "
-"automatique, la chasse se termine dès que le nombre de gagnants prévu est "
-"atteint."
-msgstr ""
-"A player is declared the winner when they have solved all the riddles. In "
-"automatic mode, the hunt ends as soon as the planned number of winners is "
-"reached."
-
-#: template-parts/chasse/chasse-edition-main.php:280
-msgid "Fin de chasse manuelle"
-msgstr "Manual hunt end"
-
-#: template-parts/chasse/chasse-edition-main.php:281
-msgid ""
-"Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans "
-"le panneau d’édition de la chasse, onglet Paramètres."
-msgstr ""
-"You can stop the hunt at any time using the button available in the hunt "
-"editing panel, Settings tab."
-
-#: template-parts/chasse/chasse-edition-main.php:426
-msgid "Coût d’accès à une chasse"
-msgstr "Hunt access cost"
-
-#: template-parts/chasse/chasse-edition-main.php:427
-msgid ""
-"Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou "
-"payant. Cet accès est indispensable pour consulter les énigmes, qui restent "
-"invisibles tant qu’il n’a pas été débloqué."
-msgstr ""
-"You are free to set the access cost to your hunt: free or paid. This access "
-"is necessary to view the riddles, which remain hidden until it has been "
-"unlocked."
-
-#: template-parts/organisateur/organisateur-edition-main.php:209
-msgid "Email de contact organisateur"
-msgstr "Organizer contact email"
-
-#: template-parts/organisateur/organisateur-edition-main.php:210
-msgid ""
-"Si aucune adresse n’est renseignée, votre adresse email utilisateur est "
-"utilisée par défaut."
-msgstr ""
-"If no address is provided, your user email is used by default."
-
-#: template-parts/organisateur/organisateur-edition-main.php:296
-msgid "Coordonnées bancaires"
-msgstr "Bank details"
-
-#: inc/enigme/affichage.php:275
-msgid "Nb joueurs :"
-msgstr "Players:"
-
-#: inc/enigme/affichage.php:281
-msgid "Nb tentatives :"
-msgstr "Attempts:"
-
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:25
-msgid "Gagnants :"
-msgstr "Winners:"
-
-#: inc/enigme/affichage.php:339
-msgid ""
-"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
-"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
-"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
-msgstr ""
-"Average share of puzzles each player has participated in, relative to the "
-"total number of puzzles in the hunt. You: Share of puzzles you have accessed "
-"Average: Average across all players."
-
-#: inc/enigme/affichage.php:347
-msgid "Définition de la progression"
-msgstr "Definition of progression"
-
-#: inc/enigme/affichage.php:398
-msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse."
-msgstr "Average share of puzzles each player has participated in, relative to the total number of puzzles in the hunt."
-
-#: inc/enigme/affichage.php:404
-msgid "Définition du taux de résolution"
-msgstr "Definition of the resolution rate"
-
-#: templates/myaccount/layout.php:34
-msgid "Accueil"
-msgstr "Dashboard"
-
-#: templates/myaccount/layout.php:41
-msgid "Commandes"
-msgstr "Orders"
-
-#: templates/myaccount/layout.php:48
-msgid "Chasses"
-msgstr "Hunts"
-
-#: templates/myaccount/layout.php:49
-msgid "Vos chasses"
-msgstr "Your hunts"
-
-#: templates/myaccount/layout.php:66
-msgid "Profil"
-msgstr "Profile"
-
-#: templates/myaccount/layout.php:154
-msgid "Votre profil"
-msgstr "Your profile"
-
-#: templates/myaccount/layout.php:95
-msgid "Déconnexion"
-msgstr "Log out"
-
-#: templates/myaccount/layout.php:100
-msgid "Administration"
-msgstr "Administration"
-
-#: templates/myaccount/layout.php:104
-msgid "Organisateurs"
-msgstr "Organizers"
-
-#: template-parts/enigme/partials/enigme-sidebar-section.php:42
-msgid "Aucune énigme disponible"
-msgstr "No puzzles available"
-
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
-msgid "Aucun gagnant pour le moment."
-msgstr "No winners yet."
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "La ou les bonnes réponses"
-msgstr "The correct answer(s)"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — selon votre réglage de respect de la casse — résout l’énigme."
-msgstr "You may enter between 1 and 5 correct answers. Any player submitting one—depending on your case sensitivity setting—solves the puzzle."
-
-#: assets/js/enigme-edit.js
-msgid "Supprimer"
-msgstr "Remove"
-
-#: assets/js/enigme-edit.js
-msgid "Ex : soleil"
-msgstr "E.g. sun"
-
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:21
-msgid "Configurer les variantes de réponse"
-msgstr "Configure answer variants"
-
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:77
-msgid "Enregistrer les variantes"
-msgstr "Save variants"
-
-#: inc/admin-functions.php:1849
-msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
-msgstr "Your validation request for the hunt “%s” was accepted."
-
-#: inc/admin-functions.php:1886
-msgid "Votre demande de validation pour la chasse « %s » nécessite des corrections."
-msgstr "Your validation request for the hunt “%s” requires corrections."
-
-#: inc/admin-functions.php:1895
-msgid "Une copie de ce message vous a été envoyée par email."
-msgstr "A copy of this message has been sent to you by email."
-
-#: inc/admin-functions.php:1891
-msgid "Message de l’administrateur : %s"
-msgstr "Administrator's message: %s"
-
-#: inc/admin-functions.php:1918
-msgid "Votre chasse « %s » a été bannie."
-msgstr "Your hunt “%s” was banned."
-
-
-#: inc/edition/edition-indice.php:73
-msgid "Indice #%d - %s"
-msgstr "Clue #%d - %s"
-
-#: template-parts/indice/indice-edition-main.php:26
-msgid "Panneau d'édition indice"
-msgstr "Clue edit panel"
-
-#: template-parts/indice/indice-edition-main.php:33
-msgid "Contenu d'édition à venir..."
-msgstr "Editing content coming soon..."
-
-#: template-parts/indice/indice-edition-main.php:104
-msgid "Image"
-msgstr "Image"
-
-#: template-parts/indice/indice-edition-main.php:123
-msgid "Texte"
-msgstr "Text"
-
-#: template-parts/indice/indice-edition-main.php:134
-msgid "Aide pour"
-msgstr "Help for"
-
-#: template-parts/indice/indice-edition-main.php:136
-msgid "Chasse"
-msgstr "Hunt"
-
-#: template-parts/indice/indice-edition-main.php:141
-msgid "Aucune énigme disponible."
-msgstr "No puzzle available."
-
-#: template-parts/indice/indice-edition-main.php:167
-msgid "Publication"
-msgstr "Publishing"
-
-#: template-parts/indice/indice-edition-main.php:169
-msgid "Immédiate"
-msgstr "Immediate"
-
-#: template-parts/indice/indice-edition-main.php:170
-msgid "Différée"
-msgstr "Delayed"
-
-#: template-parts/indice/indice-edition-main.php:181
-msgid "(points)"
-msgstr "(points)"
-
-#: template-parts/indice/indice-edition-main.php:94
-msgid "renseigner le titre de l’indice"
-msgstr "enter the clue title"
-
-#: template-parts/indice/indice-edition-main.php:124
-msgid "renseigner le texte de l’indice"
-msgstr "enter the clue text"
-
-#: template-parts/indice/panneaux/indice-edition-description.php:17
-msgid "Modifier le texte de l’indice"
-msgstr "Edit the clue text"
-
-#: template-parts/indice/panneaux/indice-edition-description.php:28
-msgid "Texte de l’indice mis à jour."
-msgstr "Clue text updated."
+#: assets/js/reponse-automatique.js:107
+#, fuzzy
+msgid "Bonne réponse"
+msgstr "Correct answers"
+
+#: assets/js/reponse-automatique.js:177
+#, fuzzy
+msgid "Mauvaise réponse"
+msgstr "Your answer"
+
+#: assets/js/reponse-automatique.js:187
+msgid "Tentatives quotidiennes"
+msgstr "Daily Attempts"
+
+#~ msgid "Activer Orgy"
+#~ msgstr "Enable Orgy"
+
+#~ msgid "Modifier la récompense"
+#~ msgstr "Edit Reward"
+
+#~ msgid "Solution"
+#~ msgstr "Solution"
+
+#~ msgid "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
+#~ msgstr "🛠️ This riddle is yours. No forms are displayed."
+
+#~ msgid "Actions"
+#~ msgstr "Actions"
+
+#~ msgid ""
+#~ "Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse "
+#~ "s’achève dès que le nombre de gagnants prévu est atteint."
+#~ msgstr ""
+#~ "A player becomes a winner when they solve all the puzzles. The hunt ends "
+#~ "as soon as the expected number of winners is reached."
+
+#~ msgid ""
+#~ "Vous arrêtez la chasse manuellement, grâce au bouton situé dans le "
+#~ "panneau d'édition chasse."
+#~ msgstr ""
+#~ "You stop the hunt manually, thanks to the button located in the hunt edit "
+#~ "panel."
+
+#~ msgid ""
+#~ "Nombre maximum de tentatives quotidiennes d'un joueur\n"
+#~ "Mode payant : tentatives illimitées.\n"
+#~ "Mode gratuit : maximum 24 tentatives par jour."
+#~ msgstr ""
+#~ "Maximum number of daily attempts by a player\n"
+#~ "Paid mode: unlimited attempts.\n"
+#~ "Free mode: maximum 24 attempts per day."
+
+#~ msgid ""
+#~ "Validation automatique : Le joueur devra saisir une réponse exacte. Celle-"
+#~ "ci sera automatiquement vérifiée selon les critères définis (réponse "
+#~ "attendue, casse, variantes)."
+#~ msgstr ""
+#~ "Automatic validation: The player must enter an exact answer. It will be "
+#~ "automatically checked based on the defined criteria (expected answer, "
+#~ "case, variants)."
+
+#~ msgid ""
+#~ "Validation manuelle : Le joueur rédige une réponse libre. Vous validez ou "
+#~ "invalidez manuellement sa tentative depuis votre espace personnel. Un "
+#~ "email et un message d'alerte vous avertit de chaque nouvelle soumission."
+#~ msgstr ""
+#~ "Manual validation: The player enters a free-form answer. You approve or "
+#~ "reject their attempt manually from your personal area. An email and alert "
+#~ "message notify you of each new submission."
+
+#~ msgid "Ajouter la récompense"
+#~ msgstr "Add reward"
+
+#~ msgid "Contenu d'édition à venir..."
+#~ msgstr "Editing content coming soon..."
+
+#~ msgid "renseigner le texte de l’indice"
+#~ msgstr "enter the clue text"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: chassesautresor.com 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/chassesautresor\n"
-"POT-Creation-Date: 2025-08-18T12:04:58+00:00\n"
+"POT-Creation-Date: 2025-08-23T01:54:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,125 +15,253 @@ msgstr ""
 "X-Domain: chassesautresor-com\n"
 "X-Generator: WP-CLI 2.12.0\n"
 
+#. Theme Name of the theme
+#. Author of the theme
 #: style.css
 msgid "chassesautresor.com"
 msgstr "chassesautresor.com"
 
+#. Description of the theme
 #: style.css
 msgid "sites dédiés aux amoureux de chasses au trésor chassesautresor.com"
 msgstr "sites dédiés aux amoureux de chasses au trésor chassesautresor.com"
 
+#. Author URI of the theme
 #: style.css
 msgid "https://chassesautresor.com/"
 msgstr "https://chassesautresor.com/"
 
+#. Template Name of the theme
 msgid "Accueil Plein Ecran"
 msgstr "Accueil Plein Ecran"
 
-#: inc/admin-functions.php:39
+#: functions.php:102
+msgid "Français"
+msgstr "Français"
+
+#: functions.php:107
+msgid "English"
+msgstr "Anglais"
+
+#: functions.php:116
+msgid "Change language"
+msgstr "Changer de langue"
+
+#: inc/admin-functions.php:40
 msgid "⛔ Accès refusé."
 msgstr "⛔ Accès refusé."
 
-#: inc/admin-functions.php:46
+#: inc/admin-functions.php:47
 msgid "❌ Requête vide."
 msgstr "❌ Requête vide."
 
-#: inc/admin-functions.php:57
+#: inc/admin-functions.php:58
 msgid "❌ Aucun utilisateur trouvé."
 msgstr "❌ Aucun utilisateur trouvé."
 
-#: inc/admin-functions.php:84 inc/admin-functions.php:388
-#: inc/admin-functions.php:577
+#: inc/admin-functions.php:85 inc/admin-functions.php:389
+#: inc/admin-functions.php:578
 msgid "❌ Vérification du nonce échouée."
 msgstr "❌ Vérification du nonce échouée."
 
-#: inc/admin-functions.php:89 inc/admin-functions.php:393
+#: inc/admin-functions.php:90 inc/admin-functions.php:394
 msgid "❌ Accès refusé."
 msgstr "❌ Accès refusé."
 
-#: inc/admin-functions.php:98
+#: inc/admin-functions.php:99
 msgid "❌ Données invalides."
 msgstr "❌ Données invalides."
 
-#: inc/admin-functions.php:104
+#: inc/admin-functions.php:105
 msgid "❌ Utilisateur introuvable."
 msgstr "❌ Utilisateur introuvable."
 
-#: inc/admin-functions.php:116
+#: inc/admin-functions.php:117
 msgid "❌ Impossible de retirer plus de points que l’utilisateur en possède."
 msgstr "❌ Impossible de retirer plus de points que l’utilisateur en possède."
 
-#: inc/admin-functions.php:121
+#: inc/admin-functions.php:122
 msgid "❌ Action invalide."
 msgstr "❌ Action invalide."
 
-#: inc/admin-functions.php:180
+#: inc/admin-functions.php:181
 msgid "Permission refusée."
 msgstr "Permission refusée."
 
-#: inc/admin-functions.php:188
+#: inc/admin-functions.php:189
 msgid "Requête invalide."
 msgstr "Requête invalide."
 
-#: inc/admin-functions.php:230
+#: inc/admin-functions.php:231
 msgid "Action inconnue."
 msgstr "Action inconnue."
 
-#: inc/admin-functions.php:399
+#: inc/admin-functions.php:400
 msgid "❌ Veuillez entrer un taux de conversion valide."
 msgstr "❌ Veuillez entrer un taux de conversion valide."
 
-#: inc/admin-functions.php:465
+#: inc/admin-functions.php:466
 msgid "Régler"
 msgstr "Régler"
 
-#: inc/admin-functions.php:466
-#: template-parts/chasse/chasse-edition-main.php:291
+#: inc/admin-functions.php:467
+#: template-parts/chasse/chasse-edition-main.php:309
 msgid "Annuler"
 msgstr "Annuler"
 
-#: inc/admin-functions.php:467
+#: inc/admin-functions.php:468
 msgid "Refuser"
 msgstr "Refuser"
 
-#: inc/admin-functions.php:582
+#: inc/admin-functions.php:583
 msgid "❌ Vous devez être connecté pour effectuer cette action."
 msgstr "❌ Vous devez être connecté pour effectuer cette action."
 
-#: inc/admin-functions.php:597
+#. translators: %d: points minimum
+#: inc/admin-functions.php:598
+#, php-format
 msgid "❌ Le minimum pour une conversion est de %d points."
 msgstr "❌ Le minimum pour une conversion est de %d points."
 
-#: inc/admin-functions.php:604
+#: inc/admin-functions.php:605
 msgid "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
 msgstr "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
 
-#: inc/admin-functions.php:894
+#: inc/admin-functions.php:895
 msgid ""
 "⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action."
 msgstr ""
 "⛔ Accès refusé. Vous n’avez pas la permission d’effectuer cette action."
 
-#: inc/admin-functions.php:901
+#: inc/admin-functions.php:902
 msgid "⛔ Erreur de sécurité. Veuillez réessayer."
 msgstr "⛔ Erreur de sécurité. Veuillez réessayer."
 
-#: inc/admin-functions.php:1342
+#: inc/admin-functions.php:1343 inc/admin-functions.php:1368
 msgid "Non autorisé"
 msgstr "Non autorisé"
 
-#: inc/admin-functions.php:1659
-#: template-parts/chasse/chasse-edition-main.php:448
+#: inc/admin-functions.php:1425
+msgid "Confirmez-vous la réinitialisation des statistiques ?"
+msgstr ""
+
+#: inc/admin-functions.php:1426
+#, fuzzy
+msgid "Statistiques effacées."
+msgstr "Statistiques"
+
+#: inc/admin-functions.php:1647
+#: templates/myaccount/content-organisateurs.php:21
+#, fuzzy
+msgid "Aucun organisateur."
+msgstr "Aucun organisateur associé."
+
+#: inc/admin-functions.php:1676
+#, fuzzy
+msgid "Organisateur"
+msgstr "Devenir Organisateur"
+
+#: inc/admin-functions.php:1677
+#: template-parts/indice/indice-edition-main.php:153
+msgid "Chasse"
+msgstr "Chasse"
+
+#: inc/admin-functions.php:1678
+#, fuzzy
+msgid "Nb énigmes"
+msgstr "Énigmes"
+
+#: inc/admin-functions.php:1679
+msgid "État"
+msgstr ""
+
+#: inc/admin-functions.php:1680 inc/organisateur-functions.php:437
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:26
+msgid "Utilisateur"
+msgstr "Utilisateur"
+
+#: inc/admin-functions.php:1681
+msgid "Créé le"
+msgstr ""
+
+#: inc/admin-functions.php:1701
+#, fuzzy
+msgid "valide"
+msgstr "Invalider"
+
+#: inc/admin-functions.php:1704
+msgid "correction"
+msgstr ""
+
+#: inc/admin-functions.php:1707
+#, fuzzy
+msgid "en attente"
+msgstr "En attente"
+
+#: inc/admin-functions.php:1710
+#, fuzzy
+msgid "création"
+msgstr "Présentation"
+
+#: inc/admin-functions.php:1714
+msgid "banni"
+msgstr ""
+
+#: inc/admin-functions.php:1730
+msgid "Demande de validation et tentatives manuelles en attente"
+msgstr ""
+
+#: inc/admin-functions.php:1732
+msgid "Demande de validation en attente"
+msgstr ""
+
+#: inc/admin-functions.php:1734
+#, fuzzy
+msgid "Tentatives manuelles en attente de réponse"
+msgstr "Configurer les variantes de réponse"
+
+#: inc/admin-functions.php:1785
+#: template-parts/chasse/chasse-edition-main.php:469
 msgid "Accès refusé."
 msgstr "Accès refusé."
 
-#: inc/admin-functions.php:1666
+#: inc/admin-functions.php:1792
 msgid "ID de chasse invalide."
 msgstr "ID de chasse invalide."
 
-#: inc/admin-functions.php:1670
+#: inc/admin-functions.php:1796
 msgid "Nonce invalide."
 msgstr "Nonce invalide."
+
+#: inc/admin-functions.php:1849
+#, fuzzy, php-format
+msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
+msgstr "Votre demande de conversion a bien été envoyée."
+
+#: inc/admin-functions.php:1886
+#, php-format
+msgid ""
+"Votre demande de validation pour la chasse « %s » nécessite des corrections."
+msgstr ""
+
+#: inc/admin-functions.php:1891
+#, php-format
+msgid "Message de l’administrateur : %s"
+msgstr ""
+
+#: inc/admin-functions.php:1895
+msgid "Une copie de ce message vous a été envoyée par email."
+msgstr ""
+
+#: inc/admin-functions.php:1918
+#, php-format
+msgid "Votre chasse « %s » a été bannie."
+msgstr ""
+
+#: inc/admin-functions.php:1940
+#, php-format
+msgid "Votre chasse « %s » a été supprimée."
+msgstr ""
 
 #: inc/chasse-functions.php:245
 msgid ""
@@ -154,10 +282,13 @@ msgid "Points insuffisants"
 msgstr "Points insuffisants"
 
 #: inc/chasse-functions.php:650 inc/organisateur-functions.php:273
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/enigme/enigme-edition-main.php:387
 msgid "points"
 msgstr "points"
 
 #: inc/chasse-functions.php:653
+#, php-format
 msgid "Il vous manque %1$d %2$s pour participer à cette chasse."
 msgstr "Il vous manque %1$d %2$s pour participer à cette chasse."
 
@@ -165,23 +296,28 @@ msgstr "Il vous manque %1$d %2$s pour participer à cette chasse."
 msgid "Certaines énigmes doivent être complétées :"
 msgstr "Certaines énigmes doivent être complétées :"
 
-#: inc/edition/edition-chasse.php:106
+#: inc/edition/edition-chasse.php:48
+#, fuzzy
+msgid "Erreur lors du chargement des indices."
+msgstr "Erreur lors de la création de la chasse."
+
+#: inc/edition/edition-chasse.php:115
 msgid "Aucun organisateur associé."
 msgstr "Aucun organisateur associé."
 
-#: inc/edition/edition-chasse.php:114
+#: inc/edition/edition-chasse.php:123
 msgid "Limite atteinte"
 msgstr "Limite atteinte"
 
-#: inc/edition/edition-chasse.php:117
+#: inc/edition/edition-chasse.php:126
 msgid "Accès refusé"
 msgstr "Accès refusé"
 
-#: inc/edition/edition-chasse.php:127
+#: inc/edition/edition-chasse.php:136
 msgid "Une chasse est déjà en attente de validation."
 msgstr "Une chasse est déjà en attente de validation."
 
-#: inc/edition/edition-chasse.php:140
+#: inc/edition/edition-chasse.php:149
 msgid "Erreur lors de la création de la chasse."
 msgstr "Erreur lors de la création de la chasse."
 
@@ -189,92 +325,343 @@ msgstr "Erreur lors de la création de la chasse."
 msgid "Chasse non spécifiée ou invalide."
 msgstr "Chasse non spécifiée ou invalide."
 
-#: inc/enigme/affichage.php:132 inc/enigme/affichage.php:147
+#: inc/edition/edition-indice.php:45
+#, fuzzy
+msgid "Type de cible invalide."
+msgstr "ID de chasse invalide."
+
+#: inc/edition/edition-indice.php:49
+#, fuzzy
+msgid "ID cible invalide."
+msgstr "ID de chasse invalide."
+
+#: inc/edition/edition-indice.php:53
+msgid "Utilisateur non connecté."
+msgstr ""
+
+#: inc/edition/edition-indice.php:57 inc/edition/edition-indice.php:65
+#, fuzzy
+msgid "Droits insuffisants."
+msgstr "Points insuffisants"
+
+#: inc/edition/edition-indice.php:82
+#, php-format
+msgid "Indice #%d - %s"
+msgstr "Indice #%d - %s"
+
+#: inc/edition/edition-indice.php:151
+#, fuzzy
+msgid "Action non autorisée."
+msgstr "Non autorisé"
+
+#: inc/edition/edition-indice.php:167
+msgid "ID cible manquant."
+msgstr ""
+
+#: inc/enigme/affichage.php:159 inc/enigme/affichage.php:204
 msgid "Vous"
 msgstr "Vous"
 
-#: inc/enigme/affichage.php:133 inc/enigme/affichage.php:148
+#: inc/enigme/affichage.php:160 inc/enigme/affichage.php:208
 msgid "Moyenne"
 msgstr "Moyenne"
 
-#: inc/enigme/affichage.php:200 inc/enigme/affichage.php:317
+#: inc/enigme/affichage.php:275
+msgid "Nb joueurs :"
+msgstr "Nb joueurs :"
+
+#: inc/enigme/affichage.php:281
+msgid "Nb tentatives :"
+msgstr "Nb tentatives :"
+
+#: inc/enigme/affichage.php:335
 msgid "Progression"
 msgstr "Progression"
 
-#: inc/enigme/affichage.php:263
+#: inc/enigme/affichage.php:339
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
+msgstr ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
+"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
+
+#: inc/enigme/affichage.php:346
+msgid "Définition de la progression"
+msgstr "Définition de la progression"
+
+#: inc/enigme/affichage.php:395
 msgid "Résolution"
 msgstr "Résolution"
 
-#: inc/enigme/affichage.php:297
-msgid "Statistiques"
-msgstr "Statistiques"
+#: inc/enigme/affichage.php:398
+msgid ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse."
+msgstr ""
+"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
+"nombre total d’énigmes de la chasse."
 
-#: inc/enigme/affichage.php:311
-msgid "Afficher les statistiques"
-msgstr "Afficher les statistiques"
+#: inc/enigme/affichage.php:403
+msgid "Définition du taux de résolution"
+msgstr "Définition du taux de résolution"
 
-#: inc/enigme/affichage.php:317
-msgid "Activer Orgy"
-msgstr "Activer Orgy"
-
-#: inc/enigme/affichage.php:325
-#: template-parts/chasse/partials/chasse-partial-participants.php:51
+#: inc/enigme/affichage.php:518 inc/enigme/affichage.php:1037
+#: template-parts/chasse/partials/chasse-partial-participants.php:53
+#: template-parts/enigme/partials/enigme-sidebar-section.php:37
+#: template-parts/indice/indice-edition-main.php:154
 msgid "Énigmes"
 msgstr "Énigmes"
 
-#: inc/enigme/affichage.php:416
-#: template-parts/chasse/chasse-edition-main.php:650
-#: template-parts/chasse/chasse-edition-main.php:662
+#: inc/enigme/affichage.php:546
+msgid "Afficher les statistiques"
+msgstr "Afficher les statistiques"
+
+#: inc/enigme/affichage.php:649
+#: template-parts/chasse/chasse-edition-main.php:708
+#: template-parts/chasse/partials/chasse-partial-indices.php:32
 msgid "Indices"
 msgstr "Indices"
 
-#: inc/enigme/affichage.php:447
+#: inc/enigme/affichage.php:677
+#, fuzzy
+msgid "automatique"
+msgstr "Automatique"
+
+#: inc/enigme/affichage.php:678
+#, fuzzy
+msgid "manuelle"
+msgstr "Manuelle"
+
+#: inc/enigme/affichage.php:680
+#, fuzzy, php-format
+msgid "Mode de validation de l'énigme : %s"
+msgstr "Modifier les images de l’énigme"
+
+#: inc/enigme/affichage.php:712
+#, php-format
+msgid "Solde : %d pts"
+msgstr ""
+
+#: inc/enigme/affichage.php:721
+#, fuzzy, php-format
+msgid "Tentatives quotidiennes : %1$d/%2$s"
+msgstr "Tentatives quotidiennes"
+
+#: inc/enigme/affichage.php:737
+#, php-format
+msgid "Coût par tentative : %d points."
+msgstr ""
+
+#: inc/enigme/affichage.php:741 assets/js/reponse-automatique.js:76
+#: assets/js/reponse-automatique.js:98
+msgid "pts"
+msgstr "pts"
+
+#: inc/enigme/affichage.php:780
 msgid "Voir la solution"
 msgstr "Voir la solution"
 
-#: inc/enigme/cta.php:215
+#: inc/enigme/affichage.php:945 inc/enigme/affichage.php:956
+#: inc/enigme/affichage.php:1012 inc/enigme/affichage.php:1013
+#: inc/enigme/affichage.php:1026 inc/enigme/affichage.php:1027
+#: single-indice.php:27 template-parts/chasse/chasse-edition-main.php:67
+#: template-parts/chasse/chasse-edition-main.php:76
+#: template-parts/enigme/enigme-edition-main.php:94
+#: template-parts/enigme/enigme-edition-main.php:104
+#: template-parts/indice/indice-edition-main.php:59
+#: template-parts/indice/indice-edition-main.php:67
+#: template-parts/organisateur/organisateur-edition-main.php:75
+#: template-parts/organisateur/organisateur-edition-main.php:85
+msgid "Paramètres"
+msgstr ""
+
+#: inc/enigme/affichage.php:1006
+msgid "Retour"
+msgstr ""
+
+#: inc/enigme/affichage.php:1017 inc/enigme/affichage.php:1018
+#, fuzzy
+msgid "Menu énigme"
+msgstr "Texte énigme"
+
+#: inc/enigme/affichage.php:1035
+#, fuzzy
+msgid "Panneau d'énigme"
+msgstr "Panneau d'édition énigme"
+
+#: inc/enigme/affichage.php:1038 inc/enigme/affichage.php:1135
+#: template-parts/chasse/chasse-edition-main.php:68
+#: template-parts/enigme/enigme-edition-main.php:95
+#: template-parts/enigme/enigme-edition-main.php:499
+#: template-parts/enigme/partials/enigme-sidebar-section.php:52
+#: template-parts/indice/indice-edition-main.php:60
+#: template-parts/indice/indice-edition-main.php:218
+#: template-parts/organisateur/organisateur-edition-main.php:76
+#: template-parts/organisateur/organisateur-edition-main.php:252
+#: templates/myaccount/layout.php:111
+msgid "Statistiques"
+msgstr "Statistiques"
+
+#: inc/enigme/cta.php:193
+msgid "À venir"
+msgstr ""
+
+#: inc/enigme/cta.php:194
+#, fuzzy
+msgid "Chasse verrouillée"
+msgstr "Chasse introuvable."
+
+#: inc/enigme/cta.php:195 template-parts/enigme/enigme-edition-main.php:451
+msgid "Pré-requis"
+msgstr "Pré-requis"
+
+#: inc/enigme/cta.php:196
+#, fuzzy
+msgid "Invalide"
+msgstr "Invalider"
+
+#: inc/enigme/cta.php:197
+msgid "Erreur config"
+msgstr ""
+
+#: inc/enigme/cta.php:198
+msgid "Bloquée"
+msgstr ""
+
+#: inc/enigme/cta.php:201
+msgid "Résolvez d'abord les énigmes prérequises."
+msgstr ""
+
+#: inc/enigme/cta.php:202
+msgid "Cette énigme est bloquée ou mal configurée."
+msgstr ""
+
+#: inc/enigme/cta.php:206
+msgid "Indisponible"
+msgstr ""
+
+#: inc/enigme/cta.php:232
 msgid "Commencer"
 msgstr "Commencer"
 
-#: inc/enigme/cta.php:219
+#: inc/enigme/cta.php:236
 msgid "À tenter"
 msgstr "À tenter"
 
-#: inc/enigme/cta.php:225
+#: inc/enigme/cta.php:242 templates/myaccount/content-chasses.php:70
 msgid "Voir"
 msgstr "Voir"
 
-#: inc/enigme/cta.php:226
+#: inc/enigme/cta.php:243
 msgid "Continuer"
 msgstr "Continuer"
 
-#: inc/enigme/cta.php:269
+#: inc/enigme/cta.php:286
 msgid "Réessayer"
 msgstr "Réessayer"
 
-#: inc/enigme/cta.php:273
+#: inc/enigme/cta.php:290
 msgid "Échouée"
 msgstr "Échouée"
 
-#: inc/enigme/cta.php:279
+#: inc/enigme/cta.php:296
 msgid "Recommencer"
 msgstr "Recommencer"
 
-#: inc/enigme/cta.php:283
+#: inc/enigme/cta.php:300
 msgid "Abandonnée"
 msgstr "Abandonnée"
 
-#: inc/enigme/reponses.php:41
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:92
+#: inc/enigme/reponses.php:74
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:162
+msgid "Votre réponse"
+msgstr "Votre réponse"
+
+#: inc/enigme/reponses.php:77
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:171
+#, php-format
 msgid "Il vous manque %d points pour soumettre votre réponse."
 msgstr "Il vous manque %d points pour soumettre votre réponse."
 
-#: inc/enigme/reponses.php:508
+#: inc/enigme/reponses.php:86 single-chasse.php:168
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:183
+msgid "Accéder à la boutique"
+msgstr "Accéder à la boutique"
+
+#: inc/enigme/reponses.php:88
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:185
+#, fuzzy
+msgid "Ajouter des points"
+msgstr "Ajouter des variantes"
+
+#: inc/enigme/reponses.php:96
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:195
+#: assets/js/reponse-automatique.js:95
+#, php-format
+msgid "Solde : %1$d → %2$d pts"
+msgstr ""
+
+#: inc/enigme/reponses.php:137
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
+msgid "Valider"
+msgstr "Valider"
+
+#: inc/enigme/reponses.php:140
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:147
+#, php-format
+msgid "Valider — %d pts"
+msgstr ""
+
+#: inc/enigme/reponses.php:448
+#, fuzzy
+msgid "Réponse acceptée"
+msgstr "Réponse"
+
+#: inc/enigme/reponses.php:449
+#, fuzzy
+msgid "Réponse refusée"
+msgstr "Accès refusé"
+
+#: inc/enigme/reponses.php:451
+msgid "Félicitations ! Votre réponse est correcte."
+msgstr ""
+
+#: inc/enigme/reponses.php:452
+#, fuzzy
+msgid "Votre réponse est incorrecte."
+msgstr "Votre réponse"
+
+#: inc/enigme/reponses.php:454
+#, fuzzy
+msgid "Retour à l’énigme"
+msgstr "Image par défaut de l’énigme"
+
+#: inc/enigme/reponses.php:455
+#, fuzzy
+msgid "Réessayer l’énigme"
+msgstr "Réessayer"
+
+#: inc/enigme/reponses.php:462
+#, fuzzy, php-format
+msgid "[Chasses au Trésor] %1$s — %2$s"
+msgstr "Chasses au Trésor"
+
+#: inc/enigme/reponses.php:491
+#, fuzzy, php-format
+msgid "Tentatives quotidiennes : %1$d / %2$s"
+msgstr "Tentatives quotidiennes"
+
+#: inc/enigme/reponses.php:618
 msgid "Tentative bien reçue."
 msgstr "Tentative bien reçue."
 
-#: inc/enigme/reponses.php:588
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:51
+#: inc/enigme/reponses.php:619
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:50
+#, php-format
 msgid ""
 "⏳ Votre tentative %1$s a été soumise le %2$s à %3$s.<br>Vous serez "
 "immédiatement averti de son traitement par l'organisateur par email et sur "
@@ -284,72 +671,96 @@ msgstr ""
 "immédiatement averti de son traitement par l'organisateur par email et sur "
 "votre <a href=\"%4$s\">espace personnel</a>."
 
-#: inc/enigme/visuels.php:129
+#: inc/enigme/tentatives.php:129
+#, php-format
+msgid ""
+"Votre demande de résolution de l'énigme %1$s%2$s%3$s a été validée. "
+"Félicitations !"
+msgstr ""
+
+#: inc/enigme/tentatives.php:133
+#, fuzzy, php-format
+msgid "Votre demande de résolution de l'énigme %1$s%2$s%3$s a été invalidée."
+msgstr "Votre demande de conversion a bien été envoyée."
+
+#: inc/enigme/visuels.php:137
+#: template-parts/enigme/partials/enigme-partial-images.php:52
+msgid "Image par défaut de l’énigme"
+msgstr "Image par défaut de l’énigme"
+
+#: inc/enigme/visuels.php:138
 msgid "Visuel énigme"
 msgstr "Visuel énigme"
 
-#: inc/enigme/visuels.php:425
+#: inc/enigme/visuels.php:377
 msgid "Pré-requis non remplis"
 msgstr "Pré-requis non remplis"
 
-#: inc/gamify-functions.php:496
+#: inc/gamify-functions.php:520
 msgid "Historique de vos points"
 msgstr "Historique de vos points"
 
-#: inc/gamify-functions.php:500
+#: inc/gamify-functions.php:524
 msgid "ID"
 msgstr "ID"
 
-#: inc/gamify-functions.php:501
+#: inc/gamify-functions.php:525
+#: template-parts/enigme/enigme-edition-main.php:577
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:35
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:25
+#: templates/myaccount/content-chasses.php:124
 msgid "Date"
 msgstr "Date"
 
-#: inc/gamify-functions.php:502
+#: inc/gamify-functions.php:526
 msgid "Origine"
 msgstr "Origine"
 
-#: inc/gamify-functions.php:503
+#: inc/gamify-functions.php:527
 msgid "Motif"
 msgstr "Motif"
 
-#: inc/gamify-functions.php:504
+#: inc/gamify-functions.php:528
 msgid "Variation"
 msgstr "Variation"
 
-#: inc/gamify-functions.php:505
+#: inc/gamify-functions.php:529 assets/js/reponse-automatique.js:76
+#: assets/js/reponse-automatique.js:98
 msgid "Solde"
 msgstr "Solde"
 
 #: inc/organisateur-functions.php:227 inc/organisateur-functions.php:233
-#: template-parts/organisateur/organisateur-edition-main.php:290
-#: template-parts/organisateur/organisateur-edition-main.php:303
+#: template-parts/organisateur/organisateur-edition-main.php:308
+#: template-parts/organisateur/organisateur-edition-main.php:321
 msgid "Ajouter des coordonnées bancaires"
 msgstr "Ajouter des coordonnées bancaires"
 
 #: inc/organisateur-functions.php:231
-#: template-parts/chasse/chasse-edition-main.php:615
-#: template-parts/chasse/chasse-edition-main.php:664
-#: template-parts/chasse/chasse-edition-main.php:666
-#: template-parts/organisateur/organisateur-edition-main.php:287
-#: template-parts/organisateur/organisateur-edition-main.php:301
+#: template-parts/chasse/chasse-edition-main.php:673
+#: template-parts/chasse/partials/chasse-partial-indices.php:46
+#: template-parts/chasse/partials/chasse-partial-indices.php:50
+#: template-parts/organisateur/organisateur-edition-main.php:305
+#: template-parts/organisateur/organisateur-edition-main.php:319
+#: template-parts/organisateur/organisateur-edition-main.php:360
 msgid "Ajouter"
 msgstr "Ajouter"
 
 #: inc/organisateur-functions.php:232
-#: template-parts/chasse/chasse-edition-main.php:616
-#: template-parts/organisateur/organisateur-edition-main.php:288
-#: template-parts/organisateur/organisateur-edition-main.php:302
+#: template-parts/chasse/chasse-edition-main.php:674
+#: template-parts/organisateur/organisateur-edition-main.php:306
+#: template-parts/organisateur/organisateur-edition-main.php:320
+#: template-parts/organisateur/organisateur-edition-main.php:361
 msgid "Éditer"
 msgstr "Éditer"
 
 #: inc/organisateur-functions.php:234
-#: template-parts/organisateur/organisateur-edition-main.php:291
-#: template-parts/organisateur/organisateur-edition-main.php:304
+#: template-parts/organisateur/organisateur-edition-main.php:309
+#: template-parts/organisateur/organisateur-edition-main.php:322
 msgid "Modifier les coordonnées bancaires"
 msgstr "Modifier les coordonnées bancaires"
 
 #: inc/organisateur-functions.php:253
+#, php-format
 msgid "1 000 points = %s €"
 msgstr "1 000 points = %s €"
 
@@ -358,11 +769,12 @@ msgid "Demande de conversion"
 msgstr "Demande de conversion"
 
 #: inc/organisateur-functions.php:258
+#, php-format
 msgid "Transformez vos %d points en euros."
 msgstr "Transformez vos %d points en euros."
 
 #: inc/organisateur-functions.php:262 inc/organisateur-functions.php:282
-#: template-parts/organisateur/organisateur-edition-main.php:262
+#: template-parts/organisateur/organisateur-edition-main.php:281
 msgid "Convertir"
 msgstr "Convertir"
 
@@ -396,11 +808,6 @@ msgstr "Voir le tableau"
 msgid "Date demande"
 msgstr "Date demande"
 
-#: inc/organisateur-functions.php:437
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:26
-msgid "Utilisateur"
-msgstr "Utilisateur"
-
 #: inc/organisateur-functions.php:439
 msgid "Montant (€)"
 msgstr "Montant (€)"
@@ -430,6 +837,7 @@ msgid "En attente"
 msgstr "En attente"
 
 #: inc/organisateur-functions.php:464 inc/organisateur-functions.php:565
+#, php-format
 msgid "ID %d"
 msgstr "ID %d"
 
@@ -453,25 +861,64 @@ msgstr "Next page"
 msgid "Last page"
 msgstr "Last page"
 
-#: inc/user-functions.php:160
+#: inc/table.php:32
+#, fuzzy
+msgid "Voir plus"
+msgstr "Voir"
+
+#: inc/table.php:33
+#, fuzzy
+msgid "Voir moins"
+msgstr "Voir la solution"
+
+#: inc/user-functions.php:165
 msgid "Statistiques - Chasses au Trésor"
 msgstr "Statistiques - Chasses au Trésor"
 
-#: inc/user-functions.php:161
+#: inc/user-functions.php:166
 msgid "Outils - Chasses au Trésor"
 msgstr "Outils - Chasses au Trésor"
 
-#: inc/user-functions.php:162
+#: inc/user-functions.php:167
 msgid "Organisateur - Chasses au Trésor"
 msgstr "Organisateur - Chasses au Trésor"
 
-#: inc/user-functions.php:167
+#: inc/user-functions.php:172
 msgid "Points - Chasses au Trésor"
 msgstr "Points - Chasses au Trésor"
 
-#: inc/user-functions.php:292
+#: inc/user-functions.php:176
+#, fuzzy
+msgid "Chasses - Chasses au Trésor"
+msgstr "Statistiques - Chasses au Trésor"
+
+#: inc/user-functions.php:233 templates/myaccount/layout.php:156
+msgid "Vos commandes"
+msgstr ""
+
+#: inc/user-functions.php:335
+#, php-format
+msgid ""
+"Votre demande de résolution de l'énigme %s est en cours de traitement. Vous "
+"recevrez une notification dès que votre demande sera traitée."
+msgstr ""
+
+#: inc/user-functions.php:351
+#, php-format
+msgid ""
+"Vos demandes de résolution d'énigmes sont en cours de traitement : %s. Vous "
+"recevrez une notification dès que vos demandes seront traitées."
+msgstr ""
+
+#. translators: 1: opening anchor tag, 2: closing anchor tag
+#: inc/user-functions.php:456
+#, php-format
 msgid "Vous avez des %1$sdemandes de conversion%2$s en attente."
 msgstr "Vous avez des %1$sdemandes de conversion%2$s en attente."
+
+#: inc/user-functions.php:478
+msgid "Important ! Des tentatives attendent votre action :"
+msgstr ""
 
 #: single-chasse.php:13
 msgid "Chasse introuvable."
@@ -485,6 +932,11 @@ msgstr ""
 "Votre chasse se termine automatiquement ; ajoutez une énigme à validation "
 "manuelle ou automatique."
 
+#: single-chasse.php:167
+#, fuzzy
+msgid "Vous n’avez pas assez de points pour engager cette énigme."
+msgstr "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
+
 #: single-organisateur.php:84
 msgid "Chasses au Trésor"
 msgstr "Chasses au Trésor"
@@ -493,137 +945,342 @@ msgstr "Chasses au Trésor"
 msgid "C'est parti !"
 msgstr "C'est parti !"
 
-#: template-parts/chasse/chasse-edition-main.php:59
+#: template-parts/chasse/chasse-edition-main.php:61
 msgid "Panneau d'édition chasse"
 msgstr "Panneau d'édition chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:134
+#: template-parts/chasse/chasse-edition-main.php:69
+#: template-parts/chasse/chasse-edition-main.php:647
+#: template-parts/enigme/enigme-edition-main.php:96
+#: template-parts/organisateur/organisateur-edition-main.php:77
+#: template-parts/organisateur/organisateur-edition-main.php:335
+#, fuzzy
+msgid "Animation"
+msgstr "Variation"
+
+#: template-parts/chasse/chasse-edition-main.php:104
+#: template-parts/enigme/enigme-edition-main.php:128
+#: template-parts/indice/indice-edition-main.php:90
+msgid "Titre"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:126
+#, fuzzy
+msgid "Image chasse"
+msgstr "Terminer la chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:133
+#: template-parts/indice/indice-edition-main.php:107
+#, fuzzy
+msgid "Modifier l’image"
+msgstr "Modifier les variantes"
+
+#: template-parts/chasse/chasse-edition-main.php:135
+#: template-parts/chasse/chasse-edition-main.php:141
+#: template-parts/indice/indice-edition-main.php:109
+#: template-parts/indice/indice-edition-main.php:115
+#, fuzzy
+msgid "ajouter une image"
+msgstr "Ajouter une variante"
+
+#: template-parts/chasse/chasse-edition-main.php:154
 msgid "Description chasse"
 msgstr "Description chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:142
-#: template-parts/enigme/enigme-edition-main.php:177
-#: template-parts/organisateur/organisateur-edition-main.php:141
+#: template-parts/chasse/chasse-edition-main.php:162
+#: template-parts/enigme/enigme-edition-main.php:172
+#: template-parts/enigme/enigme-edition-main.php:185
+#: template-parts/enigme/enigme-edition-main.php:202
+#: template-parts/indice/indice-edition-main.php:129
+#: template-parts/organisateur/organisateur-edition-main.php:161
+#: assets/js/enigme-edit.js:645
 msgid "ajouter"
 msgstr "ajouter"
 
-#: template-parts/chasse/chasse-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:174
 msgid "Modifier la description"
 msgstr "Modifier la description"
 
-#: template-parts/chasse/chasse-edition-main.php:155
-#: template-parts/chasse/chasse-edition-main.php:196
-#: template-parts/enigme/enigme-edition-main.php:189
-#: template-parts/organisateur/organisateur-edition-main.php:153
-#: template-parts/organisateur/organisateur-edition-main.php:201
-#: assets/js/chasse-edit.js:258 assets/js/core/helpers.js:218
-#: assets/js/core/helpers.js:240 assets/js/core/helpers.js:262
-#: assets/js/core/resume.js:373 assets/js/enigme-edit.js:891
+#: template-parts/chasse/chasse-edition-main.php:175
+#: template-parts/indice/indice-edition-main.php:137
+#: template-parts/organisateur/organisateur-edition-main.php:173
+#: template-parts/organisateur/organisateur-edition-main.php:220
+#: assets/js/core/helpers.js:234 assets/js/core/helpers.js:256
+#: assets/js/core/helpers.js:278 assets/js/core/resume.js:384
+#: assets/js/enigme-edit.js:743 assets/js/enigme-edit.js:988
 msgid "modifier"
 msgstr "modifier"
 
-#: template-parts/chasse/chasse-edition-main.php:171
+#: template-parts/chasse/chasse-edition-main.php:191
 msgid "Récompense"
 msgstr "Récompense"
 
-#: template-parts/chasse/chasse-edition-main.php:195
-msgid "Modifier la récompense"
-msgstr "Modifier la récompense"
+#: template-parts/chasse/chasse-edition-main.php:227
+#: template-parts/enigme/enigme-edition-main.php:238
+#: template-parts/indice/indice-edition-main.php:148
+#, fuzzy
+msgid "Réglages"
+msgstr "Régler"
 
-#: template-parts/chasse/chasse-edition-main.php:219
+#: template-parts/chasse/chasse-edition-main.php:239
 msgid "Mode de fin"
 msgstr "Mode de fin"
 
-#: template-parts/chasse/chasse-edition-main.php:230
-#: template-parts/enigme/enigme-edition-main.php:221
+#: template-parts/chasse/chasse-edition-main.php:250
+#: template-parts/enigme/enigme-edition-main.php:247
 msgid "Automatique"
 msgstr "Automatique"
 
-#: template-parts/chasse/chasse-edition-main.php:236
-#: template-parts/enigme/enigme-edition-main.php:227
+#: template-parts/chasse/chasse-edition-main.php:256
+#: template-parts/enigme/enigme-edition-main.php:253
 msgid "Explication du mode automatique"
 msgstr "Explication du mode automatique"
 
-#: template-parts/chasse/chasse-edition-main.php:253
-#: template-parts/enigme/enigme-edition-main.php:238
+#: template-parts/chasse/chasse-edition-main.php:258
+#, fuzzy
+msgid "Fin de chasse automatique"
+msgstr "Explication du mode automatique"
+
+#: template-parts/chasse/chasse-edition-main.php:259
+#, fuzzy
+msgid ""
+"Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode "
+"automatique, la chasse se termine dès que le nombre de gagnants prévu est "
+"atteint."
+msgstr ""
+"Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse "
+"s’achève dès que le nombre de gagnants prévu est atteint."
+
+#: template-parts/chasse/chasse-edition-main.php:272
+#: template-parts/enigme/enigme-edition-main.php:264
 msgid "Manuelle"
 msgstr "Manuelle"
 
-#: template-parts/chasse/chasse-edition-main.php:259
-#: template-parts/enigme/enigme-edition-main.php:244
+#: template-parts/chasse/chasse-edition-main.php:278
+#: template-parts/enigme/enigme-edition-main.php:270
 msgid "Explication du mode manuel"
 msgstr "Explication du mode manuel"
 
-#: template-parts/chasse/chasse-edition-main.php:277
+#: template-parts/chasse/chasse-edition-main.php:280
+#, fuzzy
+msgid "Fin de chasse manuelle"
+msgstr "ID de chasse invalide."
+
+#: template-parts/chasse/chasse-edition-main.php:281
+#, fuzzy
+msgid ""
+"Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans "
+"le panneau d’édition de la chasse, onglet Paramètres."
+msgstr ""
+"Vous arrêtez la chasse manuellement, grâce au bouton situé dans le panneau "
+"d'édition chasse."
+
+#: template-parts/chasse/chasse-edition-main.php:295
 msgid "Terminer la chasse"
 msgstr "Terminer la chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:279
+#: template-parts/chasse/chasse-edition-main.php:297
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
 msgid "Gagnants"
 msgstr "Gagnants"
 
-#: template-parts/chasse/chasse-edition-main.php:287
+#: template-parts/chasse/chasse-edition-main.php:305
 msgid "Valider la fin de chasse"
 msgstr "Valider la fin de chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:301
+#: template-parts/chasse/chasse-edition-main.php:319
+#, php-format
 msgid "Chasse gagnée le %s par %s"
 msgstr "Chasse gagnée le %s par %s"
 
-#: template-parts/chasse/chasse-edition-main.php:405
-#: template-parts/enigme/enigme-edition-main.php:314
+#: template-parts/chasse/chasse-edition-main.php:337
+#, fuzzy
+msgid "Nb gagnants"
+msgstr "Gagnants"
+
+#: template-parts/chasse/chasse-edition-main.php:353
+msgid "Illimité"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:374
+msgid "Début"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:390
+#, fuzzy
+msgid "Date de fin"
+msgstr "Mode de fin"
+
+#: template-parts/chasse/chasse-edition-main.php:404
+msgid "Durée illimitée"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/indice/indice-edition-main.php:198
+msgid "Coût"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:423
 msgid "En savoir plus sur les points"
 msgstr "En savoir plus sur les points"
 
-#: template-parts/chasse/chasse-edition-main.php:541
+#: template-parts/chasse/chasse-edition-main.php:426
+msgid "Coût d’accès à une chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:427
 msgid ""
-"Pourcentage moyen d’énigmes auxquelles chaque participant s’est engagé, par "
-"rapport à toutes celles proposées."
+"Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou "
+"payant. Cet accès est indispensable pour consulter les énigmes, qui restent "
+"invisibles tant qu’il n’a pas été débloqué."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:445
+#: template-parts/enigme/enigme-edition-main.php:394
+#: template-parts/indice/indice-edition-main.php:202
+msgid "Gratuit"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:552
+#: template-parts/enigme/enigme-edition-main.php:517
+msgid "Actualiser"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:554
+#: template-parts/enigme/enigme-edition-main.php:519
+msgid "Période :"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:568
+#: template-parts/enigme/enigme-edition-main.php:533
+#, fuzzy
+msgid "Participants"
+msgstr "Tx participation"
+
+#: template-parts/chasse/chasse-edition-main.php:575
+#: template-parts/enigme/enigme-edition-main.php:97
+#: template-parts/enigme/enigme-edition-main.php:540
+#: template-parts/enigme/enigme-edition-main.php:578
+#: template-parts/enigme/enigme-edition-main.php:627
+#: template-parts/enigme/partials/enigme-partial-participants.php:69
+#: templates/myaccount/content-chasses.php:108
+msgid "Tentatives"
+msgstr "Tentatives"
+
+#: template-parts/chasse/chasse-edition-main.php:582
+#: template-parts/enigme/enigme-edition-main.php:548
+#, fuzzy
+msgid "Points collectés"
+msgstr "Points achetés"
+
+#: template-parts/chasse/chasse-edition-main.php:589
+#: template-parts/chasse/chasse-edition-main.php:597
+#, fuzzy
+msgid "Taux d'engagement"
+msgstr "Trier par engagement"
+
+#: template-parts/chasse/chasse-edition-main.php:592
+#, fuzzy
+msgid ""
+"Pourcentage moyen d’énigmes auxquelles chaque joueur a participé, par "
+"rapport à l’ensemble des énigmes proposées."
 msgstr ""
 "Pourcentage moyen d’énigmes auxquelles chaque participant s’est engagé, par "
 "rapport à toutes celles proposées."
 
-#: template-parts/chasse/chasse-edition-main.php:546
+#: template-parts/chasse/chasse-edition-main.php:596
 msgid "Explication du taux d’engagement"
 msgstr "Explication du taux d’engagement"
 
-#: template-parts/chasse/chasse-edition-main.php:558
+#: template-parts/chasse/chasse-edition-main.php:605
+#: template-parts/enigme/partials/enigme-partial-participants.php:39
+msgid "Les statistiques seront disponibles une fois la chasse activée."
+msgstr "Les statistiques seront disponibles une fois la chasse activée."
+
+#: template-parts/chasse/chasse-edition-main.php:616
 msgid "Énigmes sans validation"
 msgstr "Énigmes sans validation"
 
-#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/chasse/chasse-edition-main.php:655
+#: template-parts/organisateur/organisateur-edition-main.php:342
 msgid "Communiquez"
 msgstr "Communiquez"
 
-#: template-parts/chasse/chasse-edition-main.php:604
+#: template-parts/chasse/chasse-edition-main.php:662
 msgid "Sites et réseaux de la chasse"
 msgstr "Sites et réseaux de la chasse"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:19
+#: template-parts/chasse/panneaux/chasse-edition-description.php:28
 msgid "Modifier la description de la chasse"
 msgstr "Modifier la description de la chasse"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:20
+#: template-parts/chasse/panneaux/chasse-edition-description.php:29
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:16
 #: template-parts/enigme/panneaux/enigme-edition-description.php:19
 #: template-parts/enigme/panneaux/enigme-edition-images.php:12
+#: template-parts/indice/panneaux/indice-edition-description.php:19
 msgid "Fermer le panneau"
 msgstr "Fermer le panneau"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:28
+#: template-parts/chasse/panneaux/chasse-edition-description.php:37
 #: template-parts/enigme/panneaux/enigme-edition-description.php:27
-#: template-parts/enigme/panneaux/enigme-edition-images.php:20
+#: template-parts/enigme/panneaux/enigme-edition-images.php:31
+#: template-parts/indice/panneaux/indice-edition-description.php:26
 msgid "💾 Enregistrer"
 msgstr "💾 Enregistrer"
 
-#: template-parts/chasse/panneaux/chasse-edition-description.php:33
+#: template-parts/chasse/panneaux/chasse-edition-description.php:45
 msgid "Description mise à jour."
 msgstr "Description mise à jour."
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:15
+#, fuzzy
+msgid "Configurer la récompense"
+msgstr "Modifier la récompense"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:21
+#, fuzzy
+msgid "Titre de la récompense"
+msgstr "Modifier la récompense"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:22
+msgid "Ex : Un papillon en cristal..."
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:24
+#, fuzzy
+msgid "Descripton de la récompense"
+msgstr "Modifier la récompense"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:25
+msgid "Ex : Un coffret cadeau comprenant..."
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:28
+msgid "Valeur en euros (€)"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:34
+msgid "Ex : 50"
+msgstr ""
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:37
+#, fuzzy
+msgid "Enregistrer"
+msgstr "💾 Enregistrer"
+
+#: template-parts/chasse/panneaux/chasse-edition-recompense.php:40
+#, fuzzy
+msgid "Supprimer la récompense"
+msgstr "Modifier la récompense"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:40
 msgid "Joueurs"
 msgstr "Joueurs"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:51
+#: template-parts/enigme/enigme-edition-main.php:576
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:34
 msgid "Joueur"
 msgstr "Joueur"
 
@@ -639,7 +1296,7 @@ msgstr "Trier par taux de participation"
 msgid "Tx participation"
 msgstr "Tx participation"
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:67
+#: template-parts/chasse/partials/chasse-partial-participants.php:68
 msgid "Trier par taux de résolution"
 msgstr "Trier par taux de résolution"
 
@@ -651,95 +1308,365 @@ msgstr "Tx résolution"
 msgid "Aucune donnée."
 msgstr "Aucune donnée."
 
-#: template-parts/enigme/enigme-edition-main.php:80
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:28
+#: assets/js/enigme-edit.js:1616
+#, fuzzy
+msgid "Ajouter une énigme"
+msgstr "Ajouter une variante"
+
+#: template-parts/enigme/enigme-edition-main.php:87
 msgid "Panneau d'édition énigme"
 msgstr "Panneau d'édition énigme"
 
-#: template-parts/enigme/enigme-edition-main.php:88
-msgid "Solution"
-msgstr "Solution"
+#: template-parts/enigme/enigme-edition-main.php:91
+#: template-parts/indice/indice-edition-main.php:56
+#, fuzzy
+msgid "Fermer les paramètres"
+msgstr "Fermer le panneau"
 
-#: template-parts/enigme/enigme-edition-main.php:169
+#: template-parts/enigme/enigme-edition-main.php:112
+#: template-parts/indice/indice-edition-main.php:74
+#, fuzzy
+msgid "Informations"
+msgstr "Inscription"
+
+#: template-parts/enigme/enigme-edition-main.php:138
+#, fuzzy
+msgid "renseigner le titre de l’énigme"
+msgstr "renseigner le titre de l’indice"
+
+#: template-parts/enigme/enigme-edition-main.php:156
+msgid "Illustrations"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:194
 msgid "Texte énigme"
 msgstr "Texte énigme"
 
-#: template-parts/enigme/enigme-edition-main.php:192
+#: template-parts/enigme/enigme-edition-main.php:213
 msgid "Éditer le texte"
 msgstr "Éditer le texte"
 
-#: template-parts/enigme/enigme-edition-main.php:202
-msgid "Sous-titre"
-msgstr "Sous-titre"
-
-#: template-parts/enigme/enigme-edition-main.php:204
-msgid "Ajouter un sous-titre (max 100 caractères)"
-msgstr "Ajouter un sous-titre (max 100 caractères)"
-
-#: template-parts/enigme/enigme-edition-main.php:217
-msgid "Validation"
-msgstr "Validation"
-
-#: template-parts/enigme/enigme-edition-main.php:255
-msgid "Aucune"
-msgstr "Aucune"
-
-#: template-parts/enigme/enigme-edition-main.php:272
-msgid "Variantes"
-msgstr "Variantes"
-
-#: template-parts/enigme/enigme-edition-main.php:278
-msgid "Explication des variantes"
-msgstr "Explication des variantes"
-
-#: template-parts/enigme/enigme-edition-main.php:294
-msgid "Éditer les variantes"
-msgstr "Éditer les variantes"
-
-#: template-parts/enigme/enigme-edition-main.php:295
+#: template-parts/enigme/enigme-edition-main.php:214
+#: template-parts/enigme/enigme-edition-main.php:350
+#: template-parts/enigme/enigme-edition-main.php:673
 msgid "éditer"
 msgstr "éditer"
 
-#: template-parts/enigme/enigme-edition-main.php:299
-#: assets/js/enigme-edit.js:869
+#: template-parts/enigme/enigme-edition-main.php:228
+msgid "Sous-titre"
+msgstr "Sous-titre"
+
+#: template-parts/enigme/enigme-edition-main.php:230
+msgid "Ajouter un sous-titre (max 100 caractères)"
+msgstr "Ajouter un sous-titre (max 100 caractères)"
+
+#: template-parts/enigme/enigme-edition-main.php:243
+msgid "Validation"
+msgstr "Validation"
+
+#: template-parts/enigme/enigme-edition-main.php:256
+#, fuzzy
+msgid "Validation automatique"
+msgstr "Explication du mode automatique"
+
+#: template-parts/enigme/enigme-edition-main.php:257
+msgid ""
+"Le joueur soumet une tentative de réponse. Celle-ci est automatiquement "
+"vérifiée selon les critères définis (réponse attendue, respect de la casse, "
+"variantes), et le résultat est immédiatement communiqué au joueur."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:273
+#, fuzzy
+msgid "Validation manuelle"
+msgstr "Validation"
+
+#: template-parts/enigme/enigme-edition-main.php:274
+msgid ""
+"Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa "
+"tentative depuis votre espace personnel. À chaque nouvelle soumission, vous "
+"recevez une notification par email ainsi qu’un message d’alerte."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:281
+msgid "Aucune"
+msgstr "Aucune"
+
+#: template-parts/enigme/enigme-edition-main.php:288
+msgid "Bonne(s) réponse(s)"
+msgstr "Bonne(s) réponse(s)"
+
+#: template-parts/enigme/enigme-edition-main.php:294
+msgid "La ou les bonnes réponses"
+msgstr "La ou les bonnes réponses"
+
+#: template-parts/enigme/enigme-edition-main.php:295
+msgid ""
+"Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — "
+"selon votre réglage de respect de la casse — résout l’énigme."
+msgstr ""
+"Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — "
+"selon votre réglage de respect de la casse — résout l’énigme."
+
+#: template-parts/enigme/enigme-edition-main.php:307
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
+msgid "Respecter la casse"
+msgstr "Respecter la casse"
+
+#: template-parts/enigme/enigme-edition-main.php:315
+msgid "Variantes"
+msgstr "Variantes"
+
+#: template-parts/enigme/enigme-edition-main.php:321
+msgid "Explication des variantes"
+msgstr "Explication des variantes"
+
+#: template-parts/enigme/enigme-edition-main.php:324
+#, fuzzy
+msgid "Système de variantes"
+msgstr "Ajouter des variantes"
+
+#: template-parts/enigme/enigme-edition-main.php:325
+msgid ""
+"Les variantes sont des réponses alternatives qui ne sont pas validées comme "
+"correctes, mais qui déclenchent un message personnalisé en retour (par "
+"exemple une aide, un indice, un lien ou tout autre contenu de votre choix)."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:335
+#: assets/js/enigme-edit.js:915
+#, fuzzy
+msgid "Variante"
+msgstr "Variantes"
+
+#: template-parts/enigme/enigme-edition-main.php:336
+#: assets/js/enigme-edit.js:918
+msgid "Message"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:349
+msgid "Éditer les variantes"
+msgstr "Éditer les variantes"
+
+#: template-parts/enigme/enigme-edition-main.php:354
+#: assets/js/enigme-edit.js:966
 msgid "Ajouter des variantes"
 msgstr "Ajouter des variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:300
-#: assets/js/enigme-edit.js:870
+#: template-parts/enigme/enigme-edition-main.php:355
+#: assets/js/enigme-edit.js:967
 msgid "ajouter des variantes"
 msgstr "ajouter des variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:342
+#: template-parts/enigme/enigme-edition-main.php:371
+#, fuzzy
+msgid "Coût tentative"
+msgstr "Nb tentatives :"
+
+#: template-parts/enigme/enigme-edition-main.php:377
+#, fuzzy
+msgid "Informations sur le coût des tentatives"
+msgstr "Informations sur les coordonnées bancaires"
+
+#: template-parts/enigme/enigme-edition-main.php:380
+#, fuzzy
+msgid "Tentative gratuite ou payante ?"
+msgstr "Tentative introuvable."
+
+#: template-parts/enigme/enigme-edition-main.php:381
+msgid ""
+"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
+"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
+"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:402
+#, fuzzy
+msgid "Nb tentatives"
+msgstr "Nb tentatives :"
+
+#: template-parts/enigme/enigme-edition-main.php:408
 msgid "Explication du nombre de tentatives"
 msgstr "Explication du nombre de tentatives"
 
-#: template-parts/enigme/enigme-edition-main.php:364
+#: template-parts/enigme/enigme-edition-main.php:411
+#, fuzzy
+msgid "Plafond nb de tentatives quotidiennes"
+msgstr "Tentatives quotidiennes"
+
+#: template-parts/enigme/enigme-edition-main.php:412
+#, fuzzy
+msgid ""
+"Nombre maximal de tentatives quotidiennes par joueur:\n"
+"\n"
+"Mode payant : illimitées\n"
+"\n"
+"Mode gratuit : 24 tentatives par jour"
+msgstr ""
+"Nombre maximum de tentatives quotidiennes d'un joueur\n"
+"Mode payant : tentatives illimitées.\n"
+"Mode gratuit : maximum 24 tentatives par jour."
+
+#: template-parts/enigme/enigme-edition-main.php:418
+msgid "max par jour"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:434
 msgid "Accès"
 msgstr "Accès"
 
-#: template-parts/enigme/enigme-edition-main.php:368
+#: template-parts/enigme/enigme-edition-main.php:438
 msgid "Libre"
 msgstr "Libre"
 
-#: template-parts/enigme/enigme-edition-main.php:372
+#: template-parts/enigme/enigme-edition-main.php:442
 msgid "Date programmée"
 msgstr "Date programmée"
 
-#: template-parts/enigme/enigme-edition-main.php:381
-msgid "Pré-requis"
-msgstr "Pré-requis"
-
-#: template-parts/enigme/enigme-edition-main.php:385
+#: template-parts/enigme/enigme-edition-main.php:455
 msgid "Aucune autre énigme disponible comme prérequis."
 msgstr "Aucune autre énigme disponible comme prérequis."
 
-#: template-parts/enigme/enigme-edition-main.php:569
-msgid "Solution de cette énigme"
-msgstr "Solution de cette énigme"
+#: template-parts/enigme/enigme-edition-main.php:491
+msgid "❌ Suppression énigme"
+msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:640
+#: template-parts/enigme/enigme-edition-main.php:521
+#, fuzzy
+msgid "Total"
+msgstr "Total €"
+
+#: template-parts/enigme/enigme-edition-main.php:522
+msgid "Aujourd’hui"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:523
+msgid "Semaine"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:524
+msgid "Mois"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:556
+#, fuzzy
+msgid "Bonnes réponses"
+msgstr "Bonne(s) réponse(s)"
+
+#: template-parts/enigme/enigme-edition-main.php:570
+#, php-format
+msgid "Résolue par (%s) joueurs"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:575
+msgid "Rang"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:655
+#, fuzzy
+msgid "Animation de cette énigme"
+msgstr "Animation de cette énigme"
+
+#: template-parts/enigme/enigme-edition-main.php:667
+msgid ""
+"Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée "
+"terminée. Une fois celle-ci achevée, elles restent conservées dans un coffre-"
+"fort numérique pendant le délai que vous définissez ici."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:670
+msgid "Document PDF"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:671
+#: templates/myaccount/content-outils.php:33
+msgid "Modifier"
+msgstr "Modifier"
+
+#: template-parts/enigme/enigme-edition-main.php:671
+msgid "Choisir un fichier"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:673
+msgid "Rédiger"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:675
+#, fuzzy
+msgid "aucune solution ne"
+msgstr "Aucune donnée."
+
+#: template-parts/enigme/enigme-edition-main.php:680
+#, php-format
+msgid "votre fichier %s"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:681
+#, php-format
+msgid " %d jours après la fin de la chasse, à %s"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:683
+msgid " (pdf sélectionné mais pas de fichier chargé)"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:687
+msgid "votre texte d'explication"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:688
+#, php-format
+msgid ", %d jours après la fin de la chasse, à %s"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:690
+msgid " (rédaction libre sélectionnée mais non remplie)"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:702
+#: template-parts/enigme/enigme-edition-main.php:710
+#, fuzzy
+msgid "Vider"
+msgstr "Valider"
+
+#: template-parts/enigme/enigme-edition-main.php:712
+msgid "Rédaction libre"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:720
+#, fuzzy
+msgid "Délai après fin de chasse"
+msgstr "Valider la fin de chasse"
+
+#: template-parts/enigme/enigme-edition-main.php:726
 msgid "Informations sur la publication de la solution"
 msgstr "Informations sur la publication de la solution"
+
+#: template-parts/enigme/enigme-edition-main.php:729
+#, fuzzy
+msgid "Délai de parution des solutions"
+msgstr "Définition du taux de résolution"
+
+#: template-parts/enigme/enigme-edition-main.php:745
+msgid "jours, publié à"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:760
+msgid "Vos solutions sont protégées"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:761
+msgid "Stockées dans un espace privé, hors de portée des joueurs."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:762
+msgid "Aucun lien ne peut être trouvé ni ouvert."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:763
+msgid "Débloquées uniquement au moment choisi."
+msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-description.php:18
 msgid "Modifier le texte de l’énigme"
@@ -753,17 +1680,21 @@ msgstr "Texte de l’énigme mis à jour."
 msgid "Modifier les images de l’énigme"
 msgstr "Modifier les images de l’énigme"
 
-#: template-parts/enigme/panneaux/enigme-edition-images.php:29
+#: template-parts/enigme/panneaux/enigme-edition-images.php:40
 msgid "Images mises à jour."
 msgstr "Images mises à jour."
 
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:21
+msgid "Configurer les variantes de réponse"
+msgstr "Configurer les variantes de réponse"
+
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:50
-#: assets/js/enigme-edit.js:743
+#: assets/js/enigme-edit.js:826
 msgid "réponse déclenchant l'affichage du message"
 msgstr "réponse déclenchant l'affichage du message"
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:51
-#: assets/js/enigme-edit.js:746
+#: assets/js/enigme-edit.js:829
 msgid "Message affiché au joueur"
 msgstr "Message affiché au joueur"
 
@@ -771,101 +1702,90 @@ msgstr "Message affiché au joueur"
 msgid "Ajouter une variante"
 msgstr "Ajouter une variante"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:19
-msgid "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
-msgstr "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
+#: template-parts/enigme/panneaux/enigme-edition-variantes.php:77
+msgid "Enregistrer les variantes"
+msgstr "Enregistrer les variantes"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:36
-msgid "Énigme résolue"
-msgstr "Énigme résolue"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:63
+msgid "⏳ Votre tentative est en cours de traitement."
+msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:58
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:78
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:106
+#, php-format
 msgid "Vous avez résolu cette énigme le %s."
 msgstr "Vous avez résolu cette énigme le %s."
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:55
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:48
-msgid "Valider"
-msgstr "Valider"
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:110
+msgid "Énigme résolue"
+msgstr "Énigme résolue"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:61
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:125
+#: assets/js/reponse-automatique.js:197 assets/js/reponse-automatique.js:219
 msgid "tentatives quotidiennes épuisées"
 msgstr "tentatives quotidiennes épuisées"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:70
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:134
+#, php-format
 msgid "%dh et %dmn avant réactivation"
 msgstr "%dh et %dmn avant réactivation"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:82
-#: inc/enigme/reponses.php:38
-msgid "Votre réponse"
-msgstr "Votre réponse"
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:25
+msgid "Gagnants :"
+msgstr "Gagnants :"
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:93
-msgid "Accéder à la boutique"
-msgstr "Accéder à la boutique"
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:53
+msgid "Aucun gagnant pour le moment."
+msgstr ""
 
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:105
-msgid "pts"
-msgstr "pts"
-
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:112
-msgid "Tentatives quotidiennes"
-msgstr "Tentatives quotidiennes"
-
-#: template-parts/enigme/partials/enigme-partial-images.php:39
-msgid "Image par défaut de l’énigme"
+#: template-parts/enigme/partials/enigme-partial-images.php:53
+#, fuzzy
+msgid "Image de l’énigme"
 msgstr "Image par défaut de l’énigme"
-
-#: template-parts/enigme/partials/enigme-partial-participants.php:39
-msgid "Les statistiques seront disponibles une fois la chasse activée."
-msgstr "Les statistiques seront disponibles une fois la chasse activée."
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:43
 msgid "Aucun participant engagé."
 msgstr "Aucun participant engagé."
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:50
+#: template-parts/enigme/partials/enigme-partial-participants.php:47
+#, fuzzy
+msgid "Liste participants"
+msgstr "Tx participation"
+
+#: template-parts/enigme/partials/enigme-partial-participants.php:51
 msgid "Nom"
 msgstr "Nom"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:55
+#: template-parts/enigme/partials/enigme-partial-participants.php:56
 msgid "Trier par engagement"
 msgstr "Trier par engagement"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:57
+#: template-parts/enigme/partials/enigme-partial-participants.php:58
 msgid "Engagement"
 msgstr "Engagement"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:66
+#: template-parts/enigme/partials/enigme-partial-participants.php:67
 msgid "Trier par tentatives"
 msgstr "Trier par tentatives"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:68
-msgid "Tentatives"
-msgstr "Tentatives"
-
-#: template-parts/enigme/partials/enigme-partial-participants.php:73
+#: template-parts/enigme/partials/enigme-partial-participants.php:74
 msgid "Trouvé"
 msgstr "Trouvé"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:91
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:64
+#: template-parts/enigme/partials/enigme-partial-participants.php:96
 msgid "Première page"
 msgstr "Première page"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:94
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:67
+#: template-parts/enigme/partials/enigme-partial-participants.php:99
 msgid "Page précédente"
 msgstr "Page précédente"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:100
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:73
+#: template-parts/enigme/partials/enigme-partial-participants.php:105
 msgid "Page suivante"
 msgstr "Page suivante"
 
-#: template-parts/enigme/partials/enigme-partial-participants.php:103
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:76
+#: template-parts/enigme/partials/enigme-partial-participants.php:108
 msgid "Dernière page"
 msgstr "Dernière page"
 
@@ -874,23 +1794,41 @@ msgid "Aucune tentative de soumission."
 msgstr "Aucune tentative de soumission."
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:27
-msgid "Réponse"
-msgstr "Réponse"
-
-msgid "Bonne(s) réponse(s)"
-msgstr "Bonne(s) réponse(s)"
+#: templates/myaccount/content-chasses.php:126
+#, fuzzy
+msgid "Proposition"
+msgstr "Variation"
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:28
-msgid "Actions"
-msgstr "Actions"
+#: templates/myaccount/content-chasses.php:127
+msgid "Résultat"
+msgstr ""
 
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:34
 msgid "Inconnu"
 msgstr "Inconnu"
 
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:51
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:55
+msgid "bon"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:57
+msgid "faux"
+msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:59
+#, fuzzy
+msgid "attente"
+msgstr "En attente"
+
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:71
 msgid "Invalider"
 msgstr "Invalider"
+
+#: template-parts/enigme/partials/enigme-sidebar-section.php:42
+#, fuzzy
+msgid "Aucune énigme disponible"
+msgstr "Aucune énigme disponible."
 
 #: template-parts/enigme/partials/pirate/enigme-partial-images.php:9
 msgid ""
@@ -914,33 +1852,134 @@ msgstr "🏴‍☠️ Texte (pirate)"
 msgid "🏴‍☠️ Titre (pirate)"
 msgstr "🏴‍☠️ Titre (pirate)"
 
-#: template-parts/organisateur/organisateur-edition-main.php:67
+#: template-parts/indice/indice-edition-main.php:53
+msgid "Panneau d'édition indice"
+msgstr "Panneau d'édition indice"
+
+#: template-parts/indice/indice-edition-main.php:95
+msgid "renseigner le titre de l’indice"
+msgstr "renseigner le titre de l’indice"
+
+#: template-parts/indice/indice-edition-main.php:105
+msgid "Image"
+msgstr "Image"
+
+#: template-parts/indice/indice-edition-main.php:124
+msgid "Texte"
+msgstr "Texte"
+
+#: template-parts/indice/indice-edition-main.php:136
+#: template-parts/indice/panneaux/indice-edition-description.php:18
+msgid "Modifier le texte de l’indice"
+msgstr "Modifier le texte de l’indice"
+
+#: template-parts/indice/indice-edition-main.php:151
+msgid "Aide pour"
+msgstr "Aide pour"
+
+#: template-parts/indice/indice-edition-main.php:158
+msgid "Aucune énigme disponible."
+msgstr "Aucune énigme disponible."
+
+#: template-parts/indice/indice-edition-main.php:184
+msgid "Publication"
+msgstr "Publication"
+
+#: template-parts/indice/indice-edition-main.php:186
+msgid "Immédiate"
+msgstr "Immédiate"
+
+#: template-parts/indice/indice-edition-main.php:187
+msgid "Différée"
+msgstr "Différée"
+
+#: template-parts/indice/indice-edition-main.php:198
+msgid "(points)"
+msgstr "(points)"
+
+#: template-parts/indice/indice-edition-main.php:221
+#, fuzzy
+msgid "Statistiques à venir"
+msgstr "Statistiques"
+
+#: template-parts/indice/panneaux/indice-edition-description.php:31
+msgid "Texte de l’indice mis à jour."
+msgstr "Texte de l’indice mis à jour."
+
+#: template-parts/modals/modal-points.php:9
+msgid "À quoi servent les points ?"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:10
+msgid "Les points vous permettent de débloquer :"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:12
+#, fuzzy
+msgid "🎯 Des chasses au trésor"
+msgstr "Chasses au Trésor"
+
+#: template-parts/modals/modal-points.php:13
+#, fuzzy
+msgid "❓ Des tentatives de réponse"
+msgstr "Configurer les variantes de réponse"
+
+#: template-parts/modals/modal-points.php:14
+msgid "💡 Des indices"
+msgstr ""
+
+#: template-parts/modals/modal-points.php:17
+msgid ""
+"La gratuité ou l'accès par points est choisi librement par chaque "
+"organisateur."
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:69
 msgid "Panneau d'édition organisateur"
 msgstr "Panneau d'édition organisateur"
 
-#: template-parts/organisateur/organisateur-edition-main.php:133
-msgid "Présentation"
-msgstr "Présentation"
-
-#: template-parts/organisateur/organisateur-edition-main.php:153
-msgid "Modifier la présentation"
-msgstr "Modifier la présentation"
-
-#: template-parts/organisateur/organisateur-edition-main.php:187
-msgid "Informations sur l’adresse email de contact"
-msgstr "Informations sur l’adresse email de contact"
-
-#: template-parts/organisateur/organisateur-edition-main.php:251
+#: template-parts/organisateur/organisateur-edition-main.php:78
+#: template-parts/organisateur/organisateur-edition-main.php:264
+#: template-parts/organisateur/organisateur-edition-main.php:270
 #: templates/myaccount/content-points.php:75
-#: templates/myaccount/content-points.php:96
+#: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
+#: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
 msgid "Points"
 msgstr "Points"
 
-#: template-parts/organisateur/organisateur-edition-main.php:274
+#: template-parts/organisateur/organisateur-edition-main.php:153
+msgid "Présentation"
+msgstr "Présentation"
+
+#: template-parts/organisateur/organisateur-edition-main.php:173
+msgid "Modifier la présentation"
+msgstr "Modifier la présentation"
+
+#: template-parts/organisateur/organisateur-edition-main.php:207
+msgid "Informations sur l’adresse email de contact"
+msgstr "Informations sur l’adresse email de contact"
+
+#: template-parts/organisateur/organisateur-edition-main.php:209
+#, fuzzy
+msgid "Email de contact organisateur"
+msgstr "Confirmation Organisateur"
+
+#: template-parts/organisateur/organisateur-edition-main.php:210
+msgid ""
+"Si aucune adresse n’est renseignée, votre adresse email utilisateur est "
+"utilisée par défaut."
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:293
 msgid "Informations sur les coordonnées bancaires"
 msgstr "Informations sur les coordonnées bancaires"
 
-#: template-parts/organisateur/organisateur-edition-main.php:276
+#: template-parts/organisateur/organisateur-edition-main.php:296
+#, fuzzy
+msgid "Coordonnées bancaires"
+msgstr "Ajouter des coordonnées bancaires"
+
+#: template-parts/organisateur/organisateur-edition-main.php:297
 msgid ""
 "Ces informations sont nécessaires uniquement pour vous verser les gains "
 "issus de la conversion de vos points en euros. Nous ne prélevons jamais "
@@ -950,21 +1989,80 @@ msgstr ""
 "issus de la conversion de vos points en euros. Nous ne prélevons jamais "
 "d'argent."
 
+#: template-parts/organisateur/organisateur-edition-main.php:352
+msgid "Sites et réseaux de l'organisation"
+msgstr "Sites et réseaux de l'organisation"
+
+#: template-parts/organisateur/organisateur-edition-main.php:380
+msgid "QR code de l'organisation"
+msgstr "QR code de l'organisation"
+
+#: template-parts/organisateur/organisateur-edition-main.php:381
+msgid "QR code de votre organisation"
+msgstr "QR code de votre organisation"
+
+#: template-parts/organisateur/organisateur-edition-main.php:383
+msgid "Télécharger"
+msgstr "Télécharger"
+
+#: templates/myaccount/content-chasses.php:111
+#, fuzzy, php-format
+msgid "%d tentative en attente"
+msgid_plural "%d tentatives en attente"
+msgstr[0] "Tentative bien reçue."
+msgstr[1] "Tentative bien reçue."
+
+#: templates/myaccount/content-chasses.php:113
+#, fuzzy, php-format
+msgid "%d tentative"
+msgid_plural "%d tentatives"
+msgstr[0] "Nb tentatives :"
+msgstr[1] "Nb tentatives :"
+
+#: templates/myaccount/content-chasses.php:116
+#, fuzzy, php-format
+msgid "%d bonne réponse"
+msgid_plural "%d bonnes réponses"
+msgstr[0] "Votre réponse"
+msgstr[1] "Votre réponse"
+
+#: templates/myaccount/content-chasses.php:125
+#, fuzzy
+msgid "Énigme"
+msgstr "Énigmes"
+
 #: templates/myaccount/content-dashboard-organisateur.php:25
 msgid "Votre demande de conversion a bien été envoyée."
 msgstr "Votre demande de conversion a bien été envoyée."
 
-#: templates/myaccount/content-outils.php:18
+#: templates/myaccount/content-organisateurs.php:19
+#: templates/myaccount/layout.php:104
+#, fuzzy
+msgid "Organisateurs"
+msgstr "Devenir Organisateur"
+
+#: templates/myaccount/content-organisateurs.php:37
+#, fuzzy, php-format
+msgid "%d organisateur"
+msgid_plural "%d organisateurs"
+msgstr[0] "Devenir Organisateur"
+msgstr[1] "Devenir Organisateur"
+
+#: templates/myaccount/content-organisateurs.php:44
+msgid "Filtrer par état :"
+msgstr ""
+
+#: templates/myaccount/content-organisateurs.php:46
+msgid "Tous"
+msgstr ""
+
+#: templates/myaccount/content-outils.php:18 templates/myaccount/layout.php:118
 msgid "Outils"
 msgstr "Outils"
 
 #: templates/myaccount/content-outils.php:23
 msgid "Taux Conversion"
 msgstr "Taux Conversion"
-
-#: templates/myaccount/content-outils.php:33
-msgid "Modifier"
-msgstr "Modifier"
 
 #: templates/myaccount/content-outils.php:37
 msgid "Définir un nouveau taux :"
@@ -981,6 +2079,14 @@ msgstr "ACF"
 #: templates/myaccount/content-outils.php:49
 msgid "Afficher les champs ACF"
 msgstr "Afficher les champs ACF"
+
+#: templates/myaccount/content-outils.php:61
+msgid "Reset stats"
+msgstr ""
+
+#: templates/myaccount/content-outils.php:65
+msgid "Effacer"
+msgstr ""
 
 #: templates/myaccount/content-points.php:30
 msgid "Points achetés"
@@ -1002,15 +2108,63 @@ msgstr "Points de mon organisation"
 msgid "Gérer"
 msgstr "Gérer"
 
+#: templates/myaccount/layout.php:34
+msgid "Accueil"
+msgstr ""
+
+#: templates/myaccount/layout.php:41
+#, fuzzy
+msgid "Commandes"
+msgstr "Commencer"
+
+#: templates/myaccount/layout.php:48
+#, fuzzy
+msgid "Chasses"
+msgstr "Chasse"
+
+#: templates/myaccount/layout.php:49 templates/myaccount/layout.php:158
+msgid "Vos chasses"
+msgstr ""
+
+#: templates/myaccount/layout.php:66
+msgid "Profil"
+msgstr ""
+
+#: templates/myaccount/layout.php:95
+msgid "Déconnexion"
+msgstr ""
+
+#: templates/myaccount/layout.php:100
+msgid "Administration"
+msgstr ""
+
+#: templates/myaccount/layout.php:154
+#, fuzzy
+msgid "Votre profil"
+msgstr "Créer mon profil"
+
+#: templates/myaccount/layout.php:162
+#, php-format
+msgid "Bienvenue %s"
+msgstr ""
+
+#: templates/myaccount/layout.php:187
+msgid "Content not found."
+msgstr ""
+
+#. Template Name of the theme
 msgid "Confirmation Organisateur"
 msgstr "Confirmation Organisateur"
 
+#. Template Name of the theme
 msgid "Créer mon profil"
 msgstr "Créer mon profil"
 
+#. Template Name of the theme
 msgid "Devenir Organisateur"
 msgstr "Devenir Organisateur"
 
+#. Template Name of the theme
 msgid "Traitement Engagement"
 msgstr "Traitement Engagement"
 
@@ -1019,9 +2173,11 @@ msgid "Échec de vérification de sécurité"
 msgstr "Échec de vérification de sécurité"
 
 #: templates/page-traitement-engagement.php:49
+#, php-format
 msgid "Déblocage de la chasse #%d"
 msgstr "Déblocage de la chasse #%d"
 
+#. Template Name of the theme
 msgid "Traitement Tentative (Confirmation explicite)"
 msgstr "Traitement Tentative (Confirmation explicite)"
 
@@ -1037,6 +2193,7 @@ msgstr "Tentative introuvable."
 msgid "⛔️ Accès refusé."
 msgstr "⛔️ Accès refusé."
 
+#. Template Name of the theme
 msgid "Traitement Validation Chasse"
 msgstr "Traitement Validation Chasse"
 
@@ -1056,179 +2213,103 @@ msgstr ""
 "✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien "
 "pour confirmer votre demande."
 
-#: assets/js/chasse-edit.js:414
-msgid ""
-"Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse "
-"s’achève dès que le nombre de gagnants prévu est atteint."
-msgstr ""
-"Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse "
-"s’achève dès que le nombre de gagnants prévu est atteint."
+#: assets/js/enigme-aside.js:15
+#, fuzzy
+msgid "Afficher le panneau"
+msgstr "Fermer le panneau"
 
-#: assets/js/chasse-edit.js:418
-msgid ""
-"Vous arrêtez la chasse manuellement, grâce au bouton situé dans le panneau "
-"d'édition chasse."
-msgstr ""
-"Vous arrêtez la chasse manuellement, grâce au bouton situé dans le panneau "
-"d'édition chasse."
-
-#: assets/js/enigme-edit.js:139
-msgid ""
-"Nombre maximum de tentatives quotidiennes d'un joueur\n"
-"Mode payant : tentatives illimitées.\n"
-"Mode gratuit : maximum 24 tentatives par jour."
-msgstr ""
-"Nombre maximum de tentatives quotidiennes d'un joueur\n"
-"Mode payant : tentatives illimitées.\n"
-"Mode gratuit : maximum 24 tentatives par jour."
-
-#: assets/js/enigme-edit.js:795
-msgid "Enregistrement..."
-msgstr "Enregistrement..."
-
-#: assets/js/enigme-edit.js:815
-msgid "✔️ Variantes enregistrées"
-msgstr "✔️ Variantes enregistrées"
-
-#: assets/js/enigme-edit.js:890
-msgid "Modifier les variantes"
-msgstr "Modifier les variantes"
-
-#: assets/js/enigme-edit.js:908
-msgid "❌ Erreur réseau"
-msgstr "❌ Erreur réseau"
-
-msgid "Français"
-msgstr "Français"
-
-msgid "English"
-msgstr "Anglais"
-
-msgid "Change language"
-msgstr "Changer de langue"
-
-#: inc/enigme/affichage.php:275
-msgid "Nb joueurs :"
-msgstr "Nb joueurs :"
-
-#: inc/enigme/affichage.php:281
-msgid "Nb tentatives :"
-msgstr "Nb tentatives :"
-
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:25
-msgid "Gagnants :"
-msgstr "Gagnants :"
-
-#: inc/enigme/affichage.php:339
-msgid ""
-"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
-"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
-"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
-msgstr ""
-"Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au "
-"nombre total d’énigmes de la chasse. Vous : Part des énigmes auxquelles vous "
-"avez accédé Moyenne : Moyenne sur l’ensemble des joueurs."
-
-#: inc/enigme/affichage.php:347
-msgid "Définition de la progression"
-msgstr "Définition de la progression"
-
-#: inc/enigme/affichage.php:398
-msgid "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse."
-msgstr "Part moyenne des énigmes auxquelles chaque joueur a participé, rapportée au nombre total d’énigmes de la chasse."
-
-#: inc/enigme/affichage.php:404
-msgid "Définition du taux de résolution"
-msgstr "Définition du taux de résolution"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "La ou les bonnes réponses"
-msgstr "La ou les bonnes réponses"
-
-#: template-parts/enigme/enigme-edition-main.php
-msgid "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — selon votre réglage de respect de la casse — résout l’énigme."
-msgstr "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — selon votre réglage de respect de la casse — résout l’énigme."
-
-#: assets/js/enigme-edit.js
-msgid "Supprimer"
-msgstr "Supprimer"
-
-#: assets/js/enigme-edit.js
+#: assets/js/enigme-edit.js:600
 msgid "Ex : soleil"
 msgstr "Ex : soleil"
 
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:21
-msgid "Configurer les variantes de réponse"
-msgstr "Configurer les variantes de réponse"
+#: assets/js/enigme-edit.js:605 assets/js/enigme-edit.js:657
+#, fuzzy
+msgid "valider"
+msgstr "Invalider"
 
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
-msgid "Respecter la casse"
-msgstr "Respecter la casse"
+#: assets/js/enigme-edit.js:629
+msgid "Supprimer"
+msgstr "Supprimer"
 
-#: template-parts/enigme/panneaux/enigme-edition-variantes.php:77
-msgid "Enregistrer les variantes"
-msgstr "Enregistrer les variantes"
+#: assets/js/enigme-edit.js:703
+#, fuzzy
+msgid "Ajouter une illustration"
+msgstr "Ajouter une variante"
 
-#: inc/edition/edition-indice.php:73
-msgid "Indice #%d - %s"
-msgstr "Indice #%d - %s"
+#: assets/js/enigme-edit.js:742 assets/js/enigme-edit.js:987
+msgid "Modifier les variantes"
+msgstr "Modifier les variantes"
 
-#: template-parts/indice/indice-edition-main.php:26
-msgid "Panneau d'édition indice"
-msgstr "Panneau d'édition indice"
+#: assets/js/enigme-edit.js:878
+msgid "Enregistrement..."
+msgstr "Enregistrement..."
 
-#: template-parts/indice/indice-edition-main.php:33
-msgid "Contenu d'édition à venir..."
-msgstr "Contenu d'édition à venir..."
+#: assets/js/enigme-edit.js:898
+msgid "✔️ Variantes enregistrées"
+msgstr "✔️ Variantes enregistrées"
 
-#: template-parts/indice/indice-edition-main.php:104
-msgid "Image"
-msgstr "Image"
+#: assets/js/enigme-edit.js:1005
+msgid "❌ Erreur réseau"
+msgstr "❌ Erreur réseau"
 
-#: template-parts/indice/indice-edition-main.php:123
-msgid "Texte"
-msgstr "Texte"
+#: assets/js/enigme-edit.js:1663
+#, fuzzy
+msgid "Erreur lors de l'enregistrement de l'ordre"
+msgstr "Erreur lors de la création de la chasse."
 
-#: template-parts/indice/indice-edition-main.php:134
-msgid "Aide pour"
-msgstr "Aide pour"
+#: assets/js/help-modal.js:19
+#, fuzzy
+msgid "Fermer"
+msgstr "Fermer tableau"
 
-#: template-parts/indice/indice-edition-main.php:136
-msgid "Chasse"
-msgstr "Chasse"
+#: assets/js/reponse-automatique.js:35
+msgid ""
+"Confirmer l'envoi ? Cette tentative coûtera %1$d pts. Solde après : %2$d pts."
+msgstr ""
 
-#: template-parts/indice/indice-edition-main.php:141
-msgid "Aucune énigme disponible."
-msgstr "Aucune énigme disponible."
+#: assets/js/reponse-automatique.js:55
+#, fuzzy
+msgid "Erreur serveur"
+msgstr "❌ Erreur réseau"
 
-#: template-parts/indice/indice-edition-main.php:167
-msgid "Publication"
-msgstr "Publication"
+#: assets/js/reponse-automatique.js:85
+#, fuzzy
+msgid "Tentatives quotidiennes : %1$s/%2$s"
+msgstr "Tentatives quotidiennes"
 
-#: template-parts/indice/indice-edition-main.php:169
-msgid "Immédiate"
-msgstr "Immédiate"
+#: assets/js/reponse-automatique.js:88
+#, fuzzy
+msgid "Tentatives quotidiennes :"
+msgstr "Tentatives quotidiennes"
 
-#: template-parts/indice/indice-edition-main.php:170
-msgid "Différée"
-msgstr "Différée"
+#: assets/js/reponse-automatique.js:107
+#, fuzzy
+msgid "Bonne réponse"
+msgstr "Bonne(s) réponse(s)"
 
-#: template-parts/indice/indice-edition-main.php:181
-msgid "(points)"
-msgstr "(points)"
+#: assets/js/reponse-automatique.js:177
+#, fuzzy
+msgid "Mauvaise réponse"
+msgstr "Votre réponse"
 
-#: template-parts/indice/indice-edition-main.php:94
-msgid "renseigner le titre de l’indice"
-msgstr "renseigner le titre de l’indice"
+#: assets/js/reponse-automatique.js:187
+msgid "Tentatives quotidiennes"
+msgstr "Tentatives quotidiennes"
 
-#: template-parts/indice/indice-edition-main.php:124
-msgid "renseigner le texte de l’indice"
-msgstr "renseigner le texte de l’indice"
+#~ msgid "Activer Orgy"
+#~ msgstr "Activer Orgy"
 
-#: template-parts/indice/panneaux/indice-edition-description.php:17
-msgid "Modifier le texte de l’indice"
-msgstr "Modifier le texte de l’indice"
+#~ msgid "Solution"
+#~ msgstr "Solution"
 
-#: template-parts/indice/panneaux/indice-edition-description.php:28
-msgid "Texte de l’indice mis à jour."
-msgstr "Texte de l’indice mis à jour."
+#~ msgid "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
+#~ msgstr "🛠️ Cette énigme est la vôtre. Aucun formulaire n’est affiché."
+
+#~ msgid "Actions"
+#~ msgstr "Actions"
+
+#~ msgid "Contenu d'édition à venir..."
+#~ msgstr "Contenu d'édition à venir..."
+
+#~ msgid "renseigner le texte de l’indice"
+#~ msgstr "renseigner le texte de l’indice"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -644,7 +644,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     <div id="chasse-tab-animation" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-bullhorn tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-bullhorn"></i> Animation</h2>
+        <h2><i class="fa-solid fa-bullhorn"></i> <?= esc_html__('Animation', 'chassesautresor-com'); ?></h2>
       </div>
       <div class="edition-panel-body">
         <div class="edition-panel-section edition-panel-section-ligne">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -72,17 +72,17 @@ $is_complete = (
         <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres organisateur">✖</button>
       </div>
       <div class="edition-tabs">
-        <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
-        <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
-        <button class="edition-tab" data-target="organisateur-tab-animation">Animation</button>
-        <button class="edition-tab" data-target="organisateur-tab-revenus">Points</button>
+        <button class="edition-tab active" data-target="organisateur-tab-param"><?= esc_html__('Paramètres', 'chassesautresor-com'); ?></button>
+        <button class="edition-tab" data-target="organisateur-tab-stats"><?= esc_html__('Statistiques', 'chassesautresor-com'); ?></button>
+        <button class="edition-tab" data-target="organisateur-tab-animation"><?= esc_html__('Animation', 'chassesautresor-com'); ?></button>
+        <button class="edition-tab" data-target="organisateur-tab-revenus"><?= esc_html__('Points', 'chassesautresor-com'); ?></button>
       </div>
     </div>
 
     <div id="organisateur-tab-param" class="edition-tab-content active">
       <i class="fa-solid fa-sliders tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+        <h2><i class="fa-solid fa-sliders"></i> <?= esc_html__('Paramètres', 'chassesautresor-com'); ?></h2>
       </div>
       <div class="edition-panel-body">
         <div class="edition-panel-section edition-panel-section-ligne">
@@ -249,7 +249,7 @@ $is_complete = (
     <div id="organisateur-tab-stats" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-chart-column tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
+        <h2><i class="fa-solid fa-chart-column"></i> <?= esc_html__('Statistiques', 'chassesautresor-com'); ?></h2>
       </div>
       <?php get_template_part(
           'template-parts/organisateur/panneaux/organisateur-edition-statistiques',
@@ -261,7 +261,7 @@ $is_complete = (
     <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-coins tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-coins"></i> Points</h2>
+        <h2><i class="fa-solid fa-coins"></i> <?= esc_html__('Points', 'chassesautresor-com'); ?></h2>
       </div>
         <div class="edition-panel-body">
           <div class="dashboard-grid stats-cards">
@@ -332,14 +332,14 @@ $is_complete = (
     <div id="organisateur-tab-animation" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-bullhorn tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-bullhorn"></i> Animation</h2>
+        <h2><i class="fa-solid fa-bullhorn"></i> <?= esc_html__('Animation', 'chassesautresor-com'); ?></h2>
       </div>
       <div class="edition-panel-body">
         <div class="edition-panel-section edition-panel-section-ligne">
           <div class="section-content">
             <div class="resume-blocs-grid">
               <div class="resume-bloc resume-visibilite">
-                <h3>Communiquez</h3>
+                <h3><?= esc_html__('Communiquez', 'chassesautresor-com'); ?></h3>
                 <div class="dashboard-grid stats-cards">
                   <div class="dashboard-card champ-organisateur champ-liens <?= empty($liens_publics) ? 'champ-vide' : 'champ-rempli'; ?>"
                     data-champ="liens_publics"
@@ -349,14 +349,16 @@ $is_complete = (
                     <div class="champ-affichage champ-affichage-liens">
                       <?= render_liens_publics($liens_publics, 'organisateur', ['placeholder' => false]); ?>
                     </div>
-                    <h3>Sites et réseaux de l'organisation</h3>
+                    <h3><?= esc_html__('Sites et réseaux de l\'organisation', 'chassesautresor-com'); ?></h3>
                     <?php if ($peut_modifier) : ?>
                       <a href="#"
                         class="stat-value champ-modifier ouvrir-panneau-liens"
                         data-champ="liens_publics"
                         data-cpt="organisateur"
                         data-post-id="<?= esc_attr($organisateur_id); ?>">
-                        <?= empty($liens_publics) ? 'Ajouter' : 'Éditer'; ?>
+                        <?= empty($liens_publics)
+                          ? esc_html__('Ajouter', 'chassesautresor-com')
+                          : esc_html__('Éditer', 'chassesautresor-com'); ?>
                       </a>
                     <?php endif; ?>
                     <div class="champ-donnees"
@@ -375,10 +377,10 @@ $is_complete = (
                       . '&format=' . $format;
                   ?>
                   <div class="dashboard-card champ-qr-code">
-                    <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="QR code de l'organisation">
-                    <h3>QR code de votre organisation</h3>
+                    <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de l\'organisation', 'chassesautresor-com'); ?>">
+                    <h3><?= esc_html__('QR code de votre organisation', 'chassesautresor-com'); ?></h3>
                     <a class="stat-value" href="<?= esc_url($url_qr_code); ?>"
-                      download="<?= esc_attr('qr-organisateur-' . $organisateur_id . '.' . $format); ?>">Télécharger</a>
+                      download="<?= esc_attr('qr-organisateur-' . $organisateur_id . '.' . $format); ?>"><?= esc_html__('Télécharger', 'chassesautresor-com'); ?></a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Résumé
- ajoute les traductions manquantes pour les onglets Animation et Statistiques
- régénère les fichiers PO/POT avec les nouvelles chaînes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a91eccae3883328689282e2ae75d7c