### PR TITLE
Aligner la colonne texte des indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -730,12 +730,16 @@ body.woocommerce h2 {
 
 /* Tentatives - Proposition toggle */
 .proposition-cell {
+    vertical-align: middle;
+}
+
+.proposition-cell .proposition-content {
     display: flex;
     align-items: center;
     gap: 4px;
 }
 
-.proposition-cell.expanded {
+.proposition-cell.expanded .proposition-content {
     flex-direction: column;
     align-items: flex-start;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6983,12 +6983,16 @@ body.woocommerce h2 {
 
 /* Tentatives - Proposition toggle */
 .proposition-cell {
+  vertical-align: middle;
+}
+
+.proposition-cell .proposition-content {
   display: flex;
   align-items: center;
   gap: 4px;
 }
 
-.proposition-cell.expanded {
+.proposition-cell.expanded .proposition-content {
   flex-direction: column;
   align-items: flex-start;
 }

--- a/wp-content/themes/chassesautresor/inc/table.php
+++ b/wp-content/themes/chassesautresor/inc/table.php
@@ -41,5 +41,7 @@ function cta_render_proposition_cell(string $text, bool $expanded = false, int $
         $class .= ' expanded';
     }
 
-    return '<td class="' . $class . '">' . $excerpt_html . $full_html . $button_html . '</td>';
+    $content_html = '<div class="proposition-content">' . $excerpt_html . $full_html . $button_html . '</div>';
+
+    return '<td class="' . $class . '">' . $content_html . '</td>';
 }


### PR DESCRIPTION
## Résumé
Aligne verticalement le contenu de la colonne texte dans le tableau des indices.

## Changements notables
- Ajout d'un conteneur interne pour la cellule de texte afin de préserver la hauteur de ligne
- Ajustement du CSS pour centrer verticalement les contenus de la colonne texte

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9fa4f8bc883329d11eada76dc5820