### PR TITLE
Ajout des traductions pour le QR code de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1888,6 +1888,15 @@ msgstr ""
 msgid "QR code de votre organisation"
 msgstr ""
 
+#: template-parts/chasse/chasse-edition-main.php:863
+msgid "QR code de la chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:864
+msgid "QR code de votre chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:866
 #: template-parts/organisateur/organisateur-edition-main.php:383
 msgid "Télécharger"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1999,6 +1999,15 @@ msgstr "Organization QR code"
 msgid "QR code de votre organisation"
 msgstr "Your organization's QR code"
 
+#: template-parts/chasse/chasse-edition-main.php:863
+msgid "QR code de la chasse"
+msgstr "Hunt QR code"
+
+#: template-parts/chasse/chasse-edition-main.php:864
+msgid "QR code de votre chasse"
+msgstr "Your hunt's QR code"
+
+#: template-parts/chasse/chasse-edition-main.php:866
 #: template-parts/organisateur/organisateur-edition-main.php:383
 msgid "Télécharger"
 msgstr "Download"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2014,6 +2014,15 @@ msgstr "QR code de l'organisation"
 msgid "QR code de votre organisation"
 msgstr "QR code de votre organisation"
 
+#: template-parts/chasse/chasse-edition-main.php:863
+msgid "QR code de la chasse"
+msgstr "QR code de la chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:864
+msgid "QR code de votre chasse"
+msgstr "QR code de votre chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:866
 #: template-parts/organisateur/organisateur-edition-main.php:383
 msgid "Télécharger"
 msgstr "Télécharger"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -860,10 +860,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                           . '&format=' . $format;
                   ?>
                   <div class="dashboard-card champ-qr-code">
-                    <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="QR code de la chasse">
-                    <h3>QR code de votre chasse</h3>
+                    <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de la chasse', 'chassesautresor-com'); ?>">
+                    <h3><?= esc_html__('QR code de votre chasse', 'chassesautresor-com'); ?></h3>
                     <a class="stat-value" href="<?= esc_url($url_qr_code); ?>"
-                      download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>">Télécharger</a>
+                      download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>"><?= esc_html__('Télécharger', 'chassesautresor-com'); ?></a>
                   </div>
                   <?php endif; ?>
                 </div>


### PR DESCRIPTION
## Résumé
- Internationalisation de la carte QR code dans le panneau d’édition de chasse
- Ajout des traductions anglaises correspondantes
- Mise à jour du fichier modèle de traduction

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa11b332b88332a8ff97afc05d01fd