### PR TITLE
Affichage de la date pour les indices programmés

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/table-etiquette.js
+++ b/wp-content/themes/chassesautresor/assets/js/table-etiquette.js
@@ -2,6 +2,9 @@
  * Apply label styling to table columns marked with data-format="etiquette".
  */
 document.addEventListener('DOMContentLoaded', () => {
+  const i18n = window.TableEtiquetteI18N || {};
+  const locale = document.documentElement.lang || 'en';
+
   document.querySelectorAll('.stats-table, .table-tentatives').forEach((table) => {
     table.querySelectorAll('th[data-format="etiquette"]').forEach((th) => {
       const col = th.dataset.col ? parseInt(th.dataset.col, 10) : th.cellIndex + 1;
@@ -10,9 +13,21 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         const text = td.textContent.trim();
-        if (text !== '') {
-          td.innerHTML = `<span class="etiquette">${text}</span>`;
+        if (text === '') {
+          return;
         }
+
+        let labelText = text;
+        if (text === 'programme' || text === 'programmé') {
+          const dateAttr = td.dataset.date;
+          const formattedDate = dateAttr ? new Date(dateAttr).toLocaleString(locale) : '';
+          const base = i18n.programmedOn || 'Programmé le';
+          labelText = `${base}${formattedDate ? ` ${formattedDate}` : ''}`;
+        } else if (text === 'accessible') {
+          labelText = i18n.accessible || 'Accessible';
+        }
+
+        td.innerHTML = `<span class="etiquette">${labelText}</span>`;
       });
     });
   });

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -136,6 +136,17 @@ function enqueue_core_edit_scripts(array $additional = [])
       $versions[$handle],
       true
     );
+
+    if ($handle === 'table-etiquette') {
+      wp_localize_script(
+        'table-etiquette',
+        'TableEtiquetteI18N',
+        [
+          'programmedOn' => __('Programmed on', 'chassesautresor-com'),
+          'accessible'   => __('Accessible', 'chassesautresor-com'),
+        ]
+      );
+    }
   }
 }
 

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1184,3 +1184,11 @@ msgstr ""
 msgid "Définition du taux de résolution"
 msgstr ""
 
+#: assets/js/table-etiquette.js:1
+msgid "Accessible"
+msgstr ""
+
+#: assets/js/table-etiquette.js:1
+msgid "Programmed on"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1666,3 +1666,11 @@ msgstr "No puzzles available"
 msgid "Aucun gagnant pour le moment."
 msgstr "No winners yet."
 
+#: assets/js/table-etiquette.js:1
+msgid "Accessible"
+msgstr "Accessible"
+
+#: assets/js/table-etiquette.js:1
+msgid "Programmed on"
+msgstr "Programmed on"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1138,3 +1138,11 @@ msgstr "Part moyenne des énigmes auxquelles chaque joueur a participé, rapport
 msgid "Définition du taux de résolution"
 msgstr "Définition du taux de résolution"
 
+#: assets/js/table-etiquette.js:1
+msgid "Accessible"
+msgstr "Accessible"
+
+#: assets/js/table-etiquette.js:1
+msgid "Programmed on"
+msgstr "Programmé le"
+


### PR DESCRIPTION
Affiche la date planifiée pour les indices programmés et ajoute les traductions manquantes.

- Affiche "Programmé le [date]" dans la colonne *Statut* des tableaux d'indices.
- Localise le script de mise en forme des étiquettes.
- Ajoute les chaînes de traduction pour "Accessible" et "Programmed on".

### Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9f78528f48332a20b6194b94c6ee7