### PR TITLE
Centraliser la génération d'URL de QR code

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -2169,7 +2169,7 @@ function envoyer_mail_chasse_validee(int $organisateur_id, int $chasse_id)
     $admin_email = get_option('admin_email');
     $titre_chasse = get_the_title($chasse_id);
     $url_chasse   = get_permalink($chasse_id);
-    $url_qr_code  = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data=' . rawurlencode($url_chasse);
+    $url_qr_code  = get_qr_code_url($chasse_id);
 
     $subject_raw = '✅ Votre chasse est maintenant validée !';
     $subject = function_exists('wp_encode_mime_header')

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -12,6 +12,7 @@ defined('ABSPATH') || exit;
 // 📦 FONCTIONS LIÉES À UNE CHASSE
 // ==================================================
 /**
+ * 🔹 get_qr_code_url → Build a QR code URL for a post.
  * 🔹 recuperer_infos_chasse → Récupérer les informations essentielles d’une chasse.
  * 🔹 chasse_get_champs → Récupérer les champs principaux et cachés structurés d'une chasse
  * 🔹 verifier_souscription_chasse → Vérifier si un utilisateur souscrit à une chasse pour la première fois en souscrivant à une énigme.
@@ -23,6 +24,25 @@ defined('ABSPATH') || exit;
  */
 
 
+/**
+ * Build a QR code URL for a post.
+ *
+ * @param int    $post_id Post ID.
+ * @param string $format  Output format.
+ *
+ * @return string
+ */
+function get_qr_code_url(int $post_id, string $format = 'png'): string
+{
+    $allowed = ['png', 'svg', 'eps'];
+    if (!in_array($format, $allowed, true)) {
+        $format = 'png';
+    }
+
+    $target = get_permalink($post_id);
+
+    return cat_get_qr_code_url($target, $format);
+}
 
 /**
  * Récupère les informations essentielles d'une chasse.

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -852,14 +852,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   && ($infos_chasse['statut_validation'] ?? '') === 'valide'
               ) :
                   $format = isset($_GET['format']) ? sanitize_key($_GET['format']) : 'png';
-                  $formats_autorises = ['png', 'svg', 'eps'];
-                  if (!in_array($format, $formats_autorises, true)) {
-                      $format = 'png';
-                  }
-                  $url = get_permalink($chasse_id);
-                  $url_qr_code = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data='
-                      . rawurlencode($url)
-                      . '&format=' . $format;
+                  $url_qr_code = get_qr_code_url($chasse_id, $format);
               ?>
               <div class="dashboard-card carte-orgy champ-qr-code">
                 <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de la chasse', 'chassesautresor-com'); ?>">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -368,14 +368,7 @@ $is_complete = (
                   </div>
                   <?php
                   $format = isset($_GET['format']) ? sanitize_key($_GET['format']) : 'png';
-                  $formats_autorises = ['png', 'svg', 'eps'];
-                  if (!in_array($format, $formats_autorises, true)) {
-                      $format = 'png';
-                  }
-                  $url = get_permalink($organisateur_id);
-                  $url_qr_code = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data='
-                      . rawurlencode($url)
-                      . '&format=' . $format;
+                  $url_qr_code = get_qr_code_url($organisateur_id, $format);
                   ?>
                   <div class="dashboard-card carte-orgy champ-qr-code">
                     <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de l\'organisation', 'chassesautresor-com'); ?>">


### PR DESCRIPTION
## Résumé
- Centralise la génération d'URL de QR code dans une fonction utilitaire
- Remplace les constructions inline par cette fonction dans les templates et fonctions admin

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aae2fd74ac8332838076403ed7a1df