### PR TITLE
Applique un layout fixe au tableau des indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -277,6 +277,11 @@ tbody tr:nth-child(even) {
 }
 
 /* Indices table */
+.indices-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
 .indices-table th,
 .indices-table td {
   text-align: left;
@@ -285,6 +290,31 @@ tbody tr:nth-child(even) {
 
 .indices-table td > div + div {
   margin-top: 0.25rem;
+}
+
+.indices-table th:first-child,
+.indices-table td:first-child {
+  width: 15%;
+}
+
+.indices-table th:nth-child(2),
+.indices-table td:nth-child(2) {
+  width: 25%;
+}
+
+.indices-table th:nth-child(3),
+.indices-table td:nth-child(3) {
+  width: 30%;
+}
+
+.indices-table th:nth-child(4),
+.indices-table td:nth-child(4) {
+  width: 20%;
+}
+
+.indices-table th:nth-child(5),
+.indices-table td:nth-child(5) {
+  width: 10%;
 }
 
 .indices-table th.indice-actions,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5388,6 +5388,11 @@ tbody tr:nth-child(even) {
 }
 
 /* Indices table */
+.indices-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
 .indices-table th,
 .indices-table td {
   text-align: left;
@@ -5396,6 +5401,31 @@ tbody tr:nth-child(even) {
 
 .indices-table td > div + div {
   margin-top: 0.25rem;
+}
+
+.indices-table th:first-child,
+.indices-table td:first-child {
+  width: 15%;
+}
+
+.indices-table th:nth-child(2),
+.indices-table td:nth-child(2) {
+  width: 25%;
+}
+
+.indices-table th:nth-child(3),
+.indices-table td:nth-child(3) {
+  width: 30%;
+}
+
+.indices-table th:nth-child(4),
+.indices-table td:nth-child(4) {
+  width: 20%;
+}
+
+.indices-table th:nth-child(5),
+.indices-table td:nth-child(5) {
+  width: 10%;
 }
 
 .indices-table th.indice-actions,


### PR DESCRIPTION
## Résumé
- fixe le layout de la table des indices avec des colonnes proportionnées
- met à jour les styles compilés

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ab518429dc83329907d0195bd2c523