### PR TITLE
fix: harmonize indices card ctas

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1583,6 +1583,14 @@ body.panneau-ouvert::before {
   gap: var(--space-xs);
 }
 
+.dashboard-card.champ-indices .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+  margin-top: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: 8px;
+}
+
 .dashboard-card.champ-indices .cta-indice-chasse {
   background-color: var(--color-editor-button);
   color: var(--color-white);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3219,6 +3219,14 @@ body.panneau-ouvert::before {
   gap: var(--space-xs);
 }
 
+.dashboard-card.champ-indices .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+  margin-top: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: 8px;
+}
+
 .dashboard-card.champ-indices .cta-indice-chasse {
   background-color: var(--color-editor-button);
   color: var(--color-white);
@@ -5669,6 +5677,17 @@ body.accueil-fullscreen {
 }
 
 /* 📐 Layout – Structure générale des pages */
+:root {
+  --bp-xl: 1440px;
+}
+
+@media (min-width: var(--bp-xl)) {
+  .layout-fullwidth .ast-container,
+  .layout-fullwidth .myaccount-layout {
+    width: 100vw;
+    max-width: 100%;
+  }
+}
 /* 🎯 Header top bar */
 /* 🧭 Hero  */
 /* 📄 Contenu */

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -55,28 +55,10 @@ foreach ($posts as $p) {
     break;
   }
 }
-// ✅ Une chasse publiée ne doit plus afficher la bordure d'indicateur sur les énigmes
-$chasse_publiee = (get_post_status($chasse_id) === 'publish');
 ?>
 
 <div class="bloc-enigmes-chasse">
   <div class="grille-3">
-  <?php foreach ($posts_visibles as $post): ?>
-    <?php
-    $enigme_id = $post->ID;
-    $titre = get_the_title($enigme_id);
-    $etat_systeme = enigme_get_etat_systeme($enigme_id);
-    $statut_utilisateur = enigme_get_statut_utilisateur($enigme_id, $utilisateur_id);
-    $cta = get_cta_enigme($enigme_id);
-
-  $est_orga = est_organisateur();
-  $voir_bordure = $est_orga && !$chasse_publiee && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
-    $classe_completion = '';
-    if ($voir_bordure) {
-      verifier_ou_mettre_a_jour_cache_complet($enigme_id);
-      $complet = (bool) get_field('enigme_cache_complet', $enigme_id);
-      $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
-    }
     <?php foreach ($posts_visibles as $post):
       $enigme_id = $post->ID;
       $titre = get_the_title($enigme_id);


### PR DESCRIPTION
## Résumé
- harmonise les CTA de la carte d'ajout d'indice

## Changements notables
- uniformise la mise en page des CTA de la carte indices
- conserve les couleurs distinctes pour chaque CTA

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aaa1b4af988332abb8f928ca8d7ec5