### PR TITLE
Aligne les CTA de la carte solutions avec la carte indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1692,6 +1692,56 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-success-hover);
 }
 
+.dashboard-card.champ-solutions .stat-value {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.dashboard-card.champ-solutions .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+}
+
+.dashboard-card.champ-solutions .cta-solution-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, max-height 0.3s ease;
+}
+
+.dashboard-card.champ-solutions.show-options .cta-solution-options {
+  opacity: 1;
+  max-height: 10rem;
+  pointer-events: auto;
+}
+
+.dashboard-card.champ-solutions.show-options .cta-solution-pour {
+  display: none;
+}
+
+.dashboard-card.champ-solutions .cta-solution-chasse {
+  background-color: var(--color-editor-button);
+  color: var(--color-white);
+}
+
+.dashboard-card.champ-solutions .cta-solution-chasse:hover {
+  background-color: var(--color-editor-button-hover);
+}
+
+.dashboard-card.champ-solutions .cta-solution-enigme {
+  background-color: var(--color-editor-success);
+  color: var(--color-white);
+}
+
+.dashboard-card.champ-solutions .cta-solution-enigme:hover {
+  background-color: var(--color-editor-success-hover);
+}
+
 .dashboard-card .solution-reset {
   position: absolute;
   bottom: 8px;

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -3286,6 +3286,56 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-success-hover);
 }
 
+.dashboard-card.champ-solutions .stat-value, .champ-solutions.carte-orgy .stat-value {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.dashboard-card.champ-solutions .stat-value .bouton-cta, .champ-solutions.carte-orgy .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+}
+
+.dashboard-card.champ-solutions .cta-solution-options, .champ-solutions.carte-orgy .cta-solution-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, max-height 0.3s ease;
+}
+
+.dashboard-card.champ-solutions.show-options .cta-solution-options, .champ-solutions.show-options.carte-orgy .cta-solution-options {
+  opacity: 1;
+  max-height: 10rem;
+  pointer-events: auto;
+}
+
+.dashboard-card.champ-solutions.show-options .cta-solution-pour, .champ-solutions.show-options.carte-orgy .cta-solution-pour {
+  display: none;
+}
+
+.dashboard-card.champ-solutions .cta-solution-chasse, .champ-solutions.carte-orgy .cta-solution-chasse {
+  background-color: var(--color-editor-button);
+  color: var(--color-white);
+}
+
+.dashboard-card.champ-solutions .cta-solution-chasse:hover, .champ-solutions.carte-orgy .cta-solution-chasse:hover {
+  background-color: var(--color-editor-button-hover);
+}
+
+.dashboard-card.champ-solutions .cta-solution-enigme, .champ-solutions.carte-orgy .cta-solution-enigme {
+  background-color: var(--color-editor-success);
+  color: var(--color-white);
+}
+
+.dashboard-card.champ-solutions .cta-solution-enigme:hover, .champ-solutions.carte-orgy .cta-solution-enigme:hover {
+  background-color: var(--color-editor-success-hover);
+}
+
 .dashboard-card .solution-reset, .carte-orgy .solution-reset {
   position: absolute;
   bottom: 8px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3336,6 +3336,56 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-success-hover);
 }
 
+.dashboard-card.champ-solutions .stat-value, .champ-solutions.carte-orgy .stat-value {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.dashboard-card.champ-solutions .stat-value .bouton-cta, .champ-solutions.carte-orgy .stat-value .bouton-cta {
+  display: block;
+  width: 100%;
+}
+
+.dashboard-card.champ-solutions .cta-solution-options, .champ-solutions.carte-orgy .cta-solution-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, max-height 0.3s ease;
+}
+
+.dashboard-card.champ-solutions.show-options .cta-solution-options, .champ-solutions.show-options.carte-orgy .cta-solution-options {
+  opacity: 1;
+  max-height: 10rem;
+  pointer-events: auto;
+}
+
+.dashboard-card.champ-solutions.show-options .cta-solution-pour, .champ-solutions.show-options.carte-orgy .cta-solution-pour {
+  display: none;
+}
+
+.dashboard-card.champ-solutions .cta-solution-chasse, .champ-solutions.carte-orgy .cta-solution-chasse {
+  background-color: var(--color-editor-button);
+  color: var(--color-white);
+}
+
+.dashboard-card.champ-solutions .cta-solution-chasse:hover, .champ-solutions.carte-orgy .cta-solution-chasse:hover {
+  background-color: var(--color-editor-button-hover);
+}
+
+.dashboard-card.champ-solutions .cta-solution-enigme, .champ-solutions.carte-orgy .cta-solution-enigme {
+  background-color: var(--color-editor-success);
+  color: var(--color-white);
+}
+
+.dashboard-card.champ-solutions .cta-solution-enigme:hover, .champ-solutions.carte-orgy .cta-solution-enigme:hover {
+  background-color: var(--color-editor-success-hover);
+}
+
 .dashboard-card .solution-reset, .carte-orgy .solution-reset {
   position: absolute;
   bottom: 8px;


### PR DESCRIPTION
## Résumé
- aligne les CTA de la carte solutions sur ceux de la carte indices
- compile les styles SCSS

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68abff0831288332ad75e0eacc885fee