### PR TITLE
Fix translations for hunt stats headings

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -411,6 +411,7 @@ msgstr "Definition of the resolution rate"
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
 #: template-parts/indice/indice-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:625
 msgid "Énigmes"
 msgstr "Riddles"
 
@@ -956,6 +957,7 @@ msgstr "Animation"
 #: template-parts/chasse/chasse-edition-main.php:104
 #: template-parts/enigme/enigme-edition-main.php:128
 #: template-parts/indice/indice-edition-main.php:90
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:29
 msgid "Titre"
 msgstr "Title"
 
@@ -1142,6 +1144,7 @@ msgstr "Period:"
 
 #: template-parts/chasse/chasse-edition-main.php:568
 #: template-parts/enigme/enigme-edition-main.php:533
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
 msgid "Participants"
 msgstr "Players"
 
@@ -1152,6 +1155,7 @@ msgstr "Players"
 #: template-parts/enigme/enigme-edition-main.php:627
 #: template-parts/enigme/partials/enigme-partial-participants.php:69
 #: templates/myaccount/content-chasses.php:108
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
 msgid "Tentatives"
 msgstr "Attempts"
 
@@ -1274,7 +1278,7 @@ msgstr "Sort by participation rate"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:60
 msgid "Tx participation"
-msgstr "Tx participation"
+msgstr "Participation rate"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:68
 msgid "Trier par taux de résolution"
@@ -1282,7 +1286,17 @@ msgstr "Sort by resolution rate"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:70
 msgid "Tx résolution"
-msgstr "Tx resolution"
+msgstr "Resolution rate"
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:36
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:38
+msgid "Nombre"
+msgstr "Count"
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:37
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:39
+msgid "Taux"
+msgstr "Rate"
 
 #: template-parts/common/stat-histogram-card.php:38
 msgid "Aucune donnée."
@@ -1530,6 +1544,7 @@ msgid "Mois"
 msgstr "Month"
 
 #: template-parts/enigme/enigme-edition-main.php:556
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:33
 msgid "Bonnes réponses"
 msgstr "Correct answers"
 
@@ -1914,6 +1929,7 @@ msgstr "Organizer Edit Panel"
 #: templates/myaccount/content-points.php:75
 #: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
 #: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:32
 msgid "Points"
 msgstr "Points"
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -463,7 +463,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     <div id="chasse-tab-stats" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-chart-column tab-watermark" aria-hidden="true"></i>
       <div class="edition-panel-header">
-        <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
+        <h2><i class="fa-solid fa-chart-column"></i> <?= esc_html__('Statistiques', 'chassesautresor-com'); ?></h2>
       </div>
       <?php if (!utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id)) : ?>
         <p class="edition-placeholder"><?php esc_html_e('Accès refusé.', 'chassesautresor-com'); ?></p>
@@ -622,7 +622,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <?php endif;
           endif;
           get_template_part('template-parts/chasse/partials/chasse-partial-enigmes', null, [
-              'title'         => 'Énigmes',
+              'title'         => esc_html__('Énigmes', 'chassesautresor-com'),
               'enigmes'       => $enigmes_stats,
               'total'         => $total_engagements,
               'cols_etiquette' => [2, 3, 4, 5, 6, 7],

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -26,17 +26,17 @@ if ($title !== '') {
 <table class="stats-table compact">
   <thead>
     <tr>
-      <th scope="col" rowspan="2">Titre</th>
-      <th scope="col" colspan="2">Participants</th>
-      <th scope="col" rowspan="2"<?= in_array(4, $cols_etiquette, true) ? ' data-format="etiquette" data-col="4"' : ''; ?>>Tentatives</th>
-      <th scope="col" rowspan="2"<?= in_array(5, $cols_etiquette, true) ? ' data-format="etiquette" data-col="5"' : ''; ?>>Points</th>
-      <th scope="col" colspan="2">Bonnes réponses</th>
+      <th scope="col" rowspan="2"><?= esc_html__('Titre', 'chassesautresor-com'); ?></th>
+      <th scope="col" colspan="2"><?= esc_html__('Participants', 'chassesautresor-com'); ?></th>
+      <th scope="col" rowspan="2"<?= in_array(4, $cols_etiquette, true) ? ' data-format="etiquette" data-col="4"' : ''; ?>><?= esc_html__('Tentatives', 'chassesautresor-com'); ?></th>
+      <th scope="col" rowspan="2"<?= in_array(5, $cols_etiquette, true) ? ' data-format="etiquette" data-col="5"' : ''; ?>><?= esc_html__('Points', 'chassesautresor-com'); ?></th>
+      <th scope="col" colspan="2"><?= esc_html__('Bonnes réponses', 'chassesautresor-com'); ?></th>
     </tr>
     <tr>
-      <th scope="col"<?= in_array(2, $cols_etiquette, true) ? ' data-format="etiquette" data-col="2"' : ''; ?>>Nombre</th>
-      <th scope="col"<?= in_array(3, $cols_etiquette, true) ? ' data-format="etiquette" data-col="3"' : ''; ?>>Taux</th>
-      <th scope="col"<?= in_array(6, $cols_etiquette, true) ? ' data-format="etiquette" data-col="6"' : ''; ?>>Nombre</th>
-      <th scope="col"<?= in_array(7, $cols_etiquette, true) ? ' data-format="etiquette" data-col="7"' : ''; ?>>Taux</th>
+      <th scope="col"<?= in_array(2, $cols_etiquette, true) ? ' data-format="etiquette" data-col="2"' : ''; ?>><?= esc_html__('Nombre', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(3, $cols_etiquette, true) ? ' data-format="etiquette" data-col="3"' : ''; ?>><?= esc_html__('Taux', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(6, $cols_etiquette, true) ? ' data-format="etiquette" data-col="6"' : ''; ?>><?= esc_html__('Nombre', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(7, $cols_etiquette, true) ? ' data-format="etiquette" data-col="7"' : ''; ?>><?= esc_html__('Taux', 'chassesautresor-com'); ?></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
## Résumé
- complète les traductions de l'onglet statistiques d'une chasse
- internationalise les entêtes du tableau des énigmes et les taux de participation/résolution

## Modifications notables
- traduction du titre "Statistiques" et du tableau des énigmes dans l'édition de chasse
- ajouts des équivalents anglais pour "Nombre", "Taux", et les taux de participation/résolution

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9224e65d4833283f21a9c0342ba36