### PR TITLE
Validation de la date de disponibilité des indices

### DIFF
--- a/tests/IndiceDatePrefillTest.php
+++ b/tests/IndiceDatePrefillTest.php
@@ -1,0 +1,111 @@
+<?php
+namespace {
+    if (!function_exists('esc_html__')) {
+        function esc_html__($text, $domain = null) { return $text; }
+    }
+    if (!function_exists('esc_attr__')) {
+        function esc_attr__($text, $domain = null) { return $text; }
+    }
+    if (!function_exists('esc_html')) {
+        function esc_html($text) { return $text; }
+    }
+    if (!function_exists('esc_attr')) {
+        function esc_attr($text) { return $text; }
+    }
+    if (!function_exists('esc_url')) {
+        function esc_url($url) { return $url; }
+    }
+    if (!function_exists('wp_strip_all_tags')) {
+        function wp_strip_all_tags($text) { return $text; }
+    }
+    if (!function_exists('get_field')) {
+        function get_field($key, $post_id) {
+            global $fields;
+            return $fields[$key] ?? '';
+        }
+    }
+    if (!function_exists('get_the_title')) {
+        function get_the_title($id) { return 'Titre'; }
+    }
+    if (!function_exists('get_permalink')) {
+        function get_permalink($id) {
+            if (is_object($id) && isset($id->ID)) {
+                $id = $id->ID;
+            }
+            return 'https://example.com/' . $id;
+        }
+    }
+    if (!function_exists('wp_get_attachment_image')) {
+        function wp_get_attachment_image($id, $size) { return ''; }
+    }
+    if (!function_exists('cta_render_proposition_cell')) {
+        function cta_render_proposition_cell($text) { return ''; }
+    }
+    if (!function_exists('cta_render_pager')) {
+        function cta_render_pager($page, $pages, $class = '') { return ''; }
+    }
+    if (!function_exists('mysql2date')) {
+        function mysql2date($format, $date) { return $date; }
+    }
+    if (!function_exists('__')) {
+        function __($text, $domain = null) { return $text; }
+    }
+    if (!function_exists('convertir_en_datetime')) {
+        function convertir_en_datetime(?string $date_string, array $formats = ['d/m/Y g:i a', 'Y-m-d H:i:s', 'Y-m-d\\TH:i']): ?\DateTime
+        {
+            if (empty($date_string)) {
+                return null;
+            }
+            foreach ($formats as $format) {
+                $dt = \DateTime::createFromFormat($format, $date_string);
+                if ($dt) {
+                    return $dt;
+                }
+            }
+            return null;
+        }
+    }
+}
+
+namespace IndiceDatePrefill {
+    use PHPUnit\Framework\TestCase;
+
+    class IndiceDatePrefillTest extends TestCase
+    {
+        /**
+         * @runInSeparateProcess
+         * @preserveGlobalState disabled
+         */
+        public function test_date_is_prefilled_for_editing(): void
+        {
+            global $fields;
+            $fields = [
+                'indice_image' => 0,
+                'indice_contenu' => '',
+                'indice_disponibilite' => 'differe',
+                'indice_date_disponibilite' => '14/03/2024 6:00 pm',
+                'indice_cache_etat_systeme' => 'accessible',
+                'indice_cible_type' => 'chasse',
+                'indice_chasse_linked' => 10,
+            ];
+
+            $indices = [
+                (object) [
+                    'ID' => 123,
+                    'post_date' => '2024-03-10 00:00:00',
+                ],
+            ];
+            $page = 1;
+            $pages = 1;
+            $objet_type = 'chasse';
+            $objet_id = 10;
+            $img_url = '';
+
+            ob_start();
+            require __DIR__ . '/../wp-content/themes/chassesautresor/template-parts/common/indices-table.php';
+            $output = ob_get_clean();
+
+            $this->assertStringContainsString('data-indice-date="2024-03-14T18:00"', $output);
+        }
+    }
+}

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -47,14 +47,22 @@ if (empty($indices)) {
   <tbody>
     <?php foreach ($indices as $indice) :
         $date    = mysql2date('d/m/y', $indice->post_date);
-        $img_id     = get_field('indice_image', $indice->ID);
-        $img_html   = $img_id ? wp_get_attachment_image($img_id, [80, 80]) : '';
+        $img_id   = get_field('indice_image', $indice->ID);
+        $img_html = $img_id ? wp_get_attachment_image($img_id, [80, 80]) : '';
 
-        $contenu    = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
-        $dispo      = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
-        $date_dispo = get_field('indice_date_disponibilite', $indice->ID) ?: '';
+        $contenu = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
+        $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
 
-        $etat    = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
+        $date_raw   = get_field('indice_date_disponibilite', $indice->ID) ?: '';
+        $date_dispo = '';
+        if ($date_raw) {
+            $dt = convertir_en_datetime($date_raw);
+            if ($dt) {
+                $date_dispo = $dt->format('Y-m-d\\TH:i');
+            }
+        }
+
+        $etat = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
         $etat_class = 'etiquette-error';
         if ($etat === 'accessible') {
             $etat_class = 'etiquette-success';


### PR DESCRIPTION
## Résumé
- Préremplit la date de disponibilité différée lors de l'édition d'un indice
- Vérifie via un test unitaire que la date existante est bien renvoyée à la modale

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd9042ac83329fcb5f83b95adde0