### PR TITLE
feat: ajout interrupteur pour le mode de fin

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -3,11 +3,13 @@ const html = `
   <div id="chasse-tab-param">
     <ul>
       <li class="edition-row champ-chasse champ-mode-fin" data-post-id="1">
-        <div class="edition-row-label"><label>Mode</label></div>
+        <div class="edition-row-label"><label for="chasse_mode_fin">Mode</label></div>
         <div class="edition-row-content">
           <div class="champ-mode-options">
-            <input type="radio" name="acf[chasse_mode_fin]" value="automatique" checked>
-            <input type="radio" name="acf[chasse_mode_fin]" value="manuelle">
+            <label class="switch-control">
+              <input type="checkbox" id="chasse_mode_fin" name="acf[chasse_mode_fin]" value="manuelle">
+              <span class="switch-slider"></span>
+            </label>
             <div class="fin-chasse-actions"></div>
           </div>
         </div>
@@ -55,17 +57,17 @@ describe('chasse-edit UI', () => {
   });
 
   test('manual termination block is in Paramètres tab', () => {
-    const radio = document.querySelector('input[value="manuelle"]');
-    radio.checked = true;
-    radio.dispatchEvent(new Event('change', { bubbles: true }));
+    const toggle = document.getElementById('chasse_mode_fin');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
     expect(document.querySelector('#chasse-tab-param .fin-chasse-actions .terminer-chasse-btn')).not.toBeNull();
     expect(document.querySelector('#chasse-tab-animation .fin-chasse-actions')).toBeNull();
   });
 
   test('changing termination mode saves field', async () => {
-    const radio = document.querySelector('input[value="manuelle"]');
-    radio.checked = true;
-    radio.dispatchEvent(new Event('change', { bubbles: true }));
+    const toggle = document.getElementById('chasse_mode_fin');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
     await Promise.resolve();
     expect(global.modifierChampSimple).toHaveBeenCalledWith('chasse_mode_fin', 'manuelle', '1', 'chasse');
   });
@@ -73,20 +75,19 @@ describe('chasse-edit UI', () => {
   test('terminate button toggles with mode', () => {
     const actions = document.querySelector('.fin-chasse-actions');
     expect(actions.querySelector('.terminer-chasse-btn')).toBeNull();
-    const manual = document.querySelector('input[value="manuelle"]');
-    manual.checked = true;
-    manual.dispatchEvent(new Event('change', { bubbles: true }));
+    const toggle = document.getElementById('chasse_mode_fin');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
     expect(actions.querySelector('.terminer-chasse-btn')).not.toBeNull();
-    const auto = document.querySelector('input[value="automatique"]');
-    auto.checked = true;
-    auto.dispatchEvent(new Event('change', { bubbles: true }));
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
     expect(actions.querySelector('.terminer-chasse-btn')).toBeNull();
   });
 
   test('validating manual termination updates message', async () => {
-    const radio = document.querySelector('input[value="manuelle"]');
-    radio.checked = true;
-    radio.dispatchEvent(new Event('change', { bubbles: true }));
+    const toggle = document.getElementById('chasse_mode_fin');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
     const fakeNow = new Date('2024-01-02');
     jest.spyOn(global, 'Date').mockImplementation(() => fakeNow);
     global.Date.now = () => fakeNow.getTime();

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -859,21 +859,21 @@ function initChampNbGagnants() {
 // 🔚 Gestion dynamique du mode de fin
 // ================================
 function initModeFinChasse() {
-  const radios = document.querySelectorAll('input[name="acf[chasse_mode_fin]"]');
+  const toggle = document.getElementById('chasse_mode_fin');
   const templateNb = document.getElementById('template-nb-gagnants');
   const templateFin = document.getElementById('template-fin-chasse-actions');
   const modeFinLi = document.querySelector('.champ-mode-fin');
   const finActions = modeFinLi?.querySelector('.fin-chasse-actions');
 
-  if (!radios.length || !templateNb || !modeFinLi || !finActions) return;
+  if (!toggle || !templateNb || !modeFinLi || !finActions) return;
 
   const postId = modeFinLi.dataset.postId;
 
   function update(save = false) {
-    const selected = document.querySelector('input[name="acf[chasse_mode_fin]"]:checked')?.value;
+    const selected = toggle.checked ? 'manuelle' : 'automatique';
     const existingNb = document.querySelector('.champ-nb-gagnants');
 
-    if (save && selected) {
+    if (save) {
       modifierChampSimple('chasse_mode_fin', selected, postId, 'chasse');
     }
 
@@ -894,7 +894,7 @@ function initModeFinChasse() {
       if (inputNb) {
         mettreAJourAffichageNbGagnants(postId, inputNb.value.trim());
       }
-    } else if (selected === 'manuelle') {
+    } else {
       if (existingNb) existingNb.remove();
 
       if (!finActions.querySelector('.terminer-chasse-btn') && templateFin) {
@@ -908,9 +908,7 @@ function initModeFinChasse() {
     }
   }
 
-  radios.forEach(radio => {
-    radio.addEventListener('change', () => update(true));
-  });
+  toggle.addEventListener('change', () => update(true));
 
   update();
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1832,11 +1832,64 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
-.champ-mode-options label,
 .champ-mode-fin label {
   display: flex;
   align-items: center;
   gap: var(--space-xxs);
+}
+
+.champ-mode-options .toggle-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
+.champ-mode-options .switch-control {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.champ-mode-options .switch-control input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.champ-mode-options .switch-slider {
+  position: absolute;
+  inset: 0;
+  background-color: var(--color-editor-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.champ-mode-options .switch-slider::before {
+  content: '';
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  left: 2px;
+  top: 2px;
+  background-color: var(--color-editor-background);
+  border-radius: 50%;
+  transition: transform var(--transition-fast);
+  box-shadow: 0 0 2px rgba(var(--color-black-rgb), 0.4);
+}
+
+.champ-mode-options .switch-control input:checked + .switch-slider {
+  background-color: var(--color-editor-accent);
+}
+
+.champ-mode-options .switch-control input:checked + .switch-slider::before {
+  transform: translateX(18px);
+}
+
+.champ-mode-options .switch-control input:disabled + .switch-slider {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 #champ-enigme-date {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3475,11 +3475,64 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
-.champ-mode-options label,
 .champ-mode-fin label {
   display: flex;
   align-items: center;
   gap: var(--space-xxs);
+}
+
+.champ-mode-options .toggle-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
+.champ-mode-options .switch-control {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.champ-mode-options .switch-control input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.champ-mode-options .switch-slider {
+  position: absolute;
+  inset: 0;
+  background-color: var(--color-editor-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.champ-mode-options .switch-slider::before {
+  content: "";
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  left: 2px;
+  top: 2px;
+  background-color: var(--color-editor-background);
+  border-radius: 50%;
+  transition: transform var(--transition-fast);
+  box-shadow: 0 0 2px rgba(var(--color-black-rgb), 0.4);
+}
+
+.champ-mode-options .switch-control input:checked + .switch-slider {
+  background-color: var(--color-editor-accent);
+}
+
+.champ-mode-options .switch-control input:checked + .switch-slider::before {
+  transform: translateX(18px);
+}
+
+.champ-mode-options .switch-control input:disabled + .switch-slider {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 #champ-enigme-date {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -368,15 +368,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         'content'  => function () use ($mode_fin, $peut_editer, $statut_metier, $date_decouverte_formatee, $gagnants, $bloc_fin_chasse) {
                             ?>
                             <div class="champ-mode-options">
-                                <label>
-                                    <input
-                                        id="chasse_mode_fin"
-                                        type="radio"
-                                        name="acf[chasse_mode_fin]"
-                                        value="automatique"
-                                        <?= $mode_fin === 'automatique' ? 'checked' : ''; ?>
-                                        <?= $peut_editer ? '' : 'disabled'; ?>
-                                    >
+                                <span class="toggle-option">
                                     <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
                                     <?php
                                     get_template_part(
@@ -390,15 +382,19 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         ]
                                     );
                                     ?>
-                                </label>
-                                <label>
+                                </span>
+                                <label class="switch-control">
                                     <input
-                                        type="radio"
+                                        id="chasse_mode_fin"
+                                        type="checkbox"
                                         name="acf[chasse_mode_fin]"
                                         value="manuelle"
                                         <?= $mode_fin === 'manuelle' ? 'checked' : ''; ?>
                                         <?= $peut_editer ? '' : 'disabled'; ?>
                                     >
+                                    <span class="switch-slider"></span>
+                                </label>
+                                <span class="toggle-option">
                                     <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
                                     <?php
                                     get_template_part(
@@ -412,7 +408,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         ]
                                     );
                                     ?>
-                                </label>
+                                </span>
                                 <div class="fin-chasse-actions">
                                     <?php if ($mode_fin === 'manuelle') : ?>
                                         <?= $bloc_fin_chasse; ?>


### PR DESCRIPTION
## Résumé
- ajout d'un interrupteur horizontal pour basculer entre fin automatique et manuelle
- adaptation du script JS et des tests associés
- styles dédiés utilisant les variables du mode édition

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abef4baf048332a01e017b1a788f34