### PR TITLE
Assure le lien de chasse lors de la mise à jour du cache

### DIFF
--- a/tests/MettreAJourCacheIndiceTest.php
+++ b/tests/MettreAJourCacheIndiceTest.php
@@ -7,6 +7,13 @@ namespace {
         }
     }
 
+    if (!function_exists('get_posts')) {
+        function get_posts($args)
+        {
+            return [];
+        }
+    }
+
     if (!function_exists('wp_is_post_revision')) {
         function wp_is_post_revision($id)
         {
@@ -58,6 +65,13 @@ namespace {
             $updated_post = $data;
         }
     }
+
+    if (!function_exists('recuperer_id_chasse_associee')) {
+        function recuperer_id_chasse_associee(int $enigme_id): int
+        {
+            return 42;
+        }
+    }
 }
 
 namespace MettreAJourCacheIndiceTest {
@@ -88,6 +102,30 @@ namespace MettreAJourCacheIndiceTest {
 
             $this->assertSame(0, $updated_fields['indice_cache_complet']);
             $this->assertSame('desactive', $updated_fields['indice_cache_etat_systeme']);
+        }
+
+        /**
+         * @runInSeparateProcess
+         * @preserveGlobalState disabled
+         */
+        public function test_completes_missing_chasse_link_from_target(): void
+        {
+            global $fields, $updated_fields;
+            $post_id = 456;
+            $fields  = [
+                $post_id => [
+                    'indice_cible_type'    => 'enigme',
+                    'indice_enigme_linked' => 789,
+                    'indice_contenu'       => '',
+                    'indice_image'         => null,
+                ],
+            ];
+
+            require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
+
+            \mettre_a_jour_cache_indice($post_id);
+
+            $this->assertSame(42, $updated_fields['indice_chasse_linked']);
         }
     }
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -769,10 +769,11 @@ add_action('acf/save_post', 'sauvegarder_indice_chasse_si_manquant', 20);
 /**
  * Met à jour les champs de cache d'un indice.
  *
- * @param int|string $post_id ID du post ACF.
+ * @param int|string $post_id  ID du post ACF.
+ * @param int|null   $chasse_id ID de la chasse si connu.
  * @return void
  */
-function mettre_a_jour_cache_indice($post_id): void
+function mettre_a_jour_cache_indice($post_id, ?int $chasse_id = null): void
 {
     if (!is_numeric($post_id) || get_post_type((int) $post_id) !== 'indice') {
         return;
@@ -780,6 +781,22 @@ function mettre_a_jour_cache_indice($post_id): void
 
     if (wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) {
         return;
+    }
+
+    $chasse_linked = get_field('indice_chasse_linked', $post_id);
+    if (!$chasse_linked) {
+        $cible_type = get_field('indice_cible_type', $post_id);
+        $enigme_id  = get_field('indice_enigme_linked', $post_id);
+
+        if ($cible_type === 'enigme' && $enigme_id) {
+            $chasse_linked = recuperer_id_chasse_associee((int) $enigme_id);
+        } elseif ($chasse_id !== null) {
+            $chasse_linked = $chasse_id;
+        }
+
+        if ($chasse_linked) {
+            update_field('indice_chasse_linked', $chasse_linked, $post_id);
+        }
     }
 
     $content  = trim((string) get_field('indice_contenu', $post_id));


### PR DESCRIPTION
## Résumé
- complète automatiquement `indice_chasse_linked` lorsqu'il est absent
- ajoute un test pour vérifier ce comportement

## Détails
- la fonction `mettre_a_jour_cache_indice` accepte un paramètre `chasse_id` optionnel
- mise à jour du test unitaire

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa2d48ade483329deb88bdb289866b