### PR TITLE
Center indices table rows vertically

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -280,10 +280,7 @@ tbody tr:nth-child(even) {
 .indices-table th,
 .indices-table td {
   text-align: left;
-}
-
-.indices-table td {
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .indices-table td > div + div {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5391,10 +5391,7 @@ tbody tr:nth-child(even) {
 .indices-table th,
 .indices-table td {
   text-align: left;
-}
-
-.indices-table td {
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .indices-table td > div + div {


### PR DESCRIPTION
## Summary
- centre verticalement les cellules du tableau d'indices

## Testing
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aacd9d872c83328e7d7016be78ba62