### PR TITLE
Fix: enregistrer delai et heure des solutions

### DIFF
--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -123,6 +123,12 @@ class ChasseSolutionsTest extends TestCase
         if (!function_exists('delete_post_meta')) {
             function delete_post_meta($id, $key) {}
         }
+        if (!function_exists('update_post_meta')) {
+            function update_post_meta($id, $key, $value) {}
+        }
+        if (!function_exists('wp_schedule_single_event')) {
+            function wp_schedule_single_event($timestamp, $hook, $args = []) {}
+        }
         if (!function_exists('get_post_status')) {
             function get_post_status($id) { return 'pending'; }
         }
@@ -164,6 +170,123 @@ class ChasseSolutionsTest extends TestCase
         $this->assertSame(0, $captured_fields['solution_decalage_jours']);
         $this->assertSame('00:00', $captured_fields['solution_heure_publication']);
         $this->assertSame(SOLUTION_STATE_DESACTIVE, $captured_fields['solution_cache_etat_systeme']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_creer_solution_modal_with_delay_and_time(): void
+    {
+        if (!defined('TITRE_DEFAUT_SOLUTION')) {
+            define('TITRE_DEFAUT_SOLUTION', 'solution');
+        }
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('is_user_logged_in')) {
+            function is_user_logged_in() { return true; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 3 ? 'chasse' : ($id === 123 ? 'solution' : ''); }
+        }
+        if (!function_exists('solution_action_autorisee')) {
+            function solution_action_autorisee($action, $type, $id) { return true; }
+        }
+        if (!function_exists('get_current_user_id')) {
+            function get_current_user_id() { return 1; }
+        }
+        if (!function_exists('wp_insert_post')) {
+            function wp_insert_post($args) { return 123; }
+        }
+        if (!function_exists('wp_update_post')) {
+            function wp_update_post($args) {}
+        }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) { return []; }
+        }
+        if (!function_exists('update_field')) {
+            function update_field($key, $value, $post_id)
+            {
+                global $captured_fields;
+                if ($key === 'solution_cache_etat_systeme' && array_key_exists($key, $captured_fields)) {
+                    return;
+                }
+                $captured_fields[$key] = $value;
+            }
+        }
+        if (!function_exists('wp_send_json_error')) {
+            function wp_send_json_error($data = null) { throw new Exception((string) $data); }
+        }
+        if (!function_exists('wp_send_json_success')) {
+            function wp_send_json_success($data = null) { global $json_success_data; $json_success_data = $data; return $data; }
+        }
+        if (!function_exists('sanitize_key')) {
+            function sanitize_key($key) { return $key; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($data) { return $data; }
+        }
+        if (!function_exists('sanitize_text_field')) {
+            function sanitize_text_field($text) { return $text; }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callable, $priority = 10, $accepted_args = 1) {}
+        }
+        if (!function_exists('current_time')) {
+            function current_time($type) { return 1; }
+        }
+        if (!function_exists('wp_clear_scheduled_hook')) {
+            function wp_clear_scheduled_hook($hook, $args = []) {}
+        }
+        if (!function_exists('delete_post_meta')) {
+            function delete_post_meta($id, $key) {}
+        }
+        if (!function_exists('update_post_meta')) {
+            function update_post_meta($id, $key, $value) {}
+        }
+        if (!function_exists('wp_schedule_single_event')) {
+            function wp_schedule_single_event($timestamp, $hook, $args = []) {}
+        }
+        if (!function_exists('get_post_status')) {
+            function get_post_status($id) { return 'pending'; }
+        }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($id) { return 'Titre'; }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id)
+            {
+                global $captured_fields;
+                if ($key === 'statut_chasse') {
+                    return 'terminée';
+                }
+                return $captured_fields[$key] ?? null;
+            }
+        }
+        if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
+            function recuperer_ids_enigmes_pour_chasse($id) { return [5,6]; }
+        }
+        if (!function_exists('get_template_part')) {
+            function get_template_part($slug, $name = null, $args = []) { echo 'table'; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-solution.php';
+
+        $_POST = [
+            'objet_id'                 => 3,
+            'objet_type'               => 'chasse',
+            'solution_explication'     => 'texte',
+            'solution_disponibilite'   => 'differee',
+            'solution_decalage_jours'  => 5,
+            'solution_heure_publication' => '10:30',
+        ];
+
+        ajax_creer_solution_modal();
+
+        global $captured_fields;
+        $this->assertSame(5, $captured_fields['solution_decalage_jours']);
+        $this->assertSame('10:30', $captured_fields['solution_heure_publication']);
     }
 
     /**

--- a/wp-content/themes/chassesautresor/assets/js/solutions-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/solutions-create.js
@@ -65,8 +65,8 @@
             <option value="differee">${solutionsCreate.texts.differee}</option>
           </select></label></p>
           <p class="delai-wrapper" style="display:none;">
-            <input type="number" name="solution_delai" min="0" value="${btn.dataset.solutionDelai || 0}" /> ${solutionsCreate.texts.days}
-            <input type="time" name="solution_heure" value="${btn.dataset.solutionHeure || '18:00'}" />
+            <input type="number" name="solution_decalage_jours" min="0" value="${btn.dataset.solutionDelai || 0}" /> ${solutionsCreate.texts.days}
+            <input type="time" name="solution_heure_publication" value="${btn.dataset.solutionHeure || '18:00'}" />
           </p>
           <div class="solution-modal-footer"><span class="solution-state-message"></span><button type="submit" class="solution-modal-validate bouton-cta">${solutionsCreate.texts.valider}</button></div>
         </form>
@@ -82,8 +82,8 @@
     var stateMessage = overlay.querySelector('.solution-state-message');
     var selectDispo = overlay.querySelector('select[name="solution_disponibilite"]');
     var delaiWrapper = overlay.querySelector('.delai-wrapper');
-    var delaiInput = overlay.querySelector('input[name="solution_delai"]');
-    var heureInput = overlay.querySelector('input[name="solution_heure"]');
+    var delaiInput = overlay.querySelector('input[name="solution_decalage_jours"]');
+    var heureInput = overlay.querySelector('input[name="solution_heure_publication"]');
     var explicationInput = overlay.querySelector('textarea[name="solution_explication"]');
     var fichierInput = overlay.querySelector('input[name="solution_fichier"][type="file"]');
     var existingFileInput = overlay.querySelector('input[name="solution_fichier"][type="hidden"]');


### PR DESCRIPTION
## Résumé
- corrige l'envoi des champs de délai et d'heure lors de la création/édition d'une solution
- teste la création d'une solution avec délai et horaire personnalisés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac5947679c8332aca462a560f212b7