### PR TITLE
Affichage de la date de programmation des indices

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2181,3 +2181,20 @@ msgstr ""
 msgid "Voulez-vous vraiment supprimer la récompense ?"
 msgstr ""
 
+#: template-parts/common/indices-table.php:69
+msgid "accessible"
+msgstr ""
+
+#: template-parts/common/indices-table.php:69
+msgid "programme"
+msgstr ""
+
+#: template-parts/common/indices-table.php:83
+msgid "programmé"
+msgstr ""
+
+#: template-parts/common/indices-table.php:75
+#, php-format
+msgid "programmé le %s"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2388,3 +2388,20 @@ msgstr "Please enter a value in euros between 0 and 5,000,000."
 msgid "Voulez-vous vraiment supprimer la récompense ?"
 msgstr "Do you really want to delete the reward?"
 
+#: template-parts/common/indices-table.php:69
+msgid "accessible"
+msgstr "accessible"
+
+#: template-parts/common/indices-table.php:69
+msgid "programme"
+msgstr "scheduled"
+
+#: template-parts/common/indices-table.php:83
+msgid "programmé"
+msgstr "scheduled"
+
+#: template-parts/common/indices-table.php:75
+#, php-format
+msgid "programmé le %s"
+msgstr "scheduled for %s"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2352,3 +2352,19 @@ msgstr "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
 msgid "Voulez-vous vraiment supprimer la récompense ?"
 msgstr "Voulez-vous vraiment supprimer la récompense ?"
 
+#: template-parts/common/indices-table.php:69
+msgid "accessible"
+msgstr "accessible"
+
+#: template-parts/common/indices-table.php:69
+msgid "programme"
+msgstr "programmé"
+
+#: template-parts/common/indices-table.php:83
+msgid "programmé"
+msgstr "programmé"
+
+#: template-parts/common/indices-table.php:75
+msgid "programmé le %s"
+msgstr "programmé le %s"
+

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -55,6 +55,7 @@ if (empty($indices)) {
         $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
 
         $date_raw   = get_field('indice_date_disponibilite', $indice->ID) ?: '';
+        $dt         = null;
         $date_dispo = '';
         if ($date_raw) {
             $dt = convertir_en_datetime($date_raw);
@@ -63,12 +64,24 @@ if (empty($indices)) {
             }
         }
 
-        $etat = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
+        $etat       = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
         $etat_class = 'etiquette-error';
+        $etat_label = __($etat, 'chassesautresor-com');
         if ($etat === 'accessible') {
             $etat_class = 'etiquette-success';
         } elseif ($etat === 'programme' || $etat === 'programmé') {
             $etat_class = 'etiquette-pending';
+            if ($dt instanceof DateTimeInterface) {
+                $format     = get_option('date_format') . ' ' . get_option('time_format');
+                $date_label = wp_date($format, $dt->getTimestamp());
+                $etat_label = sprintf(
+                    /* translators: %s: scheduled date */
+                    __('programmé le %s', 'chassesautresor-com'),
+                    $date_label
+                );
+            } else {
+                $etat_label = __('programmé', 'chassesautresor-com');
+            }
         }
 
         $cible_type  = get_field('indice_cible_type', $indice->ID) === 'enigme' ? 'enigme' : 'chasse';
@@ -100,7 +113,7 @@ if (empty($indices)) {
       <?php echo cta_render_proposition_cell($contenu); ?>
       <td><span class="etiquette"><?= esc_html($cible_label); ?></span></td>
       <td><?= $linked_html; ?></td>
-      <td><span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat); ?></span></td>
+      <td><span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat_label); ?></span></td>
       <td class="indice-actions">
         <button
           type="button"


### PR DESCRIPTION
## Résumé
- affichage explicite de la date pour les indices programmés
- ajout des traductions pour "accessible" et "programme"

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a9fa462288833283445182c35f5ee5