### PR TITLE
Add solution card and QR code block

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1139,3 +1139,14 @@ qrDownloadBtn?.addEventListener('click', (e) => {
       window.location.href = url;
     });
 });
+
+// ================================
+// 🔗 Défilement doux vers la section Solution
+// ================================
+const solutionLink = document.querySelector('.champ-solution .bouton-cta[href="#solution"]');
+solutionLink?.addEventListener('click', (e) => {
+  e.preventDefault();
+  document
+    .querySelector('#chasse-tab-animation #solution')
+    ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1113,3 +1113,29 @@ function enregistrerDatesChasse() {
     });
 }
 window.enregistrerDatesChasse = enregistrerDatesChasse;
+
+// ================================
+// 📥 Téléchargement du QR code sans redirection
+// ================================
+const qrDownloadBtn = document.querySelector('.qr-code-download');
+qrDownloadBtn?.addEventListener('click', (e) => {
+  e.preventDefault();
+  const url = qrDownloadBtn.getAttribute('href');
+  const filename = qrDownloadBtn.getAttribute('download') || 'qr-code.png';
+
+  fetch(url)
+    .then(res => res.blob())
+    .then(blob => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(link.href);
+    })
+    .catch(err => {
+      console.error('Erreur téléchargement QR code', err);
+      window.location.href = url;
+    });
+});

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -149,6 +149,28 @@
   margin-bottom: var(--space-xs);
 }
 
+.qr-code-block {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-md);
+  margin-top: var(--space-lg);
+}
+
+.qr-code-block .qr-code-image {
+  flex: 0 0 200px;
+}
+
+.qr-code-block .qr-code-image img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.qr-code-block .qr-code-content h3 {
+  margin-top: 0;
+}
+
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */
 
 .champ-edition {

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -153,7 +153,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-md);
+  column-gap: calc(4 * var(--space-xl));
+  row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1855,6 +1855,28 @@ a[aria-disabled=true] {
   margin-bottom: var(--space-xs);
 }
 
