### PR TITLE
Exiger la sélection d'une énigme lors de la création d'indice

### DIFF
--- a/tests/AjaxCreerIndiceModalTest.php
+++ b/tests/AjaxCreerIndiceModalTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void {}
+}
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in(): bool { return true; }
+}
+
+if (!function_exists('wp_send_json_error')) {
+    function wp_send_json_error($data = null): void { throw new Exception((string) $data); }
+}
+
+if (!function_exists('wp_send_json_success')) {
+    function wp_send_json_success($data = null) {
+        global $json_success_data;
+        $json_success_data = $data;
+        return $data;
+    }
+}
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($id) { return 'enigme'; }
+}
+
+if (!function_exists('indice_action_autorisee')) {
+    function indice_action_autorisee($action, $type, $id) { return true; }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) { return false; }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($v) { return $v; }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($v) { return $v; }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($v) { return $v; }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
+
+class AjaxCreerIndiceModalTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_POST = [];
+    }
+
+    public function test_missing_riddle_id_returns_error(): void
+    {
+        $_POST['objet_id'] = 7;
+        $_POST['objet_type'] = 'enigme';
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('post_invalide');
+
+        ajax_creer_indice_modal();
+    }
+
+    public function test_mismatched_riddle_id_returns_error(): void
+    {
+        $_POST['objet_id'] = 7;
+        $_POST['objet_type'] = 'enigme';
+        $_POST['indice_enigme_linked'] = 9;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('post_invalide');
+
+        ajax_creer_indice_modal();
+    }
+}
+

--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -3,10 +3,10 @@
     var overlay = document.createElement('div');
     overlay.className = 'indice-modal-overlay';
     var titre = indicesCreate.texts.indiceTitre.replace('%d', btn.dataset.indiceRang || '');
-    var needRiddle = btn.dataset.objetType === 'enigme' && !btn.dataset.objetId;
+    var needRiddle = btn.dataset.objetType === 'enigme' && !btn.dataset.indiceId;
     var riddleField = needRiddle
-      ? `<p><label>${indicesCreate.texts.riddle}<br><select name="objet_id"><option value="">${indicesCreate.texts.loading}</option></select></label></p>`
-      : `<input type="hidden" name="objet_id" value="${btn.dataset.objetId || ''}" />`;
+      ? `<p><label>${indicesCreate.texts.riddle}<br><select name="indice_enigme_linked"><option value="">${indicesCreate.texts.loading}</option></select></label></p>`
+      : '';
     overlay.innerHTML = `
       <div class="indice-modal">
         <div class="indice-modal-header">
@@ -18,6 +18,7 @@
           <input type="hidden" name="action" value="creer_indice_modal" />
           <input type="hidden" name="objet_type" value="${btn.dataset.objetType}" />
           ${riddleField}
+          <input type="hidden" name="objet_id" value="${btn.dataset.objetId || ''}" />
           <input type="hidden" name="indice_image" value="" />
           <p class="image-field"><button type="button" class="select-image">${indicesCreate.texts.image}</button><span class="image-preview"></span></p>
           <p><label>${indicesCreate.texts.contenu}<br><textarea name="indice_contenu"></textarea></label></p>
@@ -151,7 +152,7 @@
       var content = overlay.querySelector('textarea[name="indice_contenu"]').value.trim();
       var image = overlay.querySelector('input[name="indice_image"]').value.trim();
       var dispo = overlay.querySelector('input[name="indice_disponibilite"]:checked').value;
-      var select = overlay.querySelector('select[name="objet_id"]');
+      var select = overlay.querySelector('select[name="indice_enigme_linked"]');
       var riddleSelected = !select || select.value !== '';
       var state = 'desactive';
       var message = '';
@@ -206,7 +207,8 @@
     });
 
     if (needRiddle) {
-      var select = overlay.querySelector('select[name="objet_id"]');
+      var select = overlay.querySelector('select[name="indice_enigme_linked"]');
+      var hidden = overlay.querySelector('input[name="objet_id"]');
       var titleSpan = overlay.querySelector('.objet-titre');
       var fd = new FormData();
       fd.append('action', 'chasse_lister_enigmes');
@@ -220,6 +222,8 @@
             opt.value = '';
             opt.textContent = indicesCreate.texts.chooseRiddle;
             select.appendChild(opt);
+            btn.dataset.objetId = '';
+            hidden.value = '';
             btn.dataset.indiceRang = '';
             titleEl.textContent = indicesCreate.texts.indiceTitre.replace('%d', '');
             refreshState();
@@ -234,11 +238,12 @@
             }
             select.appendChild(opt);
           });
-          var def = btn.dataset.defaultEnigme;
+          var def = btn.dataset.defaultEnigme || btn.dataset.objetId;
           if (def) select.value = def;
           if (!select.value) select.value = select.options[0].value;
           var selected = select.options[select.selectedIndex];
           btn.dataset.objetId = select.value;
+          hidden.value = select.value;
           btn.dataset.indiceRang = selected && selected.dataset.indiceRang ? selected.dataset.indiceRang : '';
           titleSpan.textContent = selected ? selected.text : '';
           titleEl.textContent = indicesCreate.texts.indiceTitre.replace('%d', btn.dataset.indiceRang || '');
@@ -247,6 +252,7 @@
       select.addEventListener('change', function () {
         var opt = select.options[select.selectedIndex];
         btn.dataset.objetId = select.value;
+        hidden.value = select.value;
         btn.dataset.indiceRang = opt && opt.dataset.indiceRang ? opt.dataset.indiceRang : '';
         titleSpan.textContent = opt ? opt.text : '';
         titleEl.textContent = indicesCreate.texts.indiceTitre.replace('%d', btn.dataset.indiceRang || '');

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -509,6 +509,13 @@ function ajax_creer_indice_modal(): void
         wp_send_json_error('post_invalide');
     }
 
+    if ($objet_type === 'enigme') {
+        $linked = isset($_POST['indice_enigme_linked']) ? (int) $_POST['indice_enigme_linked'] : 0;
+        if (!$linked || $linked !== $objet_id) {
+            wp_send_json_error('post_invalide');
+        }
+    }
+
     if (!indice_action_autorisee('create', $objet_type, $objet_id)) {
         wp_send_json_error('acces_refuse');
     }


### PR DESCRIPTION
## Résumé
- impose le choix d'une énigme lors de l'ouverture de la modale d'indice
- rejette côté serveur toute création d'indice sans énigme liée
- ajoute un test pour vérifier cette contrainte

## Changelog
- ajout du sélecteur `indice_enigme_linked` synchronisé avec `objet_id`
- contrôle d'entrée supplémentaire dans `ajax_creer_indice_modal`
- tests pour les cas sans ou avec mauvais identifiant d'énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aaa63d4b4c8332bd5a0271ff6573b5