### PR TITLE
Filtrer et exposer les énigmes admissibles pour les indices

### DIFF
--- a/tests/ListerEnigmesPourChasseAjaxTest.php
+++ b/tests/ListerEnigmesPourChasseAjaxTest.php
@@ -1,0 +1,36 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ListerEnigmesPourChasseAjaxTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_returns_enigme_list(): void
+    {
+        if (!function_exists('is_user_logged_in')) { function is_user_logged_in() { return true; } }
+        if (!function_exists('get_post_type')) { function get_post_type($id) { return 'chasse'; } }
+        if (!function_exists('recuperer_enigmes_pour_chasse')) { function recuperer_enigmes_pour_chasse($id) { return [(object) ['ID' => 5], (object) ['ID' => 6]]; } }
+        if (!function_exists('get_the_title')) { function get_the_title($id) { return 'Enigme ' . $id; } }
+        if (!function_exists('wp_send_json_error')) { function wp_send_json_error($data = null) { throw new Exception('error'); } }
+        if (!function_exists('wp_send_json_success')) { function wp_send_json_success($data = null) { global $json_success_data; $json_success_data = $data; } }
+        if (!function_exists('current_user_can')) { function current_user_can($cap) { return false; } }
+        if (!function_exists('get_post_status')) { function get_post_status($id) { return 'publish'; } }
+        if (!function_exists('get_field')) { function get_field($key, $id) { return 'valide'; } }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) { function utilisateur_est_organisateur_associe_a_chasse($uid, $cid) { return true; } }
+        if (!function_exists('get_current_user_id')) { function get_current_user_id() { return 1; } }
+        if (!function_exists('indice_action_autorisee')) { function indice_action_autorisee($a,$t,$i){ return true; } }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
+
+        global $json_success_data;
+        $json_success_data = null;
+        $_POST = ['chasse_id' => 10];
+        ajax_lister_enigmes_pour_chasse();
+        $this->assertEquals([
+            ['id' => 5, 'title' => 'Enigme 5'],
+            ['id' => 6, 'title' => 'Enigme 6'],
+        ], $json_success_data['enigmes']);
+    }
+}

--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -199,6 +199,46 @@
     refreshState();
   }
 
