### PR TITLE
Augmente le contraste des lignes impaires de la table de stats

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -217,7 +217,7 @@ tbody tr:nth-child(even) {
 }
 
 .stats-table tbody tr:nth-child(odd) {
-  background-color: rgba(0, 0, 0, 0.02);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .stats-table-wrapper {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5328,7 +5328,7 @@ tbody tr:nth-child(even) {
 }
 
 .stats-table tbody tr:nth-child(odd) {
-  background-color: rgba(0, 0, 0, 0.02);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .stats-table-wrapper {


### PR DESCRIPTION
## Résumé
- Amélioration du contraste des lignes impaires des tableaux de statistiques.
- Regénération du CSS compilé du thème.

## Changements notables
- Accentuation de la couleur de fond des lignes impaires dans `.stats-table`.
- Recompilation des fichiers CSS via `build-css.js`.

## Testing
- `npm ci`
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aacfe06b148332b51b7f1b8bab5a92