### PR TITLE
Corrige l'affichage de l'option gagnants illimités

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -41,7 +41,7 @@ $date_debut_iso = $date_debut_obj ? $date_debut_obj->format('Y-m-d\TH:i') : '';
 $date_fin_obj = convertir_en_datetime($date_fin);
 $date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
 $illimitee  = $infos_chasse['champs']['illimitee'];
-$nb_max     = $infos_chasse['champs']['nb_max'] ?: 1;
+$nb_max     = $infos_chasse['champs']['nb_max'] ?? 1;
 $mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'automatique';
 $statut_metier = $infos_chasse['statut'] ?? 'revision';
 


### PR DESCRIPTION
## Résumé
- corrige la prise en compte de l'option "illimité" pour le nombre de gagnants dans le panneau d'édition de chasse

## Changements notables
- ajuste la valeur par défaut du champ `nb_max` pour afficher correctement l'option illimitée

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a3a923a08332a90f6182c596e99d