### PR TITLE
validate solution content

### DIFF
--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -141,6 +141,7 @@ class ChasseSolutionsTest extends TestCase
         $_POST = [
             'objet_id'   => 3,
             'objet_type' => 'chasse',
+            'solution_explication' => 'texte',
         ];
 
         ajax_creer_solution_modal();
@@ -319,5 +320,50 @@ class ChasseSolutionsTest extends TestCase
         $this->assertSame(['solution_fichier', 456], $uploaded_args);
         $this->assertSame(789, $captured_fields['solution_fichier']);
         $this->assertSame(456, $json_success_data['solution_id']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_creer_solution_modal_requires_content(): void
+    {
+        if (!defined('TITRE_DEFAUT_SOLUTION')) {
+            define('TITRE_DEFAUT_SOLUTION', 'solution');
+        }
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('is_user_logged_in')) {
+            function is_user_logged_in() { return true; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 3 ? 'chasse' : ''; }
+        }
+        if (!function_exists('solution_action_autorisee')) {
+            function solution_action_autorisee($action, $type, $id) { return true; }
+        }
+        if (!function_exists('sanitize_key')) {
+            function sanitize_key($key) { return $key; }
+        }
+        if (!function_exists('wp_send_json_error')) {
+            function wp_send_json_error($data = null) { throw new Exception((string) $data); }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callable, $priority = 10, $accepted_args = 1) {}
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+        $_POST = [
+            'objet_id'   => 3,
+            'objet_type' => 'chasse',
+        ];
+
+        $_FILES = [];
+
+        $this->expectExceptionMessage('contenu_manquant');
+
+        ajax_creer_solution_modal();
     }
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -676,6 +676,12 @@ function ajax_creer_solution_modal(): void
         wp_send_json_error('acces_refuse');
     }
 
+    $has_file   = !empty($_FILES['solution_fichier']['tmp_name']) || !empty($_POST['solution_fichier']);
+    $has_explic = isset($_POST['solution_explication']) && trim((string) $_POST['solution_explication']) !== '';
+    if (!$has_file && !$has_explic) {
+        wp_send_json_error('contenu_manquant');
+    }
+
     $solution_id = creer_solution_pour_objet($objet_id, $objet_type);
     if (is_wp_error($solution_id)) {
         wp_send_json_error($solution_id->get_error_message());
@@ -742,6 +748,12 @@ function ajax_modifier_solution_modal(): void
     }
     if (!solution_action_autorisee('edit', $objet_type, $objet_id)) {
         wp_send_json_error('acces_refuse');
+    }
+
+    $has_file   = !empty($_FILES['solution_fichier']['tmp_name']) || !empty($_POST['solution_fichier']);
+    $has_explic = isset($_POST['solution_explication']) && trim((string) $_POST['solution_explication']) !== '';
+    if (!$has_file && !$has_explic) {
+        wp_send_json_error('contenu_manquant');
     }
 
     $fichier = 0;


### PR DESCRIPTION
## Summary
- vérifie la présence d'un fichier ou d'une explication lors de la création et la modification d'une solution
- ajoute un test de non-fourniture du contenu d'une solution

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac3551885483328535de0af9da1315