### PR TITLE
Réordonne les indices de chasse lors de la suppression d'un indice d'énigme

### DIFF
--- a/tests/SupprimerIndiceEnigmeAjaxTest.php
+++ b/tests/SupprimerIndiceEnigmeAjaxTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in(): bool
+    {
+        return true;
+    }
+}
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($id)
+    {
+        return $id === 42 ? 'indice' : 'enigme';
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($field, $post_id)
+    {
+        global $fields;
+        return $fields[$field] ?? null;
+    }
+}
+
+if (!function_exists('indice_action_autorisee')) {
+    function indice_action_autorisee($action, $type, $id)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('wp_delete_post')) {
+    function wp_delete_post($id, $force = false)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('get_posts')) {
+    function get_posts($args)
+    {
+        global $captured_meta_queries;
+        $captured_meta_queries[] = $args['meta_query'];
+        return [];
+    }
+}
+
+if (!function_exists('wp_update_post')) {
+    function wp_update_post($args)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('wp_send_json_error')) {
+    function wp_send_json_error($data = null): void
+    {
+        throw new Exception((string) $data);
+    }
+}
+
+if (!function_exists('wp_send_json_success')) {
+    function wp_send_json_success($data = null)
+    {
+        global $json_success;
+        $json_success = $data;
+        return $data;
+    }
+}
+
+if (!function_exists('recuperer_id_chasse_associee')) {
+    function recuperer_id_chasse_associee($enigme_id)
+    {
+        return 77;
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
+
+final class SupprimerIndiceEnigmeAjaxTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_POST = [];
+        global $fields, $captured_meta_queries, $json_success;
+        $fields = [
+            'indice_cible_type'   => 'enigme',
+            'indice_enigme_linked' => 55,
+            'indice_chasse_linked' => 77,
+        ];
+        $captured_meta_queries = [];
+        $json_success          = null;
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_reorders_chasse_and_enigme_after_deleting_index(): void
+    {
+        global $captured_meta_queries;
+        $_POST['indice_id'] = 42;
+
+        supprimer_indice_ajax();
+
+        $this->assertCount(2, $captured_meta_queries);
+        $foundChasse = $foundEnigme = false;
+        foreach ($captured_meta_queries as $metaQuery) {
+            foreach ($metaQuery as $clause) {
+                if ($clause['key'] === 'indice_chasse_linked' && (int) $clause['value'] === 77) {
+                    $foundChasse = true;
+                }
+                if ($clause['key'] === 'indice_enigme_linked' && (int) $clause['value'] === 55) {
+                    $foundEnigme = true;
+                }
+            }
+        }
+
+        $this->assertTrue($foundChasse);
+        $this->assertTrue($foundEnigme);
+    }
+}
+

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -745,6 +745,7 @@ function supprimer_indice_ajax(): void
     }
 
     $cible_type = get_field('indice_cible_type', $indice_id) === 'enigme' ? 'enigme' : 'chasse';
+    $chasse_id  = 0;
     if ($cible_type === 'enigme') {
         $linked = get_field('indice_enigme_linked', $indice_id);
         if (is_array($linked)) {
@@ -752,6 +753,18 @@ function supprimer_indice_ajax(): void
             $objet_id = is_array($first) ? (int) ($first['ID'] ?? 0) : (int) $first;
         } else {
             $objet_id = (int) $linked;
+        }
+
+        $chasse_linked = get_field('indice_chasse_linked', $indice_id);
+        if (is_array($chasse_linked)) {
+            $first     = $chasse_linked[0] ?? null;
+            $chasse_id = is_array($first) ? (int) ($first['ID'] ?? 0) : (int) $first;
+        } else {
+            $chasse_id = (int) $chasse_linked;
+        }
+
+        if (!$chasse_id && $objet_id) {
+            $chasse_id = (int) recuperer_id_chasse_associee($objet_id);
         }
     } else {
         $linked = get_field('indice_chasse_linked', $indice_id);
@@ -773,6 +786,9 @@ function supprimer_indice_ajax(): void
     }
 
     reordonner_indices($objet_id, $cible_type);
+    if ($cible_type === 'enigme' && $chasse_id) {
+        reordonner_indices($chasse_id, 'chasse');
+    }
 
     wp_send_json_success();
 }


### PR DESCRIPTION
## Résumé
Assure la renumérotation des indices de la chasse et de l'énigme lorsqu'un indice d'énigme est supprimé via AJAX.

## Changements notables
- Récupère l'ID de la chasse associée et réordonne les indices de la chasse et de l'énigme.
- Ajoute un test vérifiant la renumérotation des indices côté chasse et énigme après suppression.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aaca5977e08332b0183be30cb900e3