### PR TITLE
Add missing English translations for clue panel

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -417,6 +417,22 @@ msgstr ""
 msgid "Indices pour %s"
 msgstr ""
 
+#: template-parts/chasse/partials/chasse-partial-indices.php:26
+msgid "Ajouter un indice"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:33
+msgid "Pour…"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:44
+msgid "La chasse entière"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+msgid "Une énigme de la chasse"
+msgstr ""
+
 #: inc/enigme/affichage.php:677
 msgid "automatique"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -447,6 +447,22 @@ msgstr "Hints"
 msgid "Indices pour %s"
 msgstr "Hints for %s"
 
+#: template-parts/chasse/partials/chasse-partial-indices.php:26
+msgid "Ajouter un indice"
+msgstr "Add a hint"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:33
+msgid "Pour…"
+msgstr "For…"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:44
+msgid "La chasse entière"
+msgstr "The entire hunt"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+msgid "Une énigme de la chasse"
+msgstr "A riddle from the hunt"
+
 #: inc/enigme/affichage.php:677
 msgid "automatique"
 msgstr "automatic"


### PR DESCRIPTION
Ajoute les traductions anglaises manquantes pour les libellés de la carte d'indice.

- Ajout des entrées pour "Ajouter un indice", "Pour…", "La chasse entière" et "Une énigme de la chasse" dans `en_US.po`
- Mise à jour du gabarit `chassesautresor-com.pot` afin d'inclure ces chaînes

### Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aac80a600c8332834df53a9dafddad