### PR TITLE
fix: add missing English translation for indices table

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2272,6 +2272,18 @@ msgstr "Your answer"
 msgid "Tentatives quotidiennes"
 msgstr "Daily Attempts"
 
+#: template-parts/common/indices-table.php:29
+msgid "Vous n'avez publié aucun indice attaché à %s"
+msgstr "You haven't published any clue attached to %s"
+
+#: template-parts/common/indices-table.php:25
+msgid "en création"
+msgstr "in creation"
+
+#: template-parts/common/indices-table.php:27
+msgid "Nouvelle chasse"
+msgstr "New hunt"
+
 #~ msgid "Activer Orgy"
 #~ msgstr "Enable Orgy"
 

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -21,6 +21,11 @@ $objet_id   = $args['objet_id'] ?? $objet_id ?? 0;
 
 if (empty($indices)) {
     $titre = get_the_title($objet_id);
+    if ($titre === TITRE_DEFAUT_ENIGME) {
+        $titre = __('en création', 'chassesautresor-com');
+    } elseif ($titre === TITRE_DEFAUT_CHASSE) {
+        $titre = __('Nouvelle chasse', 'chassesautresor-com');
+    }
     echo '<p>' . esc_html(sprintf(__('Vous n\'avez publié aucun indice attaché à %s', 'chassesautresor-com'), $titre)) . '</p>';
     return;
 }


### PR DESCRIPTION
## Résumé
- Ajout de la traduction anglaise du message indiquant l'absence d'indice publié.
- Traduction des titres par défaut "en création" et "Nouvelle chasse" dans le tableau des indices.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a949b65a1483329a17205d0b92513e