### PR TITLE
Retirer le bouton d'ajout de solution en doublon

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -907,15 +907,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               ]);
               ?>
             </div>
-            <p>
-              <button type="button" class="button ajouter-solution"
-                data-objet-type="chasse"
-                data-objet-id="<?= esc_attr($chasse_id); ?>"
-                data-objet-titre="<?= esc_attr(get_the_title($chasse_id)); ?>">
-                <?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?>
-              </button>
-            </p>
-
             <?php
             $par_page_indices = 5;
             $page_indices     = 1;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -870,7 +870,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     ]);
                     ?>
                   </div>
-                  <p><button type="button" class="button ajouter-solution" data-objet-type="enigme" data-objet-id="<?= esc_attr($enigme_id); ?>" data-objet-titre="<?= esc_attr(get_the_title($enigme_id)); ?>"><?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?></button></p>
                 </div>
 
                 <div class="resume-bloc resume-indices">


### PR DESCRIPTION
### Résumé
- supprime le bouton "Ajouter une solution" en doublon dans l'édition d'une chasse
- supprime le même bouton dans l'édition d'une énigme

### Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac0b98cfa883328346301acd7fd588