### PR TITLE
feat: utiliser le CPT solution pour l'affichage

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
@@ -6,24 +6,24 @@ if (!$post_id) {
     return;
 }
 
-$mode       = get_field('enigme_solution_mode', $post_id) ?? 'pdf';
-$texte      = get_field('enigme_solution_explication', $post_id);
-$fichier    = get_field('enigme_solution_fichier', $post_id);
-$fichier_url = is_array($fichier) ? $fichier['url'] ?? '' : '';
-$fichier_nom = is_array($fichier) ? $fichier['filename'] ?? basename($fichier_url) : basename($fichier_url);
-
-if (!solution_peut_etre_affichee($post_id)) {
+$solution = solution_recuperer_par_objet($post_id, 'enigme');
+if (!solution_peut_etre_affichee($post_id) || !$solution) {
     return;
 }
 
-if ($mode === 'pdf' && $fichier_url) {
+$fichier     = get_field('solution_fichier', $solution->ID);
+$fichier_url = is_array($fichier) ? ($fichier['url'] ?? '') : '';
+$fichier_nom = is_array($fichier) ? ($fichier['filename'] ?? basename($fichier_url)) : basename($fichier_url);
+$texte       = get_field('solution_explication', $solution->ID);
+
+if ($fichier_url) {
     echo '<a href="' . esc_url($fichier_url) . '" class="lien-solution-pdf" target="_blank" rel="noopener">';
     echo '&#128196; ' . esc_html($fichier_nom);
     echo '</a>';
     return;
 }
 
-if ($mode === 'texte' && $texte) {
+if ($texte) {
     echo '<p>' . wp_kses_post($texte) . '</p>';
 }
 ?>


### PR DESCRIPTION
## Résumé
- exploite un nouveau helper pour récupérer la solution liée à une énigme
- affiche les solutions via le CPT dédié et ses métas
- adapte les templates d'édition et d'affichage des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abdcf478e88332a85ebf9e869731d1