### PR TITLE
feat: align indice field names with new ACF schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Un endpoint dédié permet de créer rapidement un indice :
 
 - **URL :** `/creer-indice/`
 - **Paramètres :** `chasse_id`, `enigme_id` (optionnel) et `nonce`.
-- **Champs ACF initialisés :** `indice_cible`, `indice_cible_objet`, `indice_chasse_linked`, `indice_disponibilite`, `indice_date_disponibilite`, `indice_cout_points` et `indice_cache_complet`.
+- **Champs ACF initialisés :** `indice_cible_type`, `indice_enigme_linked`, `indice_chasse_linked`, `indice_disponibilite`, `indice_date_disponibilite`, `indice_cout_points` et `indice_cache_complet`.
 - **Comportement :** après création, l’utilisateur est redirigé vers l’indice et le panneau d’édition s’ouvre automatiquement.

--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -100,9 +100,9 @@ class CreerIndicePermissionsTest extends TestCase
 
         $result = \creer_indice_pour_objet(42, 'chasse');
         $this->assertSame(123, $result);
-        $this->assertSame('chasse', $updated_fields['indice_cible']);
-        $this->assertSame(42, $updated_fields['indice_cible_objet']);
+        $this->assertSame('chasse', $updated_fields['indice_cible_type']);
         $this->assertSame(42, $updated_fields['indice_chasse_linked']);
+        $this->assertArrayNotHasKey('indice_enigme_linked', $updated_fields);
         $expected_date = wp_date('Y-m-d H:i:s', (int) current_time('timestamp') + DAY_IN_SECONDS);
         $this->assertSame($expected_date, $updated_fields['indice_date_disponibilite']);
         $this->assertSame('desactive', $updated_fields['indice_cache_etat_systeme']);

--- a/tests/IndiceChasseAutoFillTest.php
+++ b/tests/IndiceChasseAutoFillTest.php
@@ -46,11 +46,11 @@ namespace IndiceChasse {
             global $fields, $updated_fields;
             $fields = [
                 'indice_chasse_linked' => null,
-                'indice_cible' => 'chasse',
-                'indice_cible_objet' => 42,
+                'indice_cible_type' => 'enigme',
+                'indice_enigme_linked' => 42,
             ];
             \sauvegarder_indice_chasse_si_manquant(123);
-            $this->assertSame(42, $updated_fields['indice_chasse_linked']);
+            $this->assertSame(99, $updated_fields['indice_chasse_linked']);
         }
     }
 }

--- a/wp-content/themes/chassesautresor/assets/js/indice-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/indice-edit.js
@@ -46,11 +46,11 @@ function initIndiceEdit() {
     }
   });
 
