### PR TITLE
feat: ajouter bloc visuels pour l'animation des chasses

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -32,7 +32,14 @@ const html = `
       </div>
     </template>
   </div>
-  <div id="chasse-tab-animation"></div>
+  <div id="chasse-tab-animation">
+    <div class="dashboard-card carte-orgy champ-visuels">
+      <p id="visuels-texte">Texte à copier</p>
+      <button type="button" class="copier-btn" data-copy-target="#visuels-texte">Copier</button>
+      <p id="visuels-complet">Message complet</p>
+      <button type="button" class="copier-btn" data-copy-target="#visuels-complet">Copier</button>
+    </div>
+  </div>
 `;
 
 describe('chasse-edit UI', () => {
@@ -50,6 +57,8 @@ describe('chasse-edit UI', () => {
     global.initChampNbGagnants = jest.fn();
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
     global.wp = { i18n: { __: (s) => s } };
+    global.navigator = global.navigator || {};
+    global.navigator.clipboard = { writeText: jest.fn() };
     jest.resetModules();
     require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');
   });
@@ -105,5 +114,13 @@ describe('chasse-edit UI', () => {
     expect(message).not.toBeNull();
     expect(message.textContent).toContain('Alice');
     expect(message.textContent).toContain('02/01/2024');
+  });
+
+  test('visuels block present and copy works', () => {
+    const bloc = document.querySelector('#chasse-tab-animation .champ-visuels');
+    expect(bloc).not.toBeNull();
+    const btn = bloc.querySelector('button[data-copy-target="#visuels-texte"]');
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Texte à copier');
   });
 });

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -597,12 +597,30 @@ window.rafraichirCarteIndices = rafraichirCarteIndices;
           }
         });
     }
-    });
+  });
 
