### PR TITLE
Affiche le rang des indices dans le modal d’édition

### DIFF
--- a/tests/IndiceDatePrefillTest.php
+++ b/tests/IndiceDatePrefillTest.php
@@ -106,6 +106,7 @@ namespace IndiceDatePrefill {
             $output = ob_get_clean();
 
             $this->assertStringContainsString('data-indice-date="2024-03-14T18:00"', $output);
+            $this->assertStringContainsString('data-indice-rang="1"', $output);
         }
     }
 }

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -45,10 +45,11 @@ if (empty($indices)) {
     </tr>
   </thead>
   <tbody>
-    <?php foreach ($indices as $indice) :
-        $date    = mysql2date('d/m/y', $indice->post_date);
-        $img_id   = get_field('indice_image', $indice->ID);
-        $img_html = $img_id ? wp_get_attachment_image($img_id, [80, 80]) : '';
+    <?php foreach ($indices as $index => $indice) :
+        $indice_rank = $index + 1;
+        $date        = mysql2date('d/m/y', $indice->post_date);
+        $img_id      = get_field('indice_image', $indice->ID);
+        $img_html    = $img_id ? wp_get_attachment_image($img_id, [80, 80]) : '';
 
         $contenu = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
         $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
@@ -108,6 +109,7 @@ if (empty($indices)) {
           data-objet-id="<?= esc_attr($objet_id); ?>"
           data-objet-titre="<?= esc_attr($objet_titre); ?>"
           data-indice-id="<?= esc_attr($indice->ID); ?>"
+          data-indice-rang="<?= esc_attr($indice_rank); ?>"
           data-indice-image="<?= esc_attr($img_id); ?>"
           data-indice-image-url="<?= esc_attr($img_url); ?>"
           data-indice-contenu="<?= esc_attr($contenu); ?>"


### PR DESCRIPTION
## Résumé
- calcule le rang de chaque indice dans la table
- ajoute l’attribut `data-indice-rang` pour les boutons d’édition
- confirme l’affichage du numéro d’indice dans le modal

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9f17ef76883328c1818673105e42e