### PR TITLE
Séparer l'étiquette de disponibilité du délai

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
@@ -122,12 +122,12 @@ if (empty($solutions)) {
             <td>
                 <div>
                     <span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat_label); ?></span>
-                    <?php if ($etat === SOLUTION_STATE_FIN_CHASSE_DIFFERE) : ?>
-                        <span class="txt-small">(<?= esc_html(sprintf(_n('%d day', '%d days', $delai, 'chassesautresor-com'), $delai)); ?> <?= esc_html__('at', 'chassesautresor-com'); ?> <?= esc_html($heure); ?>h)</span>
-                    <?php elseif ($etat === SOLUTION_STATE_A_VENIR && $date_label !== '') : ?>
-                        <span class="txt-small"><?= esc_html($date_label); ?></span>
-                    <?php endif; ?>
                 </div>
+                <?php if ($etat === SOLUTION_STATE_FIN_CHASSE_DIFFERE) : ?>
+                    <div class="txt-small">(<?= esc_html(sprintf(_n('%d day', '%d days', $delai, 'chassesautresor-com'), $delai)); ?> <?= esc_html__('at', 'chassesautresor-com'); ?> <?= esc_html($heure); ?>h)</div>
+                <?php elseif ($etat === SOLUTION_STATE_A_VENIR && $date_label !== '') : ?>
+                    <div class="txt-small"><?= esc_html($date_label); ?></div>
+                <?php endif; ?>
             </td>
             <td>
                 <div><span class="etiquette"><?= esc_html($cible_label); ?></span></div>


### PR DESCRIPTION
## Résumé
- ajoute un retour à la ligne entre le badge de statut et le délai dans le tableau des solutions

## Changements notables
- sépare l'étiquette de statut et l'indication de délai dans la colonne Availability

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac65c655f88332b8170222971eb8f4