### PR TITLE
Refactor SCSS breakpoints and add narrow container

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -267,7 +267,7 @@
   padding-bottom: var(--space-sm);
 }
 
-@media (min-width: 1280px) {
+@media (--bp-wide) {
   .menu-lateral {
     position: fixed;
     top: 50%;

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -31,13 +31,13 @@
   gap: var(--space-xl);
 }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   .grille-3 {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .grille-3 {
     grid-template-columns: 1fr;
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -97,7 +97,7 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
 
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .chasse-fiche-container {
     flex-direction: column;
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -181,7 +181,7 @@ button,
     opacity: 0.7;
 }
 
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     .bloc-reponse .reponse-cta-row {
         flex-direction: column;
         align-items: stretch;
@@ -193,12 +193,12 @@ button,
         margin-top: var(--space-xs);
     }
 }
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .bouton-cta {
         padding: 8px 13px;
     }
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     .bouton-cta {
         padding: 6px 10px;
     }
@@ -432,7 +432,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .btn-lire-plus {
     width: 100%;
   }
@@ -472,7 +472,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .bouton-retour {
     font-size: 1.25rem;
   }
@@ -537,7 +537,7 @@ a.ajout-link:focus-visible {
 .bloc-metas-inline--compact .meta-etiquette {
   padding: 0.2em 0.6em;
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     .bloc-metas-inline {
         gap:0.8rem;
     }
@@ -715,7 +715,7 @@ a.ajout-link:focus-visible {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     .separateur-2 {
         margin: 0 auto;
     }
@@ -739,7 +739,7 @@ a.ajout-link:focus-visible {
 body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     color: var(--color-text-primary);
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .formulaire-contact-wrapper {
     padding-left: var(--space-md);
     padding-right: var(--space-md);
@@ -827,7 +827,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     text-align: center;
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .countdown-container { font-size: 1rem; }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -706,7 +706,7 @@ body[class*="edition-active"] .champ-desactive .champ-modifier,
 /* ========== 📱 RESPONSIVE GLOBAL ========== */
 
 /* Empilage à partir de tablette */
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -761,7 +761,7 @@ body[class*="edition-active"] .champ-desactive .champ-modifier,
 /* ========== 📱 RESPONSIVE HEADER ========== */
 
 /* Empilage à partir de tablette */
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -1134,13 +1134,13 @@ li.ligne-email .champ-affichage {
 
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .edition-panel-body {
     flex-direction: column;
   }
 }
 
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .edition-panel-body {
     flex-direction: column;
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -19,7 +19,7 @@
   grid-column: 1;
 }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   .enigme-layout .menu-lateral {
     position: sticky;
     top: var(--space-md);
@@ -33,7 +33,7 @@
   grid-template-columns: 1fr;
 }
 
-@media (min-width: 1280px) {
+@media (--bp-wide) {
   .enigme-layout {
     display: block;
     gap: 0;
@@ -309,7 +309,7 @@ li.active .enigme-menu__edit {
   margin-top: var(--space-md);
 }
 
-@media (--bp-lg) and (hover: hover) {
+@media (--bp-desktop) and (hover: hover) {
   body.single-enigme .page-enigme {
     margin-top: calc(var(--space-4xl) + var(--space-md));
   }
@@ -338,7 +338,7 @@ li.active .enigme-menu__edit {
   font-size: 32px;
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .page-enigme {
     gap: var(--space-xl);
   }
@@ -353,7 +353,7 @@ li.active .enigme-menu__edit {
   }
 }
 
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .page-enigme {
     gap: var(--space-lg);
   }
@@ -400,7 +400,7 @@ li.active .enigme-menu__edit {
   }
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .participation {
     width: 70%;
   }
@@ -475,7 +475,7 @@ li.active .enigme-menu__edit {
   margin-inline: auto;
 }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   .enigme-layout {
     grid-template-columns: 1fr;
   }
@@ -511,7 +511,7 @@ body.topbar-visible .enigme-edit-toggle--desktop {
   top: calc(var(--space-md) + var(--space-4xl));
 }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   .enigme-layout .menu-lateral {
     display: none;
   }
@@ -691,7 +691,7 @@ body.single-enigme.topbar-visible header.site-header {
   transform: translateY(0);
 }
 
-@media (max-width: 1023px), (hover: none) {
+@media not all and (--bp-desktop), (hover: none) {
   body.single-enigme header.site-header {
     display: none;
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_gamification.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_gamification.scss
@@ -340,18 +340,18 @@ header .points-link:hover {
 
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
     .points-value {
         font-size: 16px;
     }
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .points-value {
         font-size: 14px;
     }
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .points-unite {
     display: none;
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -45,7 +45,7 @@ h1.h1-diff {/* variation couleur bronze, plus petite, centrée */
   letter-spacing: 1px;
   color: var(--color-accent);
 }
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   h1, .entry-content h1 {
     font-size: 36px;
   }
@@ -53,7 +53,7 @@ h1.h1-diff {/* variation couleur bronze, plus petite, centrée */
       font-size:30px;
   }
 }
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   h1, .entry-content h1 {
     font-size: 30px;
   }
@@ -76,13 +76,13 @@ h2, .entry-content h2 {
   font-size: 32px;
 }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   h2, .entry-content h2 {
     font-size: 28px;
   }
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   h2, .entry-content h2 {
     font-size: 24px;
   }
@@ -101,7 +101,7 @@ h3, .entry-content h3 {
   margin-bottom: var(--space-sm);
 }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   .page header.entry-header .entry-title {
     font-size: 36px;
   }
@@ -110,7 +110,7 @@ h3, .entry-content h3 {
   }
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .page header.entry-header .entry-title {
     font-size: 30px;
   }
@@ -412,12 +412,12 @@ span.champ-obligatoire {
 
 /* ========== 📱 RESPONSIVE ========== */
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul  {
         font-size:96%;
     }
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
         font-size:93%;
     }

--- a/wp-content/themes/chassesautresor/assets/scss/_grid.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_grid.scss
@@ -9,6 +9,10 @@
   padding-right: var(--space-md);
 }
 
+.container--narrow {
+  --container-max-width: var(--container-max-width-narrow);
+}
+
 .container.fullwidth,
 .container--full {
   max-width: none;
@@ -46,14 +50,14 @@
 .col-11 { --col-span: 11; }
 .col-12 { --col-span: 12; }
 
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
   .row { --grid-columns: 8; }
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .row { --grid-columns: 6; }
 }
 
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .row { --grid-columns: 4; }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -58,7 +58,7 @@
 .site-above-header-wrap .ast-builder-layout-element {
     margin-left:10px;
 }
- @media not all and (--bp-lg) {
+ @media not all and (--bp-desktop) {
      header.site-header   {
          padding: 0 10px ;
      }
@@ -67,7 +67,7 @@
          padding-right: 10px;
      }
  }
- @media not all and (--bp-sm) {
+ @media not all and (--bp-small) {
     header.site-header {
         padding: 0 7px;
     }
@@ -156,7 +156,7 @@
   margin-right: auto;
   text-shadow: 1px 1px 4px rgba(0,0,0,0.7);
 }
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .hero-title {
     font-size: 1.8rem;
   }
@@ -171,7 +171,7 @@
     padding-top: 300px;
   }
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .hero-title {
     font-size: 1.5rem;
   }
@@ -211,7 +211,7 @@ body #primary {
   align-items: flex-start; /* ✅ important : alignement haut */
   flex-wrap: wrap; /* ✅ si l’un est trop large */
 }
-@media not all and (--bp-lg) {
+@media not all and (--bp-desktop) {
     .ast-container, .ast-container-fluid {
         margin-left: auto;
         margin-right: auto;
@@ -293,7 +293,7 @@ body #primary {
   opacity: 0.9;
   line-height: 1.5;
 }
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
   .bloc-temoignages .temoignage-colonnes {
     flex-direction: column;
     align-items: center;
@@ -471,7 +471,7 @@ footer .ast-footer-widget a {
 }
 
 
-@media not all and (--bp-600) {
+@media not all and (--bp-mobile) {
   .site-footer-primary-section-1 {
     order: 2;
     margin: 30px 0;

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -313,7 +313,7 @@
 
 
 /* ✅ Mobile : Les éléments s'empilent */
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .dashboard-profile-wrapper {
         flex-direction: column; /* ✅ Empile les éléments */
         justify-content: center; /* ✅ Centre les éléments verticalement */
@@ -375,7 +375,7 @@
     vertical-align: middle;
 }
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .menu-deroulant .submenu {
         left: -50px;
     }
@@ -704,7 +704,7 @@
 
 
 /* Tablette : 2 colonnes */
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .image-container {
         height: 260px;
     }

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -215,7 +215,7 @@ a.bouton-edition-attention {
 
 /* ========== 📱 RESPONSIVE – TABLETTES (≤ 768PX) ========== */
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .conteneur-organisateur {
         flex-direction: column;
         align-items: center;
@@ -253,7 +253,7 @@ a.bouton-edition-attention {
 
 /* ========== 📱 RESPONSIVE – TABLETTES (600PX À 768PX) ========== */
 
-@media (min-width: 600px) and (--bp-md) {
+@media (min-width: 600px) and (--bp-tablet) {
     .conteneur-organisateur {
         flex-direction: row;
         align-items: center;
@@ -283,7 +283,7 @@ a.bouton-edition-attention {
 
 /* ========== 📱 BASCULE EN COLONNE (≤ 600PX) ========== */
 
-@media not all and (--bp-600) {
+@media not all and (--bp-mobile) {
     .conteneur-organisateur {
         gap:var(--space-md);
     }
@@ -297,7 +297,7 @@ a.bouton-edition-attention {
 
 /* ========== 📱 RESPONSIVE – MOBILE (≤ 480PX) ========== */
 
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
   .conteneur-organisateur {
     gap: 0.2rem;
   }
@@ -464,7 +464,7 @@ section#presentation .presentation-fermer {
 
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     .lien-public .texte-lien {
         display: none;
     }
@@ -570,7 +570,7 @@ section#presentation .presentation-fermer {
 
 /* ========== 📱 RESPONSIVE ========== */
 
-@media not all and (--bp-md) {
+@media not all and (--bp-tablet) {
     .separateur-avec-icone {
         margin: 2.1rem 0;
     }
@@ -586,7 +586,7 @@ section#presentation .presentation-fermer {
         height: 50px;
     }
 }
-@media not all and (--bp-sm) {
+@media not all and (--bp-small) {
     .separateur-avec-icone {
         margin: var(--space-xl) 0;
     }

--- a/wp-content/themes/chassesautresor/assets/scss/_variables.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_variables.scss
@@ -1,30 +1,40 @@
 /* 🎨 Variables globales */
 @custom-media --bp-xs (min-width: 374px);
-@custom-media --bp-sm (min-width: 480px);
-@custom-media --bp-600 (min-width: 600px);
-@custom-media --bp-540 (min-width: 600px); /* alias ancien 540px */
-@custom-media --bp-md (min-width: 768px);
-@custom-media --bp-lg (min-width: 1024px);
-@custom-media --bp-921 (min-width: 1024px); /* alias ancien 921px */
-@custom-media --bp-922 (min-width: 1024px); /* alias ancien 922px */
-@custom-media --bp-xl (min-width: 1280px);
+@custom-media --bp-small (min-width: 480px);
+@custom-media --bp-mobile (min-width: 600px);
+@custom-media --bp-tablet (min-width: 768px);
+@custom-media --bp-desktop (min-width: 1024px);
+@custom-media --bp-wide (min-width: 1280px);
 @custom-media --bp-xxl (min-width: 1440px);
 @custom-media --bp-xxxl (min-width: 1920px);
+/* Legacy aliases */
+@custom-media --bp-sm (--bp-small);
+@custom-media --bp-600 (--bp-mobile);
+@custom-media --bp-md (--bp-tablet);
+@custom-media --bp-lg (--bp-desktop);
+@custom-media --bp-xl (--bp-wide);
 
 :root {
   /* Typographie et breakpoints */
   --font-main: 'Poppins', sans-serif; /* Police principale */
   --bp-xs: 374px;
-  --bp-sm: 480px;
-  --bp-600: 600px;
-  --bp-540: 600px; /* alias 540px */
-  --bp-md: 768px;
-  --bp-lg: 1024px;
-  --bp-921: 1024px; /* alias 921px */
-  --bp-922: 1024px; /* alias 922px */
-  --bp-xl: 1280px;
+  --bp-small: 480px;
+  --bp-mobile: 600px;
+  --bp-tablet: 768px;
+  --bp-desktop: 1024px;
+  --bp-wide: 1280px;
   --bp-xxl: 1440px;
   --bp-xxxl: 1920px;
+
+  /* Legacy variables */
+  --bp-sm: var(--bp-small);
+  --bp-600: var(--bp-mobile);
+  --bp-540: var(--bp-mobile);
+  --bp-md: var(--bp-tablet);
+  --bp-lg: var(--bp-desktop);
+  --bp-921: var(--bp-desktop);
+  --bp-922: var(--bp-desktop);
+  --bp-xl: var(--bp-wide);
 
   /* Couleurs globales */
   --color-primary: #FFD700;   /* 🟡 Couleur principale : jaune or */
@@ -73,6 +83,7 @@
 
   /* Grille */
   --container-max-width: 1200px;
+  --container-max-width-narrow: 800px;
   --grid-gap: 1rem;
   --grid-columns: 12;
   --dashboard-card-max-width: 420px; /* 🔲 Largeur max des dashboard-card isolées */
@@ -95,9 +106,11 @@
   --transition-slow: 0.6s ease;
 
   /* Breakpoints layout */
-  --breakpoint-desktop: 1280px;
-  --breakpoint-tablette: 1024px;
-  --breakpoint-mobile: 768px;
+  --breakpoint-small: 480px;
+  --breakpoint-mobile: 600px;
+  --breakpoint-tablet: 768px;
+  --breakpoint-desktop: 1024px;
+  --breakpoint-wide: 1280px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4568,7 +4568,7 @@ body.single-enigme.topbar-visible header.site-header {
   transform: translateY(0);
 }
 
-@media (max-width: 1023px), (hover: none) {
+@media not all and (min-width: 1024px), (hover: none) {
   body.single-enigme header.site-header {
     display: none;
   }
@@ -5723,6 +5723,10 @@ span.champ-obligatoire {
   margin-right: auto;
   padding-left: var(--space-md);
   padding-right: var(--space-md);
+}
+
+.container--narrow {
+  --container-max-width: var(--container-max-width-narrow);
 }
 
 .container.fullwidth,
@@ -7815,21 +7819,28 @@ section#presentation .presentation-fermer {
   resize: vertical;
 }
 
-/* 🎨 Variables globales */ /* alias ancien 540px */ /* alias ancien 921px */ /* alias ancien 922px */
+/* 🎨 Variables globales */
+/* Legacy aliases */
 :root {
   /* Typographie et breakpoints */
   --font-main: "Poppins", sans-serif; /* Police principale */
   --bp-xs: 374px;
-  --bp-sm: 480px;
-  --bp-600: 600px;
-  --bp-540: 600px; /* alias 540px */
-  --bp-md: 768px;
-  --bp-lg: 1024px;
-  --bp-921: 1024px; /* alias 921px */
-  --bp-922: 1024px; /* alias 922px */
-  --bp-xl: 1280px;
+  --bp-small: 480px;
+  --bp-mobile: 600px;
+  --bp-tablet: 768px;
+  --bp-desktop: 1024px;
+  --bp-wide: 1280px;
   --bp-xxl: 1440px;
   --bp-xxxl: 1920px;
+  /* Legacy variables */
+  --bp-sm: var(--bp-small);
+  --bp-600: var(--bp-mobile);
+  --bp-540: var(--bp-mobile);
+  --bp-md: var(--bp-tablet);
+  --bp-lg: var(--bp-desktop);
+  --bp-921: var(--bp-desktop);
+  --bp-922: var(--bp-desktop);
+  --bp-xl: var(--bp-wide);
   /* Couleurs globales */
   --color-primary: #FFD700; /* 🟡 Couleur principale : jaune or */
   --color-secondary: #E1A95F; /* 🟠 Couleur secondaire : lien */
@@ -7868,6 +7879,7 @@ section#presentation .presentation-fermer {
   --aside-opacity: 0.15; /* ⚙️ Opacité standard des fonds d'aside */
   /* Grille */
   --container-max-width: 1200px;
+  --container-max-width-narrow: 800px;
   --grid-gap: 1rem;
   --grid-columns: 12;
   --dashboard-card-max-width: 420px; /* 🔲 Largeur max des dashboard-card isolées */
@@ -7887,9 +7899,11 @@ section#presentation .presentation-fermer {
   --transition-medium: 0.3s ease;
   --transition-slow: 0.6s ease;
   /* Breakpoints layout */
-  --breakpoint-desktop: 1280px;
-  --breakpoint-tablette: 1024px;
-  --breakpoint-mobile: 768px;
+  --breakpoint-small: 480px;
+  --breakpoint-mobile: 600px;
+  --breakpoint-tablet: 768px;
+  --breakpoint-desktop: 1024px;
+  --breakpoint-wide: 1280px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/wp-content/themes/chassesautresor/dist/variables.css
+++ b/wp-content/themes/chassesautresor/dist/variables.css
@@ -1,81 +1,102 @@
+@charset "UTF-8";
+/* 🎨 Variables globales */
+@custom-media --bp-xs (min-width: 374px);
+@custom-media --bp-small (min-width: 480px);
+@custom-media --bp-mobile (min-width: 600px);
+@custom-media --bp-tablet (min-width: 768px);
+@custom-media --bp-desktop (min-width: 1024px);
+@custom-media --bp-wide (min-width: 1280px);
+@custom-media --bp-xxl (min-width: 1440px);
+@custom-media --bp-xxxl (min-width: 1920px);
+/* Legacy aliases */
+@custom-media --bp-sm (--bp-small);
+@custom-media --bp-600 (--bp-mobile);
+@custom-media --bp-md (--bp-tablet);
+@custom-media --bp-lg (--bp-desktop);
+@custom-media --bp-xl (--bp-wide);
 :root {
-  --font-main: 'Poppins', sans-serif;
+  /* Typographie et breakpoints */
+  --font-main: "Poppins", sans-serif; /* Police principale */
   --bp-xs: 374px;
-  --bp-sm: 480px;
-  --bp-600: 600px;
-  --bp-540: 600px;
-  --bp-md: 768px;
-  --bp-lg: 1024px;
-  --bp-921: 1024px;
-  --bp-922: 1024px;
-  --bp-xl: 1280px;
+  --bp-small: 480px;
+  --bp-mobile: 600px;
+  --bp-tablet: 768px;
+  --bp-desktop: 1024px;
+  --bp-wide: 1280px;
   --bp-xxl: 1440px;
   --bp-xxxl: 1920px;
-
-  --color-primary: #FFD700;
-  --color-secondary: #E1A95F;
-  --color-accent: #CD7F32;
-
-  --color-text-primary: #F5F5DC;
-  --color-text-secondary: #555555;
-  --color-titre-enigme: #E5C07B;
-
-  --color-background: #0B132B;
-  --color-background-button: #880000;
-  --color-background-button-hover: #a00000;
-  --color-background-button-inactive: #A9A9A9;
-  --color-success: #228B22;
-  --color-error: #D93025;
-
-  --color-white: #FFFFFF;
-  --color-black: #000000;
-  --color-black-rgb: 0, 0, 0;
-  --color-grey-light: #EEEEEE;
-  --color-grey-medium: #CCCCCC;
-  --color-grey-dark: #333333;
-
-  --color-primary-dark: #B8860B;
-  --color-background-dark: #060A1F;
-
-  --color-gris-3: #adadad;
-  --color-text-fond-clair: #1c1c1c;
-  --color-text-fond-clair-rgb: 28, 28, 28;
-  --color-gris-carte: #c2c2c2;
-
-  --etat-enigme-menu-en-cours: currentColor;
+  /* Legacy variables */
+  --bp-sm: var(--bp-small);
+  --bp-600: var(--bp-mobile);
+  --bp-540: var(--bp-mobile);
+  --bp-md: var(--bp-tablet);
+  --bp-lg: var(--bp-desktop);
+  --bp-921: var(--bp-desktop);
+  --bp-922: var(--bp-desktop);
+  --bp-xl: var(--bp-wide);
+  /* Couleurs globales */
+  --color-primary: #FFD700; /* 🟡 Couleur principale : jaune or */
+  --color-secondary: #E1A95F; /* 🟠 Couleur secondaire : lien */
+  --color-accent: #CD7F32; /* 🟤 Accent : bronze */
+  --color-text-primary: #F5F5DC; /* 📜 Texte principal : beige clair */
+  --color-text-secondary: #555555; /* 🎨 Texte secondaire : gris foncé */
+  --color-titre-enigme: #E5C07B; /* 🏆 Titre des énigmes : or vieilli */
+  --color-background: #0B132B; /* 🎭 Fond général */
+  --color-background-button: #880000; /* 🔘 Fond des boutons : rouge profond */
+  --color-background-button-hover: #a00000; /* 🔘 Survol des boutons : rouge foncé */
+  --color-background-button-inactive: #A9A9A9; /* 🔘 Boutons inactifs : gris */
+  --color-success: #228B22; /* ✅ Barre de progression */
+  --color-error: #D93025; /* ⚠️ Messages d'erreur */
+  --color-white: #FFFFFF; /* ⚪ Blanc */
+  --color-black: #000000; /* ⚫ Noir */
+  --color-black-rgb: 0, 0, 0; /* ⚫ Noir en RGB */
+  --color-grey-light: #EEEEEE; /* 🌫️ Gris clair */
+  --color-grey-medium: #CCCCCC; /* 🌫️ Gris moyen */
+  --color-grey-dark: #333333; /* 🌫️ Gris foncé */
+  --color-primary-dark: #B8860B; /* 🟡 Or sombre (dégradé) */
+  --color-background-dark: #060A1F; /* 🎭 Fond sombre profond */
+  --color-gris-3: #adadad; /* ⚪ Gris neutre n°3 */
+  --color-text-fond-clair: #1c1c1c; /* noir clair */
+  --color-text-fond-clair-rgb: 28, 28, 28; /* noir clair en RGB */
+  --color-gris-carte: #c2c2c2; /* 🧩 Fond de carte énigme : gris bleuté doux */
+  /* Groupe d'état : etat-enigme-menu */
+  --etat-enigme-menu-en-cours: currentColor; /* état par défaut */
   --etat-enigme-menu-bloquee: var(--color-grey-medium);
-  --etat-enigme-menu-en-attente: var(--color-grey-medium);
+  --etat-enigme-menu-en-attente: var(--color-grey-medium); /* tentative manuelle en cours */
   --etat-enigme-menu-succes: var(--color-success);
   --etat-enigme-menu-non-engagee: transparent;
   --etat-enigme-menu-incomplete: var(--color-error);
-
-  --aside-bg-rgb: 238, 238, 238;
-  --aside-border-color: var(--color-grey-medium);
-  --aside-opacity: 0.15;
-
+  /* Asides */
+  --aside-bg-rgb: 238, 238, 238; /* 🎨 Couleur de fond des asides : gris clair du nuancier (var(--color-grey-light)) */
+  --aside-border-color: var(--color-grey-medium); /* 🖊 Couleur de bordure des asides */
+  --aside-opacity: 0.15; /* ⚙️ Opacité standard des fonds d'aside */
+  /* Grille */
   --container-max-width: 1200px;
+  --container-max-width-narrow: 800px;
   --grid-gap: 1rem;
   --grid-columns: 12;
-  --dashboard-card-max-width: 420px;
-
+  --dashboard-card-max-width: 420px; /* 🔲 Largeur max des dashboard-card isolées */
+  /* Espacements */
   --space-0: 0;
-  --space-xxs: 0.25rem;
-  --space-xs: 0.5rem;
-  --space-sm: 0.75rem;
-  --space-md: 1rem;
-  --space-lg: 1.25rem;
-  --space-xl: 1.5rem;
-  --space-2xl: 2rem;
-  --space-3xl: 2.5rem;
-  --space-4xl: 3rem;
-
+  --space-xxs: 0.25rem; /* 4px */
+  --space-xs: 0.5rem; /* 8px */
+  --space-sm: 0.75rem; /* 12px */
+  --space-md: 1rem; /* 16px */
+  --space-lg: 1.25rem; /* 20px */
+  --space-xl: 1.5rem; /* 24px */
+  --space-2xl: 2rem; /* 32px */
+  --space-3xl: 2.5rem; /* 40px */
+  --space-4xl: 3rem; /* 48px */
+  /* Transitions globales */
   --transition-fast: 0.15s ease-in-out;
   --transition-medium: 0.3s ease;
   --transition-slow: 0.6s ease;
-
-  --breakpoint-desktop: 1280px;
-  --breakpoint-tablette: 1024px;
-  --breakpoint-mobile: 768px;
+  /* Breakpoints layout */
+  --breakpoint-small: 480px;
+  --breakpoint-mobile: 600px;
+  --breakpoint-tablet: 768px;
+  --breakpoint-desktop: 1024px;
+  --breakpoint-wide: 1280px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -85,10 +106,12 @@
     --transition-slow: 0s;
   }
 }
-
+/* 📝 Variables d’édition */
 .mode-edition {
-  --color-editor-button: #1A73E8;
-  --color-editor-button-hover: #1558B0;
-  --editor-button-hsl: 214 82% 51%;
-  --editor-button-hover-hsl: 214 79% 39%;
+  --color-editor-button: #1A73E8; /* 🔘 Boutons */
+  --color-editor-button-hover: #1558B0; /*       Hover bouton */
+  --editor-button-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-button) */
+  --editor-button-hover-hsl: 214 79% 39%; /* = #1558B0 → var(--color-editor-button-hover) */
 }
+
+/*# sourceMappingURL=variables.css.map */


### PR DESCRIPTION
## Résumé
- harmonisation des breakpoints SCSS avec de nouveaux alias sémantiques
- ajout d'une variante `.container--narrow` pour les sections étroites

## Changements notables
- déclaration des `@custom-media` `--bp-small`, `--bp-mobile`, `--bp-tablet`, `--bp-desktop`, `--bp-wide` et variables `--breakpoint-*` associées
- remplacement des références `--bp-sm`, `--bp-md`, `--bp-lg` dans les feuilles SCSS et ajout d'alias pour compatibilité
- mise à jour des styles de la page énigme pour correspondre aux nouveaux seuils
- nouvelle classe `.container--narrow` utilisant `--container-max-width-narrow`

## Testing
- `npm run build:css`
- `npx sass wp-content/themes/chassesautresor/assets/scss/_variables.scss wp-content/themes/chassesautresor/dist/variables.css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abde5145e08332adcc2c78c8e69b55