### PR TITLE
Add error handling for indices operations

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -196,6 +196,8 @@
       e.preventDefault();
       var form = e.target;
       var data = new FormData(form);
+      validateBtn.disabled = true;
+      stateMessage.textContent = '';
       fetch(indicesCreate.ajaxUrl, { method: 'POST', credentials: 'same-origin', body: data })
         .then(function (r) { return r.json(); })
         .then(function (res) {
@@ -232,6 +234,10 @@
             }
           }
           window.dispatchEvent(new Event('indice-created'));
+        })
+        .catch(function () {
+          stateMessage.textContent = indicesCreate.texts.ajaxError;
+          validateBtn.disabled = false;
         });
     });
 

--- a/wp-content/themes/chassesautresor/assets/js/indices-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-pager.js
@@ -18,6 +18,15 @@
         wrapper.innerHTML = res.data.html;
         wrapper.dataset.page = String(res.data.page);
         wrapper.dataset.pages = String(res.data.pages);
+      })
+      .catch(function () {
+        var txt =
+          window.indicesCreate &&
+          indicesCreate.texts &&
+          indicesCreate.texts.ajaxError
+            ? indicesCreate.texts.ajaxError
+            : wp.i18n.__('Erreur réseau', 'chassesautresor-com');
+        wrapper.innerHTML = '<p class="error">' + txt + '</p>';
       });
   }
 
@@ -58,6 +67,15 @@
         if (!res.success) return;
         reloadTable(wrapper);
         window.dispatchEvent(new Event('indice-created'));
+      })
+      .catch(function () {
+        var txt =
+          window.indicesCreate &&
+          indicesCreate.texts &&
+          indicesCreate.texts.ajaxError
+            ? indicesCreate.texts.ajaxError
+            : wp.i18n.__('Erreur réseau', 'chassesautresor-com');
+        wrapper.innerHTML = '<p class="error">' + txt + '</p>';
       });
   });
 })();

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -164,6 +164,7 @@ function enqueue_core_edit_scripts(array $additional = [])
             'needContent' => __('Au moins une image ou un texte nécessaire', 'chassesautresor-com'),
             'needDate'    => __('Date et heure requises', 'chassesautresor-com'),
             'invalidDate' => __('Date invalide', 'chassesautresor-com'),
+            'ajaxError'   => __('Erreur réseau', 'chassesautresor-com'),
           ],
         ]
       );


### PR DESCRIPTION
Ajoute la gestion des erreurs réseau pour les opérations sur les indices.

- Affiche un message d'erreur lors du rechargement ou de la suppression des indices.
- Gère les erreurs d'envoi dans la modale de création d'indice et réactive le bouton de validation.
- Centralise le texte d'erreur via `indicesCreate.texts`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml` — OK (69 tests, 164 assertions)


------
https://chatgpt.com/codex/tasks/task_e_68aadc3aae908332812c0f36e029e828