### PR TITLE
Réutiliser le modal d'indice pour l'édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -1,16 +1,16 @@
 (function () {
   function openModal(btn) {
     var overlay = document.createElement('div');
-    overlay.className = 'indice-create-overlay';
+    overlay.className = 'indice-modal-overlay';
     var titre = indicesCreate.texts.indiceTitre.replace('%d', btn.dataset.indiceRang || '');
     overlay.innerHTML = `
-      <div class="indice-create-modal">
-        <div class="indice-create-header">
+      <div class="indice-modal">
+        <div class="indice-modal-header">
           <h2>${titre}</h2>
           <p>${indicesCreate.texts.lieA} - ${btn.dataset.objetTitre || ''}</p>
         </div>
-        <button type="button" class="indice-create-close" aria-label="${indicesCreate.texts.close}">×</button>
-        <form class="indice-create-form">
+        <button type="button" class="indice-modal-close" aria-label="${indicesCreate.texts.close}">×</button>
+        <form class="indice-modal-form">
           <input type="hidden" name="action" value="creer_indice_modal" />
           <input type="hidden" name="objet_type" value="${btn.dataset.objetType}" />
           <input type="hidden" name="objet_id" value="${btn.dataset.objetId}" />
@@ -20,15 +20,40 @@
           <p><label><input type="radio" name="indice_disponibilite" value="immediate" checked /> ${indicesCreate.texts.immediate}</label>
              <label><input type="radio" name="indice_disponibilite" value="differe" /> ${indicesCreate.texts.differe}</label></p>
           <p class="date-wrapper" style="display:none;"><input type="datetime-local" name="indice_date_disponibilite" /></p>
-          <p><button type="submit" class="indice-create-validate">${indicesCreate.texts.valider}</button></p>
+          <p><button type="submit" class="indice-modal-validate">${indicesCreate.texts.valider}</button></p>
         </form>
       </div>`;
     document.body.appendChild(overlay);
 
+    var isEdit = !!btn.dataset.indiceId;
+    if (isEdit) {
+      overlay.querySelector('input[name="action"]').value = 'modifier_indice_modal';
+      var idInput = document.createElement('input');
+      idInput.type = 'hidden';
+      idInput.name = 'indice_id';
+      idInput.value = btn.dataset.indiceId;
+      overlay.querySelector('.indice-modal-form').appendChild(idInput);
+      if (btn.dataset.indiceImage) {
+        overlay.querySelector('input[name="indice_image"]').value = btn.dataset.indiceImage;
+      }
+      if (btn.dataset.indiceContenu) {
+        overlay.querySelector('textarea[name="indice_contenu"]').value = btn.dataset.indiceContenu;
+      }
+      var dispo = btn.dataset.indiceDisponibilite || 'immediate';
+      overlay.querySelectorAll('input[name="indice_disponibilite"]').forEach(function (radio) {
+        radio.checked = radio.value === dispo;
+      });
+      if (dispo === 'differe') {
+        var dateInput = overlay.querySelector('input[name="indice_date_disponibilite"]');
+        dateInput.value = btn.dataset.indiceDate || '';
+        overlay.querySelector('.date-wrapper').style.display = '';
+      }
+    }
+
     function close() {
       overlay.remove();
     }
-    overlay.querySelector('.indice-create-close').addEventListener('click', close);
+    overlay.querySelector('.indice-modal-close').addEventListener('click', close);
 
     overlay.addEventListener('click', function (e) {
       if (e.target === overlay) close();
@@ -56,7 +81,7 @@
       frame.open();
     });
 
-    overlay.querySelector('.indice-create-form').addEventListener('submit', function (e) {
+    overlay.querySelector('.indice-modal-form').addEventListener('submit', function (e) {
       e.preventDefault();
       var form = e.target;
       var data = new FormData(form);
@@ -71,7 +96,7 @@
             wrapper.dataset.page = '1';
             window.reloadIndicesTable(wrapper);
           }
-          if (btn.dataset.indiceRang) {
+          if (!btn.dataset.indiceId && btn.dataset.indiceRang) {
             btn.dataset.indiceRang = parseInt(btn.dataset.indiceRang, 10) + 1;
           }
         });
@@ -83,7 +108,7 @@
     if (target && target.nodeType !== 1) {
       target = target.parentElement;
     }
-    var btn = target && target.closest ? target.closest('.cta-creer-indice') : null;
+    var btn = target && target.closest ? target.closest('.cta-creer-indice, .badge-action.edit') : null;
     if (!btn) return;
     e.preventDefault();
     openModal(btn);
@@ -93,5 +118,5 @@
     document.body.addEventListener('click', handleClick, true);
   });
 
-  window.openIndiceCreateModal = openModal;
+  window.openIndiceModal = openModal;
 })();

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -2002,8 +2002,8 @@ body.panneau-ouvert::before {
   }
 }
 