+  function openEnigmeSelector(btn) {
+    var chasseId = btn.dataset.chasseId;
+    if (!chasseId) return;
+    var data = new URLSearchParams({ action: 'lister_enigmes_pour_chasse', chasse_id: chasseId });
+    fetch(indicesCreate.ajaxUrl, { method: 'POST', credentials: 'same-origin', body: data })
+      .then(function (r) { return r.json(); })
+      .then(function (res) {
+        if (!res.success || !res.data || !res.data.enigmes || !res.data.enigmes.length) {
+          return;
+        }
+        var overlay = document.createElement('div');
+        overlay.className = 'indice-modal-overlay';
+        var options = res.data.enigmes
+          .map(function (e) { return '<option value="' + e.id + '">' + e.title + '</option>'; })
+          .join('');
+        overlay.innerHTML = '\
+      <div class="indice-modal">\
+        <div class="indice-modal-header">\
+          <h2>' + indicesCreate.texts.selectionEnigme + '</h2>\
+        </div>\
+        <button type="button" class="indice-modal-close" aria-label="' + indicesCreate.texts.close + '">×</button>\
+        <div class="indice-modal-form">\
+          <p><label>' + indicesCreate.texts.selectionEnigme + '<br><select class="enigme-select">' + options + '</select></label></p>\
+          <div class="indice-modal-footer"><button type="button" class="indice-modal-validate bouton-cta">' + indicesCreate.texts.valider + '</button></div>\
+        </div>\
+      </div>';
+        document.body.appendChild(overlay);
+        function close() { overlay.remove(); }
+        overlay.querySelector('.indice-modal-close').addEventListener('click', close);
+        overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
+        overlay.querySelector('.indice-modal-validate').addEventListener('click', function () {
+          var select = overlay.querySelector('.enigme-select');
+          var id = select.value;
+          var title = select.options[select.selectedIndex].textContent;
+          close();
+          openModal({ dataset: { objetType: 'enigme', objetId: id, objetTitre: title } });
+        });
+      });
+  }
+
   function handleClick(e) {
     var target = e.target;
     if (target && target.nodeType !== 1) {
@@ -207,6 +247,7 @@
     var placeholder = target && target.closest ? target.closest('.cta-indice-enigme') : null;
     if (placeholder) {
       e.preventDefault();
+      openEnigmeSelector(placeholder);
       return;
     }
     var btn = target && target.closest ? target.closest('.cta-creer-indice, .badge-action.edit') : null;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -158,6 +158,7 @@ function enqueue_core_edit_scripts(array $additional = [])
             'needContent' => __('Au moins une image ou un texte nécessaire', 'chassesautresor-com'),
             'needDate'    => __('Date et heure requises', 'chassesautresor-com'),
             'invalidDate' => __('Date invalide', 'chassesautresor-com'),
+            'selectionEnigme' => __('Sélectionner une énigme', 'chassesautresor-com'),
           ],
         ]
       );

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -384,6 +384,38 @@ function ajax_chasse_lister_indices(): void
 add_action('wp_ajax_chasse_lister_indices', 'ajax_chasse_lister_indices');
 
 /**
+ * Retourne via AJAX les énigmes admissibles d'une chasse.
+ *
+ * @return void
+ */
+function ajax_lister_enigmes_pour_chasse(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $chasse_id = isset($_POST['chasse_id']) ? (int) $_POST['chasse_id'] : 0;
+
+    if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+        wp_send_json_error('post_invalide');
+    }
+
+    if (!indice_action_autorisee('create', 'chasse', $chasse_id)) {
+        wp_send_json_error('acces_refuse');
+    }
+
+    $posts = recuperer_enigmes_pour_chasse($chasse_id);
+
+    $enigmes = array_map(
+        static fn($p) => ['id' => $p->ID, 'title' => get_the_title($p->ID)],
+        $posts
+    );
+
+    wp_send_json_success(['enigmes' => $enigmes]);
+}
+add_action('wp_ajax_lister_enigmes_pour_chasse', 'ajax_lister_enigmes_pour_chasse');
+
+/**
  * AJAX handler returning indices table HTML.
  *
  * @return void

--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -451,14 +451,26 @@ function recuperer_enigmes_pour_chasse(int $chasse_id): array
   $query = new WP_Query([
     'post_type'      => 'enigme',
     'posts_per_page' => -1,
-    'post_status'    => ['publish', 'pending', 'draft'], // extensible
-    'orderby'        => 'menu_order', // ou autre critère futur
+    'post_status'    => ['publish', 'pending'],
+    'orderby'        => 'menu_order',
     'order'          => 'ASC',
     'meta_query'     => [
       [
         'key'     => 'enigme_chasse_associee',
         'value'   => $chasse_id,
-        'compare' => '=', // champ Relationship stocké sous forme d'ID
+        'compare' => '=',
+      ],
+      [
+        'relation' => 'OR',
+        [
+          'key'     => 'enigme_cache_statut_validation',
+          'value'   => 'banni',
+          'compare' => '!=',
+        ],
+        [
+          'key'     => 'enigme_cache_statut_validation',
+          'compare' => 'NOT EXISTS',
+        ],
       ],
     ],
   ]);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -17,6 +17,7 @@ $objet_titre = get_the_title($objet_id);
 $indice_rang = prochain_rang_indice($objet_id, $objet_type);
 
 $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
+$has_enigmes = $objet_type === 'chasse' && !empty(recuperer_enigmes_pour_chasse($objet_id));
 ?>
 <div class="dashboard-card champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?>">
   <i class="fa-solid fa-kit-medical icone-defaut" aria-hidden="true"></i>
@@ -33,9 +34,11 @@ $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
       >
         <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
       </a>
-      <a href="#" class="bouton-cta cta-indice-enigme">
+      <?php if ($has_enigmes) : ?>
+      <a href="#" class="bouton-cta cta-indice-enigme" data-chasse-id="<?= esc_attr($objet_id); ?>">
         <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
       </a>
+      <?php endif; ?>
     </div>
   <?php else : ?>
     <span class="stat-value">


### PR DESCRIPTION
## Résumé
- Limite la récupération aux énigmes publiées ou en attente non bannies.
- Expose une action AJAX pour lister ces énigmes et alimente la sélection dans la modale.
- Masque le bouton d’ajout d’indice si aucune énigme admissible n’est disponible.

## Changements notables
- Filtrage dans `recuperer_enigmes_pour_chasse`.
- Nouveau endpoint `lister_enigmes_pour_chasse` et adaptation JS correspondante.
- Ajout du test `ListerEnigmesPourChasseAjaxTest`.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa94f5ad08833298f06d585b35eef2