### PR TITLE
Style Orgy pour la carte des liens de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -229,7 +229,7 @@ function updateTargetBlocks(bloc, champ, postId, donnees) {
     if (!zoneAffichage.dataset.noEdit && !bloc.querySelector('.champ-modifier')) {
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'champ-modifier txt-small ouvrir-panneau-liens';
+      btn.className = 'bouton-cta champ-modifier ouvrir-panneau-liens';
       btn.setAttribute('aria-label', 'Configurer vos liens');
       btn.textContent = wp.i18n.__('modifier', 'chassesautresor-com');
       zoneAffichage.appendChild(btn);
@@ -251,7 +251,7 @@ function updateTargetBlocks(bloc, champ, postId, donnees) {
         if (!zone.dataset.noEdit && !blocCible.querySelector('.champ-modifier')) {
           const btn = document.createElement('button');
           btn.type = 'button';
-          btn.className = 'champ-modifier txt-small ouvrir-panneau-liens';
+          btn.className = 'bouton-cta champ-modifier ouvrir-panneau-liens';
           btn.setAttribute('aria-label', 'Configurer vos liens');
           btn.textContent = wp.i18n.__('modifier', 'chassesautresor-com');
           zone.appendChild(btn);
@@ -273,7 +273,7 @@ function updateTargetBlocks(bloc, champ, postId, donnees) {
         if (!zone.dataset.noEdit && !blocCible.querySelector('.champ-modifier')) {
           const btn = document.createElement('button');
           btn.type = 'button';
-          btn.className = 'champ-modifier txt-small ouvrir-panneau-liens';
+          btn.className = 'bouton-cta champ-modifier ouvrir-panneau-liens';
           btn.setAttribute('aria-label', 'Configurer vos liens');
           btn.textContent = wp.i18n.__('modifier', 'chassesautresor-com');
           zone.appendChild(btn);

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -515,7 +515,7 @@ body .header-img-modifiable .icone-modif {
 
 
 /* Boutons d’édition */
-body[class*="edition-active"] .champ-modifier {
+body[class*="edition-active"] .champ-modifier:not(.bouton-cta) {
   background: none;
   border: none;
   color: var(--color-editor-accent);
@@ -543,11 +543,11 @@ body.edition-active-enigme .champ-modifier .icone-modif {
   display: unset;
 }
 
-body[class*="edition-active"] .champ-modifier:hover {
+body[class*="edition-active"] .champ-modifier:not(.bouton-cta):hover {
   opacity: 1;
 }
 
-body[class*="edition-active"] .champ-modifier:focus {
+body[class*="edition-active"] .champ-modifier:not(.bouton-cta):focus {
   outline: 2px solid var(--color-editor-accent);
   outline-offset: 2px;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2209,7 +2209,7 @@ body .header-img-modifiable .icone-modif {
 
 /* ========== 🎯 BOUTON ✏️ ÉDITION DE CONTENU ========== */
 /* Boutons d’édition */
-body[class*=edition-active] .champ-modifier {
+body[class*=edition-active] .champ-modifier:not(.bouton-cta) {
   background: none;
   border: none;
   color: var(--color-editor-accent);
@@ -2237,11 +2237,11 @@ body.edition-active-enigme .champ-modifier .icone-modif {
   display: unset;
 }
 
-body[class*=edition-active] .champ-modifier:hover {
+body[class*=edition-active] .champ-modifier:not(.bouton-cta):hover {
   opacity: 1;
 }
 
-body[class*=edition-active] .champ-modifier:focus {
+body[class*=edition-active] .champ-modifier:not(.bouton-cta):focus {
   outline: 2px solid var(--color-editor-accent);
   outline-offset: 2px;
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -861,11 +861,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       . rawurlencode($url)
                       . '&format=' . $format;
               ?>
-              <div class="dashboard-card champ-qr-code">
+              <div class="dashboard-card carte-orgy champ-qr-code">
                 <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de la chasse', 'chassesautresor-com'); ?>">
                 <h3><?= esc_html__('QR code de votre chasse', 'chassesautresor-com'); ?></h3>
-                <a class="stat-value" href="<?= esc_url($url_qr_code); ?>"
-                  download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>"><?= esc_html__('Télécharger', 'chassesautresor-com'); ?></a>
+                <a class="bouton-cta" href="<?= esc_url($url_qr_code); ?>" download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>">
+                  <?= esc_html__('Télécharger', 'chassesautresor-com'); ?>
+                </a>
               </div>
               <?php endif; ?>
             </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -821,25 +821,25 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 'objet_type' => 'chasse',
               ]);
               ?>
-              <div class="dashboard-card champ-chasse champ-liens <?= empty($liens) ? 'champ-vide' : 'champ-rempli'; ?>"
+              <div class="dashboard-card carte-orgy champ-chasse champ-liens <?= empty($liens) ? 'champ-vide' : 'champ-rempli'; ?>"
                 data-champ="chasse_principale_liens"
                 data-cpt="chasse"
                 data-post-id="<?= esc_attr($chasse_id); ?>">
                 <i class="fa-solid fa-share-nodes icone-defaut" aria-hidden="true"></i>
-                <h3><?= esc_html__('Sites et réseaux de la chasse', 'chassesautresor-com'); ?></h3>
                 <div class="champ-affichage champ-affichage-liens">
                   <?= render_liens_publics($liens, 'chasse', ['placeholder' => false]); ?>
                 </div>
+                <h3><?= esc_html__('Sites et réseaux de la chasse', 'chassesautresor-com'); ?></h3>
                 <?php if ($peut_modifier) : ?>
-                  <a href="#"
-                    class="stat-value champ-modifier ouvrir-panneau-liens"
+                  <button type="button"
+                    class="bouton-cta champ-modifier ouvrir-panneau-liens"
                     data-champ="chasse_principale_liens"
                     data-cpt="chasse"
                     data-post-id="<?= esc_attr($chasse_id); ?>">
                     <?= empty($liens)
                       ? esc_html__('Ajouter', 'chassesautresor-com')
                       : esc_html__('Éditer', 'chassesautresor-com'); ?>
-                  </a>
+                  </button>
                 <?php endif; ?>
                 <div class="champ-donnees"
                   data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -376,11 +376,12 @@ $is_complete = (
                       . rawurlencode($url)
                       . '&format=' . $format;
                   ?>
-                  <div class="dashboard-card champ-qr-code">
+                  <div class="dashboard-card carte-orgy champ-qr-code">
                     <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de l\'organisation', 'chassesautresor-com'); ?>">
                     <h3><?= esc_html__('QR code de votre organisation', 'chassesautresor-com'); ?></h3>
-                    <a class="stat-value" href="<?= esc_url($url_qr_code); ?>"
-                      download="<?= esc_attr('qr-organisateur-' . $organisateur_id . '.' . $format); ?>"><?= esc_html__('Télécharger', 'chassesautresor-com'); ?></a>
+                    <a class="bouton-cta" href="<?= esc_url($url_qr_code); ?>" download="<?= esc_attr('qr-organisateur-' . $organisateur_id . '.' . $format); ?>">
+                      <?= esc_html__('Télécharger', 'chassesautresor-com'); ?>
+                    </a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Résumé
- harmonise la carte "Sites et réseaux de la chasse" avec le style Orgy
- applique le style CTA Orgy sur le bouton d'édition des liens

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aaa793b324833281239cd622da6a74