### PR TITLE
Traduction des états système des solutions

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2474,3 +2474,31 @@ msgstr "Solution for"
 msgid "PDF"
 msgstr "PDF"
 
+#: template-parts/common/solutions-table.php:???
+msgid "Invalid solution"
+msgstr "Invalid solution"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Hunt finished"
+msgstr "Hunt finished"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Hunt end delayed"
+msgstr "Hunt end delayed"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Coming soon"
+msgstr "Coming soon"
+
+#: template-parts/common/solutions-table.php:???
+msgid "In progress"
+msgstr "In progress"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Disabled"
+msgstr "Disabled"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Coming on %s"
+msgstr "Coming on %s"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2445,3 +2445,31 @@ msgstr "Solution pour"
 msgid "PDF"
 msgstr "PDF"
 
+#: template-parts/common/solutions-table.php:???
+msgid "Invalid solution"
+msgstr "Solution invalide"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Hunt finished"
+msgstr "Fin de chasse"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Hunt end delayed"
+msgstr "Fin de chasse différée"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Coming soon"
+msgstr "À venir"
+
+#: template-parts/common/solutions-table.php:???
+msgid "In progress"
+msgstr "En cours"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Disabled"
+msgstr "Désactivée"
+
+#: template-parts/common/solutions-table.php:???
+msgid "Coming on %s"
+msgstr "À venir le %s"
+

--- a/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
@@ -72,7 +72,15 @@ if (empty($solutions)) {
             $date_raw   = get_field('solution_date_disponibilite', $solution->ID) ?: '';
             $dt         = $date_raw ? convertir_en_datetime($date_raw) : null;
             $etat_class = 'etiquette-error';
-            $etat_label = __($etat, 'chassesautresor-com');
+            $state_labels = [
+                SOLUTION_STATE_INVALIDE           => __('Invalid solution', 'chassesautresor-com'),
+                SOLUTION_STATE_FIN_CHASSE         => __('Hunt finished', 'chassesautresor-com'),
+                SOLUTION_STATE_FIN_CHASSE_DIFFERE => __('Hunt end delayed', 'chassesautresor-com'),
+                SOLUTION_STATE_A_VENIR            => __('Coming soon', 'chassesautresor-com'),
+                SOLUTION_STATE_EN_COURS           => __('In progress', 'chassesautresor-com'),
+                SOLUTION_STATE_DESACTIVE          => __('Disabled', 'chassesautresor-com'),
+            ];
+            $etat_label = $state_labels[$etat] ?? $etat;
 
             switch ($etat) {
                 case SOLUTION_STATE_EN_COURS:
@@ -92,7 +100,7 @@ if (empty($solutions)) {
                     : date($format, $dt->getTimestamp());
                 $etat_label = sprintf(
                     /* translators: %s: scheduled date */
-                    __('à venir le %s', 'chassesautresor-com'),
+                    __('Coming on %s', 'chassesautresor-com'),
                     $date_label
                 );
             }


### PR DESCRIPTION
## Résumé
- ajoute un mapping des états système vers des libellés traduits
- ajoute les chaînes de traduction pour les libellés d'état

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac4d5c34f48332b62f97c55bf53fad