### PR TITLE
Limite du tableau d’indices à cinq lignes

### DIFF
--- a/tests/IndicesListerTableChasseTest.php
+++ b/tests/IndicesListerTableChasseTest.php
@@ -72,6 +72,7 @@ class IndicesListerTableChasseTest extends TestCase {
         ajax_indices_lister_table();
 
         $meta = $captured_query_args['meta_query'];
+        $this->assertSame(5, $captured_query_args['posts_per_page']);
         $this->assertSame('OR', $meta['relation']);
         $this->assertSame('AND', $meta[0]['relation']);
         $this->assertSame('indice_chasse_linked', $meta[0][1]['key']);

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -462,7 +462,7 @@ function ajax_indices_lister_table(): void
         wp_send_json_error('acces_refuse');
     }
 
-    $per_page = 8;
+    $per_page = $objet_type === 'chasse' ? 5 : 8;
     if ($objet_type === 'chasse') {
         $enigme_ids = recuperer_ids_enigmes_pour_chasse($objet_id);
         $meta       = [

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -872,7 +872,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             </div>
 
             <?php
-            $par_page_indices = 8;
+            $par_page_indices = 5;
             $page_indices     = 1;
             $enigme_ids       = recuperer_ids_enigmes_pour_chasse($chasse_id);
             $meta             = [


### PR DESCRIPTION
## Résumé
- limite l’affichage des indices de chasse à cinq entrées
- adapte l’API AJAX pour renvoyer cinq indices
- met à jour les tests associés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abd884f6e083329ea78aaacf71cb79