-/* Overlay création d'indice */
-.indice-create-form label {
+/* Overlay indice */
+.indice-modal-form label {
     display: block;
     margin-bottom: var(--space-sm);
     color: var(--color-editor-text);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1711,7 +1711,7 @@ a[aria-disabled=true] {
   margin-bottom: var(--space-md);
 }
 
-.indice-create-overlay {
+.indice-modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -1724,7 +1724,7 @@ a[aria-disabled=true] {
   z-index: 20000;
 }
 
-.indice-create-modal {
+.indice-modal {
   background: var(--color-editor-background);
   color: var(--color-editor-text);
   padding: var(--space-lg);
@@ -1738,26 +1738,26 @@ a[aria-disabled=true] {
   z-index: 20001;
 }
 
-.indice-create-header {
+.indice-modal-header {
   border-bottom: 1px solid var(--color-editor-border);
   margin-bottom: var(--space-md);
   padding-bottom: var(--space-sm);
 }
 
-.indice-create-header h2 {
+.indice-modal-header h2 {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
   color: var(--color-editor-heading);
 }
 
-.indice-create-header p {
+.indice-modal-header p {
   margin: var(--space-xs) 0 0;
   color: var(--color-editor-text-muted);
   font-size: 0.875rem;
 }
 
-.indice-create-close {
+.indice-modal-close {
   position: absolute;
   top: var(--space-sm);
   right: var(--space-sm);
@@ -1768,13 +1768,13 @@ a[aria-disabled=true] {
   color: var(--color-editor-heading);
 }
 
-.indice-create-form label {
+.indice-modal-form label {
   display: block;
   margin-bottom: var(--space-sm);
   color: var(--color-editor-text);
 }
 
-.indice-create-form textarea {
+.indice-modal-form textarea {
   width: 100%;
   min-height: 100px;
   background: var(--color-editor-background);
@@ -1785,8 +1785,8 @@ a[aria-disabled=true] {
   box-sizing: border-box;
 }
 
-.indice-create-form .select-image,
-.indice-create-form .indice-create-validate {
+.indice-modal-form .select-image,
+.indice-modal-form .indice-modal-validate {
   background: var(--color-editor-button);
   color: var(--color-white);
   border: none;
@@ -1796,12 +1796,12 @@ a[aria-disabled=true] {
   transition: background var(--transition-fast);
 }
 
-.indice-create-form .select-image:hover,
-.indice-create-form .indice-create-validate:hover {
+.indice-modal-form .select-image:hover,
+.indice-modal-form .indice-modal-validate:hover {
   background: var(--color-editor-button-hover);
 }
 
-.indice-create-form .date-wrapper input {
+.indice-modal-form .date-wrapper input {
   width: 100%;
   background: var(--color-editor-background);
   color: var(--color-editor-text);

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -391,6 +391,51 @@ function ajax_creer_indice_modal(): void
 add_action('wp_ajax_creer_indice_modal', 'ajax_creer_indice_modal');
 
 /**
+ * Met à jour un indice existant via le modal d'édition.
+ *
+ * @return void
+ */
+function ajax_modifier_indice_modal(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $indice_id  = isset($_POST['indice_id']) ? (int) $_POST['indice_id'] : 0;
+    $objet_id   = isset($_POST['objet_id']) ? (int) $_POST['objet_id'] : 0;
+    $objet_type = sanitize_key($_POST['objet_type'] ?? '');
+
+    if (!$indice_id || get_post_type($indice_id) !== 'indice') {
+        wp_send_json_error('indice_invalide');
+    }
+    if (!$objet_id || !in_array($objet_type, ['chasse', 'enigme'], true) || get_post_type($objet_id) !== $objet_type) {
+        wp_send_json_error('post_invalide');
+    }
+    if (!indice_action_autorisee('edit', $objet_type, $objet_id)) {
+        wp_send_json_error('acces_refuse');
+    }
+
+    $image   = isset($_POST['indice_image']) ? (int) $_POST['indice_image'] : 0;
+    $contenu = wp_kses_post($_POST['indice_contenu'] ?? '');
+    $dispo   = sanitize_key($_POST['indice_disponibilite'] ?? 'immediate');
+    $date    = sanitize_text_field($_POST['indice_date_disponibilite'] ?? '');
+
+    update_field('indice_image', $image, $indice_id);
+    update_field('indice_contenu', $contenu, $indice_id);
+
+    $dispo = $dispo === 'differe' ? 'differe' : 'immediate';
+    update_field('indice_disponibilite', $dispo, $indice_id);
+    if ($dispo === 'differe') {
+        update_field('indice_date_disponibilite', $date, $indice_id);
+    } else {
+        update_field('indice_date_disponibilite', '', $indice_id);
+    }
+
+    wp_send_json_success(['indice_id' => $indice_id]);
+}
+add_action('wp_ajax_modifier_indice_modal', 'ajax_modifier_indice_modal');
+
+/**
  * Gère l’enregistrement AJAX des champs ACF ou natifs du CPT indice.
  *
  * @hook wp_ajax_modifier_champ_indice

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -18,6 +18,7 @@ $page       = $args['page'] ?? $page ?? 1;
 $pages      = $args['pages'] ?? $pages ?? 1;
 $objet_type = $args['objet_type'] ?? $objet_type ?? 'chasse';
 $objet_id   = $args['objet_id'] ?? $objet_id ?? 0;
+$objet_titre = get_the_title($objet_id);
 
 if (empty($indices)) {
     $titre = get_the_title($objet_id);
@@ -46,9 +47,11 @@ if (empty($indices)) {
   <tbody>
     <?php foreach ($indices as $indice) :
         $date    = mysql2date('d/m/y', $indice->post_date);
-        $img_id  = get_field('indice_image', $indice->ID);
-        $img_html = $img_id ? wp_get_attachment_image($img_id, 'thumbnail') : '';
-        $contenu = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
+        $img_id     = get_field('indice_image', $indice->ID);
+        $img_html   = $img_id ? wp_get_attachment_image($img_id, 'thumbnail') : '';
+        $contenu    = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
+        $dispo      = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
+        $date_dispo = get_field('indice_date_disponibilite', $indice->ID) ?: '';
 
         $etat    = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
         $etat_class = 'etiquette-error';
@@ -89,13 +92,21 @@ if (empty($indices)) {
       <td><?= $linked_html; ?></td>
       <td><span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat); ?></span></td>
       <td class="indice-actions">
-        <a
-          href="<?= esc_url(add_query_arg('edition', 'open', get_permalink($indice))); ?>"
+        <button
+          type="button"
           class="badge-action edit"
+          data-objet-type="<?= esc_attr($objet_type); ?>"
+          data-objet-id="<?= esc_attr($objet_id); ?>"
+          data-objet-titre="<?= esc_attr($objet_titre); ?>"
+          data-indice-id="<?= esc_attr($indice->ID); ?>"
+          data-indice-image="<?= esc_attr($img_id); ?>"
+          data-indice-contenu="<?= esc_attr($contenu); ?>"
+          data-indice-disponibilite="<?= esc_attr($dispo); ?>"
+          data-indice-date="<?= esc_attr($date_dispo); ?>"
           title="<?= esc_attr__('Éditer', 'chassesautresor-com'); ?>"
         >
           <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
-        </a>
+        </button>
         <button
           type="button"
           class="badge-action delete"


### PR DESCRIPTION
## Résumé
- permettre l'édition d'un indice via le même modal que la création
- renommer les classes CSS/JS du modal d'indice

## Détails
- ajout d'une action `modifier_indice_modal` côté serveur
- préremplissage du modal d'indice et ouverture depuis le tableau

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9c2829cd883328f807137ea04d2c4