### PR TITLE
Dispatch indice-created event on index changes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -42,7 +42,9 @@ function rafraichirCarteIndices() {
         card.classList.remove('loading');
         card.innerHTML = `<p class="error">${ChasseIndices.errorText}</p>`;
       });
-  }
+}
+
+window.rafraichirCarteIndices = rafraichirCarteIndices;
 
   function initIndicesOptions(card) {
     if (!card) return;

--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -231,6 +231,7 @@
                 parseInt(chasseBtn.dataset.indiceRang, 10) + 1;
             }
           }
+          window.dispatchEvent(new Event('indice-created'));
         });
     });
 

--- a/wp-content/themes/chassesautresor/assets/js/indices-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-pager.js
@@ -57,6 +57,7 @@
       .then(function (res) {
         if (!res.success) return;
         reloadTable(wrapper);
+        window.dispatchEvent(new Event('indice-created'));
       });
   });
 })();


### PR DESCRIPTION
## Résumé
- émet l’événement `indice-created` après création ou modification d’un indice
- déclenche le même événement après suppression d’un indice
- expose `rafraichirCarteIndices` pour permettre un rafraîchissement manuel

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aad20bf1c08332877988d9bfef97e3