### PR TITLE
Remove 'Vos liens' heading from chasse edit animation tab

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2458,10 +2458,6 @@ msgstr "Make access to your hunt easy with a simple scan. A QR code avoids typin
 msgid "Contenu de la solution à venir."
 msgstr "Solution content coming soon."
 
-#: template-parts/chasse/chasse-edition-main.php:973
-msgid "Vos liens"
-msgstr "Your links"
-
 #: template-parts/chasse/chasse-edition-main.php:976
 msgid "Adresse de votre chasse&nbsp;:"
 msgstr "Your hunt's address:"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -865,7 +865,6 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               </div>
 
               <?php if ($afficher_qr_code) : ?>
-                <h3><?= esc_html__('Vos liens', 'chassesautresor-com'); ?></h3>
                 <div class="dashboard-card carte-orgy champ-qr-code">
                   <div class="qr-code-block">
                     <div class="qr-code-url txt-small">


### PR DESCRIPTION
### Résumé
- Supprime le titre inutile "Vos liens" avant le bloc QR code dans l'onglet Animation
- Nettoie le fichier de traduction en supprimant l'entrée correspondante

### Changements notables
- Retrait du `<h3>Vos liens</h3>` du panneau d'édition de chasse
- Mise à jour de la traduction `en_US.po`

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68ac8b55cd088332bccd10c37ea34dcc