### PR TITLE
Centre la carte QR code à 75 % sur desktop

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1626,6 +1626,17 @@ body.panneau-ouvert::before {
   height: 2rem;
 }
 
+.dashboard-card.champ-qr-code {
+  width: 75%;
+  margin: 0 auto;
+}
+
+@media not all and (--bp-desktop) {
+  .dashboard-card.champ-qr-code {
+    width: 100%;
+  }
+}
+
 .dashboard-card.solution-option {
   cursor: pointer;
   transition: background-color 0.2s, border-color 0.2s, opacity 0.2s;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3270,6 +3270,16 @@ body.panneau-ouvert::before {
   height: 2rem;
 }
 
+.dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy {
+  width: 75%;
+  margin: 0 auto;
+}
+
+@media not all and (min-width: 1024px) {
+  .dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy {
+    width: 100%;
+  }
+}
 .dashboard-card.solution-option, .solution-option.carte-orgy {
   cursor: pointer;
   transition: background-color 0.2s, border-color 0.2s, opacity 0.2s;


### PR DESCRIPTION
## Résumé
- Ajuste la largeur de la carte QR code de l’édition de chasse à 75 % sur desktop et la centre horizontalement

## Changements
- Ajout d’un style responsive pour `.champ-qr-code`
- Compilation des styles CSS

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac89dbfac88332866adb637538d120