### PR TITLE
Filtrer les énigmes admissibles pour un indice

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Un endpoint dédié permet de créer rapidement un indice :
 
 Les liens déclenchant la modale de création peuvent utiliser la classe `.cta-indice-enigme`
 avec l’attribut `data-objet-type="enigme"`. Un attribut optionnel `data-default-enigme`
-permet de présélectionner une énigme.
+permet de présélectionner une énigme. L’attribut `data-chasse-id` doit être fourni pour
+charger via l’endpoint AJAX `chasse_lister_enigmes` la liste des énigmes admissibles.
 
 ### Accessibilité
 

--- a/tests/RecupererEnigmesPourChasseTest.php
+++ b/tests/RecupererEnigmesPourChasseTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace {
+    class WP_Query
+    {
+        public $posts = [];
+        public function __construct($args)
+        {
+            global $last_query_args;
+            $last_query_args = $args;
+            $this->posts = [];
+        }
+        public function have_posts()
+        {
+            return !empty($this->posts);
+        }
+    }
+    if (!function_exists('get_post_type')) {
+        function get_post_type($id)
+        {
+            return 'chasse';
+        }
+    }
+}
+
+namespace RelationsFunctions {
+    use PHPUnit\Framework\TestCase;
+
+    class RecupererEnigmesPourChasseTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/relations-functions.php';
+            global $last_query_args;
+            $last_query_args = [];
+        }
+
+        /**
+         * @runInSeparateProcess
+         * @preserveGlobalState disabled
+         */
+        public function test_excludes_draft_and_banned(): void
+        {
+            global $last_query_args;
+            \recuperer_enigmes_pour_chasse(10);
+            $this->assertSame(['publish', 'pending'], $last_query_args['post_status']);
+            $meta = $last_query_args['meta_query'];
+            $this->assertSame('enigme_chasse_associee', $meta[0]['key']);
+            $this->assertSame('enigme_cache_statut_validation', $meta[1]['key']);
+            $this->assertSame('banni', $meta[1]['value']);
+            $this->assertSame('!=', $meta[1]['compare']);
+        }
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -348,6 +348,41 @@ function creer_indice_et_rediriger_si_appel(): void
 add_action('template_redirect', 'creer_indice_et_rediriger_si_appel');
 
 /**
+ * AJAX handler listing enigmas available for a hunt.
+ *
+ * @return void
+ */
+function ajax_chasse_lister_enigmes(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $chasse_id = isset($_POST['chasse_id']) ? (int) $_POST['chasse_id'] : 0;
+
+    if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+        wp_send_json_error('post_invalide');
+    }
+
+    if (!indice_action_autorisee('create', 'chasse', $chasse_id)) {
+        wp_send_json_error('acces_refuse');
+    }
+
+    $posts = recuperer_enigmes_pour_chasse($chasse_id);
+
+    $enigmes = array_map(
+        static fn($p) => [
+            'id'    => $p->ID,
+            'title' => get_the_title($p),
+        ],
+        $posts
+    );
+
+    wp_send_json_success(['enigmes' => $enigmes]);
+}
+add_action('wp_ajax_chasse_lister_enigmes', 'ajax_chasse_lister_enigmes');
+
+/**
  * AJAX handler returning indices card HTML for a hunt.
  *
  * @return void

--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -451,14 +451,19 @@ function recuperer_enigmes_pour_chasse(int $chasse_id): array
   $query = new WP_Query([
     'post_type'      => 'enigme',
     'posts_per_page' => -1,
-    'post_status'    => ['publish', 'pending', 'draft'], // extensible
-    'orderby'        => 'menu_order', // ou autre critère futur
+    'post_status'    => ['publish', 'pending'],
+    'orderby'        => 'menu_order',
     'order'          => 'ASC',
     'meta_query'     => [
       [
         'key'     => 'enigme_chasse_associee',
         'value'   => $chasse_id,
-        'compare' => '=', // champ Relationship stocké sous forme d'ID
+        'compare' => '=',
+      ],
+      [
+        'key'     => 'enigme_cache_statut_validation',
+        'value'   => 'banni',
+        'compare' => '!=',
       ],
     ],
   ]);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -18,6 +18,8 @@ $objet_titre = get_the_title($objet_id);
 $indice_rang = prochain_rang_indice($objet_id, $objet_type);
 
 $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
+$enigmes_disponibles = $objet_type === 'chasse' ? recuperer_enigmes_pour_chasse($objet_id) : [];
+$has_enigmes = !empty($enigmes_disponibles);
 ?>
 <div class="dashboard-card champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?>">
   <i class="fa-solid fa-kit-medical icone-defaut" aria-hidden="true"></i>
@@ -34,16 +36,19 @@ $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
       >
         <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
       </a>
-      <a
-        href="#"
-        class="bouton-cta cta-indice-enigme"
-        data-objet-type="enigme"
-        <?php if ($default_enigme) : ?>
-          data-default-enigme="<?= esc_attr($default_enigme); ?>"
-        <?php endif; ?>
-      >
-        <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
-      </a>
+      <?php if ($has_enigmes) : ?>
+        <a
+          href="#"
+          class="bouton-cta cta-indice-enigme"
+          data-objet-type="enigme"
+          data-chasse-id="<?= esc_attr($objet_id); ?>"
+          <?php if ($default_enigme) : ?>
+            data-default-enigme="<?= esc_attr($default_enigme); ?>"
+          <?php endif; ?>
+        >
+          <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
+        </a>
+      <?php endif; ?>
     </div>
   <?php else : ?>
     <span class="stat-value">


### PR DESCRIPTION
## Résumé
- filtre les énigmes bannies ou en brouillon lors de la création d’un indice
- expose un endpoint AJAX listant les énigmes d’une chasse
- masque le bouton d’indice par énigme s’il n’existe aucune énigme admissible

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa9cb247888332acccb232ad13a52a