### PR TITLE
Amélioration du nommage des solutions

### DIFF
--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -73,6 +73,9 @@ class ChasseSolutionsTest extends TestCase
         if (!function_exists('wp_update_post')) {
             function wp_update_post($args) {}
         }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) { return []; }
+        }
         if (!function_exists('update_field')) {
             function update_field($key, $value, $post_id)
             {
@@ -112,6 +115,9 @@ class ChasseSolutionsTest extends TestCase
         }
         if (!function_exists('get_post_status')) {
             function get_post_status($id) { return 'pending'; }
+        }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($id) { return 'Titre'; }
         }
         if (!function_exists('get_field')) {
             function get_field($key, $post_id)
@@ -178,6 +184,12 @@ class ChasseSolutionsTest extends TestCase
         }
         if (!function_exists('wp_send_json_success')) {
             function wp_send_json_success($data = null) { global $json_success_data; $json_success_data = $data; return $data; }
+        }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) { return []; }
+        }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($id) { return 'Titre'; }
         }
         if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
             function recuperer_ids_enigmes_pour_chasse($id) { return [5,6]; }

--- a/tests/SolutionNamingTest.php
+++ b/tests/SolutionNamingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('__')) {
+    function __($text, $domain = null) { return $text; }
+}
+if (!function_exists('add_action')) {
+    function add_action($hook, $callable, $priority = 10, $accepted_args = 1) {}
+}
+if (!function_exists('get_posts')) {
+    function get_posts($args) { return [11, 12]; }
+}
+if (!function_exists('wp_update_post')) {
+    function wp_update_post($args) { global $updated_posts; $updated_posts[] = $args; }
+}
+if (!function_exists('get_the_title')) {
+    function get_the_title($id) { return 'Titre'; }
+}
+if (!function_exists('get_field')) {
+    function get_field($key, $post_id) { return null; }
+}
+
+class SolutionNamingTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        global $updated_posts;
+        $updated_posts = [];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_reordonner_solutions_formats_titles(): void
+    {
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+        reordonner_solutions(5, 'chasse');
+
+        global $updated_posts;
+        $this->assertSame('Solution Titre #1', $updated_posts[0]['post_title']);
+        $this->assertSame('Solution Titre #2', $updated_posts[1]['post_title']);
+    }
+}
+


### PR DESCRIPTION
## Résumé
- Harmonisation du nommage des solutions par chasse ou énigme
- Réordonnancement automatique des solutions lors des modifications
- Ajout de tests pour vérifier le format des titres

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac15c214708332bc20c7f151cf82a1