### PR TITLE
Remove duplicate translation string

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2395,10 +2395,6 @@ msgstr "Date and time required"
 msgid "Date invalide"
 msgstr "Invalid date"
 
-#: inc/edition/edition-core.php
-msgid "Disponibilité"
-msgstr "Availability"
-
 #: template-parts/common/indices-table.php:69
 msgid "accessible"
 msgstr "accessible"
@@ -2514,7 +2510,7 @@ msgstr "Solution text"
 msgid "Fichier"
 msgstr "File"
 
-#: inc/edition/edition-core.php:182
+#: inc/edition/edition-core.php inc/edition/edition-core.php:182
 msgid "Disponibilité"
 msgstr "Availability"
 


### PR DESCRIPTION
## Résumé
- Supprime l’entrée en double pour "Disponibilité" dans les traductions anglaises.

## Changements notables
- Fusion des références de la chaîne "Disponibilité" afin d’éviter les conflits lors de la compilation.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `msgfmt wp-content/themes/chassesautresor/languages/en_US.po -o /tmp/en_US.mo`


------
https://chatgpt.com/codex/tasks/task_e_68ac67a62b28833280597ef781e7f15a