### PR TITLE
Fix card alignment in animation tab

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1594,7 +1594,6 @@ body.panneau-ouvert::before {
 .dashboard-card.champ-indices .stat-value {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
 }
 
 .dashboard-card.champ-indices .stat-value .bouton-cta {
@@ -1607,6 +1606,7 @@ body.panneau-ouvert::before {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  margin-top: var(--space-xs);
   opacity: 0;
   max-height: 0;
   overflow: hidden;

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1596,7 +1596,8 @@ body.panneau-ouvert::before {
   flex-direction: column;
 }
 
-.dashboard-card.champ-indices .stat-value .bouton-cta {
+.dashboard-card.champ-indices .stat-value .bouton-cta,
+.dashboard-card.champ-liens .bouton-cta {
   display: block;
   width: 100%;
   margin-top: 0;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3240,7 +3240,9 @@ body.panneau-ouvert::before {
   flex-direction: column;
 }
 
-.dashboard-card.champ-indices .stat-value .bouton-cta, .champ-indices.carte-orgy .stat-value .bouton-cta {
+.dashboard-card.champ-indices .stat-value .bouton-cta, .champ-indices.carte-orgy .stat-value .bouton-cta,
+.dashboard-card.champ-liens .bouton-cta,
+.champ-liens.carte-orgy .bouton-cta {
   display: block;
   width: 100%;
   margin-top: 0;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3238,7 +3238,6 @@ body.panneau-ouvert::before {
 .dashboard-card.champ-indices .stat-value, .champ-indices.carte-orgy .stat-value {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
 }
 
 .dashboard-card.champ-indices .stat-value .bouton-cta, .champ-indices.carte-orgy .stat-value .bouton-cta {
@@ -3251,6 +3250,7 @@ body.panneau-ouvert::before {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  margin-top: var(--space-xs);
   opacity: 0;
   max-height: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary
Corrige l'alignement du contenu des cartes dans l'onglet Animation de l'édition de chasse.

## Changes
- Supprime l'espacement interne de la carte d'ajout d'indice et ajoute une marge conditionnelle aux options
- Recompile la feuille de style du thème

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab525965748332a8009ab9c259edd1