### PR TITLE
Réorganisation du tableau des indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -282,6 +282,22 @@ tbody tr:nth-child(even) {
   text-align: left;
 }
 
+.indices-table td {
+  vertical-align: top;
+}
+
+.indices-table td > div + div {
+  margin-top: 0.25rem;
+}
+
+.indices-table-header {
+  margin-bottom: 0.5rem;
+}
+
+.indices-table-header .etiquette + .etiquette {
+  margin-left: 0.25rem;
+}
+
 .indices-table td img {
   width: 80px;
   height: 80px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5393,6 +5393,22 @@ tbody tr:nth-child(even) {
   text-align: left;
 }
 
+.indices-table td {
+  vertical-align: top;
+}
+
+.indices-table td > div + div {
+  margin-top: 0.25rem;
+}
+
+.indices-table-header {
+  margin-bottom: 0.5rem;
+}
+
+.indices-table-header .etiquette + .etiquette {
+  margin-left: 0.25rem;
+}
+
 .indices-table td img {
   width: 80px;
   height: 80px;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -516,13 +516,74 @@ function ajax_indices_lister_table(): void
         'meta_query'     => $meta,
     ]);
 
+    $count_chasse = 0;
+    $count_enigme = 0;
+    if ($objet_type === 'chasse') {
+        $count_chasse = function_exists('get_posts') ? count(get_posts([
+            'post_type'      => 'indice',
+            'post_status'    => ['publish', 'pending', 'draft'],
+            'fields'         => 'ids',
+            'nopaging'       => true,
+            'meta_query'     => [
+                [
+                    'key'   => 'indice_cible_type',
+                    'value' => 'chasse',
+                ],
+                [
+                    'key'   => 'indice_chasse_linked',
+                    'value' => $objet_id,
+                ],
+            ],
+        ])) : 0;
+        if (!empty($enigme_ids)) {
+            $count_enigme = function_exists('get_posts') ? count(get_posts([
+                'post_type'      => 'indice',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'fields'         => 'ids',
+                'nopaging'       => true,
+                'meta_query'     => [
+                    [
+                        'key'   => 'indice_cible_type',
+                        'value' => 'enigme',
+                    ],
+                    [
+                        'key'     => 'indice_enigme_linked',
+                        'value'   => $enigme_ids,
+                        'compare' => 'IN',
+                    ],
+                ],
+            ])) : 0;
+        }
+    } else {
+        $count_enigme = function_exists('get_posts') ? count(get_posts([
+            'post_type'      => 'indice',
+            'post_status'    => ['publish', 'pending', 'draft'],
+            'fields'         => 'ids',
+            'nopaging'       => true,
+            'meta_query'     => [
+                [
+                    'key'   => 'indice_cible_type',
+                    'value' => 'enigme',
+                ],
+                [
+                    'key'   => 'indice_enigme_linked',
+                    'value' => $objet_id,
+                ],
+            ],
+        ])) : 0;
+    }
+    $count_total = $count_chasse + $count_enigme;
+
     ob_start();
     get_template_part('template-parts/common/indices-table', null, [
-        'indices'    => $query->posts,
-        'page'       => max(1, $page),
-        'pages'      => (int) $query->max_num_pages,
-        'objet_type' => $objet_type,
-        'objet_id'   => $objet_id,
+        'indices'      => $query->posts,
+        'page'         => max(1, $page),
+        'pages'        => (int) $query->max_num_pages,
+        'objet_type'   => $objet_type,
+        'objet_id'     => $objet_id,
+        'count_total'  => $count_total,
+        'count_chasse' => $count_chasse,
+        'count_enigme' => $count_enigme,
     ]);
     $html = ob_get_clean();
 

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2207,3 +2207,33 @@ msgstr ""
 msgid "programmé le %s"
 msgstr ""
 
