### PR TITLE
Normalise les CTA d'ajout d'indice

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1587,6 +1587,12 @@ body.panneau-ouvert::before {
   gap: var(--space-xs);
 }
 
+.dashboard-card.champ-indices .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+  margin-top: 0;
+}
+
 .dashboard-card.champ-indices .cta-indice-chasse {
   background-color: var(--color-editor-button);
   color: var(--color-white);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3230,6 +3230,12 @@ body.panneau-ouvert::before {
   gap: var(--space-xs);
 }
 
+.dashboard-card.champ-indices .stat-value .bouton-cta, .champ-indices.carte-orgy .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+  margin-top: 0;
+}
+
 .dashboard-card.champ-indices .cta-indice-chasse, .champ-indices.carte-orgy .cta-indice-chasse {
   background-color: var(--color-editor-button);
   color: var(--color-white);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -28,7 +28,7 @@ $has_enigmes = !empty($enigmes_disponibles);
     <div class="stat-value">
       <a
         href="#"
-        class="bouton-cta cta-creer-indice cta-indice-chasse"
+        class="bouton-cta bouton-cta--color cta-creer-indice cta-indice-chasse"
         data-objet-type="<?= esc_attr($objet_type); ?>"
         data-objet-id="<?= esc_attr($objet_id); ?>"
         data-objet-titre="<?= esc_attr($objet_titre); ?>"
@@ -39,7 +39,7 @@ $has_enigmes = !empty($enigmes_disponibles);
       <?php if ($has_enigmes) : ?>
         <a
           href="#"
-          class="bouton-cta cta-indice-enigme"
+          class="bouton-cta bouton-cta--color cta-indice-enigme"
           data-objet-type="enigme"
           data-chasse-id="<?= esc_attr($objet_id); ?>"
           <?php if ($default_enigme) : ?>


### PR DESCRIPTION
## Summary
- Harmonise les CTA de la carte "Ajouter un indice" avec le style Orgy
- Rend les boutons plein largeur pour éviter les disproportions
- Recompile la feuille de style du thème

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aaa66288448332a5324d2a3b9d5185