### PR TITLE
feat: add solutions list to chasse edition

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -35,6 +35,8 @@ function enqueue_script_chasse_edit()
     'chasse-stats',
     'table-etiquette',
     'tentatives-toggle',
+    'solutions-pager',
+    'solutions-create',
     'indices-pager',
     'indices-create',
   ]);

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -169,6 +169,29 @@ function enqueue_core_edit_scripts(array $additional = [])
         ]
       );
     }
+    if ($handle === 'solutions-create') {
+      wp_localize_script(
+        'solutions-create',
+        'solutionsCreate',
+        [
+          'ajaxUrl' => admin_url('admin-ajax.php'),
+          'texts'   => [
+            'close'      => __('Fermer', 'chassesautresor-com'),
+            'contenu'    => __('Texte de la solution', 'chassesautresor-com'),
+            'fichier'    => __('Fichier', 'chassesautresor-com'),
+            'disponibilite' => __('Disponibilité', 'chassesautresor-com'),
+            'finChasse'  => __('Fin de la chasse', 'chassesautresor-com'),
+            'differee'   => __('Différée', 'chassesautresor-com'),
+            'days'       => __('jours', 'chassesautresor-com'),
+            'valider'    => __('Valider', 'chassesautresor-com'),
+            'addTitre'   => __('Ajouter une solution', 'chassesautresor-com'),
+            'editTitre'  => __('Modifier la solution', 'chassesautresor-com'),
+            'success'    => __('Solution enregistrée.', 'chassesautresor-com'),
+            'ajaxError'  => __('Erreur réseau', 'chassesautresor-com'),
+          ],
+        ]
+      );
+    }
   }
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -868,6 +868,56 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             </div>
 
             <?php
+            $par_page_solutions = 5;
+            $page_solutions     = 1;
+            $solutions_query    = new WP_Query([
+              'post_type'      => 'solution',
+              'post_status'    => ['publish', 'pending', 'draft'],
+              'orderby'        => 'date',
+              'order'          => 'DESC',
+              'posts_per_page' => $par_page_solutions,
+              'paged'          => $page_solutions,
+              'meta_query'     => [
+                [
+                  'key'   => 'solution_cible_type',
+                  'value' => 'chasse',
+                ],
+                [
+                  'key'   => 'solution_chasse_linked',
+                  'value' => $chasse_id,
+                ],
+              ],
+            ]);
+            $solutions_list  = $solutions_query->posts;
+            $pages_solutions = (int) $solutions_query->max_num_pages;
+            ?>
+            <h3><?= esc_html__('Solutions', 'chassesautresor-com'); ?></h3>
+            <div class="liste-solutions"
+              data-page="1"
+              data-pages="<?= esc_attr($pages_solutions); ?>"
+              data-objet-type="chasse"
+              data-objet-id="<?= esc_attr($chasse_id); ?>"
+              data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
+              <?php
+              get_template_part('template-parts/common/solutions-table', null, [
+                'solutions'  => $solutions_list,
+                'page'       => 1,
+                'pages'      => $pages_solutions,
+                'objet_type' => 'chasse',
+                'objet_id'   => $chasse_id,
+              ]);
+              ?>
+            </div>
+            <p>
+              <button type="button" class="button ajouter-solution"
+                data-objet-type="chasse"
+                data-objet-id="<?= esc_attr($chasse_id); ?>"
+                data-objet-titre="<?= esc_attr(get_the_title($chasse_id)); ?>">
+                <?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?>
+              </button>
+            </p>
+
+            <?php
             $par_page_indices = 5;
             $page_indices     = 1;
             $enigme_ids       = recuperer_ids_enigmes_pour_chasse($chasse_id);


### PR DESCRIPTION
## Summary
- affiche la liste des solutions d'une chasse avec création possible
- charge les scripts de pagination et de création des solutions

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abf31235808332b86e7e486117fe03