+#: template-parts/common/indices-table.php:41
+#, php-format
+msgid "%d indice au total"
+msgid_plural "%d indices au total"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/indices-table.php:44
+#, php-format
+msgid "%d indice chasse"
+msgid_plural "%d indices chasse"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/indices-table.php:47
+#, php-format
+msgid "%d indice énigme"
+msgid_plural "%d indices énigme"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/indices-table.php:55
+msgid "Indice"
+msgstr ""
+
+#: template-parts/common/indices-table.php:136
+#, php-format
+msgid "à %s"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2455,3 +2455,33 @@ msgstr "scheduled"
 msgid "programmé le %s"
 msgstr "scheduled for %s"
 
+#: template-parts/common/indices-table.php:41
+#, php-format
+msgid "%d indice au total"
+msgid_plural "%d indices au total"
+msgstr[0] "%d total hint"
+msgstr[1] "%d total hints"
+
+#: template-parts/common/indices-table.php:44
+#, php-format
+msgid "%d indice chasse"
+msgid_plural "%d indices chasse"
+msgstr[0] "%d hunt hint"
+msgstr[1] "%d hunt hints"
+
+#: template-parts/common/indices-table.php:47
+#, php-format
+msgid "%d indice énigme"
+msgid_plural "%d indices énigme"
+msgstr[0] "%d riddle hint"
+msgstr[1] "%d riddle hints"
+
+#: template-parts/common/indices-table.php:55
+msgid "Indice"
+msgstr "Hint"
+
+#: template-parts/common/indices-table.php:136
+#, php-format
+msgid "à %s"
+msgstr "at %s"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2401,3 +2401,33 @@ msgstr "programmé"
 msgid "programmé le %s"
 msgstr "programmé le %s"
 
+#: template-parts/common/indices-table.php:41
+#, php-format
+msgid "%d indice au total"
+msgid_plural "%d indices au total"
+msgstr[0] "%d indice au total"
+msgstr[1] "%d indices au total"
+
+#: template-parts/common/indices-table.php:44
+#, php-format
+msgid "%d indice chasse"
+msgid_plural "%d indices chasse"
+msgstr[0] "%d indice chasse"
+msgstr[1] "%d indices chasse"
+
+#: template-parts/common/indices-table.php:47
+#, php-format
+msgid "%d indice énigme"
+msgid_plural "%d indices énigme"
+msgstr[0] "%d indice énigme"
+msgstr[1] "%d indices énigme"
+
+#: template-parts/common/indices-table.php:55
+msgid "Indice"
+msgstr "Indice"
+
+#: template-parts/common/indices-table.php:136
+#, php-format
+msgid "à %s"
+msgstr "à %s"
+

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -914,6 +914,40 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             ]);
             $indices_list  = $indices_query->posts;
             $pages_indices = (int) $indices_query->max_num_pages;
+              $count_chasse  = function_exists('get_posts') ? count(get_posts([
+                'post_type'      => 'indice',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'fields'         => 'ids',
+                'nopaging'       => true,
+                'meta_query'     => [
+                  [
+                    'key'   => 'indice_cible_type',
+                    'value' => 'chasse',
+                  ],
+                  [
+                    'key'   => 'indice_chasse_linked',
+                    'value' => $chasse_id,
+                  ],
+                ],
+              ])) : 0;
+              $count_enigme = !empty($enigme_ids) && function_exists('get_posts') ? count(get_posts([
+                'post_type'      => 'indice',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'fields'         => 'ids',
+                'nopaging'       => true,
+                'meta_query'     => [
+                  [
+                    'key'   => 'indice_cible_type',
+                    'value' => 'enigme',
+                  ],
+                  [
+                    'key'     => 'indice_enigme_linked',
+                    'value'   => $enigme_ids,
+                    'compare' => 'IN',
+                  ],
+                ],
+              ])) : 0;
+            $count_total  = $count_chasse + $count_enigme;
             ?>
             <h3><?= esc_html__('Indices', 'chassesautresor-com'); ?></h3>
             <div class="liste-indices" data-page="1" data-pages="<?= esc_attr($pages_indices); ?>" data-objet-type="chasse" data-objet-id="<?= esc_attr($chasse_id); ?>" data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
@@ -924,6 +958,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 'pages'      => $pages_indices,
                 'objet_type' => 'chasse',
                 'objet_id'   => $chasse_id,