-    window.addEventListener('message', (e) => {
-      if (e.data && (e.data.type === 'indice-created' || e.data === 'indice-created')) {
-        rafraichirCarteIndices();
-      }
+  // ==============================
+  // 📋 Copie visuels
+  // ==============================
+  const blocVisuels = document.querySelector('.champ-visuels');
+  if (blocVisuels) {
+    blocVisuels.querySelectorAll('button[data-copy-target]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const sel = btn.getAttribute('data-copy-target');
+        const cible = sel ? blocVisuels.querySelector(sel) : null;
+        if (!cible) return;
+        const texte = cible.textContent || cible.value || '';
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(texte);
+        }
+      });
+    });
+  }
+
+  window.addEventListener('message', (e) => {
+    if (e.data && (e.data.type === 'indice-created' || e.data === 'indice-created')) {
+      rafraichirCarteIndices();
+    }
     });
     window.addEventListener('indice-created', rafraichirCarteIndices);
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -2232,3 +2232,39 @@ body.panneau-ouvert::before {
 .indice-modal-form .image-preview .image-actions button:hover {
     background-color: rgba(var(--color-black-rgb), 0.8);
 }
+
+/* ========== 🎨 VISUELS PARTAGE ========== */
+.champ-visuels {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+}
+
+.champ-visuels .visuel-web {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    align-items: center;
+}
+
+.champ-visuels .visuel-image,
+.champ-visuels .visuel-qr {
+    max-width: 150px;
+    height: auto;
+}
+
+.champ-visuels .visuel-contenu {
+    flex: 1;
+    min-width: 200px;
+}
+
+.champ-visuels .visuel-description {
+    font-size: clamp(0.85rem, 2.5vw, 1rem);
+}
+
+@media (max-width: 600px) {
+    .champ-visuels .visuel-web {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3871,6 +3871,41 @@ body.panneau-ouvert::before {
   background-color: rgba(var(--color-black-rgb), 0.8);
 }
 
+/* ========== 🎨 VISUELS PARTAGE ========== */
+.champ-visuels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.champ-visuels .visuel-web {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: center;
+}
+
+.champ-visuels .visuel-image,
+.champ-visuels .visuel-qr {
+  max-width: 150px;
+  height: auto;
+}
+
+.champ-visuels .visuel-contenu {
+  flex: 1;
+  min-width: 200px;
+}
+
+.champ-visuels .visuel-description {
+  font-size: clamp(0.85rem, 2.5vw, 1rem);
+}
+
+@media (max-width: 600px) {
+  .champ-visuels .visuel-web {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
 /* Layout for enigma pages */
 .enigme-layout {
   display: grid;

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -267,6 +267,7 @@ require_once $inc_path . 'relations-functions.php';
 require_once $inc_path . 'layout-functions.php';
 require_once $inc_path . 'myaccount-functions.php';
 require_once $inc_path . 'utils/liens.php';
+require_once $inc_path . 'utils/qr.php';
 require_once $inc_path . 'chasse/stats.php';
 require_once $inc_path . 'organisateur/stats.php';
 require_once $inc_path . 'pager.php';

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1209,3 +1209,50 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
 
     return $memo[$cache_key];
 }
+
+/**
+ * Retrieve visual data for a hunt.
+ *
+ * @param int $chasse_id Hunt ID.
+ * @return array<string,mixed>
+ */
+function chasse_get_visuels_data(int $chasse_id): array
+{
+    $image_id = get_field('chasse_principale_image', $chasse_id);
+    $image_url = '';
+    if ($image_id) {
+        $image_data = wp_get_attachment_image_src($image_id, 'large');
+        if ($image_data) {
+            $image_url = $image_data[0];
+        }
+    }
+
+    $qr_url = cat_get_qr_code_url(get_permalink($chasse_id));
+
+    $organisateur_id   = get_organisateur_from_chasse($chasse_id);
+    $organisateur_titre = get_the_title($organisateur_id);
+    $logo_id           = get_field('organisateur_principale_logo', $organisateur_id);
+    $logo_url          = $logo_id ? wp_get_attachment_image_url($logo_id, 'thumbnail') : '';
+    $description       = get_field('organisateur_principale_description', $organisateur_id) ?? '';
+
+    $liens = get_field('chasse_principale_liens', $chasse_id);
+    if (empty($liens)) {
+        $liens = get_field('organisateur_principale_liens', $organisateur_id) ?: [];
+    }
+    $liens_html = render_liens_publics($liens, 'chasse', ['placeholder' => false]);
+
+    return [
+        'image'       => $image_url,
+        'qr'          => $qr_url,
+        'titre'       => get_the_title($chasse_id),
+        'organisateur_titre' => $organisateur_titre,
+        'logo'        => $logo_url,
+        'description' => $description,
+        'liens'       => $liens_html,
+        'texte'       => sprintf(
+            /* translators: %s: hunt title */
+            __('Découvrez la chasse "%s" sur Chasses au trésor !', 'chassesautresor-com'),
+            get_the_title($chasse_id)
+        ),
+    ];
+}

--- a/wp-content/themes/chassesautresor/inc/utils/qr.php
+++ b/wp-content/themes/chassesautresor/inc/utils/qr.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * QR code utilities.
+ *
+ * @package chassesautresor.com
+ */
+
+defined('ABSPATH') || exit;
+
+/**
+ * Builds a QR code URL for a target URL.
+ *
+ * @param string $target URL to encode.
+ * @param string $format Output format (png|svg|eps).
+ * @param string $size   Size in WIDTHxHEIGHT format.
+ *
+ * @return string
+ */
+function cat_get_qr_code_url(string $target, string $format = 'png', string $size = '400x400'): string
+{
+    $allowed = ['png', 'svg', 'eps'];
+    if (!in_array($format, $allowed, true)) {
+        $format = 'png';
+    }
+
+    $base   = 'https://api.qrserver.com/v1/create-qr-code/';
+    $params = [
+        'size'   => $size,
+        'data'   => $target,
+        'format' => $format,
+    ];
+
+    return $base . '?' . http_build_query($params);
+}

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -964,6 +964,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               ]);
               ?>
             </div>
+            <div class="dashboard-card carte-orgy champ-visuels">
+              <?php get_template_part('template-parts/chasse/partials/chasse-partial-visuels', null, [
+                'chasse_id' => $chasse_id,
+              ]); ?>
+            </div>
           </div>
         </div>
       </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-visuels.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-visuels.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Visual share block for a hunt.
+ *
+ * Variables:
+ * - $chasse_id (int)
+ *
+ * @package chassesautresor.com
+ */
+
+defined('ABSPATH') || exit;
+
+$args      = $args ?? [];
+$chasse_id = $args['chasse_id'] ?? 0;
+$visuels   = chasse_get_visuels_data($chasse_id);
+?>
+<div class="visuel-web">
+    <?php if ($visuels['image']) : ?>
+        <img class="visuel-image" src="<?= esc_url($visuels['image']); ?>" alt="">
+    <?php endif; ?>
+    <div class="visuel-contenu">
+        <?php if ($visuels['logo']) : ?>
+            <img class="visuel-logo" src="<?= esc_url($visuels['logo']); ?>" alt="">
+        <?php endif; ?>
+        <h4 class="visuel-titre"><?= esc_html($visuels['titre']); ?></h4>
+        <p class="visuel-description" id="visuels-description"><?= esc_html($visuels['description']); ?></p>
+        <?= $visuels['liens']; ?>
+        <img class="visuel-qr" src="<?= esc_url($visuels['qr']); ?>" alt="QR">
+    </div>
+</div>
+<p class="visuel-texte" id="visuels-texte"><?= esc_html($visuels['texte']); ?></p>
+<button type="button" class="bouton-cta copier-btn copier-texte" data-copy-target="#visuels-texte">
+    <?= esc_html__('Copier le texte', 'chassesautresor-com'); ?>
+</button>
+<div class="visuel-message-complet" id="visuels-complet">
+    <p><?= esc_html($visuels['texte']); ?></p>
+    <img class="visuel-image" src="<?= esc_url($visuels['image']); ?>" alt="">
+    <img class="visuel-qr" src="<?= esc_url($visuels['qr']); ?>" alt="QR">
+    <?= $visuels['liens']; ?>
+</div>
+<button type="button" class="bouton-cta copier-btn copier-complet" data-copy-target="#visuels-complet">
+    <?= esc_html__('Copier le message complet', 'chassesautresor-com'); ?>
+</button>
+<p class="visuel-qr-brut">
+    <a href="<?= esc_url($visuels['qr']); ?>" target="_blank" rel="noopener">
+        <?= esc_html__('QR code brut', 'chassesautresor-com'); ?>
+    </a>
+</p>


### PR DESCRIPTION
## Résumé
- centralisation de la génération d'URL de QR code
- nouveau bloc "Visuels" dans l'onglet Animation avec contenu prêt à copier
- styles responsives et gestion JS de la copie

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aae0ec23ac83328d34733b60378d40