### PR TITLE
Adapte la carte d'ajout d'indice au mode Orgy

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1585,33 +1585,39 @@ body.panneau-ouvert::before {
   color: var(--color-editor-heading);
 }
 
-.dashboard-card.champ-indices .stat-value {
+.dashboard-card.champ-indices .stat-value,
+.champ-indices.carte-orgy .stat-value {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.dashboard-card.champ-indices .stat-value .bouton-cta {
+.dashboard-card.champ-indices .stat-value .bouton-cta,
+.champ-indices.carte-orgy .stat-value .bouton-cta {
   display: block;
   width: 100%;
   margin-top: 0;
 }
 
-.dashboard-card.champ-indices .cta-indice-chasse {
+.dashboard-card.champ-indices .cta-indice-chasse,
+.champ-indices.carte-orgy .cta-indice-chasse {
   background-color: var(--color-editor-button);
   color: var(--color-white);
 }
 
-.dashboard-card.champ-indices .cta-indice-chasse:hover {
+.dashboard-card.champ-indices .cta-indice-chasse:hover,
+.champ-indices.carte-orgy .cta-indice-chasse:hover {
   background-color: var(--color-editor-button-hover);
 }
 
-.dashboard-card.champ-indices .cta-indice-enigme {
+.dashboard-card.champ-indices .cta-indice-enigme,
+.champ-indices.carte-orgy .cta-indice-enigme {
   background-color: var(--color-editor-success);
   color: var(--color-white);
 }
 
-.dashboard-card.champ-indices .cta-indice-enigme:hover {
+.dashboard-card.champ-indices .cta-indice-enigme:hover,
+.champ-indices.carte-orgy .cta-indice-enigme:hover {
   background-color: var(--color-editor-success-hover);
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3228,33 +3228,39 @@ body.panneau-ouvert::before {
   color: var(--color-editor-heading);
 }
 
-.dashboard-card.champ-indices .stat-value, .champ-indices.carte-orgy .stat-value {
+.dashboard-card.champ-indices .stat-value,
+.champ-indices.carte-orgy .stat-value {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.dashboard-card.champ-indices .stat-value .bouton-cta, .champ-indices.carte-orgy .stat-value .bouton-cta {
+.dashboard-card.champ-indices .stat-value .bouton-cta,
+.champ-indices.carte-orgy .stat-value .bouton-cta {
   display: block;
   width: 100%;
   margin-top: 0;
 }
 
-.dashboard-card.champ-indices .cta-indice-chasse, .champ-indices.carte-orgy .cta-indice-chasse {
+.dashboard-card.champ-indices .cta-indice-chasse,
+.champ-indices.carte-orgy .cta-indice-chasse {
   background-color: var(--color-editor-button);
   color: var(--color-white);
 }
 
-.dashboard-card.champ-indices .cta-indice-chasse:hover, .champ-indices.carte-orgy .cta-indice-chasse:hover {
+.dashboard-card.champ-indices .cta-indice-chasse:hover,
+.champ-indices.carte-orgy .cta-indice-chasse:hover {
   background-color: var(--color-editor-button-hover);
 }
 
-.dashboard-card.champ-indices .cta-indice-enigme, .champ-indices.carte-orgy .cta-indice-enigme {
+.dashboard-card.champ-indices .cta-indice-enigme,
+.champ-indices.carte-orgy .cta-indice-enigme {
   background-color: var(--color-editor-success);
   color: var(--color-white);
 }
 
-.dashboard-card.champ-indices .cta-indice-enigme:hover, .champ-indices.carte-orgy .cta-indice-enigme:hover {
+.dashboard-card.champ-indices .cta-indice-enigme:hover,
+.champ-indices.carte-orgy .cta-indice-enigme:hover {
   background-color: var(--color-editor-success-hover);
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -21,14 +21,14 @@ $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
 $enigmes_disponibles = $objet_type === 'chasse' ? recuperer_enigmes_pour_chasse($objet_id) : [];
 $has_enigmes = !empty($enigmes_disponibles);
 ?>
-<div class="dashboard-card champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?>">
+<div class="dashboard-card carte-orgy champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?>">
   <i class="fa-solid fa-kit-medical icone-defaut" aria-hidden="true"></i>
   <h3><?= esc_html__('Ajouter un indice pour…', 'chassesautresor-com'); ?></h3>
   <?php if ($peut_ajouter) : ?>
     <div class="stat-value">
       <a
         href="#"
-        class="bouton-cta bouton-cta--color cta-creer-indice cta-indice-chasse"
+        class="bouton-cta cta-creer-indice cta-indice-chasse"
         data-objet-type="<?= esc_attr($objet_type); ?>"
         data-objet-id="<?= esc_attr($objet_id); ?>"
         data-objet-titre="<?= esc_attr($objet_titre); ?>"
@@ -39,7 +39,7 @@ $has_enigmes = !empty($enigmes_disponibles);
       <?php if ($has_enigmes) : ?>
         <a
           href="#"
-          class="bouton-cta bouton-cta--color cta-indice-enigme"
+          class="bouton-cta cta-indice-enigme"
           data-objet-type="enigme"
           data-chasse-id="<?= esc_attr($objet_id); ?>"
           <?php if ($default_enigme) : ?>


### PR DESCRIPTION
## Résumé
- Conversion de la carte d'ajout d'indice au format Orgy.
- Boutons CTA adaptés avec variantes de couleur distinctes.
- Styles SCSS étendus pour appliquer les couleurs en mode Orgy.

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aab4ce8ac483328d728ca5e0ec077d