### PR TITLE
fix: restore index text toggle in hunt edit

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -30,7 +30,14 @@ function enqueue_script_chasse_edit()
   }
 
   // Enfile les scripts nécessaires
-  enqueue_core_edit_scripts(['chasse-edit', 'chasse-stats', 'table-etiquette', 'indices-pager', 'indices-create']);
+  enqueue_core_edit_scripts([
+    'chasse-edit',
+    'chasse-stats',
+    'table-etiquette',
+    'tentatives-toggle',
+    'indices-pager',
+    'indices-create',
+  ]);
   wp_localize_script(
     'chasse-stats',
     'ChasseStats',


### PR DESCRIPTION
## Summary
- charger le script de bascule de texte dans le panneau d'édition de chasse

## Notable Changes
- ajout du script `tentatives-toggle` pour permettre l'ouverture des textes longs dans la table des indices

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aacb57828883328bb235ccae774f48