+                'count_total'  => $count_total,
+                'count_chasse' => $count_chasse,
+                'count_enigme' => $count_enigme,
               ]);
               ?>
             </div>

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -12,13 +12,16 @@
 
 defined('ABSPATH') || exit;
 
-$args       = $args ?? [];
-$indices    = $args['indices'] ?? $indices ?? [];
-$page       = $args['page'] ?? $page ?? 1;
-$pages      = $args['pages'] ?? $pages ?? 1;
-$objet_type = $args['objet_type'] ?? $objet_type ?? 'chasse';
-$objet_id   = $args['objet_id'] ?? $objet_id ?? 0;
-$objet_titre = get_the_title($objet_id);
+$args         = $args ?? [];
+$indices      = $args['indices'] ?? $indices ?? [];
+$page         = $args['page'] ?? $page ?? 1;
+$pages        = $args['pages'] ?? $pages ?? 1;
+$objet_type   = $args['objet_type'] ?? $objet_type ?? 'chasse';
+$objet_id     = $args['objet_id'] ?? $objet_id ?? 0;
+$objet_titre  = get_the_title($objet_id);
+$count_total  = isset($args['count_total']) ? (int) $args['count_total'] : 0;
+$count_chasse = isset($args['count_chasse']) ? (int) $args['count_chasse'] : 0;
+$count_enigme = isset($args['count_enigme']) ? (int) $args['count_enigme'] : 0;
 
 if (empty($indices)) {
     $titre = get_the_title($objet_id);
@@ -31,124 +34,159 @@ if (empty($indices)) {
     return;
 }
 ?>
+
+<?php if ($count_total || $count_chasse || $count_enigme) : ?>
+<div class="indices-table-header">
+    <?php if ($count_total) : ?>
+        <span class="etiquette"><?php echo esc_html(sprintf(_n('%d indice au total', '%d indices au total', $count_total, 'chassesautresor-com'), $count_total)); ?></span>
+    <?php endif; ?>
+    <?php if ($count_chasse) : ?>
+        <span class="etiquette"><?php echo esc_html(sprintf(_n('%d indice chasse', '%d indices chasse', $count_chasse, 'chassesautresor-com'), $count_chasse)); ?></span>
+    <?php endif; ?>
+    <?php if ($count_enigme) : ?>
+        <span class="etiquette"><?php echo esc_html(sprintf(_n('%d indice énigme', '%d indices énigme', $count_enigme, 'chassesautresor-com'), $count_enigme)); ?></span>
+    <?php endif; ?>
+</div>
+<?php endif; ?>
+
 <table class="stats-table indices-table">
-  <thead>
-    <tr>
-      <th><?= esc_html__('Date', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Image', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Titre', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Texte', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Indice pour', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Titre contenu', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Statut', 'chassesautresor-com'); ?></th>
-      <th><?= esc_html__('Action', 'chassesautresor-com'); ?></th>
-    </tr>
-  </thead>
-  <tbody>
-    <?php foreach ($indices as $index => $indice) :
-        $indice_rank = $index + 1;
-        $date        = mysql2date('d/m/y', $indice->post_date);
-        $img_id      = get_field('indice_image', $indice->ID);
-        $img_html    = '';
-        $img_url     = '';
-        if ($img_id) {
-            $img_html = wp_get_attachment_image($img_id, [80, 80]);
-            $img_url  = wp_get_attachment_image_url($img_id, 'thumbnail') ?: '';
-        }
-
-        $contenu = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
-        $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
-
-        $date_raw   = get_field('indice_date_disponibilite', $indice->ID) ?: '';
-        $dt         = null;
-        $date_dispo = '';
-        if ($date_raw) {
-            $dt = convertir_en_datetime($date_raw);
-            if ($dt) {
-                $date_dispo = $dt->format('Y-m-d\\TH:i');
+    <thead>
+        <tr>
+            <th><?= esc_html__('Date', 'chassesautresor-com'); ?></th>
+            <th><?= esc_html__('Indice', 'chassesautresor-com'); ?></th>
+            <th><?= esc_html__('Texte', 'chassesautresor-com'); ?></th>
+            <th><?= esc_html__('Indice pour', 'chassesautresor-com'); ?></th>
+            <th><?= esc_html__('Action', 'chassesautresor-com'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($indices as $index => $indice) :
+            $indice_rank = $index + 1;
+            $timestamp   = strtotime($indice->post_date);
+            $locale      = function_exists('determine_locale')
+                ? determine_locale()
+                : (function_exists('get_locale') ? get_locale() : 'fr_FR');
+            $date_format = str_starts_with($locale, 'en') ? 'm/d/y' : 'd/m/y';
+            $date_value  = function_exists('wp_date')
+                ? wp_date($date_format, $timestamp)
+                : date($date_format, $timestamp);
+            $time_value  = function_exists('wp_date')
+                ? wp_date('H:i', $timestamp)
+                : date('H:i', $timestamp);
+            $img_id      = get_field('indice_image', $indice->ID);
+            $img_html    = '';
+            $img_url     = '';
+            if ($img_id) {
+                $img_html = wp_get_attachment_image($img_id, [80, 80]);
+                $img_url  = wp_get_attachment_image_url($img_id, 'thumbnail') ?: '';
             }
-        }
 
-        $etat       = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
-        $etat_class = 'etiquette-error';
-        $etat_label = __($etat, 'chassesautresor-com');
-        if ($etat === 'accessible') {
-            $etat_class = 'etiquette-success';
-        } elseif ($etat === 'programme' || $etat === 'programmé') {
-            $etat_class = 'etiquette-pending';
-            if ($dt instanceof DateTimeInterface) {
-                $format     = get_option('date_format') . ' ' . get_option('time_format');
-                $date_label = wp_date($format, $dt->getTimestamp());
-                $etat_label = sprintf(
-                    /* translators: %s: scheduled date */
-                    __('programmé le %s', 'chassesautresor-com'),
-                    $date_label
-                );
-            } else {
-                $etat_label = __('programmé', 'chassesautresor-com');
-            }
-        }
+            $contenu = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
+            $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
 
-        $cible_type  = get_field('indice_cible_type', $indice->ID) === 'enigme' ? 'enigme' : 'chasse';
-        $cible_label = $cible_type === 'enigme'
-            ? __('Énigme', 'chassesautresor-com')
-            : __('Chasse', 'chassesautresor-com');
-        $linked_html = '';
-        $linked      = $cible_type === 'enigme'
-            ? get_field('indice_enigme_linked', $indice->ID)
-            : get_field('indice_chasse_linked', $indice->ID);
-        if ($linked) {
-            if (is_array($linked)) {
-                $first     = $linked[0] ?? null;
-                $linked_id = is_array($first) ? ($first['ID'] ?? 0) : $first;
-            } else {
-                $linked_id = $linked;
+            $date_raw   = get_field('indice_date_disponibilite', $indice->ID) ?: '';
+            $dt         = null;
+            $date_dispo = '';
+            if ($date_raw) {
+                $dt = convertir_en_datetime($date_raw);
+                if ($dt) {
+                    $date_dispo = $dt->format('Y-m-d\\TH:i');
+                }
             }
-            if (!empty($linked_id)) {
-                $linked_title = get_the_title($linked_id);
-                $linked_html  = '<a href="' . esc_url(get_permalink($linked_id)) . '">' .
-                    esc_html($linked_title) . '</a>';
+
+            $etat       = get_field('indice_cache_etat_systeme', $indice->ID) ?: '';
+            $etat_class = 'etiquette-error';
+            $etat_label = __($etat, 'chassesautresor-com');
+            if ($etat === 'accessible') {
+                $etat_class = 'etiquette-success';
+            } elseif ($etat === 'programme' || $etat === 'programmé') {
+                $etat_class = 'etiquette-pending';
+                if ($dt instanceof DateTimeInterface) {
+                    $format     = get_option('date_format') . ' ' . get_option('time_format');
+                    $date_label = function_exists('wp_date')
+                        ? wp_date($format, $dt->getTimestamp())
+                        : date($format, $dt->getTimestamp());
+                    $etat_label = sprintf(
+                        /* translators: %s: scheduled date */
+                        __('programmé le %s', 'chassesautresor-com'),
+                        $date_label
+                    );
+                } else {
+                    $etat_label = __('programmé', 'chassesautresor-com');
+                }
             }
-        }
-    ?>
-    <tr>
-      <td><?= esc_html($date); ?></td>
-      <td><?= $img_html; ?></td>
-      <td><a href="<?= esc_url(get_permalink($indice)); ?>"><?= esc_html(get_the_title($indice)); ?></a></td>
-      <?php echo cta_render_proposition_cell($contenu); ?>
-      <td><span class="etiquette"><?= esc_html($cible_label); ?></span></td>
-      <td><?= $linked_html; ?></td>
-      <td><span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat_label); ?></span></td>
-      <td class="indice-actions">
-        <button
-          type="button"
-          class="badge-action edit"
-          data-objet-type="<?= esc_attr($objet_type); ?>"
-          data-objet-id="<?= esc_attr($objet_id); ?>"
-          data-objet-titre="<?= esc_attr($objet_titre); ?>"
-          data-indice-id="<?= esc_attr($indice->ID); ?>"
-          data-indice-rang="<?= esc_attr($indice_rank); ?>"
-          data-indice-image="<?= esc_attr($img_id); ?>"
-          data-indice-image-url="<?= esc_attr($img_url); ?>"
-          data-indice-contenu="<?= esc_attr($contenu); ?>"
-          data-indice-disponibilite="<?= esc_attr($dispo); ?>"
-          data-indice-date="<?= esc_attr($date_dispo); ?>"
-          title="<?= esc_attr__('Éditer', 'chassesautresor-com'); ?>"
-        >
-          <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
-        </button>
-        <button
-          type="button"
-          class="badge-action delete"
-          data-indice-id="<?= esc_attr($indice->ID); ?>"
-          data-confirm="<?= esc_attr__('Supprimer cet indice ?', 'chassesautresor-com'); ?>"
-          title="<?= esc_attr__('Supprimer', 'chassesautresor-com'); ?>"
-        >
-          <i class="fa-solid fa-trash" aria-hidden="true"></i>
-        </button>
-      </td>
-    </tr>
-    <?php endforeach; ?>
-  </tbody>
+
+            $cible_type  = get_field('indice_cible_type', $indice->ID) === 'enigme' ? 'enigme' : 'chasse';
+            $cible_label = $cible_type === 'enigme'
+                ? __('Énigme', 'chassesautresor-com')
+                : __('Chasse', 'chassesautresor-com');
+            $linked_html = '';
+            $linked      = $cible_type === 'enigme'
+                ? get_field('indice_enigme_linked', $indice->ID)
+                : get_field('indice_chasse_linked', $indice->ID);
+            if ($linked) {
+                if (is_array($linked)) {
+                    $first     = $linked[0] ?? null;
+                    $linked_id = is_array($first) ? ($first['ID'] ?? 0) : $first;
+                } else {
+                    $linked_id = $linked;
+                }
+                if (!empty($linked_id)) {
+                    $linked_title = get_the_title($linked_id);
+                    $linked_html  = '<a href="' . esc_url(get_permalink($linked_id)) . '">' .
+                        esc_html($linked_title) . '</a>';
+                }
+            }
+        ?>
+        <tr>
+            <td>
+                <div><?= esc_html($date_value); ?></div>
+                <div><?= esc_html(sprintf(__('à %s', 'chassesautresor-com'), $time_value)); ?></div>
+            </td>
+            <td>
+                <div><a href="<?= esc_url(get_permalink($indice)); ?>"><?= esc_html(get_the_title($indice)); ?></a></div>
+                <?php if ($img_html) : ?>
+                    <div><?= $img_html; ?></div>
+                <?php endif; ?>
+            </td>
+            <?php echo cta_render_proposition_cell($contenu); ?>
+            <td>
+                <div><span class="etiquette"><?= esc_html($cible_label); ?></span></div>
+                <div><?= $linked_html; ?></div>
+            </td>
+            <td class="indice-actions">
+                <div><span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat_label); ?></span></div>
+                <div class="indice-action-buttons">
+                    <button
+                        type="button"
+                        class="badge-action edit"
+                        data-objet-type="<?= esc_attr($objet_type); ?>"
+                        data-objet-id="<?= esc_attr($objet_id); ?>"
+                        data-objet-titre="<?= esc_attr($objet_titre); ?>"
+                        data-indice-id="<?= esc_attr($indice->ID); ?>"
+                        data-indice-rang="<?= esc_attr($indice_rank); ?>"
+                        data-indice-image="<?= esc_attr($img_id); ?>"
+                        data-indice-image-url="<?= esc_attr($img_url); ?>"
+                        data-indice-contenu="<?= esc_attr($contenu); ?>"
+                        data-indice-disponibilite="<?= esc_attr($dispo); ?>"
+                        data-indice-date="<?= esc_attr($date_dispo); ?>"
+                        title="<?= esc_attr__('Éditer', 'chassesautresor-com'); ?>"
+                    >
+                        <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+                    </button>
+                    <button
+                        type="button"
+                        class="badge-action delete"
+                        data-indice-id="<?= esc_attr($indice->ID); ?>"
+                        data-confirm="<?= esc_attr__('Supprimer cet indice ?', 'chassesautresor-com'); ?>"
+                        title="<?= esc_attr__('Supprimer', 'chassesautresor-com'); ?>"
+                    >
+                        <i class="fa-solid fa-trash" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
 </table>
 <?php echo cta_render_pager($page, $pages, 'indices-pager'); ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -982,15 +982,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                   ]);
                   $indices_list  = $indices_query->posts;
                   $pages_indices = (int) $indices_query->max_num_pages;
+                  $count_enigme  = function_exists('get_posts') ? count(get_posts([
+                    'post_type'      => 'indice',
+                    'post_status'    => ['publish', 'pending', 'draft'],
+                    'fields'         => 'ids',
+                    'nopaging'       => true,
+                    'meta_query'     => [
+                      [
+                        'key'   => 'indice_cible_type',
+                        'value' => 'enigme',
+                      ],
+                      [
+                        'key'   => 'indice_enigme_linked',
+                        'value' => $enigme_id,
+                      ],
+                    ],
+                  ])) : 0;
+                  $count_total = $count_enigme;
                   ?>
                   <div class="liste-indices" data-page="1" data-pages="<?= esc_attr($pages_indices); ?>" data-objet-type="enigme" data-objet-id="<?= esc_attr($enigme_id); ?>" data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
                     <?php
                     get_template_part('template-parts/common/indices-table', null, [
-                      'indices'    => $indices_list,
-                      'page'       => 1,
-                      'pages'      => $pages_indices,
-                      'objet_type' => 'enigme',
-                      'objet_id'   => $enigme_id,
+                      'indices'      => $indices_list,
+                      'page'         => 1,
+                      'pages'        => $pages_indices,
+                      'objet_type'   => 'enigme',
+                      'objet_id'     => $enigme_id,
+                      'count_total'  => $count_total,
+                      'count_chasse' => 0,
+                      'count_enigme' => $count_enigme,
                     ]);
                     ?>
                   </div>


### PR DESCRIPTION
## Résumé
- Mise en place d’un résumé des indices au-dessus du tableau
- Regroupement des colonnes et affichage clair des dates, cibles et actions
- Calcul des totaux d’indices côté serveur pour les pages et les appels AJAX

## Liste des modifications
- Ajout d’une entête récapitulative (total, chasse, énigme)
- Fusion image/titre, statut/actions et contenus visés dans le tableau
- Comptage des indices chasse/énigme lors du rendu initial et via AJAX
- Styles SCSS/CSS pour gérer la nouvelle présentation
- Mises à jour des fichiers de traduction

## Testing
- `source ./setup-env.sh`
- `npm install`
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aac772b0588332ad0a5828718e617c