### PR TITLE
Masquer le CTA "Ajouter une solution" quand aucune solution n'existe

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -907,14 +907,16 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               ]);
               ?>
             </div>
-            <p>
-              <button type="button" class="button ajouter-solution"
-                data-objet-type="chasse"
-                data-objet-id="<?= esc_attr($chasse_id); ?>"
-                data-objet-titre="<?= esc_attr(get_the_title($chasse_id)); ?>">
-                <?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?>
-              </button>
-            </p>
+            <?php if (!empty($solutions_list)) : ?>
+              <p>
+                <button type="button" class="button ajouter-solution"
+                  data-objet-type="chasse"
+                  data-objet-id="<?= esc_attr($chasse_id); ?>"
+                  data-objet-titre="<?= esc_attr(get_the_title($chasse_id)); ?>">
+                  <?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?>
+                </button>
+              </p>
+            <?php endif; ?>
 
             <?php
             $par_page_indices = 5;


### PR DESCRIPTION
### Résumé
- Masque le bouton d'ajout de solution sur l'onglet Animation lorsqu'aucune solution n'est publiée.

### Changements notables
- N'affiche plus le CTA "Ajouter une solution" si la liste des solutions est vide.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac046f4dd08332b122ff3d9e2afcce