### PR TITLE
Fix side-effect opening indice modal when editing solutions

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -315,6 +315,9 @@
     }
     var btn = target && target.closest ? target.closest('.cta-creer-indice, .badge-action.edit') : null;
     if (!btn) return;
+    if (btn.classList.contains('badge-action') && !btn.closest('.liste-indices')) {
+      return;
+    }
     e.preventDefault();
     openModal(btn);
   }


### PR DESCRIPTION
## Résumé
- Empêche l'ouverture de la modale d'indice lors de l'édition d'une solution

## Changements notables
- Restreint la capture du clic sur `.badge-action.edit` aux tableaux d'indices

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac0c3f7c608332b54736115112930c