### PR TITLE
Retirer le suffixe h superflu dans l'heure de disponibilité

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/solutions-table.php
@@ -124,7 +124,7 @@ if (empty($solutions)) {
                     <span class="etiquette <?= esc_attr($etat_class); ?>"><?= esc_html($etat_label); ?></span>
                 </div>
                 <?php if ($etat === SOLUTION_STATE_FIN_CHASSE_DIFFERE) : ?>
-                    <div class="txt-small">(<?= esc_html(sprintf(_n('%d day', '%d days', $delai, 'chassesautresor-com'), $delai)); ?> <?= esc_html__('at', 'chassesautresor-com'); ?> <?= esc_html($heure); ?>h)</div>
+                    <div class="txt-small">(<?= esc_html(sprintf(_n('%d day', '%d days', $delai, 'chassesautresor-com'), $delai)); ?> <?= esc_html__('at', 'chassesautresor-com'); ?> <?= esc_html($heure); ?>)</div>
                 <?php elseif ($etat === SOLUTION_STATE_A_VENIR && $date_label !== '') : ?>
                     <div class="txt-small"><?= esc_html($date_label); ?></div>
                 <?php endif; ?>


### PR DESCRIPTION
## Résumé
- supprime le `h` ajouté après l'heure dans l'onglet d'animation

## Changements notables
- retrait du suffixe `h` de l'heure de disponibilité dans le tableau des solutions

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b59bb888332974430c18c366da3