+.qr-code-block {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-md);
+  margin-top: var(--space-lg);
+}
+
+.qr-code-block .qr-code-image {
+  flex: 0 0 200px;
+}
+
+.qr-code-block .qr-code-image img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.qr-code-block .qr-code-content h3 {
+  margin-top: 0;
+}
+
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */
 .champ-edition {
   display: flex;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1859,7 +1859,9 @@ a[aria-disabled=true] {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-md);
+  -moz-column-gap: calc(4 * var(--space-xl));
+       column-gap: calc(4 * var(--space-xl));
+  row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
 

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2253,3 +2253,19 @@ msgstr ""
 msgid "à %s"
 msgstr ""
 
+#: template-parts/chasse/chasse-edition-main.php:867 template-parts/chasse/chasse-edition-main.php:986
+msgid "Solution"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:974
+msgid "Partagez votre chasse en un scan"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:975
+msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:987
+msgid "Contenu de la solution à venir."
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2501,3 +2501,19 @@ msgstr "Hint"
 msgid "à %s"
 msgstr "at %s"
 
+#: template-parts/chasse/chasse-edition-main.php:867 template-parts/chasse/chasse-edition-main.php:986
+msgid "Solution"
+msgstr "Solution"
+
+#: template-parts/chasse/chasse-edition-main.php:974
+msgid "Partagez votre chasse en un scan"
+msgstr "Share your hunt with a single scan"
+
+#: template-parts/chasse/chasse-edition-main.php:975
+msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
+msgstr "Make access to your hunt easy with a simple scan. A QR code avoids typing a URL and is easy to share."
+
+#: template-parts/chasse/chasse-edition-main.php:987
+msgid "Contenu de la solution à venir."
+msgstr "Solution content coming soon."
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2431,3 +2431,19 @@ msgstr "Indice"
 msgid "à %s"
 msgstr "à %s"
 
+#: template-parts/chasse/chasse-edition-main.php:867 template-parts/chasse/chasse-edition-main.php:986
+msgid "Solution"
+msgstr "Solution"
+
+#: template-parts/chasse/chasse-edition-main.php:974
+msgid "Partagez votre chasse en un scan"
+msgstr "Partagez votre chasse en un scan"
+
+#: template-parts/chasse/chasse-edition-main.php:975
+msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
+msgstr "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
+
+#: template-parts/chasse/chasse-edition-main.php:987
+msgid "Contenu de la solution à venir."
+msgstr "Contenu de la solution à venir."
+

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -814,6 +814,23 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       <div class="edition-panel-body">
         <div class="edition-panel-section edition-panel-section-ligne">
           <div class="section-content">
+            <?php
+            $afficher_qr_code = est_organisateur()
+                && ($infos_chasse['statut'] ?? '') !== 'revision'
+                && ($infos_chasse['statut_validation'] ?? '') === 'valide';
+
+            if ($afficher_qr_code) {
+                $format            = isset($_GET['format']) ? sanitize_key($_GET['format']) : 'png';
+                $formats_autorises = ['png', 'svg', 'eps'];
+                if (!in_array($format, $formats_autorises, true)) {
+                    $format = 'png';
+                }
+                $url         = get_permalink($chasse_id);
+                $url_qr_code = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data='
+                    . rawurlencode($url)
+                    . '&format=' . $format;
+            }
+            ?>
             <div class="dashboard-grid stats-cards">
               <?php
               get_template_part('template-parts/chasse/partials/chasse-partial-indices', null, [
@@ -845,30 +862,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
                 <div class="champ-feedback"></div>
               </div>
-              <?php
-              if (
-                  est_organisateur()
-                  && ($infos_chasse['statut'] ?? '') !== 'revision'
-                  && ($infos_chasse['statut_validation'] ?? '') === 'valide'
-              ) :
-                  $format = isset($_GET['format']) ? sanitize_key($_GET['format']) : 'png';
-                  $formats_autorises = ['png', 'svg', 'eps'];
-                  if (!in_array($format, $formats_autorises, true)) {
-                      $format = 'png';
-                  }
-                  $url = get_permalink($chasse_id);
-                  $url_qr_code = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data='
-                      . rawurlencode($url)
-                      . '&format=' . $format;
-              ?>
-              <div class="dashboard-card carte-orgy champ-qr-code">
-                <img class="qr-code-icon" src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de la chasse', 'chassesautresor-com'); ?>">
-                <h3><?= esc_html__('QR code de votre chasse', 'chassesautresor-com'); ?></h3>
-                <a class="bouton-cta" href="<?= esc_url($url_qr_code); ?>" download="<?= esc_attr('qr-chasse-' . $chasse_id . '.' . $format); ?>">
-                  <?= esc_html__('Télécharger', 'chassesautresor-com'); ?>
+              <div class="dashboard-card carte-orgy champ-solution">
+                <i class="fa-solid fa-lightbulb icone-defaut" aria-hidden="true"></i>
+                <h3><?= esc_html__('Solution', 'chassesautresor-com'); ?></h3>
+                <a class="bouton-cta" href="#solution">
+                  <?= esc_html__('Voir la solution', 'chassesautresor-com'); ?>
                 </a>
               </div>
-              <?php endif; ?>
             </div>
 
             <?php
@@ -964,6 +964,27 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               ]);
               ?>
             </div>
+            <?php if ($afficher_qr_code) : ?>
+              <div class="qr-code-block">
+                <div class="qr-code-image">
+                  <img src="<?= esc_url($url_qr_code); ?>" alt="<?= esc_attr__('QR code de votre chasse', 'chassesautresor-com'); ?>">
+                </div>
+                <div class="qr-code-content">
+                  <h3><?= esc_html__('QR code de votre chasse', 'chassesautresor-com'); ?></h3>
+                  <h4><?= esc_html__('Partagez votre chasse en un scan', 'chassesautresor-com'); ?></h4>
+                  <p><?= esc_html__('Facilitez l\'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement.', 'chassesautresor-com'); ?></p>
+                  <a class="bouton-cta" href="<?= esc_url($url_qr_code); ?>" download="<?= esc_attr('qr-chasse-' . $chasse_id . '.png'); ?>">
+                    <?= esc_html__('Télécharger', 'chassesautresor-com'); ?>
+                  </a>
+                </div>
+              </div>
+            <?php endif; ?>
+          </div>
+        </div>
+        <div id="solution" class="edition-panel-section">
+          <div class="section-content">
+            <h3><?= esc_html__('Solution', 'chassesautresor-com'); ?></h3>
+            <p><?= esc_html__('Contenu de la solution à venir.', 'chassesautresor-com'); ?></p>
           </div>
         </div>
       </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -973,7 +973,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   <h3><?= esc_html__('QR code de votre chasse', 'chassesautresor-com'); ?></h3>
                   <h4><?= esc_html__('Partagez votre chasse en un scan', 'chassesautresor-com'); ?></h4>
                   <p><?= esc_html__('Facilitez l\'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement.', 'chassesautresor-com'); ?></p>
-                  <a class="bouton-cta" href="<?= esc_url($url_qr_code); ?>" download="<?= esc_attr('qr-chasse-' . $chasse_id . '.png'); ?>">
+                  <a class="bouton-cta qr-code-download" href="<?= esc_url($url_qr_code); ?>" download="<?= esc_attr('qr-chasse-' . $chasse_id . '.png'); ?>">
                     <?= esc_html__('Télécharger', 'chassesautresor-com'); ?>
                   </a>
                 </div>


### PR DESCRIPTION
## Résumé
- remplace la carte QR code par une carte Solution
- ajoute un bloc QR code descriptif sous le tableau des indices
- prépare une section Solution et met à jour les traductions

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ae9f57083328a187aa310211853