### PR TITLE
Include riddle solutions in hunt edit panel

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -984,14 +984,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <?php
               $par_page_solutions = 5;
               $page_solutions     = 1;
-              $solutions_query    = new WP_Query([
-                'post_type'      => 'solution',
-                'post_status'    => ['publish', 'pending', 'draft'],
-                'orderby'        => 'date',
-                'order'          => 'DESC',
-                'posts_per_page' => $par_page_solutions,
-                'paged'          => $page_solutions,
-                'meta_query'     => [
+              $meta_solutions     = [
+                'relation' => 'OR',
+                [
+                  'relation' => 'AND',
                   [
                     'key'   => 'solution_cible_type',
                     'value' => 'chasse',
@@ -1001,6 +997,29 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     'value' => $chasse_id,
                   ],
                 ],
+              ];
+              if (!empty($enigme_ids)) {
+                $meta_solutions[] = [
+                  'relation' => 'AND',
+                  [
+                    'key'   => 'solution_cible_type',
+                    'value' => 'enigme',
+                  ],
+                  [
+                    'key'     => 'solution_enigme_linked',
+                    'value'   => $enigme_ids,
+                    'compare' => 'IN',
+                  ],
+                ];
+              }
+              $solutions_query = new WP_Query([
+                'post_type'      => 'solution',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'posts_per_page' => $par_page_solutions,
+                'paged'          => $page_solutions,
+                'meta_query'     => $meta_solutions,
               ]);
               $solutions_list  = $solutions_query->posts;
               $pages_solutions = (int) $solutions_query->max_num_pages;


### PR DESCRIPTION
## Summary
- affiche également les solutions associées aux énigmes dans l’onglet Animation

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68ac6b0ba0c08332903496e426e7db85