### PR TITLE
Add missing hint section translation

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -402,6 +402,12 @@ msgstr ""
 msgid "Indices"
 msgstr ""
 
+#: template-parts/chasse/chasse-edition-main.php:708
+#: template-parts/enigme/enigme-edition-main.php:774
+#, php-format
+msgid "Indices pour %s"
+msgstr ""
+
 #: inc/enigme/affichage.php:677
 msgid "automatique"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -425,6 +425,12 @@ msgstr "View Stats"
 msgid "Indices"
 msgstr "Hints"
 
+#: template-parts/chasse/chasse-edition-main.php:708
+#: template-parts/enigme/enigme-edition-main.php:774
+#, php-format
+msgid "Indices pour %s"
+msgstr "Hints for %s"
+
 #: inc/enigme/affichage.php:677
 msgid "automatique"
 msgstr "automatic"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -425,6 +425,12 @@ msgstr "Afficher les statistiques"
 msgid "Indices"
 msgstr "Indices"
 
+#: template-parts/chasse/chasse-edition-main.php:708
+#: template-parts/enigme/enigme-edition-main.php:774
+#, php-format
+msgid "Indices pour %s"
+msgstr "Indices pour %s"
+
 #: inc/enigme/affichage.php:677
 #, fuzzy
 msgid "automatique"


### PR DESCRIPTION
Ajout de la traduction anglaise pour le titre des sections d'indices.

- Ajout de la chaîne `Indices pour %s` au fichier modèle et aux traductions FR/EN
- Mise à jour des fichiers `.po` pour l'anglais et le français

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a94bb8ccc88332833e5f363c08f4e5