### PR TITLE
Documenter le CPT solution et retirer les champs enigme_solution

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -338,39 +338,6 @@ Label : chasse associée
 Instructions : (vide)
 Requis : oui
 ----------------------------------------
-— enigme_solution_mode —
-Type : radio
-Label : Mode de publication des solutions
-Instructions : (vide)
-Requis : non
-Choices :
-  - pdf : Télécharger un PDF
-  - texte : Rédiger la solution
-----------------------------------------
-— enigme_solution_delai —
-Type : number
-Label : délai de publication des solutions
-Instructions : (vide)
-Requis : non
-----------------------------------------
-— enigme_solution_heure —
-Type : time_picker
-Label : Heure de publication
-Instructions : Heure à laquelle la solution sera publiée, X jours après la fin de la chasse
-Requis : non
-----------------------------------------
-— enigme_solution_fichier —
-Type : file
-Label : Fichier PDF de solution
-Instructions : Ajoutez un fichier PDF contenant la solution complète, si vous ne souhaitez pas utiliser l’éditeur texte.
-Requis : non
-----------------------------------------
-— enigme_solution_explication —
-Type : wysiwyg
-Label : Solution expliquée
-Instructions : La solution ne sera publiée que si la chasse est terminée, et selon le délai de votre choix
-Requis : non
-----------------------------------------
 — enigme_cache_complet —
 Type : true_false
 Label : enigme_cache_complet
@@ -537,7 +504,7 @@ Requis : non
 — solution_cible_type —
 Type : radio
 Label : for
-Instructions : (vide)
+Instructions : Définit si la solution concerne une chasse ou une énigme
 Requis : non
 Choices :
   - chasse : chasse
@@ -546,31 +513,31 @@ Choices :
 — solution_chasse_linked —
 Type : relationship
 Label : chasse liée
-Instructions : (vide)
+Instructions : Référence la chasse cible lorsque la solution concerne une chasse
 Requis : non
 ----------------------------------------
 — solution_enigme_linked —
 Type : relationship
 Label : énigme liée
-Instructions : (vide)
+Instructions : Référence l’énigme cible lorsque la solution concerne une énigme
 Requis : non
 ----------------------------------------
 — solution_fichier —
 Type : file
 Label : fichier pdf de solution
-Instructions : (vide)
+Instructions : Permet de téléverser un PDF de solution
 Requis : non
 ----------------------------------------
 — solution_explication —
 Type : wysiwyg
 Label : explication
-Instructions : (vide)
+Instructions : Texte explicatif affiché si aucun PDF n’est fourni
 Requis : non
 ----------------------------------------
 — solution_disponibilite —
 Type : radio
 Label : disponibilité
-Instructions : (vide)
+Instructions : fin_chasse : publication dès la fin ; differee : selon le délai et l’heure définis
 Requis : non
 Choices :
   - fin_chasse : fin de chasse
@@ -579,13 +546,13 @@ Choices :
 — solution_decalage_jours —
 Type : number
 Label : jours de décalage
-Instructions : (vide)
+Instructions : Nombre de jours à attendre en mode différé
 Requis : non
 ----------------------------------------
 — solution_heure_publication —
 Type : time_picker
 Label : heure de publication
-Instructions : (vide)
+Instructions : Heure de mise en ligne en mode différé
 Requis : non
 ----------------------------------------
 — solution_cache_etat_systeme —

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -117,6 +117,7 @@ Le dossier `notices/` contient la documentation technique et fonctionnelle du th
 - organisateur : référence un ou plusieurs utilisateurs (organisateurs) + infos classiques. Structure pivot d identification
 - chasse : reliée au cpt organisateur, reliée au minimum à une énigme
 - enigme : obligatoirement reliée à une seule chasse
+- solution : publie la solution d’une chasse ou d’une énigme
 
 
 🧑‍🤝‍🧑 Rôles & accès (joueur, organisateur, organisateur_creation, admin)
@@ -402,11 +403,6 @@ Groupe : Paramètres de l’énigme
 * enigme_acces_pre_requis (relationship)
 * enigme_cache_etat_systeme (select)
 * enigme_chasse_associee (relationship)
-* enigme_solution_mode (radio)
-* enigme_solution_delai (number)
-* enigme_solution_heure (time_picker)
-* enigme_solution_fichier (file)
-* enigme_solution_explication (wysiwyg)
 * enigme_cache_complet (true_false)
 
 CPT : indice
@@ -438,11 +434,11 @@ Groupe : paramètres solution
 * solution_cible_type (radio, chasse/enigme)
 * solution_chasse_linked (relationship)
 * solution_enigme_linked (relationship)
-* solution_fichier (file)
-* solution_explication (wysiwyg)
-* solution_disponibilite (radio, fin_chasse/differee)
-* solution_decalage_jours (number)
-* solution_heure_publication (time_picker)
+* solution_fichier (file, PDF de la solution)
+* solution_explication (wysiwyg, solution rédigée)
+* solution_disponibilite (radio, fin_chasse/differee — fin_chasse : publication à la fin de la chasse ; differee : publication après `solution_decalage_jours` jours à `solution_heure_publication`)
+* solution_decalage_jours (number, délai en jours pour mode differee)
+* solution_heure_publication (time_picker, heure de mise en ligne pour mode differee)
 * solution_cache_etat_systeme (select, accessible/programme/invalide/desactive)
 * solution_cache_complet (true_false)
 


### PR DESCRIPTION
## Résumé
- retire les références aux anciens champs `enigme_solution_*`
- documente les nouveaux champs `solution_*` et leurs comportements
- ajoute le CPT `solution` dans les notices globales

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abea01cb68833294418945dde2802a