### PR TITLE
Add missing solution modal translations

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2285,3 +2285,27 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+#: inc/edition/edition-core.php:180
+msgid "Texte de la solution"
+msgstr ""
+
+#: inc/edition/edition-core.php:181
+msgid "Fichier"
+msgstr ""
+
+#: inc/edition/edition-core.php:182
+msgid "Disponibilité"
+msgstr ""
+
+#: inc/edition/edition-core.php:187 template-parts/chasse/partials/chasse-partial-solutions.php:24
+msgid "Ajouter une solution"
+msgstr ""
+
+#: inc/edition/edition-core.php:195
+msgid "Ajoutez un fichier ou un texte"
+msgstr ""
+
+#: inc/edition/edition-core.php:200
+msgid "Aucun fichier choisi"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2502,3 +2502,27 @@ msgstr "Disabled"
 msgid "Coming on %s"
 msgstr "Coming on %s"
 
+#: inc/edition/edition-core.php:180
+msgid "Texte de la solution"
+msgstr "Solution text"
+
+#: inc/edition/edition-core.php:181
+msgid "Fichier"
+msgstr "File"
+
+#: inc/edition/edition-core.php:182
+msgid "Disponibilité"
+msgstr "Availability"
+
+#: inc/edition/edition-core.php:187 template-parts/chasse/partials/chasse-partial-solutions.php:24
+msgid "Ajouter une solution"
+msgstr "Add a solution"
+
+#: inc/edition/edition-core.php:195
+msgid "Ajoutez un fichier ou un texte"
+msgstr "Add a file or text"
+
+#: inc/edition/edition-core.php:200
+msgid "Aucun fichier choisi"
+msgstr "No file selected"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2473,3 +2473,27 @@ msgstr "Désactivée"
 msgid "Coming on %s"
 msgstr "À venir le %s"
 
+#: inc/edition/edition-core.php:180
+msgid "Texte de la solution"
+msgstr "Texte de la solution"
+
+#: inc/edition/edition-core.php:181
+msgid "Fichier"
+msgstr "Fichier"
+
+#: inc/edition/edition-core.php:182
+msgid "Disponibilité"
+msgstr "Disponibilité"
+
+#: inc/edition/edition-core.php:187 template-parts/chasse/partials/chasse-partial-solutions.php:24
+msgid "Ajouter une solution"
+msgstr "Ajouter une solution"
+
+#: inc/edition/edition-core.php:195
+msgid "Ajoutez un fichier ou un texte"
+msgstr "Ajoutez un fichier ou un texte"
+
+#: inc/edition/edition-core.php:200
+msgid "Aucun fichier choisi"
+msgstr "Aucun fichier choisi"
+


### PR DESCRIPTION
Ajout des traductions manquantes pour le panneau de solutions.

- Ajout des nouvelles chaînes dans le modèle de traduction et les fichiers `po`
- Complétion des traductions anglaises et françaises pour le modal de solution

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac580d3c5c83329b6a6c7568654145