### PR TITLE
Initialize date input during edit and autofill on deferred switch

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -50,11 +50,11 @@
         overlay.querySelector('textarea[name="indice_contenu"]').value = btn.dataset.indiceContenu;
       }
       var dispo = btn.dataset.indiceDisponibilite || 'immediate';
+      dateInput.value = btn.dataset.indiceDate || defaultDate;
       overlay.querySelectorAll('input[name="indice_disponibilite"]').forEach(function (radio) {
         radio.checked = radio.value === dispo;
       });
       if (dispo === 'differe') {
-        dateInput.value = btn.dataset.indiceDate || defaultDate;
         overlay.querySelector('.date-wrapper').style.display = '';
       }
     } else {
@@ -114,6 +114,9 @@
         var dateWrap = overlay.querySelector('.date-wrapper');
         if (radio.value === 'differe' && radio.checked) {
           dateWrap.style.display = '';
+          if (!dateInput.value) {
+            dateInput.value = lastDateValue || defaultDate;
+          }
         } else {
           dateWrap.style.display = 'none';
         }


### PR DESCRIPTION
Résumé : Pré-remplit la date lors de l'édition d'un indice et gère son affichage selon la disponibilité.

- Initialise toujours la valeur du champ date en mode édition.
- N'affiche la date que pour une disponibilité différée.
- Remplit la date lors du passage à "différé" si le champ est vide.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa23584c988332b46d8ce25825490a