### PR TITLE
Déplace les liens dans l'onglet Animation de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -1009,12 +1009,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               ]);
               ?>
             </div>
-          </div>
-        </div>
-        <?php if ($afficher_qr_code) : ?>
-          <div class="edition-panel-section">
-            <h3><?= esc_html__('Vos liens', 'chassesautresor-com'); ?></h3>
-            <div class="section-content">
+            <?php if ($afficher_qr_code) : ?>
+              <h3><?= esc_html__('Vos liens', 'chassesautresor-com'); ?></h3>
               <div class="dashboard-card carte-orgy champ-qr-code">
                 <div class="qr-code-block">
                   <div class="qr-code-url txt-small">
@@ -1034,9 +1030,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   </div>
                 </div>
               </div>
-            </div>
+            <?php endif; ?>
           </div>
-        <?php endif; ?>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Résumé
- Intègre la section des liens directement dans le contenu de l'onglet Animation.

## Changements notables
- Place le QR code de partage au même niveau que les cartes, solutions et indices.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac01ff87e083329b385ddba71002e6