### PR TITLE
feat: améliorer le tableau des solutions

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -362,6 +362,77 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
+.solutions-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.solutions-table th,
+.solutions-table td {
+  text-align: left;
+  vertical-align: middle;
+}
+
+.solutions-table td > div + div {
+  margin-top: 0.25rem;
+}
+
+.solutions-table th:first-child,
+.solutions-table td:first-child {
+  width: 15%;
+}
+
+.solutions-table th:nth-child(2),
+.solutions-table td:nth-child(2) {
+  width: 25%;
+}
+
+.solutions-table th:nth-child(3),
+.solutions-table td:nth-child(3) {
+  width: 15%;
+}
+
+.solutions-table th:nth-child(4),
+.solutions-table td:nth-child(4) {
+  width: 35%;
+}
+
+.solutions-table th:nth-child(5),
+.solutions-table td:nth-child(5) {
+  width: 10%;
+}
+
+.solutions-table th.solution-actions,
+.solutions-table td.solution-actions {
+  text-align: center;
+}
+
+.solutions-table .badge-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  border: 0;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.solutions-table .badge-action.edit {
+  background: var(--color-secondary);
+}
+
+.solutions-table .badge-action.delete {
+  background: var(--color-error);
+}
+
+.solutions-table .badge-action + .badge-action {
+  margin-left: 0.25rem;
+}
+
 /* Labels */
 .etiquette {
   display: inline-block;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5649,6 +5649,77 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
+.solutions-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.solutions-table th,
+.solutions-table td {
+  text-align: left;
+  vertical-align: middle;
+}
+
+.solutions-table td > div + div {
+  margin-top: 0.25rem;
+}
+
+.solutions-table th:first-child,
+.solutions-table td:first-child {
+  width: 15%;
+}
+
+.solutions-table th:nth-child(2),
+.solutions-table td:nth-child(2) {
+  width: 25%;
+}
+
+.solutions-table th:nth-child(3),
+.solutions-table td:nth-child(3) {
+  width: 15%;
+}
+
+.solutions-table th:nth-child(4),
+.solutions-table td:nth-child(4) {
+  width: 35%;
+}
+
+.solutions-table th:nth-child(5),
+.solutions-table td:nth-child(5) {
+  width: 10%;
+}
+
+.solutions-table th.solution-actions,
+.solutions-table td.solution-actions {
+  text-align: center;
+}
+
+.solutions-table .badge-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  border: 0;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.solutions-table .badge-action.edit {
+  background: var(--color-secondary);
+}
+
+.solutions-table .badge-action.delete {
+  background: var(--color-error);
+}
+
+.solutions-table .badge-action + .badge-action {
+  margin-left: 0.25rem;
+}
+
 /* Labels */
 .etiquette {
   display: inline-block;

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2277,3 +2277,11 @@ msgstr ""
 msgid "Adresse de votre chasse&nbsp;:"
 msgstr ""
 
+#: template-parts/common/solutions-table.php:33
+msgid "Solution pour"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:105
+msgid "PDF"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2466,3 +2466,11 @@ msgstr "Your links"
 msgid "Adresse de votre chasse&nbsp;:"
 msgstr "Your hunt's address:"
 
+#: template-parts/common/solutions-table.php:33
+msgid "Solution pour"
+msgstr "Solution for"
+
+#: template-parts/common/solutions-table.php:105
+msgid "PDF"
+msgstr "PDF"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2437,3 +2437,11 @@ msgstr "Vos liens"
 msgid "Adresse de votre chasse&nbsp;:"
 msgstr "Adresse de votre chasse&nbsp;:"
 
+#: template-parts/common/solutions-table.php:33
+msgid "Solution pour"
+msgstr "Solution pour"
+
+#: template-parts/common/solutions-table.php:105
+msgid "PDF"
+msgstr "PDF"
+

--- a/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
@@ -30,30 +30,92 @@ if (empty($solutions)) {
             <th><?= esc_html__('Date', 'chassesautresor-com'); ?></th>
             <th><?= esc_html__('Solution', 'chassesautresor-com'); ?></th>
             <th><?= esc_html__('Type', 'chassesautresor-com'); ?></th>
+            <th><?= esc_html__('Solution pour', 'chassesautresor-com'); ?></th>
             <th class="solution-actions"><?= esc_html__('Action', 'chassesautresor-com'); ?></th>
         </tr>
     </thead>
     <tbody>
         <?php foreach ($solutions as $solution) :
-            $timestamp = strtotime($solution->post_date);
-            $date_value = function_exists('wp_date') ? wp_date('d/m/y', $timestamp) : date('d/m/y', $timestamp);
-            $time_value = function_exists('wp_date') ? wp_date('H:i', $timestamp) : date('H:i', $timestamp);
-            $fichier_id = get_field('solution_fichier', $solution->ID);
+            $timestamp   = strtotime($solution->post_date);
+            $date_value  = function_exists('wp_date') ? wp_date('d/m/y', $timestamp) : date('d/m/y', $timestamp);
+            $time_value  = function_exists('wp_date') ? wp_date('H:i', $timestamp) : date('H:i', $timestamp);
+            $fichier_id  = get_field('solution_fichier', $solution->ID);
             $fichier_url = $fichier_id ? wp_get_attachment_url($fichier_id) : '';
             $explication = wp_strip_all_tags(get_field('solution_explication', $solution->ID) ?: '');
-            $dispo = get_field('solution_disponibilite', $solution->ID) ?: 'fin_chasse';
-            $delai = (int) get_field('solution_decalage_jours', $solution->ID);
-            $heure = get_field('solution_heure_publication', $solution->ID) ?: '18:00';
-            $type_label = $fichier_url ? __('PDF', 'chassesautresor-com') : ($explication !== '' ? __('Texte', 'chassesautresor-com') : '-');
+            $dispo       = get_field('solution_disponibilite', $solution->ID) ?: 'fin_chasse';
+            $delai       = (int) get_field('solution_decalage_jours', $solution->ID);
+            $heure       = get_field('solution_heure_publication', $solution->ID) ?: '18:00';
+
+            $cible_type  = get_field('solution_cible_type', $solution->ID) === 'chasse' ? 'chasse' : 'enigme';
+            $cible_label = $cible_type === 'enigme'
+                ? __('Énigme', 'chassesautresor-com')
+                : __('Chasse', 'chassesautresor-com');
+            $linked      = $cible_type === 'enigme'
+                ? get_field('solution_enigme_linked', $solution->ID)
+                : get_field('solution_chasse_linked', $solution->ID);
+            $linked_id   = 0;
+            if ($linked) {
+                if (is_array($linked)) {
+                    $first     = $linked[0] ?? null;
+                    $linked_id = is_array($first) ? ($first['ID'] ?? 0) : $first;
+                } else {
+                    $linked_id = $linked;
+                }
+            }
+            $linked_html = '';
+            if ($linked_id) {
+                $linked_title = get_the_title($linked_id);
+                $linked_html  = '<a href="' . esc_url(get_permalink($linked_id)) . '">' . esc_html($linked_title) . '</a>';
+            }
+
+            $etat       = get_field('solution_cache_etat_systeme', $solution->ID) ?: '';
+            $date_raw   = get_field('solution_date_disponibilite', $solution->ID) ?: '';
+            $dt         = $date_raw ? convertir_en_datetime($date_raw) : null;
+            $etat_class = 'etiquette-error';
+            $etat_label = __($etat, 'chassesautresor-com');
+            if ($etat === 'accessible') {
+                $etat_class = 'etiquette-success';
+            } elseif ($etat === 'programme' || $etat === 'programmé') {
+                $etat_class = 'etiquette-pending';
+                if ($dt instanceof DateTimeInterface) {
+                    $format     = get_option('date_format') . ' ' . get_option('time_format');
+                    $date_label = function_exists('wp_date')
+                        ? wp_date($format, $dt->getTimestamp())
+                        : date($format, $dt->getTimestamp());
+                    $etat_label = sprintf(
+                        /* translators: %s: scheduled date */
+                        __('programmé le %s', 'chassesautresor-com'),
+                        $date_label
+                    );
+                } else {
+                    $etat_label = __('programmé', 'chassesautresor-com');
+                }
+            }
+
+            $target_url = $linked_id ? get_permalink($linked_id) : get_permalink($solution);
         ?>
         <tr>
             <td>
                 <div><?= esc_html($date_value); ?></div>
                 <div><?= esc_html(sprintf(__('à %s', 'chassesautresor-com'), $time_value)); ?></div>
             </td>
-            <td><a href="<?= esc_url(get_permalink($solution)); ?>"><?= esc_html(get_the_title($solution)); ?></a></td>
-            <td><?= esc_html($type_label); ?></td>
+            <td><a href="<?= esc_url($target_url); ?>"><?= esc_html(get_the_title($solution)); ?></a></td>
+            <td>
+                <?php if ($fichier_url) : ?>
+                    <span class="etiquette"><?= esc_html__('PDF', 'chassesautresor-com'); ?></span>
+                <?php endif; ?>
+                <?php if ($explication !== '') : ?>
+                    <span class="etiquette"><?= esc_html__('Texte', 'chassesautresor-com'); ?></span>
+                <?php endif; ?>
+                <?php if (!$fichier_url && $explication === '') : ?>-
+                <?php endif; ?>
+            </td>
+            <td>
+                <div><span class="etiquette"><?= esc_html($cible_label); ?></span></div>
+                <div><?= $linked_html; ?></div>
+            </td>
             <td class="solution-actions">
+                <div><span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat_label); ?></span></div>
                 <div class="solution-action-buttons">
                     <button type="button"
                         class="badge-action edit"


### PR DESCRIPTION
## Résumé
- harmonise le tableau des solutions des chasses
- expose le contenu ciblé et le type de chaque solution
- affiche le statut des solutions

## Changements notables
- colonne "Solution pour" avec lien vers la chasse ou l'énigme
- étiquettes PDF/Texte et badge de statut
- layout fixe pour les colonnes du tableau des solutions

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac1766da8483328b10e4554be6ef0c