-  initChampConditionnel('acf[indice_cible]', {
+  initChampConditionnel('acf[indice_cible_type]', {
     chasse: [],
     enigme: ['#champ-indice-cible-enigmes']
   });
-  initChampRadioAjax('acf[indice_cible]', 'indice');
+  initChampRadioAjax('acf[indice_cible_type]', 'indice');
 
   initChampConditionnel('acf[indice_disponibilite]', {
     immediate: [],
@@ -73,7 +73,7 @@ function initIndiceEdit() {
     });
 
   document
-    .querySelectorAll('input[name="acf[indice_cible]"]')
+    .querySelectorAll('input[name="acf[indice_cible_type]"]')
     .forEach((radio) => {
       radio.addEventListener('change', () => {
         if (radio.value === 'chasse') {
@@ -81,7 +81,7 @@ function initIndiceEdit() {
           const chasseId = bloc?.dataset.chasseId;
           const postId = bloc?.dataset.postId;
           if (chasseId && postId) {
-            modifierChampSimple('indice_cible_objet', [chasseId], postId, 'indice');
+            modifierChampSimple('indice_chasse_linked', [chasseId], postId, 'indice');
           }
         }
       });

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -356,7 +356,7 @@ function utilisateur_peut_modifier_post($post_id)
             }
 
             if (!$chasse_id) {
-                $cible = get_field('indice_cible_objet', $post_id);
+                $cible = get_field('indice_enigme_linked', $post_id);
                 if (is_array($cible)) {
                     $first    = $cible[0] ?? null;
                     $cible_id = is_array($first) ? ($first['ID'] ?? null) : $first;
@@ -365,12 +365,7 @@ function utilisateur_peut_modifier_post($post_id)
                 }
 
                 if ($cible_id) {
-                    $cible_type = get_post_type($cible_id);
-                    if ($cible_type === 'chasse') {
-                        $chasse_id = $cible_id;
-                    } elseif ($cible_type === 'enigme') {
-                        $chasse_id = recuperer_id_chasse_associee($cible_id);
-                    }
+                    $chasse_id = recuperer_id_chasse_associee($cible_id);
                 }
             }
 

--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -468,18 +468,18 @@ Label : texte de l indice
 Instructions : (vide)
 Requis : non
 ----------------------------------------
-— indice_cible —
+— indice_cible_type —
 Type : radio
-Label : contenu ciblé
+Label : type de contenu ciblé
 Instructions : (vide)
 Requis : non
 Choices :
   - chasse : chasse
   - enigme : énigme
 ----------------------------------------
-— indice_cible_objet —
+— indice_enigme_linked —
 Type : relationship
-Label : cible
+Label : énigme liée
 Instructions : (vide)
 Requis : non
 ----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -414,8 +414,8 @@ Groupe : paramètres indices
 
 * indice_image (image)
 * indice_contenu (wysiwyg)
-* indice_cible (radio)
-* indice_cible_objet (relationship)
+* indice_cible_type (radio)
+* indice_enigme_linked (relationship)
 * indice_chasse_linked (relationship)
 * indice_disponibilite (radio)
 * indice_date_disponibilite (date_time_picker, retour d/m/Y g:i a)

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -716,11 +716,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       'order'          => 'ASC',
                       'meta_query'     => [
                         [
-                          'key'   => 'indice_cible',
+                          'key'   => 'indice_cible_type',
                           'value' => 'chasse',
                         ],
                         [
-                          'key'   => 'indice_cible_objet',
+                          'key'   => 'indice_chasse_linked',
                           'value' => $chasse_id,
                         ],
                       ],

--- a/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/indice/indice-edition-main.php
@@ -20,8 +20,8 @@ $titre          = get_the_title($indice_id);
 $image_id       = get_field('indice_image', $indice_id);
 $image_url      = $image_id ? wp_get_attachment_image_url($image_id, 'thumbnail') : '';
 $texte          = get_field('indice_contenu', $indice_id);
-$cible          = get_field('indice_cible', $indice_id) ?: 'chasse';
-$cible_objet    = (array) get_field('indice_cible_objet', $indice_id, false);
+$cible          = get_field('indice_cible_type', $indice_id) ?: 'chasse';
+$enigmes_liees  = (array) get_field('indice_enigme_linked', $indice_id, false);
 $chasse_liee    = get_field('indice_chasse_linked', $indice_id, false);
 $disponibilite  = get_field('indice_disponibilite', $indice_id) ?: 'immediate';
 $date_dispo     = get_field('indice_date_disponibilite', $indice_id);
@@ -42,7 +42,7 @@ foreach ($enigmes_posts as $enigma) {
         $enigmes_eligibles[$enigma->ID] = get_the_title($enigma->ID);
     }
 }
-$selection = array_map('intval', $cible_objet);
+$selection = array_map('intval', $enigmes_liees);
 ?>
 
 <section class="edition-panel edition-panel-indice edition-panel-modal" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
@@ -147,13 +147,13 @@ $selection = array_map('intval', $cible_objet);
                         <div class="resume-bloc resume-reglages">
                             <h3><?= esc_html__('Réglages', 'chassesautresor-com'); ?></h3>
                             <ul class="resume-infos">
-                                <li class="champ-indice champ-cible <?= ($cible === 'enigme' && empty($selection)) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_cible" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
+                                <li class="champ-indice champ-cible <?= ($cible === 'enigme' && empty($selection)) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="indice_cible_type" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>">
                                     <label><?= esc_html__('Aide pour', 'chassesautresor-com'); ?></label>
                                     <div class="champ-radio">
-                                        <label><input type="radio" name="acf[indice_cible]" value="chasse" <?= $cible === 'chasse' ? 'checked' : ''; ?>> <?= esc_html__('Chasse', 'chassesautresor-com'); ?></label>
-                                        <label><input type="radio" name="acf[indice_cible]" value="enigme" <?= $cible === 'enigme' ? 'checked' : ''; ?>> <?= esc_html__('Énigmes', 'chassesautresor-com'); ?></label>
+                                        <label><input type="radio" name="acf[indice_cible_type]" value="chasse" <?= $cible === 'chasse' ? 'checked' : ''; ?>> <?= esc_html__('Chasse', 'chassesautresor-com'); ?></label>
+                                        <label><input type="radio" name="acf[indice_cible_type]" value="enigme" <?= $cible === 'enigme' ? 'checked' : ''; ?>> <?= esc_html__('Énigmes', 'chassesautresor-com'); ?></label>
                                     </div>
-                                    <div id="champ-indice-cible-enigmes" class="champ-indice champ-pre-requis<?= $cible === 'enigme' ? '' : ' cache'; ?><?= empty($enigmes_eligibles) ? ' champ-vide' : ''; ?>" data-champ="indice_cible_objet" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>" data-no-edit="1" data-chasse-id="<?= esc_attr($chasse_liee); ?>">
+                                    <div id="champ-indice-cible-enigmes" class="champ-indice champ-pre-requis<?= $cible === 'enigme' ? '' : ' cache'; ?><?= empty($enigmes_eligibles) ? ' champ-vide' : ''; ?>" data-champ="indice_enigme_linked" data-cpt="indice" data-post-id="<?= esc_attr($indice_id); ?>" data-no-edit="1" data-chasse-id="<?= esc_attr($chasse_liee); ?>">
                                         <?php if (empty($enigmes_eligibles)) : ?>
                                             <em><?= esc_html__('Aucune énigme disponible.', 'chassesautresor-com'); ?></em>
                                         <?php else : ?>


### PR DESCRIPTION
## Résumé
- renomme les champs ACF des indices pour distinguer chasse et énigme
- met à jour la documentation et les tests en conséquence

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a93726fc3c833284e682e0c4748574