### PR TITLE
feat: infobulle pour solutions désactivées

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -73,14 +73,21 @@ function rafraichirCarteSolutions() {
       if (!res.success || !res.data) return;
       if (btnChasse) {
         const disableChasse = !!res.data.has_solution_chasse;
-        btnChasse.disabled = disableChasse;
         btnChasse.classList.toggle('disabled', disableChasse);
+        btnChasse.setAttribute('aria-disabled', disableChasse);
+        if (ChasseSolutions && ChasseSolutions.tooltipChasse) {
+          btnChasse.title = disableChasse ? ChasseSolutions.tooltipChasse : '';
+        }
       }
       if (btnEnigme) {
         const disableEnigme = !res.data.has_enigmes;
-        btnEnigme.disabled = disableEnigme;
         btnEnigme.classList.toggle('disabled', disableEnigme);
+        btnEnigme.setAttribute('aria-disabled', disableEnigme);
+        if (ChasseSolutions && ChasseSolutions.tooltipEnigme) {
+          btnEnigme.title = disableEnigme ? ChasseSolutions.tooltipEnigme : '';
+        }
       }
+      initDisabledSolutionButtons();
     })
     .catch(() => {});
 }
@@ -166,6 +173,27 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
       .querySelectorAll('.dashboard-card.champ-solutions')
       .forEach((c) => {
         initSolutionsOptions(c);
+      });
+    initDisabledSolutionButtons();
+  }
+
+  function initDisabledSolutionButtons() {
+    document
+      .querySelectorAll('.cta-solution-chasse, .cta-solution-enigme')
+      .forEach((btn) => {
+        if (btn.dataset.scrollBound) return;
+        btn.dataset.scrollBound = '1';
+        btn.addEventListener('click', (e) => {
+          if (!btn.classList.contains('disabled')) return;
+          e.preventDefault();
+          const targetId =
+            (ChasseSolutions && ChasseSolutions.scrollTarget) ||
+            '#chasse-section-solutions';
+          const anchor = document.querySelector(targetId);
+          if (anchor) {
+            anchor.scrollIntoView({ behavior: 'smooth' });
+          }
+        });
       });
   }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1739,6 +1739,12 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-success-hover);
 }
 
+.dashboard-card.champ-solutions .cta-solution-chasse.disabled,
+.dashboard-card.champ-solutions .cta-solution-enigme.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .dashboard-card .solution-reset {
   position: absolute;
   bottom: 8px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3383,6 +3383,13 @@ body.panneau-ouvert::before {
   background-color: var(--color-editor-success-hover);
 }
 
+.dashboard-card.champ-solutions .cta-solution-chasse.disabled, .champ-solutions.carte-orgy .cta-solution-chasse.disabled,
+.dashboard-card.champ-solutions .cta-solution-enigme.disabled,
+.champ-solutions.carte-orgy .cta-solution-enigme.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .dashboard-card .solution-reset, .carte-orgy .solution-reset {
   position: absolute;
   bottom: 8px;

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -58,6 +58,16 @@ function enqueue_script_chasse_edit()
     ]
   );
 
+  wp_localize_script(
+    'chasse-edit',
+    'ChasseSolutions',
+    [
+      'scrollTarget'  => '#chasse-section-solutions',
+      'tooltipChasse' => __('Il existe déjà une solution pour cette chasse', 'chassesautresor-com'),
+      'tooltipEnigme' => __('Toutes les énigmes de la chasse ont déjà une solution', 'chassesautresor-com'),
+    ]
+  );
+
   // Injecte les valeurs par défaut pour JS
   wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [
     'titre' => strtolower(TITRE_DEFAUT_CHASSE),

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2310,3 +2310,11 @@ msgid "Aucun fichier choisi"
 
 msgstr ""
 
+#: template-parts/chasse/partials/chasse-partial-solutions.php:47
+msgid "Il existe déjà une solution pour cette chasse"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-solutions.php:62
+msgid "Toutes les énigmes de la chasse ont déjà une solution"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2526,3 +2526,11 @@ msgstr "Add a file or text"
 msgid "Aucun fichier choisi"
 msgstr "No file selected"
 
+#: template-parts/chasse/partials/chasse-partial-solutions.php:47
+msgid "Il existe déjà une solution pour cette chasse"
+msgstr "A solution already exists for this hunt"
+
+#: template-parts/chasse/partials/chasse-partial-solutions.php:62
+msgid "Toutes les énigmes de la chasse ont déjà une solution"
+msgstr "All riddles in this hunt already have a solution"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2497,3 +2497,11 @@ msgstr "Ajoutez un fichier ou un texte"
 msgid "Aucun fichier choisi"
 msgstr "Aucun fichier choisi"
 
+#: template-parts/chasse/partials/chasse-partial-solutions.php:47
+msgid "Il existe déjà une solution pour cette chasse"
+msgstr "Il existe déjà une solution pour cette chasse"
+
+#: template-parts/chasse/partials/chasse-partial-solutions.php:62
+msgid "Toutes les énigmes de la chasse ont déjà une solution"
+msgstr "Toutes les énigmes de la chasse ont déjà une solution"
+

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-solutions.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-solutions.php
@@ -42,7 +42,10 @@ $has_enigmes = !empty($enigmes_disponibles);
                 data-objet-type='chasse'
                 data-objet-id='<?= esc_attr($objet_id); ?>'
                 data-objet-titre='<?= esc_attr(get_the_title($objet_id)); ?>'
-                <?= $has_solution_chasse ? 'disabled' : ''; ?>
+                <?php if ($has_solution_chasse) : ?>
+                    aria-disabled="true"
+                    title="<?= esc_attr__('Il existe déjà une solution pour cette chasse', 'chassesautresor-com'); ?>"
+                <?php endif; ?>
             >
                 <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
             </button>
@@ -54,7 +57,10 @@ $has_enigmes = !empty($enigmes_disponibles);
                 <?php if ($default_enigme) : ?>
                     data-default-enigme='<?= esc_attr($default_enigme); ?>'
                 <?php endif; ?>
-                <?= $has_enigmes ? '' : 'disabled'; ?>
+                <?php if (!$has_enigmes) : ?>
+                    aria-disabled="true"
+                    title="<?= esc_attr__('Toutes les énigmes de la chasse ont déjà une solution', 'chassesautresor-com'); ?>"
+                <?php endif; ?>
             >
                 <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
             </button>


### PR DESCRIPTION
## Résumé
Ajout d’une infobulle et d’un défilement vers la section des solutions lorsqu’un CTA de création de solution est désactivé.

## Changements notables
- Infobulles et style désactivé pour les boutons de création de solution
- Défilement doux vers la section des solutions lors du clic sur un CTA désactivé
- Localisation et mise à jour des traductions

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac84e2d078833286032666742162fc