### PR TITLE
feat: validate solution content

### DIFF
--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -158,6 +158,112 @@ class ChasseSolutionsTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function test_creer_solution_modal_sets_programme_when_hunt_not_finished(): void
+    {
+        if (!defined('TITRE_DEFAUT_SOLUTION')) {
+            define('TITRE_DEFAUT_SOLUTION', 'solution');
+        }
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('is_user_logged_in')) {
+            function is_user_logged_in() { return true; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 3 ? 'chasse' : ($id === 123 ? 'solution' : ''); }
+        }
+        if (!function_exists('solution_action_autorisee')) {
+            function solution_action_autorisee($action, $type, $id) { return true; }
+        }
+        if (!function_exists('get_current_user_id')) {
+            function get_current_user_id() { return 1; }
+        }
+        if (!function_exists('wp_insert_post')) {
+            function wp_insert_post($args) { return 123; }
+        }
+        if (!function_exists('wp_update_post')) {
+            function wp_update_post($args) {}
+        }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) { return []; }
+        }
+        if (!function_exists('update_field')) {
+            function update_field($key, $value, $post_id)
+            {
+                global $captured_fields;
+                $captured_fields[$key] = $value;
+            }
+        }
+        if (!function_exists('wp_send_json_error')) {
+            function wp_send_json_error($data = null) { throw new Exception((string) $data); }
+        }
+        if (!function_exists('wp_send_json_success')) {
+            function wp_send_json_success($data = null) { global $json_success_data; $json_success_data = $data; return $data; }
+        }
+        if (!function_exists('sanitize_key')) {
+            function sanitize_key($key) { return $key; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($data) { return $data; }
+        }
+        if (!function_exists('sanitize_text_field')) {
+            function sanitize_text_field($text) { return $text; }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callable, $priority = 10, $accepted_args = 1) {}
+        }
+        if (!function_exists('current_time')) {
+            function current_time($type) { return 1; }
+        }
+        if (!function_exists('wp_clear_scheduled_hook')) {
+            function wp_clear_scheduled_hook($hook, $args = []) {}
+        }
+        if (!function_exists('delete_post_meta')) {
+            function delete_post_meta($id, $key) {}
+        }
+        if (!function_exists('get_post_status')) {
+            function get_post_status($id) { return 'pending'; }
+        }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($id) { return 'Titre'; }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id)
+            {
+                global $captured_fields;
+                if ($key === 'statut_chasse') {
+                    return 'active';
+                }
+                return $captured_fields[$key] ?? null;
+            }
+        }
+        if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
+            function recuperer_ids_enigmes_pour_chasse($id) { return [5,6]; }
+        }
+        if (!function_exists('get_template_part')) {
+            function get_template_part($slug, $name = null, $args = []) { echo 'table'; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+        $_POST = [
+            'objet_id'   => 3,
+            'objet_type' => 'chasse',
+            'solution_explication' => 'Test',
+        ];
+
+        ajax_creer_solution_modal();
+
+        global $captured_fields, $json_success_data;
+        $this->assertSame(123, $json_success_data['solution_id']);
+        $this->assertSame('programme', $captured_fields['solution_cache_etat_systeme']);
+        $this->assertSame(1, $captured_fields['solution_cache_complet']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_lister_table_for_hunt_includes_riddle_solutions(): void
     {
         if (!defined('TITRE_DEFAUT_SOLUTION')) {

--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -141,6 +141,7 @@ class ChasseSolutionsTest extends TestCase
         $_POST = [
             'objet_id'   => 3,
             'objet_type' => 'chasse',
+            'solution_explication' => 'Test',
         ];
 
         ajax_creer_solution_modal();
@@ -223,5 +224,98 @@ class ChasseSolutionsTest extends TestCase
         $this->assertSame([5,6], $meta[1][1]['value']);
         $this->assertSame('IN', $meta[1][1]['compare']);
         $this->assertIsArray($json_success_data);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_creer_solution_modal_requires_content(): void
+    {
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('is_user_logged_in')) {
+            function is_user_logged_in() { return true; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 3 ? 'chasse' : ''; }
+        }
+        if (!function_exists('solution_action_autorisee')) {
+            function solution_action_autorisee($action, $type, $id) { return true; }
+        }
+        if (!function_exists('sanitize_key')) {
+            function sanitize_key($key) { return $key; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($data) { return $data; }
+        }
+        if (!function_exists('wp_send_json_error')) {
+            function wp_send_json_error($data = null) { throw new Exception((string) $data); }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callable, $priority = 10, $accepted_args = 1) {}
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+        $_POST = [
+            'objet_id'   => 3,
+            'objet_type' => 'chasse',
+        ];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('contenu_manquant');
+        ajax_creer_solution_modal();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_modifier_solution_modal_requires_content(): void
+    {
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('is_user_logged_in')) {
+            function is_user_logged_in() { return true; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 10 ? 'solution' : ($id === 3 ? 'chasse' : ''); }
+        }
+        if (!function_exists('solution_action_autorisee')) {
+            function solution_action_autorisee($action, $type, $id) { return true; }
+        }
+        if (!function_exists('sanitize_key')) {
+            function sanitize_key($key) { return $key; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($data) { return $data; }
+        }
+        if (!function_exists('sanitize_text_field')) {
+            function sanitize_text_field($text) { return $text; }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $id) { return ''; }
+        }
+        if (!function_exists('wp_send_json_error')) {
+            function wp_send_json_error($data = null) { throw new Exception((string) $data); }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callable, $priority = 10, $accepted_args = 1) {}
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+        $_POST = [
+            'solution_id' => 10,
+            'objet_id'    => 3,
+            'objet_type'  => 'chasse',
+        ];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('contenu_manquant');
+        ajax_modifier_solution_modal();
     }
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -702,8 +702,16 @@ function ajax_creer_solution_modal(): void
     update_field('solution_disponibilite', $dispo, $solution_id);
     update_field('solution_decalage_jours', $delai, $solution_id);
     update_field('solution_heure_publication', $heure ?: '00:00', $solution_id);
-
-    solution_planifier_publication($solution_id);
+    $complet = $fichier || $explic !== '';
+    if ($complet) {
+        update_field('solution_cache_complet', 1, $solution_id);
+        solution_planifier_publication($solution_id);
+    } else {
+        update_field('solution_cache_complet', 0, $solution_id);
+        update_field('solution_cache_etat_systeme', 'invalide', $solution_id);
+        wp_clear_scheduled_hook('publier_solution_programmee', [$solution_id]);
+        delete_post_meta($solution_id, 'solution_date_disponibilite');
+    }
 
     wp_send_json_success(['solution_id' => $solution_id]);
 }
@@ -764,8 +772,16 @@ function ajax_modifier_solution_modal(): void
     update_field('solution_disponibilite', $dispo, $solution_id);
     update_field('solution_decalage_jours', $delai, $solution_id);
     update_field('solution_heure_publication', $heure ?: '00:00', $solution_id);
-
-    solution_planifier_publication($solution_id);
+    $complet = $fichier || $explic !== '';
+    if ($complet) {
+        update_field('solution_cache_complet', 1, $solution_id);
+        solution_planifier_publication($solution_id);
+    } else {
+        update_field('solution_cache_complet', 0, $solution_id);
+        update_field('solution_cache_etat_systeme', 'invalide', $solution_id);
+        wp_clear_scheduled_hook('publier_solution_programmee', [$solution_id]);
+        delete_post_meta($solution_id, 'solution_date_disponibilite');
+    }
 
     wp_send_json_success(['solution_id' => $solution_id]);
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -141,7 +141,19 @@ function solution_acf_save_post(int $post_id): void
         return;
     }
 
-    solution_planifier_publication($post_id);
+    $fichier = (int) get_field('solution_fichier', $post_id);
+    $explic  = (string) get_field('solution_explication', $post_id);
+    $complet = $fichier || $explic !== '';
+    if ($complet) {
+        update_field('solution_cache_complet', 1, $post_id);
+        update_field('solution_cache_etat_systeme', 'programme', $post_id);
+        solution_planifier_publication($post_id);
+    } else {
+        update_field('solution_cache_complet', 0, $post_id);
+        update_field('solution_cache_etat_systeme', 'invalide', $post_id);
+        wp_clear_scheduled_hook('publier_solution_programmee', [$post_id]);
+        delete_post_meta($post_id, 'solution_date_disponibilite');
+    }
     reordonner_solutions_pour_solution($post_id);
 }
 add_action('acf/save_post', 'solution_acf_save_post', 40);
@@ -705,6 +717,7 @@ function ajax_creer_solution_modal(): void
     $complet = $fichier || $explic !== '';
     if ($complet) {
         update_field('solution_cache_complet', 1, $solution_id);
+        update_field('solution_cache_etat_systeme', 'programme', $solution_id);
         solution_planifier_publication($solution_id);
     } else {
         update_field('solution_cache_complet', 0, $solution_id);
@@ -775,6 +788,7 @@ function ajax_modifier_solution_modal(): void
     $complet = $fichier || $explic !== '';
     if ($complet) {
         update_field('solution_cache_complet', 1, $solution_id);
+        update_field('solution_cache_etat_systeme', 'programme', $solution_id);
         solution_planifier_publication($solution_id);
     } else {
         update_field('solution_cache_complet', 0, $solution_id);

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2285,3 +2285,11 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+#: template-parts/common/solutions-table.php:81
+msgid "fin de chasse"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:83
+msgid "différée"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2474,3 +2474,11 @@ msgstr "Solution for"
 msgid "PDF"
 msgstr "PDF"
 
+#: template-parts/common/solutions-table.php:81
+msgid "fin de chasse"
+msgstr "end of hunt"
+
+#: template-parts/common/solutions-table.php:83
+msgid "différée"
+msgstr "deferred"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2445,3 +2445,11 @@ msgstr "Solution pour"
 msgid "PDF"
 msgstr "PDF"
 
+#: template-parts/common/solutions-table.php:81
+msgid "fin de chasse"
+msgstr "fin de chasse"
+
+#: template-parts/common/solutions-table.php:83
+msgid "différée"
+msgstr "différée"
+

--- a/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
@@ -77,7 +77,11 @@ if (empty($solutions)) {
                 $etat_class = 'etiquette-success';
             } elseif ($etat === 'programme' || $etat === 'programmé') {
                 $etat_class = 'etiquette-pending';
-                if ($dt instanceof DateTimeInterface) {
+                if ($dispo === 'fin_chasse') {
+                    $etat_label = __('fin de chasse', 'chassesautresor-com');
+                } elseif ($dispo === 'differee') {
+                    $etat_label = __('différée', 'chassesautresor-com');
+                } elseif ($dt instanceof DateTimeInterface) {
                     $format     = get_option('date_format') . ' ' . get_option('time_format');
                     $date_label = function_exists('wp_date')
                         ? wp_date($format, $dt->getTimestamp())


### PR DESCRIPTION
## Summary
- impose server-side content validation for solutions
- cover missing-content cases in tests

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68ac1abc35848332a80dbeb37511a541