### PR TITLE
Limite la table des indices à huit éléments

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/pager.js
@@ -31,7 +31,9 @@
      if (select) {
        select.value = String(current);
      }
-     pager.dispatchEvent(new CustomEvent('pager:change', { detail: { page: current } }));
+    pager.dispatchEvent(
+      new CustomEvent('pager:change', { detail: { page: current }, bubbles: true })
+    );
    });
  
    document.body.addEventListener('change', (e) => {
@@ -45,6 +47,8 @@
      }
      const page = parseInt(select.value, 10);
      pager.dataset.current = String(page);
-     pager.dispatchEvent(new CustomEvent('pager:change', { detail: { page } }));
-   });
- });
+    pager.dispatchEvent(
+      new CustomEvent('pager:change', { detail: { page }, bubbles: true })
+    );
+  });
+});

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -462,7 +462,7 @@ function ajax_indices_lister_table(): void
         wp_send_json_error('acces_refuse');
     }
 
-    $per_page = 10;
+    $per_page = 8;
     if ($objet_type === 'chasse') {
         $enigme_ids = recuperer_ids_enigmes_pour_chasse($objet_id);
         $meta       = [

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -872,7 +872,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             </div>
 
             <?php
-            $par_page_indices = 10;
+            $par_page_indices = 8;
             $page_indices     = 1;
             $enigme_ids       = recuperer_ids_enigmes_pour_chasse($chasse_id);
             $meta             = [

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -960,7 +960,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     ?>
                   </div>
                   <?php
-                  $par_page_indices = 10;
+                  $par_page_indices = 8;
                   $page_indices     = 1;
                   $indices_query    = new WP_Query([
                     'post_type'      => 'indice',


### PR DESCRIPTION
## Résumé
- Limite les tableaux d'indices à huit lignes par page
- Confirme l'utilisation du pager du thème pour naviguer dans ces tableaux

## Changements
- Ajuste la pagination des indices à 8 éléments
- Préserve le pager `cta_render_pager` pour la navigation

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aae17b8f788332ad0a35d96c268f61