### PR TITLE
Ajout de la création d’indice pour les énigmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Un endpoint dédié permet de créer rapidement un indice :
 - **Champs ACF initialisés :** `indice_cible_type`, `indice_enigme_linked`, `indice_chasse_linked`, `indice_disponibilite`, `indice_date_disponibilite`, `indice_cout_points` et `indice_cache_complet`.
 - **Comportement :** après création, l’utilisateur est redirigé vers la chasse ou l’énigme associée.
 
+Dans l’interface d’édition, le lien `.cta-indice-enigme` ouvre le même formulaire modale que pour les chasses. Ce lien porte
+les attributs `data-objet-type="enigme"` et, lorsque disponible, `data-default-enigme` pour pré‑remplir l’identifiant de
+l’énigme. Les appels modaux sont signalés aux technologies d’assistance via `aria-haspopup="dialog"`.
+
 ### Accessibilité
 
 Les libellés du formulaire utilisent `color: var(--color-editor-text)` afin de rester lisibles sur fond clair. Évitez d'appliquer `--color-text-primary` dans ce contexte pour garantir un contraste suffisant.

--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -204,9 +204,14 @@
     if (target && target.nodeType !== 1) {
       target = target.parentElement;
     }
-    var placeholder = target && target.closest ? target.closest('.cta-indice-enigme') : null;
-    if (placeholder) {
+    var enigmeLink = target && target.closest ? target.closest('.cta-indice-enigme') : null;
+    if (enigmeLink) {
       e.preventDefault();
+      enigmeLink.dataset.objetType = 'enigme';
+      if (enigmeLink.dataset.defaultEnigme) {
+        enigmeLink.dataset.objetId = enigmeLink.dataset.defaultEnigme;
+      }
+      openModal(enigmeLink);
       return;
     }
     var btn = target && target.closest ? target.closest('.cta-creer-indice, .badge-action.edit') : null;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -30,10 +30,19 @@ $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
         data-objet-id="<?= esc_attr($objet_id); ?>"
         data-objet-titre="<?= esc_attr($objet_titre); ?>"
         data-indice-rang="<?= esc_attr($indice_rang); ?>"
+        aria-haspopup="dialog"
       >
         <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
       </a>
-      <a href="#" class="bouton-cta cta-indice-enigme">
+      <a
+        href="#"
+        class="bouton-cta cta-indice-enigme"
+        data-objet-type="enigme"
+        <?php if ('enigme' === $objet_type) : ?>
+          data-default-enigme="<?= esc_attr($objet_id); ?>"
+        <?php endif; ?>
+        aria-haspopup="dialog"
+      >
         <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
       </a>
     </div>


### PR DESCRIPTION
## Résumé
- support de la création d’indice sur une énigme depuis la carte dédiée
- ouverture du formulaire via `openModal` lors d’un clic sur le lien d’énigme
- documentation enrichie sur le lien `.cta-indice-enigme`

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa94e2eb3c8332b39c5864a4b6be02