### PR TITLE
Conserver la date des indices lors des changements de statut

### DIFF
--- a/tests/MettreAJourCacheIndiceTest.php
+++ b/tests/MettreAJourCacheIndiceTest.php
@@ -36,6 +36,16 @@ namespace {
         }
     }
 
+    if (!function_exists('get_post')) {
+        function get_post($post_id)
+        {
+            return (object) [
+                'post_date'     => '2024-01-01 00:00:00',
+                'post_date_gmt' => '2024-01-01 00:00:00',
+            ];
+        }
+    }
+
     if (!function_exists('update_field')) {
         function update_field($name, $value, $post_id): void
         {

--- a/tests/ModifierIndiceImageRemovalTest.php
+++ b/tests/ModifierIndiceImageRemovalTest.php
@@ -33,6 +33,14 @@ namespace {
     if (!function_exists('get_field')) {
         function get_field($field, $post_id) { return null; }
     }
+    if (!function_exists('get_post')) {
+        function get_post($post_id) {
+            return (object) [
+                'post_date'     => '2024-01-01 00:00:00',
+                'post_date_gmt' => '2024-01-01 00:00:00',
+            ];
+        }
+    }
     if (!function_exists('current_time')) {
         function current_time($type) { return $type === 'timestamp' ? 1704067200 : '2024-01-01 00:00:00'; }
     }

--- a/tests/ModifierIndiceImmediateDateTest.php
+++ b/tests/ModifierIndiceImmediateDateTest.php
@@ -36,6 +36,14 @@ namespace {
             return $updated_fields[$field] ?? ($existing_fields[$field] ?? null);
         }
     }
+    if (!function_exists('get_post')) {
+        function get_post($post_id) {
+            return (object) [
+                'post_date'     => '2024-01-01 00:00:00',
+                'post_date_gmt' => '2024-01-01 00:00:00',
+            ];
+        }
+    }
     if (!function_exists('current_time')) {
         function current_time($type) { return $type === 'timestamp' ? 1704067200 : '2024-01-01 00:00:00'; }
     }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -960,12 +960,26 @@ function mettre_a_jour_cache_indice($post_id, ?int $chasse_id = null): void
     update_field('indice_cache_etat_systeme', $state, $post_id);
 
     $status = get_post_status($post_id);
+    $post   = get_post($post_id);
+
     if ($complete && $state === 'accessible') {
         if ($status !== 'publish') {
-            wp_update_post(['ID' => $post_id, 'post_status' => 'publish']);
+            wp_update_post([
+                'ID'            => $post_id,
+                'post_status'   => 'publish',
+                'post_date'     => $post->post_date,
+                'post_date_gmt' => $post->post_date_gmt,
+                'edit_date'     => true,
+            ]);
         }
     } elseif ($status === 'publish') {
-        wp_update_post(['ID' => $post_id, 'post_status' => 'pending']);
+        wp_update_post([
+            'ID'            => $post_id,
+            'post_status'   => 'pending',
+            'post_date'     => $post->post_date,
+            'post_date_gmt' => $post->post_date_gmt,
+            'edit_date'     => true,
+        ]);
     }
 
     reordonner_indices_pour_indice((int) $post_id);


### PR DESCRIPTION
## Résumé
- Préserve la date d'origine lors du passage d'un indice entre `publish` et `pending`
- Ajout de stubs `get_post` dans les tests pour refléter ce comportement

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f52eb3c83329fb92c304d1aa60b