### PR TITLE
Ajoute gestion AJAX des solutions

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -452,6 +452,22 @@ function indice_action_autorisee(string $action, string $object_type, int $objec
 }
 
 /**
+ * Détermine si une action sur une solution est autorisée.
+ *
+ * Wrapper autour de indice_action_autorisee afin de réutiliser les
+ * règles d'accès existantes pour les chasses et les énigmes.
+ *
+ * @param string $action      Action souhaitée (create, edit, delete).
+ * @param string $object_type Type de cible (chasse ou enigme).
+ * @param int    $object_id   ID de la cible.
+ * @return bool
+ */
+function solution_action_autorisee(string $action, string $object_type, int $object_id): bool
+{
+    return indice_action_autorisee($action, $object_type, $object_id);
+}
+
+/**
  * Détermine si un utilisateur peut voir une énigme donnée.
  *
  * @param int $enigme_id ID du post de type 'enigme'

--- a/wp-content/themes/chassesautresor/inc/utils/titres.php
+++ b/wp-content/themes/chassesautresor/inc/utils/titres.php
@@ -16,11 +16,12 @@ define('TITRE_DEFAUT_ORGANISATEUR', 'Votre nom d’organisateur');
 define('TITRE_DEFAUT_CHASSE', 'Nouvelle chasse');
 define('TITRE_DEFAUT_ENIGME', 'en création');
 define('TITRE_DEFAUT_INDICE', 'Nouvel indice');
+define('TITRE_DEFAUT_SOLUTION', 'Nouvelle solution');
 
 /**
  * Retourne le titre par défaut associé à un type de post donné.
  *
- * @param string $post_type Type de post (organisateur, chasse, énigme, indice).
+ * @param string $post_type Type de post (organisateur, chasse, énigme, indice, solution).
  * @return string Titre par défaut ou chaîne vide si inconnu.
  */
 function get_titre_defaut(string $post_type): string {
@@ -33,6 +34,8 @@ function get_titre_defaut(string $post_type): string {
             return TITRE_DEFAUT_ENIGME;
         case 'indice':
             return TITRE_DEFAUT_INDICE;
+        case 'solution':
+            return TITRE_DEFAUT_SOLUTION;
         default:
             return '';
     }


### PR DESCRIPTION
## Résumé
- prise en charge de la création et de l’édition des solutions
- ajout de l’endpoint `/creer-solution/`
- listing AJAX des solutions via un gabarit dédié

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abe7b2e14083328a45aa5aa7e04879