### PR TITLE
Alignement vertical de la colonne texte des indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/general.css
+++ b/wp-content/themes/chassesautresor/assets/css/general.css
@@ -210,6 +210,7 @@ tbody tr:nth-child(even) {
   padding: 8px 12px;
   border: none;
   /*color: var(--color-text-primary);*/
+  vertical-align: middle;
 }
 
 .stats-table th {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5379,6 +5379,7 @@ tbody tr:nth-child(even) {
   padding: 8px 12px;
   border: none;
   /*color: var(--color-text-primary);*/
+  vertical-align: middle;
 }
 
 .stats-table th {
@@ -5741,6 +5742,16 @@ body.accueil-fullscreen {
 }
 
 /* 📐 Layout – Structure générale des pages */
+
+:root { --bp-xl: 1440px; }
+
+@media (min-width: var(--bp-xl)) {
+  .layout-fullwidth .ast-container,
+  .layout-fullwidth .myaccount-layout {
+    width: 100vw;
+    max-width: 100%;
+  }
+}
 
 /* 🎯 Header top bar */
 


### PR DESCRIPTION
## Résumé
- centre verticalement le contenu des cellules dans les tableaux de statistiques

## Changements notables
- applique `vertical-align: middle` aux cellules `.stats-table`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f83d48c48332b004ce3e2454612f