### PR TITLE
Corrige l'affichage de l'image lors de l'édition d'un indice

### DIFF
--- a/tests/js/image-utils.test.js
+++ b/tests/js/image-utils.test.js
@@ -1,0 +1,35 @@
+describe('initChampImage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div class="champ-img" data-champ="indice_image" data-cpt="enigme" data-post-id="1"><img><input class="champ-input" value="123"><div class="champ-feedback"></div></div>';
+    global.window = window;
+    global.wp = {
+      media: {
+        attachment: jest.fn(() => ({
+          attributes: {
+            url: 'full.jpg',
+            sizes: {
+              thumbnail: { url: 'thumb.jpg' },
+              medium: { url: 'medium.jpg' },
+            },
+          },
+          fetch: jest.fn(() => Promise.resolve()),
+        })),
+        view: { settings: { post: {} } },
+      },
+    };
+    global.ajaxurl = '/ajax';
+    delete require.cache[require.resolve('../../wp-content/themes/chassesautresor/assets/js/core/image-utils.js')];
+    global.initChampImage = require('../../wp-content/themes/chassesautresor/assets/js/core/image-utils.js');
+  });
+
+  test('loads existing image from input value', async () => {
+    const bloc = document.querySelector('.champ-img');
+    initChampImage(bloc);
+    await Promise.resolve();
+    await Promise.resolve();
+    const img = bloc.querySelector('img');
+    expect(img.src).toContain('thumb.jpg');
+    expect(bloc.classList.contains('champ-vide')).toBe(false);
+    expect(wp.media.attachment).toHaveBeenCalledWith(123);
+  });
+});

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -12,6 +12,26 @@ function initChampImage(bloc) {
 
   if (!champ || !cpt || !postId || !input || !image) return;
 
+  // 🔄 Charge l'image existante si un ID est déjà présent
+  const idInitial = parseInt(input.value, 10);
+  if (idInitial) {
+    const attachment = wp.media.attachment(idInitial);
+    attachment
+      .fetch()
+      .then(() => {
+        const data = attachment.attributes || {};
+        const thumb =
+          (data.sizes && (data.sizes.thumbnail || data.sizes.medium)?.url) ||
+          data.url;
+        if (thumb) {
+          image.src = thumb;
+          image.srcset = thumb;
+          bloc.classList.remove('champ-vide');
+        }
+      })
+      .catch(() => {});
+  }
+
   // ✅ Création du frame à la volée quand appelé
   const ouvrirMedia = () => {
     // ✅ Empêcher double ouverture : reuse si déjà initialisé
@@ -98,4 +118,8 @@ function initChampImage(bloc) {
 
   // ✅ On expose la fonction pour la déclencher manuellement
   bloc.__ouvrirMedia = ouvrirMedia;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = initChampImage;
 }


### PR DESCRIPTION
### Résumé
- charge l'image existante dans la modale d'édition d'indice
- ajoute un test unitaire pour l'initialisation des images

### Détails
- utilise `wp.media.attachment` pour récupérer la vignette depuis l'identifiant stocké
- expose `initChampImage` en CommonJS pour les tests

### Testing
- `source ./setup-env.sh` *(aucune sortie)*
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f652e72c83329519d64f7d4ad9e8