### PR TITLE
docs: ajouter groupe ACF parametres solution

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -528,3 +528,80 @@ Label : complétion de l'indice
 Instructions : (vide)
 Requis : non
 ----------------------------------------
+
+🔹 Groupe : paramètres solution
+🆔 ID : 9756
+🔑 Key : group_68abd01f80aee
+📦 Champs trouvés : 10
+
+— solution_cible_type —
+Type : radio
+Label : for
+Instructions : (vide)
+Requis : non
+Choices :
+  - chasse : chasse
+  - enigme : enigme
+----------------------------------------
+— solution_chasse_linked —
+Type : relationship
+Label : chasse liée
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— solution_enigme_linked —
+Type : relationship
+Label : énigme liée
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— solution_fichier —
+Type : file
+Label : fichier pdf de solution
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— solution_explication —
+Type : wysiwyg
+Label : explication
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— solution_disponibilite —
+Type : radio
+Label : disponibilité
+Instructions : (vide)
+Requis : non
+Choices :
+  - fin_chasse : fin de chasse
+  - differee : différée
+----------------------------------------
+— solution_decalage_jours —
+Type : number
+Label : jours de décalage
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— solution_heure_publication —
+Type : time_picker
+Label : heure de publication
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— solution_cache_etat_systeme —
+Type : select
+Label : état système
+Instructions : (vide)
+Requis : non
+Choices :
+  - accessible : accessible
+  - programme : programmé
+  - invalide : invalide
+  - desactive : désactivé
+----------------------------------------
+— solution_cache_complet —
+Type : true_false
+Label : complétion de la solution
+Instructions : (vide)
+Requis : non
+----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -432,6 +432,29 @@ Groupe : paramètres indices
 | invalide  | Indice marqué comme invalide                  |
 | desactive | Indice incomplet ou désactivé                 |
 
+CPT : solution
+Groupe : paramètres solution
+
+* solution_cible_type (radio, chasse/enigme)
+* solution_chasse_linked (relationship)
+* solution_enigme_linked (relationship)
+* solution_fichier (file)
+* solution_explication (wysiwyg)
+* solution_disponibilite (radio, fin_chasse/differee)
+* solution_decalage_jours (number)
+* solution_heure_publication (time_picker)
+* solution_cache_etat_systeme (select, accessible/programme/invalide/desactive)
+* solution_cache_complet (true_false)
+
+États possibles pour `solution_cache_etat_systeme` :
+
+| Valeur    | Description                                   |
+|-----------|-----------------------------------------------|
+| accessible| Solution visible immédiatement                |
+| programme | Disponible à une date ultérieure              |
+| invalide  | Solution marquée comme invalide               |
+| desactive | Solution incomplète ou désactivée             |
+
 liste avec tous les détails des groupes de champs ACF dans champs-acf-liste.md
 
 


### PR DESCRIPTION
## Résumé
- Documente le nouveau groupe de champs ACF "paramètres solution"

## Changements notables
- Ajout de la liste détaillée des champs du groupe solution
- Mise à jour de la vue d'ensemble ACF pour inclure ce groupe

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abd954f2848332bc9aebd4f5d057f1