### PR TITLE
Préserve la date de publication des solutions

### DIFF
--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -31,6 +31,16 @@ if (!class_exists('WP_Query')) {
     }
 }
 
+if (!function_exists('get_post')) {
+    function get_post($post_id)
+    {
+        return (object) [
+            'post_date'     => '2024-01-01 00:00:00',
+            'post_date_gmt' => '2024-01-01 00:00:00',
+        ];
+    }
+}
+
 class ChasseSolutionsTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/SolutionRendreAccessibleTest.php
+++ b/tests/SolutionRendreAccessibleTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace {
+    if (!function_exists('get_post_type')) {
+        function get_post_type($id)
+        {
+            return 'solution';
+        }
+    }
+
+    if (!function_exists('update_field')) {
+        function update_field($key, $value, $post_id): void
+        {
+        }
+    }
+
+    if (!function_exists('delete_post_meta')) {
+        function delete_post_meta($id, $key): void
+        {
+        }
+    }
+
+    if (!function_exists('get_post_status')) {
+        function get_post_status($id)
+        {
+            return 'draft';
+        }
+    }
+
+    if (!function_exists('get_post')) {
+        function get_post($id)
+        {
+            return (object) [
+                'post_date'     => '2024-03-10 00:00:00',
+                'post_date_gmt' => '2024-03-10 00:00:00',
+            ];
+        }
+    }
+
+    if (!function_exists('wp_update_post')) {
+        function wp_update_post(array $data): void
+        {
+            global $updated_post;
+            $updated_post = $data;
+        }
+    }
+
+    if (!function_exists('add_action')) {
+        function add_action($hook, $callable, $priority = 10, $accepted_args = 1): void
+        {
+        }
+    }
+}
+
+namespace SolutionRendreAccessibleTest {
+    use PHPUnit\Framework\TestCase;
+
+    class SolutionRendreAccessibleTest extends TestCase
+    {
+        /**
+         * @runInSeparateProcess
+         * @preserveGlobalState disabled
+         */
+        public function test_post_date_is_preserved_when_publishing(): void
+        {
+            global $updated_post;
+
+            require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+            \solution_rendre_accessible(123);
+
+            $this->assertSame('2024-03-10 00:00:00', $updated_post['post_date']);
+            $this->assertSame('2024-03-10 00:00:00', $updated_post['post_date_gmt']);
+        }
+    }
+}
+

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -78,7 +78,14 @@ function solution_rendre_accessible(int $solution_id): void
     update_field('solution_cache_etat_systeme', 'accessible', $solution_id);
     delete_post_meta($solution_id, 'solution_date_disponibilite');
     if (get_post_status($solution_id) !== 'publish') {
-        wp_update_post(['ID' => $solution_id, 'post_status' => 'publish']);
+        $post = get_post($solution_id);
+        wp_update_post([
+            'ID'            => $solution_id,
+            'post_status'   => 'publish',
+            'post_date'     => $post->post_date,
+            'post_date_gmt' => $post->post_date_gmt,
+            'edit_date'     => true,
+        ]);
     }
 }
 add_action('publier_solution_programmee', 'solution_rendre_accessible');


### PR DESCRIPTION
## Résumé
- Conservation de la date originale lors du passage d'une solution en publication
- Couverture de tests améliorée pour vérifier la date de publication

## Changements notables
- Récupération des champs `post_date` et `post_date_gmt` lors de la mise en ligne d'une solution
- Ajout d'un test unitaire pour garantir l'intégrité de la date de publication
- Ajout d'un mock `get_post` dans un test existant

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac489846b8833289e85bc8bebb7472