### PR TITLE
Ajout des boutons de copie pour les visuels

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -35,9 +35,9 @@ const html = `
   <div id="chasse-tab-animation">
     <div class="dashboard-card carte-orgy champ-visuels">
       <p id="visuels-texte">Texte à copier</p>
-      <button type="button" class="copier-btn" data-copy-target="#visuels-texte">Copier</button>
+      <button type="button" class="copy-message" data-target="#visuels-texte">Copier</button>
       <p id="visuels-complet">Message complet</p>
-      <button type="button" class="copier-btn" data-copy-target="#visuels-complet">Copier</button>
+      <button type="button" class="copy-message" data-target="#visuels-complet">Copier</button>
     </div>
   </div>
 `;
@@ -58,7 +58,7 @@ describe('chasse-edit UI', () => {
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
     global.wp = { i18n: { __: (s) => s } };
     global.navigator = global.navigator || {};
-    global.navigator.clipboard = { writeText: jest.fn() };
+    global.navigator.clipboard = { writeText: jest.fn().mockResolvedValue(undefined) };
     jest.resetModules();
     require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');
   });
@@ -119,7 +119,7 @@ describe('chasse-edit UI', () => {
   test('visuels block present and copy works', () => {
     const bloc = document.querySelector('#chasse-tab-animation .champ-visuels');
     expect(bloc).not.toBeNull();
-    const btn = bloc.querySelector('button[data-copy-target="#visuels-texte"]');
+    const btn = bloc.querySelector('button[data-target="#visuels-texte"]');
     btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Texte à copier');
   });

--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -123,4 +123,14 @@ describe('chasse-edit UI', () => {
     btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Texte à copier');
   });
+
+  test('copy works for dynamically added button', () => {
+    const newBtn = document.createElement('button');
+    newBtn.type = 'button';
+    newBtn.className = 'copy-message';
+    newBtn.dataset.target = '#visuels-texte';
+    document.querySelector('#chasse-tab-animation .champ-visuels').appendChild(newBtn);
+    newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Texte à copier');
+  });
 });

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -611,19 +611,17 @@ window.rafraichirCarteIndices = rafraichirCarteIndices;
   // ==============================
   // 📋 Copie visuels
   // ==============================
-  document.querySelectorAll('.copy-message').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const target = btn.dataset.target;
-      if (!target) {
-        return;
-      }
-      copyToClipboard(target).then(() => {
-        const original = btn.innerHTML;
-        btn.innerHTML = wp.i18n.__('Copié !', 'chassesautresor-com');
-        setTimeout(() => {
-          btn.innerHTML = original;
-        }, 2000);
-      });
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.copy-message');
+    if (!btn) return;
+    const target = btn.dataset.target;
+    if (!target) return;
+    copyToClipboard(target).then(() => {
+      const original = btn.innerHTML;
+      btn.innerHTML = wp.i18n.__('Copié !', 'chassesautresor-com');
+      setTimeout(() => {
+        btn.innerHTML = original;
+      }, 2000);
     });
   });
 

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -8,6 +8,15 @@ let erreurDebut;
 let erreurFin;
 let checkboxIllimitee;
 
+function copyToClipboard(selector) {
+  const element = document.querySelector(selector);
+  if (!element || !navigator.clipboard) {
+    return Promise.reject();
+  }
+  const text = element.value || element.textContent || '';
+  return navigator.clipboard.writeText(text);
+}
+
 function rafraichirCarteIndices() {
   const card = document.querySelector('.dashboard-card.champ-indices');
   if (!card || !window.ChasseIndices) return;
@@ -602,20 +611,21 @@ window.rafraichirCarteIndices = rafraichirCarteIndices;
   // ==============================
   // 📋 Copie visuels
   // ==============================
-  const blocVisuels = document.querySelector('.champ-visuels');
-  if (blocVisuels) {
-    blocVisuels.querySelectorAll('button[data-copy-target]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const sel = btn.getAttribute('data-copy-target');
-        const cible = sel ? blocVisuels.querySelector(sel) : null;
-        if (!cible) return;
-        const texte = cible.textContent || cible.value || '';
-        if (navigator.clipboard) {
-          navigator.clipboard.writeText(texte);
-        }
+  document.querySelectorAll('.copy-message').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.target;
+      if (!target) {
+        return;
+      }
+      copyToClipboard(target).then(() => {
+        const original = btn.innerHTML;
+        btn.innerHTML = wp.i18n.__('Copié !', 'chassesautresor-com');
+        setTimeout(() => {
+          btn.innerHTML = original;
+        }, 2000);
       });
     });
-  }
+  });
 
   window.addEventListener('message', (e) => {
     if (e.data && (e.data.type === 'indice-created' || e.data === 'indice-created')) {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-visuels.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-visuels.php
@@ -24,13 +24,26 @@ $visuels   = chasse_get_visuels_data($chasse_id);
         <?php endif; ?>
         <h4 class="visuel-titre"><?= esc_html($visuels['titre']); ?></h4>
         <p class="visuel-description" id="visuels-description"><?= esc_html($visuels['description']); ?></p>
+        <button
+            type="button"
+            class="copy-message"
+            data-target="#visuels-description"
+            aria-label="<?= esc_attr__('Copier', 'chassesautresor-com'); ?>"
+        >
+            <?= esc_html__('Copier', 'chassesautresor-com'); ?>
+        </button>
         <?= $visuels['liens']; ?>
         <img class="visuel-qr" src="<?= esc_url($visuels['qr']); ?>" alt="QR">
     </div>
 </div>
 <p class="visuel-texte" id="visuels-texte"><?= esc_html($visuels['texte']); ?></p>
-<button type="button" class="bouton-cta copier-btn copier-texte" data-copy-target="#visuels-texte">
-    <?= esc_html__('Copier le texte', 'chassesautresor-com'); ?>
+<button
+    type="button"
+    class="copy-message"
+    data-target="#visuels-texte"
+    aria-label="<?= esc_attr__('Copier', 'chassesautresor-com'); ?>"
+>
+    <?= esc_html__('Copier', 'chassesautresor-com'); ?>
 </button>
 <div class="visuel-message-complet" id="visuels-complet">
     <p><?= esc_html($visuels['texte']); ?></p>
@@ -38,8 +51,13 @@ $visuels   = chasse_get_visuels_data($chasse_id);
     <img class="visuel-qr" src="<?= esc_url($visuels['qr']); ?>" alt="QR">
     <?= $visuels['liens']; ?>
 </div>
-<button type="button" class="bouton-cta copier-btn copier-complet" data-copy-target="#visuels-complet">
-    <?= esc_html__('Copier le message complet', 'chassesautresor-com'); ?>
+<button
+    type="button"
+    class="copy-message"
+    data-target="#visuels-complet"
+    aria-label="<?= esc_attr__('Copier', 'chassesautresor-com'); ?>"
+>
+    <?= esc_html__('Copier', 'chassesautresor-com'); ?>
 </button>
 <p class="visuel-qr-brut">
     <a href="<?= esc_url($visuels['qr']); ?>" target="_blank" rel="noopener">


### PR DESCRIPTION
## Résumé
Ajout de la fonctionnalité de copie dans le panneau visuels.

## Changements
- Ajout des boutons de copie pour chaque zone texte
- Fonction `copyToClipboard` avec retour visuel
- Tests Jest mis à jour

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm install`
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aae475a9688332a0d7595189099574