### PR TITLE
Ajuste la largeur des champs numériques

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -419,7 +419,7 @@ body .header-img-modifiable .icone-modif {
 }
 
 .edition-panel-body input.champ-number {
-  width: 75px;
+  width: 100px;
 }
 
 @media (min-width: 768px) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2105,7 +2105,7 @@ body .header-img-modifiable .icone-modif {
 }
 
 .edition-panel-body input.champ-number {
-  width: 75px;
+  width: 100px;
 }
 
 @media (min-width: 768px) {

--- a/wp-content/themes/chassesautresor/docs/panneau-enigme-parametres.md
+++ b/wp-content/themes/chassesautresor/docs/panneau-enigme-parametres.md
@@ -39,7 +39,7 @@ Lorsqu'un champ obligatoire est vide, la classe `champ-attention` colore son lab
 
 ## Saisie des nombres
 
-Les champs numériques « Coût » et « Nb tentatives » sont limités à six chiffres (`max="999999"`) et leur largeur est fixée à 75px (classe `champ-number`).
+Les champs numériques « Coût » et « Nb tentatives » sont limités à six chiffres (`max="999999"`) et leur largeur est fixée à 100px (classe `champ-number`).
 
 ## Variantes de réponse
 


### PR DESCRIPTION
## Résumé
- Ajuste la largeur des champs numériques des panneaux d'édition

## Changements notables
- Élargissement des champs numériques à 100px
- Documentation mise à jour

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a99e68590c8332bb344e71017cd929