### PR TITLE
Fix clue modal rank for riddle selection

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -392,7 +392,7 @@ function ajax_chasse_lister_enigmes(): void
         static fn($p) => [
             'id'          => $p->ID,
             'title'       => get_the_title($p),
-            'indice_rang' => prochain_rang_indice($p->ID, 'enigme'),
+            'indice_rang' => prochain_rang_indice($chasse_id, 'chasse'),
         ],
         $posts
     );


### PR DESCRIPTION
## Summary
- corrige le calcul du rang pour les indices lors de la sélection d'une énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aabad9d4b48332acbbbb2d9edba4c8