### PR TITLE
Center action column in indices table

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -290,6 +290,11 @@ tbody tr:nth-child(even) {
   margin-top: 0.25rem;
 }
 
+.indices-table th.indice-actions,
+.indices-table td.indice-actions {
+  text-align: center;
+}
+
 .indices-table-header {
   margin-bottom: 0.5rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5401,6 +5401,11 @@ tbody tr:nth-child(even) {
   margin-top: 0.25rem;
 }
 
+.indices-table th.indice-actions,
+.indices-table td.indice-actions {
+  text-align: center;
+}
+
 .indices-table-header {
   margin-bottom: 0.5rem;
 }

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -56,7 +56,7 @@ if (empty($indices)) {
             <th><?= esc_html__('Indice', 'chassesautresor-com'); ?></th>
             <th><?= esc_html__('Texte', 'chassesautresor-com'); ?></th>
             <th><?= esc_html__('Indice pour', 'chassesautresor-com'); ?></th>
-            <th><?= esc_html__('Action', 'chassesautresor-com'); ?></th>
+            <th class="indice-actions"><?= esc_html__('Action', 'chassesautresor-com'); ?></th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- Centre l'en-tête et le contenu de la colonne Action dans le tableau des indices

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aacbc743b083329b4c9fba4650ea28