### PR TITLE
Style du bouton de suppression de fichier dans la modale solution

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/solutions-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/solutions-create.js
@@ -41,7 +41,7 @@
       solutionsCreate.texts.chooseFile +
       '</button> <span class="solution-file-name">' +
       (initialName || solutionsCreate.texts.noFile) +
-      '</span> <button type="button" class="solution-file-remove' +
+      '</span> <button type="button" class="solution-file-remove champ-modifier' +
       (initialName ? '' : '" style="display:none"') +
       '">' +
       solutionsCreate.texts.removeFile +


### PR DESCRIPTION
## Résumé
- harmonise le bouton de suppression de fichier dans la modale de solution avec le style d'édition

## Changements notables
- ajoute la classe `champ-modifier` au bouton de suppression de fichier pour reprendre les styles d'édition

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac68561be48332aa196dfdbe7c1266