### PR TITLE
docs: add translation workflow tips

### DIFF
--- a/wp-content/themes/chassesautresor/docs/traductions.md
+++ b/wp-content/themes/chassesautresor/docs/traductions.md
@@ -32,3 +32,27 @@ done
 ```
 
 Ne pas versionner les fichiers `.mo` compilés.
+
+## Mise à jour du catalogue de chaînes
+
+À la racine du thème, regénérer le fichier modèle avant toute session de traduction :
+
+```bash
+wp i18n make-pot . languages/chassesautresor-com.pot
+```
+
+## Traductions JavaScript
+
+Après avoir mis à jour les fichiers `.po`, créer les fichiers `json` nécessaires aux scripts :
+
+```bash
+wp i18n make-json languages
+```
+
+## Conseils pratiques
+
+- Encapsuler toutes les chaînes destinées aux utilisateurs avec `__()` ou une fonction équivalente et le domaine `chassesautresor-com`.
+- Ajouter des commentaires `/* translators: ... */` pour expliquer les placeholders complexes.
+- Utiliser l’interface anglaise pendant le développement pour repérer immédiatement les textes non traduits.
+- Utiliser `rg` pour repérer les chaînes non internationalisées dans le code.
+- Poedit ou Loco Translate peuvent générer des rapports de couverture de traduction.


### PR DESCRIPTION
## Résumé
- Ajout de conseils pour enrichir la gestion des traductions

## Changements notables
- Décrit la régénération du fichier POT
- Documente la création des JSON pour les scripts
- Ajoute plusieurs recommandations pratiques pour couvrir toutes les chaînes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a92a2009c88332a03f24a5b754a3e9