### PR TITLE
Style indices card CTAs for Orgy design

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -21,25 +21,25 @@ $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
 $enigmes_disponibles = $objet_type === 'chasse' ? recuperer_enigmes_pour_chasse($objet_id) : [];
 $has_enigmes = !empty($enigmes_disponibles);
 ?>
-<div class="dashboard-card champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?>">
+<div class="dashboard-card carte-orgy champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?>">
   <i class="fa-solid fa-kit-medical icone-defaut" aria-hidden="true"></i>
   <h3><?= esc_html__('Ajouter un indice pour…', 'chassesautresor-com'); ?></h3>
-  <?php if ($peut_ajouter) : ?>
+<?php if ($peut_ajouter) : ?>
     <div class="stat-value">
-      <a
-        href="#"
-        class="bouton-cta bouton-cta--color cta-creer-indice cta-indice-chasse"
+      <button
+        type="button"
+        class="bouton-cta cta-creer-indice cta-indice-chasse"
         data-objet-type="<?= esc_attr($objet_type); ?>"
         data-objet-id="<?= esc_attr($objet_id); ?>"
         data-objet-titre="<?= esc_attr($objet_titre); ?>"
         data-indice-rang="<?= esc_attr($indice_rang); ?>"
       >
         <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
-      </a>
+      </button>
       <?php if ($has_enigmes) : ?>
-        <a
-          href="#"
-          class="bouton-cta bouton-cta--color cta-indice-enigme"
+        <button
+          type="button"
+          class="bouton-cta cta-indice-enigme"
           data-objet-type="enigme"
           data-chasse-id="<?= esc_attr($objet_id); ?>"
           <?php if ($default_enigme) : ?>
@@ -47,7 +47,7 @@ $has_enigmes = !empty($enigmes_disponibles);
           <?php endif; ?>
         >
           <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
-        </a>
+        </button>
       <?php endif; ?>
     </div>
   <?php else : ?>


### PR DESCRIPTION
## Résumé
- Harmonise les boutons d'ajout d'indice avec la charte Orgy des cartes
- Conserve une différenciation colorée entre les CTA chasse et énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aab69a8a688332b6a9048f8948f646