### PR TITLE
Utiliser la nouvelle carte solutions dans l'onglet Animation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -132,9 +132,7 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
 
   function initAllSolutionsOptions() {
     document
-      .querySelectorAll(
-        '.dashboard-card.champ-solution, .dashboard-card.champ-solutions'
-      )
+      .querySelectorAll('.dashboard-card.champ-solutions')
       .forEach((c) => {
         initSolutionsOptions(c);
       });
@@ -1198,13 +1196,3 @@ qrDownloadBtn?.addEventListener('click', (e) => {
     });
 });
 
-// ================================
-// 🔗 Défilement doux vers la section Solution
-// ================================
-const solutionLink = document.querySelector('.champ-solution .bouton-cta[href="#solution"]');
-solutionLink?.addEventListener('click', (e) => {
-  e.preventDefault();
-  document
-    .querySelector('#chasse-tab-animation #solution')
-    ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-});

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -858,13 +858,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
                 <div class="champ-feedback"></div>
               </div>
-              <div class="dashboard-card carte-orgy champ-solution">
-                <i class="fa-solid fa-lightbulb icone-defaut" aria-hidden="true"></i>
-                <h3><?= esc_html__('Solution', 'chassesautresor-com'); ?></h3>
-                <a class="bouton-cta" href="#solution">
-                  <?= esc_html__('Voir la solution', 'chassesautresor-com'); ?>
-                </a>
-              </div>
+              <?php
+              get_template_part('template-parts/chasse/partials/chasse-partial-solutions', null, [
+                'objet_id'   => $chasse_id,
+                'objet_type' => 'chasse',
+              ]);
+              ?>
             </div>
 
             <?php
@@ -1040,12 +1039,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             </div>
           </div>
         <?php endif; ?>
-        <div id="solution" class="edition-panel-section">
-          <div class="section-content">
-            <h3><?= esc_html__('Solution', 'chassesautresor-com'); ?></h3>
-            <p><?= esc_html__('Contenu de la solution à venir.', 'chassesautresor-com'); ?></p>
-          </div>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Résumé
- remplace la carte solution basique par la nouvelle carte solutions calquée sur la carte indice
- nettoie le script d’édition de chasse et supprime le défilement vers l’ancre obsolète

## Changements notables
- inclusion de `chasse-partial-solutions` dans la grille du panneau Animation
- retrait du lien d’ancre et de la logique JS associée

## Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abf6d236a483329c1261db28395684