### PR TITLE
Gérer la modale d'indice pour les énigmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Un endpoint dédié permet de créer rapidement un indice :
 - **Champs ACF initialisés :** `indice_cible_type`, `indice_enigme_linked`, `indice_chasse_linked`, `indice_disponibilite`, `indice_date_disponibilite`, `indice_cout_points` et `indice_cache_complet`.
 - **Comportement :** après création, l’utilisateur est redirigé vers la chasse ou l’énigme associée.
 
+Les liens déclenchant la modale de création peuvent utiliser la classe `.cta-indice-enigme`
+avec l’attribut `data-objet-type="enigme"`. Un attribut optionnel `data-default-enigme`
+permet de présélectionner une énigme.
+
 ### Accessibilité
 
 Les libellés du formulaire utilisent `color: var(--color-editor-text)` afin de rester lisibles sur fond clair. Évitez d'appliquer `--color-text-primary` dans ce contexte pour garantir un contraste suffisant.

--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -204,9 +204,13 @@
     if (target && target.nodeType !== 1) {
       target = target.parentElement;
     }
-    var placeholder = target && target.closest ? target.closest('.cta-indice-enigme') : null;
-    if (placeholder) {
+    var enigmeBtn = target && target.closest ? target.closest('.cta-indice-enigme') : null;
+    if (enigmeBtn) {
       e.preventDefault();
+      if (!enigmeBtn.dataset.objetType) {
+        enigmeBtn.dataset.objetType = 'enigme';
+      }
+      openModal(enigmeBtn);
       return;
     }
     var btn = target && target.closest ? target.closest('.cta-creer-indice, .badge-action.edit') : null;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -12,6 +12,7 @@ defined('ABSPATH') || exit;
 $args       = $args ?? [];
 $objet_id   = $args['objet_id'] ?? $chasse_id ?? 0;
 $objet_type = $args['objet_type'] ?? 'chasse';
+$default_enigme = $args['default_enigme'] ?? null;
 
 $objet_titre = get_the_title($objet_id);
 $indice_rang = prochain_rang_indice($objet_id, $objet_type);
@@ -33,7 +34,14 @@ $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
       >
         <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
       </a>
-      <a href="#" class="bouton-cta cta-indice-enigme">
+      <a
+        href="#"
+        class="bouton-cta cta-indice-enigme"
+        data-objet-type="enigme"
+        <?php if ($default_enigme) : ?>
+          data-default-enigme="<?= esc_attr($default_enigme); ?>"
+        <?php endif; ?>
+      >
         <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
       </a>
     </div>


### PR DESCRIPTION
## Summary
- prise en charge de `.cta-indice-enigme` pour créer un indice d'énigme
- appel d'`openModal` avec `objet_type` configuré
- documentation mise à jour sur les attributs requis

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa992d8be48332888fc92f4033f4b0