### PR TITLE
Add translation for reward value alert

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2164,3 +2164,8 @@ msgstr ""
 #: assets/js/reponse-automatique.js:187
 msgid "Tentatives quotidiennes"
 msgstr ""
+
+#: assets/js/chasse-edit.js:376
+msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2371,3 +2371,8 @@ msgstr "Action"
 #: assets/js/core/resume.js:322
 msgid "renseigner le titre de la chasse"
 msgstr "enter the hunt title"
+
+#: assets/js/chasse-edit.js:376
+msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+msgstr "Please enter a value in euros between 0 and 5,000,000."
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2324,3 +2324,8 @@ msgstr "Tentatives quotidiennes"
 #: assets/js/core/resume.js:322
 msgid "renseigner le titre de la chasse"
 msgstr "renseigner le titre de la chasse"
+
+#: assets/js/chasse-edit.js:376
+msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+msgstr "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+


### PR DESCRIPTION
## Summary
- Ajout de la traduction anglaise pour le message de validation de la récompense.
- Synchronisation des fichiers de langue en_US et fr_FR.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a99226d29c8332bec1a3d33243fcb1