### PR TITLE
Préfille et valide le délai des solutions

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/solutions-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/solutions-create.js
@@ -45,6 +45,25 @@
         '" />';
     }
     fileField += '</p>';
+
+    var delaiValue = btn.dataset.solutionDelai;
+    var heureValue = btn.dataset.solutionHeure;
+    if (isEdit) {
+      var now = new Date();
+      var pad = function (n) {
+        return String(n).padStart(2, '0');
+      };
+      if (delaiValue === undefined || delaiValue === '') {
+        delaiValue = 0;
+      }
+      if (!heureValue) {
+        heureValue = pad(now.getHours()) + ':' + pad(now.getMinutes());
+      }
+    } else {
+      delaiValue = delaiValue || 0;
+      heureValue = heureValue || '18:00';
+    }
+
     overlay.innerHTML = `
       <div class="solution-modal">
         <div class="solution-modal-header">
@@ -65,8 +84,8 @@
             <option value="differee">${solutionsCreate.texts.differee}</option>
           </select></label></p>
           <p class="delai-wrapper" style="display:none;">
-            <input type="number" name="solution_delai" min="0" value="${btn.dataset.solutionDelai || 0}" /> ${solutionsCreate.texts.days}
-            <input type="time" name="solution_heure" value="${btn.dataset.solutionHeure || '18:00'}" />
+            <input type="number" name="solution_delai" min="0" value="${delaiValue}" /> ${solutionsCreate.texts.days}
+            <input type="time" name="solution_heure" value="${heureValue}" />
           </p>
           <div class="solution-modal-footer"><span class="solution-state-message"></span><button type="submit" class="solution-modal-validate bouton-cta">${solutionsCreate.texts.valider}</button></div>
         </form>
@@ -196,15 +215,22 @@
       } else {
         state = 'accessible';
         if (selectDispo.value === 'differee') {
-          var delai = parseInt(delaiInput.value, 10) || 0;
-          var heure = heureInput.value || '00:00';
-          var now = new Date();
-          var target = new Date(now);
-          var parts = heure.split(':');
-          target.setDate(target.getDate() + delai);
-          target.setHours(parseInt(parts[0], 10), parseInt(parts[1], 10), 0, 0);
-          if (target > now) {
-            state = 'programme';
+          var delaiVide = delaiInput.value === '';
+          var heureVide = heureInput.value === '';
+          if (delaiVide || heureVide) {
+            state = 'desactive';
+            message = solutionsCreate.texts.needDate;
+          } else {
+            var delai = parseInt(delaiInput.value, 10) || 0;
+            var heure = heureInput.value;
+            var now = new Date();
+            var target = new Date(now);
+            var parts = heure.split(':');
+            target.setDate(target.getDate() + delai);
+            target.setHours(parseInt(parts[0], 10), parseInt(parts[1], 10), 0, 0);
+            if (target > now) {
+              state = 'programme';
+            }
           }
         }
       }

--- a/wp-content/themes/chassesautresor/assets/js/solutions-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/solutions-create.js
@@ -10,13 +10,22 @@
     var needEnigme = btn.dataset.chasseId && !btn.dataset.objetId;
     var existingFileId = btn.dataset.solutionFichierId || '';
     var existingFileUrl = btn.dataset.solutionFichierUrl || '';
-    var enigmeField = needEnigme
-      ? '<p><label>' +
+    var enigmeField;
+    if (needEnigme) {
+      enigmeField =
+        '<p><label>' +
         solutionsCreate.texts.enigmeLabel +
         '<br><select name="solution_enigme_linked"><option value="">' +
         solutionsCreate.texts.loading +
-        '</option></select></label></p>'
-      : '';
+        '</option></select></label></p>';
+    } else if (btn.dataset.objetType === 'enigme') {
+      enigmeField =
+        '<input type="hidden" name="solution_enigme_linked" value="' +
+        (btn.dataset.objetId || '') +
+        '" />';
+    } else {
+      enigmeField = '';
+    }
     var initialName = '';
     if (existingFileUrl) {
       initialName = '<a href="' +
@@ -84,8 +93,8 @@
             <option value="differee">${solutionsCreate.texts.differee}</option>
           </select></label></p>
           <p class="delai-wrapper" style="display:none;">
-            <input type="number" name="solution_delai" min="0" value="${delaiValue}" /> ${solutionsCreate.texts.days}
-            <input type="time" name="solution_heure" value="${heureValue}" />
+            <input type="number" name="solution_decalage_jours" min="0" value="${delaiValue}" /> ${solutionsCreate.texts.days}
+            <input type="time" name="solution_heure_publication" value="${heureValue}" />
           </p>
           <div class="solution-modal-footer"><span class="solution-state-message"></span><button type="submit" class="solution-modal-validate bouton-cta">${solutionsCreate.texts.valider}</button></div>
         </form>
@@ -101,8 +110,8 @@
     var stateMessage = overlay.querySelector('.solution-state-message');
     var selectDispo = overlay.querySelector('select[name="solution_disponibilite"]');
     var delaiWrapper = overlay.querySelector('.delai-wrapper');
-    var delaiInput = overlay.querySelector('input[name="solution_delai"]');
-    var heureInput = overlay.querySelector('input[name="solution_heure"]');
+    var delaiInput = overlay.querySelector('input[name="solution_decalage_jours"]');
+    var heureInput = overlay.querySelector('input[name="solution_heure_publication"]');
     var explicationInput = overlay.querySelector('textarea[name="solution_explication"]');
     var fichierInput = overlay.querySelector('input[name="solution_fichier"][type="file"]');
     var existingFileInput = overlay.querySelector('input[name="solution_fichier"][type="hidden"]');

--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -199,6 +199,7 @@ function enqueue_core_edit_scripts(array $additional = [])
             'chooseFile'       => __('Choisir un fichier', 'chassesautresor-com'),
             'noFile'           => __('Aucun fichier choisi', 'chassesautresor-com'),
             'removeFile'       => __('Supprimer le fichier', 'chassesautresor-com'),
+            'needDate'         => __('Date et heure requises', 'chassesautresor-com'),
           ],
         ]
       );

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2285,3 +2285,11 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+#: inc/edition/edition-core.php
+msgid "Disponibilité"
+msgstr ""
+
+#: inc/edition/edition-core.php
+msgid "Date et heure requises"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2395,6 +2395,10 @@ msgstr "Date and time required"
 msgid "Date invalide"
 msgstr "Invalid date"
 
+#: inc/edition/edition-core.php
+msgid "Disponibilité"
+msgstr "Availability"
+
 #: template-parts/common/indices-table.php:69
 msgid "accessible"
 msgstr "accessible"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2473,3 +2473,11 @@ msgstr "Désactivée"
 msgid "Coming on %s"
 msgstr "À venir le %s"
 
+#: inc/edition/edition-core.php
+msgid "Date et heure requises"
+msgstr "Date et heure requises"
+
+#: inc/edition/edition-core.php
+msgid "Disponibilité"
+msgstr "Disponibilité"
+


### PR DESCRIPTION
## Résumé
- Préremplit le délai lors de l’édition d’une solution
- Empêche la validation si le mode différé est incomplet
- Ajoute la traduction manquante pour « Disponibilité »

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac570bc8cc83329c5784f602ad4edc