### PR TITLE
Add loading spinner to AJAX pager

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/pager.js
@@ -4,49 +4,54 @@
  * Listens for clicks and selection changes on elements with the `.pager` class
  * and dispatches a `pager:change` CustomEvent with the selected page number.
  */
- document.addEventListener('DOMContentLoaded', () => {
-   document.body.addEventListener('click', (e) => {
-     const btn = e.target.closest('.pager-first, .pager-prev, .pager-next, .pager-last');
-     if (!btn) {
-       return;
-     }
-     const pager = btn.closest('.pager');
-     if (!pager) {
-       return;
-     }
-     e.preventDefault();
-     const total = parseInt(pager.dataset.total || '1', 10);
-     let current = parseInt(pager.dataset.current || '1', 10);
-     if (btn.classList.contains('pager-first')) {
-       current = 1;
-     } else if (btn.classList.contains('pager-prev')) {
-       if (current > 1) current -= 1;
-     } else if (btn.classList.contains('pager-next')) {
-       if (current < total) current += 1;
-     } else if (btn.classList.contains('pager-last')) {
-       current = total;
-     }
-     pager.dataset.current = String(current);
-     const select = pager.querySelector('.pager-select');
-     if (select) {
-       select.value = String(current);
-     }
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.addEventListener('click', (e) => {
+    const btn = e.target.closest('.pager-first, .pager-prev, .pager-next, .pager-last');
+    if (!btn) {
+      return;
+    }
+    const pager = btn.closest('.pager');
+    if (!pager) {
+      return;
+    }
+    e.preventDefault();
+    const total = parseInt(pager.dataset.total || '1', 10);
+    let current = parseInt(pager.dataset.current || '1', 10);
+    if (btn.classList.contains('pager-first')) {
+      current = 1;
+    } else if (btn.classList.contains('pager-prev')) {
+      if (current > 1) current -= 1;
+    } else if (btn.classList.contains('pager-next')) {
+      if (current < total) current += 1;
+    } else if (btn.classList.contains('pager-last')) {
+      current = total;
+    }
+
+    // Show a loading spinner while data is fetched.
+    btn.disabled = true;
+    btn.innerHTML = '<span class="pager-loading" aria-hidden="true"></span>';
+
+    pager.dataset.current = String(current);
+    const select = pager.querySelector('.pager-select');
+    if (select) {
+      select.value = String(current);
+    }
     pager.dispatchEvent(
       new CustomEvent('pager:change', { detail: { page: current }, bubbles: true })
     );
-   });
- 
-   document.body.addEventListener('change', (e) => {
-     const select = e.target.closest('.pager-select');
-     if (!select) {
-       return;
-     }
-     const pager = select.closest('.pager');
-     if (!pager) {
-       return;
-     }
-     const page = parseInt(select.value, 10);
-     pager.dataset.current = String(page);
+  });
+
+  document.body.addEventListener('change', (e) => {
+    const select = e.target.closest('.pager-select');
+    if (!select) {
+      return;
+    }
+    const pager = select.closest('.pager');
+    if (!pager) {
+      return;
+    }
+    const page = parseInt(select.value, 10);
+    pager.dataset.current = String(page);
     pager.dispatchEvent(
       new CustomEvent('pager:change', { detail: { page }, bubbles: true })
     );

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -548,3 +548,21 @@ span.champ-obligatoire {
   align-items: center;
   gap: var(--space-md);
 }
+
+/* 🔄 Loading spinner for pager */
+.pager-loading {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: pager-spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes pager-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5698,6 +5698,23 @@ span.champ-obligatoire {
   gap: var(--space-md);
 }
 
+/* 🔄 Loading spinner for pager */
+.pager-loading {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: pager-spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes pager-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 /* \uD83D\uDCC0 Grid system */
 .container {
   width: 100%;


### PR DESCRIPTION
## Résumé
Ajoute un indicateur de chargement par défaut pour les navigations AJAX du pager.

## Changements notables
- Affiche une icône de chargement et désactive le bouton cliqué pendant la requête.
- Ajoute les styles `.pager-loading` et met à jour la feuille CSS compilée.

## Testing
- `npm test`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68abdadcc6808332992bd1984b3e2586