### PR TITLE
Réorganise les blocs d’animation dans l’édition de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -918,6 +918,52 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   ],
                 ];
               }
+              $indices_query = new WP_Query([
+                'post_type'      => 'indice',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'posts_per_page' => $par_page_indices,
+                'paged'          => $page_indices,
+                'meta_query'     => $meta,
+              ]);
+              $indices_list  = $indices_query->posts;
+              $pages_indices = (int) $indices_query->max_num_pages;
+              $count_chasse  = function_exists('get_posts') ? count(get_posts([
+                'post_type'      => 'indice',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'fields'         => 'ids',
+                'nopaging'       => true,
+                'meta_query'     => [
+                  [
+                    'key'   => 'indice_cible_type',
+                    'value' => 'chasse',
+                  ],
+                  [
+                    'key'   => 'indice_chasse_linked',
+                    'value' => $chasse_id,
+                  ],
+                ],
+              ])) : 0;
+              $count_enigme = !empty($enigme_ids) && function_exists('get_posts') ? count(get_posts([
+                'post_type'      => 'indice',
+                'post_status'    => ['publish', 'pending', 'draft'],
+                'fields'         => 'ids',
+                'nopaging'       => true,
+                'meta_query'     => [
+                  [
+                    'key'   => 'indice_cible_type',
+                    'value' => 'enigme',
+                  ],
+                  [
+                    'key'     => 'indice_enigme_linked',
+                    'value'   => $enigme_ids,
+                    'compare' => 'IN',
+                  ],
+                ],
+              ])) : 0;
+              $count_total  = $count_chasse + $count_enigme;
+
               $par_page_solutions = 5;
               $page_solutions     = 1;
               $meta_solutions     = [
@@ -960,22 +1006,20 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               $solutions_list  = $solutions_query->posts;
               $pages_solutions = (int) $solutions_query->max_num_pages;
               ?>
-              <h3 id="chasse-section-solutions"><?= esc_html__('Solutions', 'chassesautresor-com'); ?></h3>
-              <div class="liste-solutions"
-                data-page="1"
-                data-pages="<?= esc_attr($pages_solutions); ?>"
-                data-objet-type="chasse"
-                data-objet-id="<?= esc_attr($chasse_id); ?>"
-                data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
+              <h3 style="margin-top: var(--space-xl);"><?= esc_html__('Indices', 'chassesautresor-com'); ?></h3>
+              <div class="liste-indices" data-page="1" data-pages="<?= esc_attr($pages_indices); ?>" data-objet-type="chasse" data-objet-id="<?= esc_attr($chasse_id); ?>" data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
                 <?php
-                get_template_part('template-parts/common/solutions-table', null, [
-                  'solutions'  => $solutions_list,
-                  'page'       => 1,
-                  'pages'      => $pages_solutions,
-                  'objet_type' => 'chasse',
-                  'objet_id'   => $chasse_id,
-                ]);
-                ?>
+              get_template_part('template-parts/common/indices-table', null, [
+                'indices'     => $indices_list,
+                'page'        => 1,
+                'pages'       => $pages_indices,
+                'objet_type'  => 'chasse',
+                'objet_id'    => $chasse_id,
+                'count_total' => $count_total,
+                'count_chasse' => $count_chasse,
+                'count_enigme' => $count_enigme,
+              ]);
+              ?>
               </div>
 
               <div class="dashboard-card carte-orgy champ-protection-solutions">
@@ -1004,67 +1048,22 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 </div>
               </div>
 
-              <?php
-              $indices_query = new WP_Query([
-                'post_type'      => 'indice',
-                'post_status'    => ['publish', 'pending', 'draft'],
-                'orderby'        => 'date',
-                'order'          => 'DESC',
-                'posts_per_page' => $par_page_indices,
-                'paged'          => $page_indices,
-                'meta_query'     => $meta,
-              ]);
-              $indices_list  = $indices_query->posts;
-              $pages_indices = (int) $indices_query->max_num_pages;
-                $count_chasse  = function_exists('get_posts') ? count(get_posts([
-                  'post_type'      => 'indice',
-                  'post_status'    => ['publish', 'pending', 'draft'],
-                  'fields'         => 'ids',
-                  'nopaging'       => true,
-                  'meta_query'     => [
-                    [
-                      'key'   => 'indice_cible_type',
-                      'value' => 'chasse',
-                    ],
-                    [
-                      'key'   => 'indice_chasse_linked',
-                      'value' => $chasse_id,
-                    ],
-                  ],
-                ])) : 0;
-                $count_enigme = !empty($enigme_ids) && function_exists('get_posts') ? count(get_posts([
-                  'post_type'      => 'indice',
-                  'post_status'    => ['publish', 'pending', 'draft'],
-                  'fields'         => 'ids',
-                  'nopaging'       => true,
-                  'meta_query'     => [
-                    [
-                      'key'   => 'indice_cible_type',
-                      'value' => 'enigme',
-                    ],
-                    [
-                      'key'     => 'indice_enigme_linked',
-                      'value'   => $enigme_ids,
-                      'compare' => 'IN',
-                    ],
-                  ],
-                ])) : 0;
-              $count_total  = $count_chasse + $count_enigme;
-              ?>
-              <h3 style="margin-top: var(--space-xl);"><?= esc_html__('Indices', 'chassesautresor-com'); ?></h3>
-              <div class="liste-indices" data-page="1" data-pages="<?= esc_attr($pages_indices); ?>" data-objet-type="chasse" data-objet-id="<?= esc_attr($chasse_id); ?>" data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
+              <h3 id="chasse-section-solutions"><?= esc_html__('Solutions', 'chassesautresor-com'); ?></h3>
+              <div class="liste-solutions"
+                data-page="1"
+                data-pages="<?= esc_attr($pages_solutions); ?>"
+                data-objet-type="chasse"
+                data-objet-id="<?= esc_attr($chasse_id); ?>"
+                data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
                 <?php
-              get_template_part('template-parts/common/indices-table', null, [
-                'indices'     => $indices_list,
-                'page'        => 1,
-                'pages'       => $pages_indices,
-                'objet_type'  => 'chasse',
-                'objet_id'    => $chasse_id,
-                'count_total' => $count_total,
-                'count_chasse' => $count_chasse,
-                'count_enigme' => $count_enigme,
-              ]);
-              ?>
+                get_template_part('template-parts/common/solutions-table', null, [
+                  'solutions'  => $solutions_list,
+                  'page'       => 1,
+                  'pages'      => $pages_solutions,
+                  'objet_type' => 'chasse',
+                  'objet_id'   => $chasse_id,
+                ]);
+                ?>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Résumé
- réorganise l’ordre d’affichage des indices, bloc de sécurité PDF et solutions dans l’onglet Animation de l’édition de chasse

## Changements notables
- table des indices affichée avant le bloc d’information sur la sécurité des PDF
- table des solutions déplacée après ce bloc

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ac94386a24833299a58532f3464c56