### PR TITLE
Préserve les dates des solutions lors du renommage

### DIFF
--- a/tests/SolutionNamingTest.php
+++ b/tests/SolutionNamingTest.php
@@ -16,6 +16,14 @@ if (!function_exists('get_posts')) {
 if (!function_exists('wp_update_post')) {
     function wp_update_post($args) { global $updated_posts; $updated_posts[] = $args; }
 }
+if (!function_exists('get_post')) {
+    function get_post($id) {
+        return (object) [
+            'post_date'     => '2023-01-01 10:00:00',
+            'post_date_gmt' => '2023-01-01 09:00:00',
+        ];
+    }
+}
 if (!function_exists('get_the_title')) {
     function get_the_title($id) { return 'Titre'; }
 }

--- a/tests/SupprimerSolutionAjaxTest.php
+++ b/tests/SupprimerSolutionAjaxTest.php
@@ -76,6 +76,14 @@ if (!function_exists('wp_update_post')) {
     }
 }
 
+if (!function_exists('get_post')) {
+    function get_post($id)
+    {
+        global $posts;
+        return $posts[$id] ?? null;
+    }
+}
+
 if (!function_exists('get_the_title')) {
     function get_the_title($id)
     {
@@ -98,7 +106,7 @@ final class SupprimerSolutionAjaxTest extends TestCase
     {
         parent::setUp();
         $_POST = [];
-        global $fields, $permission_args, $deleted_id, $deleted_force, $json_success, $updated_posts;
+        global $fields, $permission_args, $deleted_id, $deleted_force, $json_success, $updated_posts, $posts;
         $fields = [
             'solution_cible_type'   => 'enigme',
             'solution_enigme_linked' => 55,
@@ -108,6 +116,16 @@ final class SupprimerSolutionAjaxTest extends TestCase
         $deleted_force   = null;
         $json_success    = null;
         $updated_posts   = [];
+        $posts           = [
+            11 => (object) [
+                'post_date'     => '2023-01-01 10:00:00',
+                'post_date_gmt' => '2023-01-01 09:00:00',
+            ],
+            12 => (object) [
+                'post_date'     => '2023-02-01 10:00:00',
+                'post_date_gmt' => '2023-02-01 09:00:00',
+            ],
+        ];
     }
 
     /**
@@ -126,7 +144,13 @@ final class SupprimerSolutionAjaxTest extends TestCase
         $this->assertTrue($deleted_force);
         $this->assertNull($json_success);
         $this->assertSame('Solution Titre #1', $updated_posts[0]['post_title']);
+        $this->assertSame('2023-01-01 10:00:00', $updated_posts[0]['post_date']);
+        $this->assertSame('2023-01-01 09:00:00', $updated_posts[0]['post_date_gmt']);
+        $this->assertTrue($updated_posts[0]['edit_date']);
         $this->assertSame('Solution Titre #2', $updated_posts[1]['post_title']);
+        $this->assertSame('2023-02-01 10:00:00', $updated_posts[1]['post_date']);
+        $this->assertSame('2023-02-01 09:00:00', $updated_posts[1]['post_date_gmt']);
+        $this->assertTrue($updated_posts[1]['edit_date']);
     }
 }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -405,10 +405,14 @@ function reordonner_solutions(int $objet_id, string $objet_type): void
     $objet_titre = get_the_title($objet_id);
     $i          = 1;
     foreach ($solutions as $sid) {
+        $post  = get_post($sid);
         $title = sprintf(__('Solution %s #%d', 'chassesautresor-com'), $objet_titre, $i);
         wp_update_post([
-            'ID'         => $sid,
-            'post_title' => $title,
+            'ID'            => $sid,
+            'post_title'    => $title,
+            'post_date'     => $post->post_date,
+            'post_date_gmt' => $post->post_date_gmt,
+            'edit_date'     => true,
         ]);
         $i++;
     }


### PR DESCRIPTION
## Résumé
- Conserve la date originale des solutions lors du réordonnancement pour éviter des modifications après suppression.
- Met à jour les tests pour simuler la récupération des posts et vérifier le maintien de la `post_date`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac66ae74f48332b315b2793228c09e