### PR TITLE
feat: bascule illimité/limité pour nombre de gagnants

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -19,8 +19,17 @@ const html = `
       <li class="edition-row champ-nb-gagnants" data-post-id="1">
         <div class="edition-row-label"><label for="chasse-nb-gagnants">Nb gagnants</label></div>
         <div class="edition-row-content">
-          <input type="number" id="chasse-nb-gagnants" value="0" class="champ-input champ-number">
-          <input type="checkbox" id="nb-gagnants-illimite">
+          <div class="champ-mode-options">
+            <span class="toggle-option">Illimité</span>
+            <label class="switch-control">
+              <input type="checkbox" id="nb-gagnants-limite">
+              <span class="switch-slider"></span>
+            </label>
+            <span class="toggle-option">Limité</span>
+          </div>
+          <div class="nb-gagnants-actions" style="display:none;">
+            <input type="number" id="chasse-nb-gagnants" value="0" class="champ-input champ-number">
+          </div>
         </div>
       </li>
     </template>

--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -59,7 +59,7 @@ const html = `
             </label>
             <span class="toggle-option">Points</span>
             <div class="cout-points-actions" style="display:none;">
-              <input type="number" value="0" class="champ-input champ-cout champ-number">
+              <input type="number" value="0" min="1" step="1" placeholder="10" class="champ-input champ-cout champ-number">
             </div>
           </div>
         </div>
@@ -227,6 +227,8 @@ describe('chasse-edit UI', () => {
     toggle.dispatchEvent(new Event('change', { bubbles: true }));
     expect(actions.style.display).toBe('');
     expect(input.disabled).toBe(false);
+    expect(input.value).toBe('10');
+    expect(input.min).toBe('1');
   });
 
   test('access toggle hides points input when unchecked', () => {
@@ -239,5 +241,6 @@ describe('chasse-edit UI', () => {
     toggle.dispatchEvent(new Event('change', { bubbles: true }));
     expect(actions.style.display).toBe('none');
     expect(input.disabled).toBe(true);
+    expect(input.value).toBe('0');
   });
 });

--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -26,9 +26,9 @@ const html = `
               <span class="switch-slider"></span>
             </label>
             <span class="toggle-option">Limité</span>
-          </div>
-          <div class="nb-gagnants-actions" style="display:none;">
-            <input type="number" id="chasse-nb-gagnants" value="0" class="champ-input champ-number">
+            <div class="nb-gagnants-actions" style="display:none;">
+              <input type="number" id="chasse-nb-gagnants" value="0" class="champ-input champ-number">
+            </div>
           </div>
         </div>
       </li>

--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -31,6 +31,39 @@ const html = `
           </div>
         </div>
       </li>
+      <li class="edition-row champ-chasse champ-date-fin" data-post-id="1">
+        <div class="edition-row-label"><label for="chasse-date-fin">Fin</label></div>
+        <div class="edition-row-content">
+          <div class="champ-mode-options">
+            <span class="toggle-option">Illimitée</span>
+            <label class="switch-control">
+              <input type="checkbox" id="date-fin-limitee">
+              <span class="switch-slider"></span>
+            </label>
+            <span class="toggle-option">Limitée</span>
+            <div class="date-fin-actions" style="display:none;">
+              <input type="date" id="chasse-date-fin" value="" class="champ-inline-date champ-date-edit">
+              <div id="erreur-date-fin" class="message-erreur"></div>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="edition-row champ-chasse champ-cout-points" data-post-id="1">
+        <div class="edition-row-label"><label>Accès</label></div>
+        <div class="edition-row-content">
+          <div class="champ-mode-options">
+            <span class="toggle-option">Gratuit</span>
+            <label class="switch-control">
+              <input type="checkbox" id="cout-payant">
+              <span class="switch-slider"></span>
+            </label>
+            <span class="toggle-option">Points</span>
+            <div class="cout-points-actions" style="display:none;">
+              <input type="number" value="0" class="champ-input champ-cout champ-number">
+            </div>
+          </div>
+        </div>
+      </li>
     </ul>
     <template id="template-nb-gagnants">
       <li class="edition-row champ-nb-gagnants" data-post-id="1">
@@ -77,6 +110,8 @@ describe('chasse-edit UI', () => {
     global.mettreAJourEtatIntroChasse = jest.fn();
     global.initChampNbGagnants = jest.fn();
     global.initChampDate = jest.fn();
+    global.mettreAJourAffichageDateFin = jest.fn();
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
     global.wp = { i18n: { __: (s) => s } };
     jest.resetModules();
@@ -151,6 +186,53 @@ describe('chasse-edit UI', () => {
     const toggle = document.getElementById('date-debut-differee');
     const actions = document.querySelector('.date-debut-actions');
     const input = document.getElementById('chasse-date-debut');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(actions.style.display).toBe('none');
+    expect(input.disabled).toBe(true);
+  });
+
+  test('end date toggle reveals datepicker when checked', () => {
+    const toggle = document.getElementById('date-fin-limitee');
+    const actions = document.querySelector('.date-fin-actions');
+    const input = document.getElementById('chasse-date-fin');
+    expect(actions.style.display).toBe('none');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(actions.style.display).toBe('');
+    expect(input.disabled).toBe(false);
+    expect(global.initChampDate).toHaveBeenCalledWith(input);
+  });
+
+  test('end date toggle hides datepicker when unchecked', () => {
+    const toggle = document.getElementById('date-fin-limitee');
+    const actions = document.querySelector('.date-fin-actions');
+    const input = document.getElementById('chasse-date-fin');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(actions.style.display).toBe('none');
+    expect(input.disabled).toBe(true);
+  });
+
+  test('access toggle reveals points input when checked', () => {
+    const toggle = document.getElementById('cout-payant');
+    const actions = document.querySelector('.cout-points-actions');
+    const input = document.querySelector('.champ-cout');
+    expect(actions.style.display).toBe('none');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(actions.style.display).toBe('');
+    expect(input.disabled).toBe(false);
+  });
+
+  test('access toggle hides points input when unchecked', () => {
+    const toggle = document.getElementById('cout-payant');
+    const actions = document.querySelector('.cout-points-actions');
+    const input = document.querySelector('.champ-cout');
     toggle.checked = true;
     toggle.dispatchEvent(new Event('change', { bubbles: true }));
     toggle.checked = false;

--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -14,6 +14,23 @@ const html = `
           </div>
         </div>
       </li>
+      <li class="edition-row champ-chasse champ-date-debut" data-post-id="1">
+        <div class="edition-row-label"><label for="chasse-date-debut">Début</label></div>
+        <div class="edition-row-content">
+          <div class="champ-mode-options">
+            <span class="toggle-option">Now</span>
+            <label class="switch-control">
+              <input type="checkbox" id="date-debut-differee">
+              <span class="switch-slider"></span>
+            </label>
+            <span class="toggle-option">Later</span>
+            <div class="date-debut-actions" style="display:none;">
+              <input type="datetime-local" id="chasse-date-debut" value="" class="champ-inline-date champ-date-edit">
+              <div id="erreur-date-debut" class="message-erreur"></div>
+            </div>
+          </div>
+        </div>
+      </li>
     </ul>
     <template id="template-nb-gagnants">
       <li class="edition-row champ-nb-gagnants" data-post-id="1">
@@ -59,6 +76,7 @@ describe('chasse-edit UI', () => {
     global.mettreAJourCarteAjoutEnigme = jest.fn();
     global.mettreAJourEtatIntroChasse = jest.fn();
     global.initChampNbGagnants = jest.fn();
+    global.initChampDate = jest.fn();
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
     global.wp = { i18n: { __: (s) => s } };
     jest.resetModules();
@@ -115,5 +133,29 @@ describe('chasse-edit UI', () => {
     expect(message).not.toBeNull();
     expect(message.textContent).toContain('Alice');
     expect(message.textContent).toContain('02/01/2024');
+  });
+
+  test('start date toggle reveals datepicker when checked', () => {
+    const toggle = document.getElementById('date-debut-differee');
+    const actions = document.querySelector('.date-debut-actions');
+    const input = document.getElementById('chasse-date-debut');
+    expect(actions.style.display).toBe('none');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(actions.style.display).toBe('');
+    expect(input.disabled).toBe(false);
+    expect(global.initChampDate).toHaveBeenCalledWith(input);
+  });
+
+  test('start date toggle hides datepicker when unchecked', () => {
+    const toggle = document.getElementById('date-debut-differee');
+    const actions = document.querySelector('.date-debut-actions');
+    const input = document.getElementById('chasse-date-debut');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(actions.style.display).toBe('none');
+    expect(input.disabled).toBe(true);
   });
 });

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -956,29 +956,34 @@ document.querySelectorAll('.champ-cout-points .champ-annuler').forEach(bouton =>
 // ================================
 function initChampNbGagnants() {
   const inputNb = document.getElementById('chasse-nb-gagnants');
-  const checkboxIllimite = document.getElementById('nb-gagnants-illimite');
+  const toggleLimite = document.getElementById('nb-gagnants-limite');
+  const actions = inputNb?.closest('.nb-gagnants-actions');
 
-  if (!inputNb || !checkboxIllimite) return;
+  if (!inputNb || !toggleLimite || !actions) return;
 
   let timerDebounce;
 
-  checkboxIllimite.addEventListener('change', function () {
+  function updateVisibility() {
     const postId = inputNb.closest('li').dataset.postId;
     if (!postId) return;
 
-    if (checkboxIllimite.checked) {
-      inputNb.disabled = true;
-      inputNb.value = '0';
-    } else {
+    if (toggleLimite.checked) {
+      actions.style.display = '';
       inputNb.disabled = false;
       if (parseInt(inputNb.value.trim(), 10) === 0 || inputNb.value.trim() === '') {
         inputNb.value = '1';
       }
+    } else {
+      actions.style.display = 'none';
+      inputNb.disabled = true;
+      inputNb.value = '0';
     }
 
     inputNb.dispatchEvent(new Event('input', { bubbles: true }));
     mettreAJourAffichageNbGagnants(postId, inputNb.value.trim());
-  });
+  }
+
+  toggleLimite.addEventListener('change', updateVisibility);
 
   inputNb.addEventListener('input', function () {
     const postId = inputNb.closest('li').dataset.postId;
@@ -994,6 +999,8 @@ function initChampNbGagnants() {
       mettreAJourAffichageNbGagnants(postId, valeur);
     }, 500);
   });
+
+  updateVisibility();
 }
 
 // ================================

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1004,6 +1004,37 @@ function initChampNbGagnants() {
 }
 
 // ================================
+// 🕒 Gestion du champ Date de début (Maintenant / Plus tard)
+// ================================
+function initChampDateDebut() {
+  const input = document.getElementById('chasse-date-debut');
+  const toggle = document.getElementById('date-debut-differee');
+  const actions = input?.closest('.date-debut-actions');
+
+  if (!input || !toggle || !actions) return;
+
+  function updateVisibility() {
+    if (toggle.checked) {
+      actions.style.display = '';
+      input.disabled = false;
+      if (typeof window.initChampDate === 'function') {
+        window.initChampDate(input);
+      }
+    } else {
+      actions.style.display = 'none';
+      input.disabled = true;
+      const now = new Date();
+      const iso = now.toISOString().slice(0, 16);
+      input.value = iso;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
+  toggle.addEventListener('change', updateVisibility);
+  updateVisibility();
+}
+
+// ================================
 // 🔚 Gestion dynamique du mode de fin
 // ================================
 function initModeFinChasse() {
@@ -1062,6 +1093,7 @@ function initModeFinChasse() {
 }
 
 // À appeler :
+initChampDateDebut();
 initChampNbGagnants();
 initModeFinChasse();
 

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1039,14 +1039,12 @@ function initChampCoutPoints() {
   if (!input || !toggle || !actions) return;
 
   function updateVisibility() {
-    const postId = input.closest('li')?.dataset.postId;
-    if (!postId) return;
-
     if (toggle.checked) {
       actions.style.display = '';
       input.disabled = false;
+      input.min = '1';
       if (parseInt(input.value.trim(), 10) === 0 || input.value.trim() === '') {
-        input.value = '1';
+        input.value = '10';
       }
     } else {
       actions.style.display = 'none';

--- a/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
@@ -35,11 +35,11 @@ function mettreAJourAffichageDateFin() {
   console.log('[mettreAJourAffichageDateFin]');
   const spanDateFin = document.querySelector('.chasse-date-plage .date-fin');
   const inputDateFin = document.getElementById('chasse-date-fin');
-  const checkboxIllimitee = document.getElementById('duree-illimitee');
+  const toggleLimitee = document.getElementById('date-fin-limitee');
 
-  if (!spanDateFin || !inputDateFin || !checkboxIllimitee) return;
+  if (!spanDateFin || !inputDateFin || !toggleLimitee) return;
 
-  if (checkboxIllimitee.checked) {
+  if (!toggleLimitee.checked) {
     spanDateFin.textContent = 'Illimitée';
   } else {
     spanDateFin.textContent = formatDateFr(inputDateFin.value);

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1089,6 +1089,14 @@ msgstr ""
 msgid "Limité"
 msgstr ""
 
+#: template-parts/chasse/chasse-edition-main.php:514
+msgid "Now"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:524
+msgid "Later"
+msgstr ""
+
 #: template-parts/chasse/chasse-edition-main.php:374
 msgid "Début"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1077,11 +1077,16 @@ msgid "Chasse gagnée le %s par %s"
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:337
+#: template-parts/chasse/chasse-edition-main.php:448
 msgid "Nb gagnants"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:353
+#: template-parts/chasse/chasse-edition-main.php:454
 msgid "Illimité"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:464
+msgid "Limité"
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:374

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1101,17 +1101,20 @@ msgstr ""
 msgid "Début"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:390
+#: template-parts/chasse/chasse-edition-main.php:554
 msgid "Date de fin"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:404
-msgid "Durée illimitée"
+#: template-parts/chasse/chasse-edition-main.php:560
+msgid "Illimitée"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:417
-#: template-parts/indice/indice-edition-main.php:198
-msgid "Coût"
+#: template-parts/chasse/chasse-edition-main.php:569
+msgid "Limitée"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:601
+msgid "Accès"
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:423
@@ -1126,7 +1129,7 @@ msgstr ""
 msgid "Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou payant. Cet accès est indispensable pour consulter les énigmes, qui restent invisibles tant qu’il n’a pas été débloqué."
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:445
+#: template-parts/chasse/chasse-edition-main.php:621
 #: template-parts/enigme/enigme-edition-main.php:394
 #: template-parts/indice/indice-edition-main.php:202
 msgid "Gratuit"
@@ -1862,6 +1865,7 @@ msgstr ""
 msgid "Panneau d'édition organisateur"
 msgstr ""
 
+#: template-parts/chasse/chasse-edition-main.php:629
 #: template-parts/organisateur/organisateur-edition-main.php:78
 #: template-parts/organisateur/organisateur-edition-main.php:264
 #: template-parts/organisateur/organisateur-edition-main.php:270

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1121,13 +1121,17 @@ msgstr "Validate the end of hunting"
 msgid "Chasse gagnée le %s par %s"
 msgstr "Hunting won on %s by %s"
 
-#: template-parts/chasse/chasse-edition-main.php:337
+#: template-parts/chasse/chasse-edition-main.php:448
 msgid "Nb gagnants"
 msgstr "Number of winners"
 
-#: template-parts/chasse/chasse-edition-main.php:353
+#: template-parts/chasse/chasse-edition-main.php:454
 msgid "Illimité"
 msgstr "Unlimited"
+
+#: template-parts/chasse/chasse-edition-main.php:464
+msgid "Limité"
+msgstr "Limited"
 
 #: template-parts/chasse/chasse-edition-main.php:374
 msgid "Début"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1133,6 +1133,14 @@ msgstr "Unlimited"
 msgid "Limité"
 msgstr "Limited"
 
+#: template-parts/chasse/chasse-edition-main.php:514
+msgid "Now"
+msgstr "Now"
+
+#: template-parts/chasse/chasse-edition-main.php:524
+msgid "Later"
+msgstr "Later"
+
 #: template-parts/chasse/chasse-edition-main.php:374
 msgid "Début"
 msgstr "Start"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1145,26 +1145,29 @@ msgstr "Later"
 msgid "Début"
 msgstr "Start"
 
-#: template-parts/chasse/chasse-edition-main.php:390
+#: template-parts/chasse/chasse-edition-main.php:554
 msgid "Date de fin"
 msgstr "End date"
 
-#: template-parts/chasse/chasse-edition-main.php:404
-msgid "Durée illimitée"
-msgstr "Unlimited duration"
+#: template-parts/chasse/chasse-edition-main.php:560
+msgid "Illimitée"
+msgstr "Unlimited"
 
-#: template-parts/chasse/chasse-edition-main.php:417
-#: template-parts/indice/indice-edition-main.php:198
-msgid "Coût"
-msgstr "Cost"
+#: template-parts/chasse/chasse-edition-main.php:569
+msgid "Limitée"
+msgstr "Limited"
 
-#: template-parts/chasse/chasse-edition-main.php:423
+#: template-parts/chasse/chasse-edition-main.php:607
 msgid "En savoir plus sur les points"
 msgstr "Learn more about loyalty points"
 
-#: template-parts/chasse/chasse-edition-main.php:426
+#: template-parts/chasse/chasse-edition-main.php:610
 msgid "Coût d’accès à une chasse"
 msgstr "Hunt access cost"
+
+#: template-parts/chasse/chasse-edition-main.php:601
+msgid "Accès"
+msgstr "Access"
 
 #: template-parts/chasse/chasse-edition-main.php:427
 msgid ""
@@ -1182,7 +1185,7 @@ msgstr ""
 msgid "Gratuit"
 msgstr "Free"
 
-#: template-parts/chasse/chasse-edition-main.php:552
+#: template-parts/chasse/chasse-edition-main.php:621
 #: template-parts/enigme/enigme-edition-main.php:517
 msgid "Actualiser"
 msgstr "Refresh"
@@ -1977,6 +1980,7 @@ msgstr "Free access or point access is chosen freely by each organizer."
 msgid "Panneau d'édition organisateur"
 msgstr "Organizer Edit Panel"
 
+#: template-parts/chasse/chasse-edition-main.php:629
 #: template-parts/organisateur/organisateur-edition-main.php:78
 #: template-parts/organisateur/organisateur-edition-main.php:264
 #: template-parts/organisateur/organisateur-edition-main.php:270

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1116,14 +1116,17 @@ msgstr "Valider la fin de chasse"
 msgid "Chasse gagnée le %s par %s"
 msgstr "Chasse gagnée le %s par %s"
 
-#: template-parts/chasse/chasse-edition-main.php:337
-#, fuzzy
+#: template-parts/chasse/chasse-edition-main.php:448
 msgid "Nb gagnants"
 msgstr "Gagnants"
 
-#: template-parts/chasse/chasse-edition-main.php:353
+#: template-parts/chasse/chasse-edition-main.php:454
 msgid "Illimité"
-msgstr ""
+msgstr "Illimité"
+
+#: template-parts/chasse/chasse-edition-main.php:464
+msgid "Limité"
+msgstr "Limité"
 
 #: template-parts/chasse/chasse-edition-main.php:374
 msgid "Début"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1128,6 +1128,14 @@ msgstr "Illimité"
 msgid "Limité"
 msgstr "Limité"
 
+#: template-parts/chasse/chasse-edition-main.php:514
+msgid "Now"
+msgstr "Maintenant"
+
+#: template-parts/chasse/chasse-edition-main.php:524
+msgid "Later"
+msgstr "Plus tard"
+
 #: template-parts/chasse/chasse-edition-main.php:374
 msgid "Début"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1142,25 +1142,29 @@ msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:390
 #, fuzzy
+#: template-parts/chasse/chasse-edition-main.php:554
 msgid "Date de fin"
-msgstr "Mode de fin"
-
-#: template-parts/chasse/chasse-edition-main.php:404
-msgid "Durée illimitée"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:417
-#: template-parts/indice/indice-edition-main.php:198
-msgid "Coût"
+#: template-parts/chasse/chasse-edition-main.php:560
+msgid "Illimitée"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:423
+#: template-parts/chasse/chasse-edition-main.php:569
+msgid "Limitée"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:607
 msgid "En savoir plus sur les points"
 msgstr "En savoir plus sur les points"
 
-#: template-parts/chasse/chasse-edition-main.php:426
+#: template-parts/chasse/chasse-edition-main.php:610
 msgid "Coût d’accès à une chasse"
 msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:601
+msgid "Accès"
+msgstr "Accès"
 
 #: template-parts/chasse/chasse-edition-main.php:427
 msgid ""
@@ -1175,7 +1179,7 @@ msgstr ""
 msgid "Gratuit"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:552
+#: template-parts/chasse/chasse-edition-main.php:621
 #: template-parts/enigme/enigme-edition-main.php:517
 msgid "Actualiser"
 msgstr ""
@@ -1976,6 +1980,7 @@ msgstr "Panneau d'édition organisateur"
 
 #: template-parts/organisateur/organisateur-edition-main.php:78
 #: template-parts/organisateur/organisateur-edition-main.php:264
+#: template-parts/chasse/chasse-edition-main.php:629
 #: template-parts/organisateur/organisateur-edition-main.php:270
 #: templates/myaccount/content-points.php:75
 #: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -622,6 +622,36 @@ En revanche, les champs obligatoires ou facultatifs sont masqués derrière un r
 </li>
 
 
+<!-- Date de début -->
+<li class="champ-chasse champ-date-debut <?= $peut_editer ? '' : ' champ-desactive'; ?>"
+    data-champ="chasse_infos_date_debut"
+    data-cpt="chasse"
+    data-post-id="<?= esc_attr($chasse_id); ?>">
+
+  <label for="chasse-date-debut">Début</label>
+
+  <div class="champ-mode-options">
+    <span class="toggle-option">Now</span>
+    <label class="switch-control">
+      <input
+        id="date-debut-differee"
+        type="checkbox"
+        <?= $debut_differe ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+      <span class="switch-slider"></span>
+    </label>
+    <span class="toggle-option">Later</span>
+    <div class="date-debut-actions" style="<?= $debut_differe ? '' : 'display:none;'; ?>">
+      <input type="datetime-local"
+            id="chasse-date-debut"
+            name="chasse-date-debut"
+            value="<?= esc_attr($date_debut_iso); ?>"
+            class="champ-inline-date champ-date-edit" <?= ($peut_editer && $debut_differe) ? '' : 'disabled'; ?> />
+      <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+    </div>
+  </div>
+</li>
+
+
 👉 Ajout d’un comportement spécial pour la date programmée des énigmes :
 
 Le champ enigme_acces_date est visible uniquement si enigme_acces_condition === date_programmee

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -608,17 +608,16 @@ En revanche, les champs obligatoires ou facultatifs sont masqués derrière un r
       <span class="switch-slider"></span>
     </label>
     <span class="toggle-option">Limité</span>
-  </div>
-
-  <div class="nb-gagnants-actions" style="<?= $nb_max != 0 ? '' : 'display:none;'; ?>">
-    <input type="number"
-          id="chasse-nb-gagnants"
-          name="chasse-nb-gagnants"
-          value="<?= esc_attr($nb_max); ?>"
-          min="1"
-          class="champ-inline-nb champ-nb-edit champ-input champ-number"
-          <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
-    <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+    <div class="nb-gagnants-actions" style="<?= $nb_max != 0 ? '' : 'display:none;'; ?>">
+      <input type="number"
+            id="chasse-nb-gagnants"
+            name="chasse-nb-gagnants"
+            value="<?= esc_attr($nb_max); ?>"
+            min="1"
+            class="champ-inline-nb champ-nb-edit champ-input champ-number"
+            <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
+      <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+    </div>
   </div>
 </li>
 

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -597,20 +597,29 @@ En revanche, les champs obligatoires ou facultatifs sont masqués derrière un r
           id="chasse-nb-gagnants"
           name="chasse-nb-gagnants"
           value="<?= esc_attr($nb_max); ?>"
-          min="1"
-          class="champ-inline-nb champ-nb-edit champ-number"
-          <?= ($nb_max == 0 ? 'disabled' : ''); ?> />
-
-  <div class="champ-option-illimitee ">
-    <input type="checkbox"
-            id="nb-gagnants-illimite"
-            name="nb-gagnants-illimite"
-            <?= ($nb_max == 0 ? 'checked' : ''); ?>
-            data-champ="chasse_infos_nb_max_gagants">
-    <label for="nb-gagnants-illimite">Illimité</label>
+  <div class="champ-mode-options">
+    <span class="toggle-option">Illimité</span>
+    <label class="switch-control">
+      <input
+        id="nb-gagnants-limite"
+        type="checkbox"
+        <?= $nb_max != 0 ? 'checked' : ''; ?>
+        <?= $peut_editer ? '' : 'disabled'; ?>>
+      <span class="switch-slider"></span>
+    </label>
+    <span class="toggle-option">Limité</span>
   </div>
 
-  <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+  <div class="nb-gagnants-actions" style="<?= $nb_max != 0 ? '' : 'display:none;'; ?>">
+    <input type="number"
+          id="chasse-nb-gagnants"
+          name="chasse-nb-gagnants"
+          value="<?= esc_attr($nb_max); ?>"
+          min="1"
+          class="champ-inline-nb champ-nb-edit champ-input champ-number"
+          <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
+    <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+  </div>
 </li>
 
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -556,20 +556,25 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         },
                         'content'  => function () use ($date_fin_iso, $peut_editer, $illimitee) {
                             ?>
-                            <input type="date"
-                                id="chasse-date-fin"
-                                name="chasse-date-fin"
-                                value="<?= esc_attr($date_fin_iso); ?>"
-                                class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
-                            <div id="erreur-date-fin" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
-
-                            <div class="champ-option-illimitee">
-                                <input type="checkbox"
-                                    id="duree-illimitee"
-                                    name="duree-illimitee"
-                                    data-champ="chasse_infos_duree_illimitee"
-                                    <?= ($illimitee ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                                <label for="duree-illimitee"><?= esc_html__('Durée illimitée', 'chassesautresor-com'); ?></label>
+                            <div class="champ-mode-options">
+                                <span class="toggle-option"><?= esc_html__('Illimitée', 'chassesautresor-com'); ?></span>
+                                <label class="switch-control">
+                                    <input type="checkbox"
+                                        id="date-fin-limitee"
+                                        name="date-fin-limitee"
+                                        data-champ="chasse_infos_duree_illimitee"
+                                        <?= $illimitee ? '' : 'checked'; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                                    <span class="switch-slider"></span>
+                                </label>
+                                <span class="toggle-option"><?= esc_html__('Limitée', 'chassesautresor-com'); ?></span>
+                                <div class="date-fin-actions" style="<?= $illimitee ? 'display:none;' : ''; ?>">
+                                    <input type="date"
+                                        id="chasse-date-fin"
+                                        name="chasse-date-fin"
+                                        value="<?= esc_attr($date_fin_iso); ?>"
+                                        class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
+                                    <div id="erreur-date-fin" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                </div>
                             </div>
                             <?php
                         },
@@ -578,13 +583,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 ?>
 
 
-                <!-- Coût -->
+                <!-- Accès -->
                 <?php
                 get_template_part(
                     'template-parts/common/edition-row',
                     null,
                     [
-                        'class'      => 'champ-chasse champ-cout-points ' . (empty($cout) ? 'champ-vide' : 'champ-rempli') . ($peut_editer_cout ? '' : ' champ-desactive'),
+                        'class'      => 'champ-chasse champ-cout-points ' . ((int) $cout === 0 ? 'champ-vide' : 'champ-rempli') . ($peut_editer_cout ? '' : ' champ-desactive'),
                         'attributes' => [
                             'data-champ'   => 'chasse_infos_cout_points',
                             'data-cpt'     => 'chasse',
@@ -592,7 +597,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         ],
                         'label'    => function () {
                             ?>
-                            <label><?= esc_html__('Coût', 'chassesautresor-com'); ?> <span class="txt-small"><?= esc_html__('points', 'chassesautresor-com'); ?></span>
+                            <label>
+                                <?= esc_html__('Accès', 'chassesautresor-com'); ?>
                                 <?php
                                 get_template_part(
                                     'template-parts/common/help-icon',
@@ -611,20 +617,23 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         },
                         'content'  => function () use ($cout, $peut_editer_cout) {
                             ?>
-                            <div style="display: flex; align-items: center;">
-                                <input type="number"
-                                    class="champ-input champ-cout champ-number"
-                                    min="0"
-                                    step="1"
-                                    value="<?= esc_attr($cout); ?>"
-                                    placeholder="0" <?= $peut_editer_cout ? '' : 'disabled'; ?> />
-
-                                <div class="champ-option-gratuit" style="margin-left: 15px;">
+                            <div class="champ-mode-options">
+                                <span class="toggle-option"><?= esc_html__('Gratuit', 'chassesautresor-com'); ?></span>
+                                <label class="switch-control">
                                     <input type="checkbox"
-                                        id="cout-gratuit"
-                                        name="cout-gratuit"
-                                        <?= ((int) $cout === 0) ? 'checked' : ''; ?> <?= $peut_editer_cout ? '' : 'disabled'; ?>>
-                                    <label for="cout-gratuit"><?= esc_html__('Gratuit', 'chassesautresor-com'); ?></label>
+                                        id="cout-payant"
+                                        name="cout-payant"
+                                        <?= ((int) $cout > 0) ? 'checked' : ''; ?> <?= $peut_editer_cout ? '' : 'disabled'; ?>>
+                                    <span class="switch-slider"></span>
+                                </label>
+                                <span class="toggle-option"><?= esc_html__('Points', 'chassesautresor-com'); ?></span>
+                                <div class="cout-points-actions" style="<?= ((int) $cout > 0) ? '' : 'display:none;'; ?>">
+                                    <input type="number"
+                                        class="champ-input champ-cout champ-number"
+                                        min="0"
+                                        step="1"
+                                        value="<?= esc_attr($cout); ?>"
+                                        placeholder="0" <?= $peut_editer_cout ? '' : 'disabled'; ?> />
                                 </div>
                             </div>
                             <div class="champ-feedback"></div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -462,17 +462,17 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                     <span class="switch-slider"></span>
                                 </label>
                                 <span class="toggle-option"><?= esc_html__('Limité', 'chassesautresor-com'); ?></span>
-                            </div>
-                            <div class="nb-gagnants-actions" style="<?= $nb_max != 0 ? '' : 'display:none;'; ?>">
-                                <input type="number"
-                                    id="chasse-nb-gagnants"
-                                    name="chasse-nb-gagnants"
-                                    value="<?= esc_attr($nb_max); ?>"
-                                    min="1"
-                                    class="champ-inline-nb champ-nb-edit champ-input champ-number"
-                                    <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
+                                <div class="nb-gagnants-actions" style="<?= $nb_max != 0 ? '' : 'display:none;'; ?>">
+                                    <input type="number"
+                                        id="chasse-nb-gagnants"
+                                        name="chasse-nb-gagnants"
+                                        value="<?= esc_attr($nb_max); ?>"
+                                        min="1"
+                                        class="champ-inline-nb champ-nb-edit champ-input champ-number"
+                                        <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
 
-                                <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                </div>
                             </div>
                             <?php
                         },

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -450,23 +450,30 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                         },
                         'content'  => function () use ($nb_max, $peut_editer) {
                             ?>
-                            <input type="number"
-                                id="chasse-nb-gagnants"
-                                name="chasse-nb-gagnants"
-                                value="<?= esc_attr($nb_max); ?>"
-                                min="1"
-                                class="champ-inline-nb champ-nb-edit champ-input champ-number"
-                                <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
-
-                            <div class="champ-option-illimitee ">
-                                <input type="checkbox"
-                                    id="nb-gagnants-illimite"
-                                    name="nb-gagnants-illimite"
-                                    <?= ($nb_max == 0 ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>>
-                                <label for="nb-gagnants-illimite"><?= esc_html__('Illimité', 'chassesautresor-com'); ?></label>
+                            <div class="champ-mode-options">
+                                <span class="toggle-option"><?= esc_html__('Illimité', 'chassesautresor-com'); ?></span>
+                                <label class="switch-control">
+                                    <input
+                                        id="nb-gagnants-limite"
+                                        type="checkbox"
+                                        <?= $nb_max != 0 ? 'checked' : ''; ?>
+                                        <?= $peut_editer ? '' : 'disabled'; ?>
+                                    >
+                                    <span class="switch-slider"></span>
+                                </label>
+                                <span class="toggle-option"><?= esc_html__('Limité', 'chassesautresor-com'); ?></span>
                             </div>
+                            <div class="nb-gagnants-actions" style="<?= $nb_max != 0 ? '' : 'display:none;'; ?>">
+                                <input type="number"
+                                    id="chasse-nb-gagnants"
+                                    name="chasse-nb-gagnants"
+                                    value="<?= esc_attr($nb_max); ?>"
+                                    min="1"
+                                    class="champ-inline-nb champ-nb-edit champ-input champ-number"
+                                    <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
 
-                            <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                            </div>
                             <?php
                         },
                     ]

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -630,10 +630,10 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                 <div class="cout-points-actions" style="<?= ((int) $cout > 0) ? '' : 'display:none;'; ?>">
                                     <input type="number"
                                         class="champ-input champ-cout champ-number"
-                                        min="0"
+                                        min="1"
                                         step="1"
                                         value="<?= esc_attr($cout); ?>"
-                                        placeholder="0" <?= $peut_editer_cout ? '' : 'disabled'; ?> />
+                                        placeholder="10" <?= $peut_editer_cout ? '' : 'disabled'; ?> />
                                 </div>
                             </div>
                             <div class="champ-feedback"></div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -40,6 +40,8 @@ $date_debut_iso = $date_debut_obj ? $date_debut_obj->format('Y-m-d\TH:i') : '';
 
 $date_fin_obj = convertir_en_datetime($date_fin);
 $date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
+$maintenant    = current_datetime();
+$debut_differe = $date_debut_obj && $date_debut_obj > $maintenant;
 $illimitee  = $infos_chasse['champs']['illimitee'];
 $nb_max     = $infos_chasse['champs']['nb_max'] ?? 1;
 $mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'automatique';
@@ -506,14 +508,29 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             <label for="chasse-date-debut"><?= esc_html__('Début', 'chassesautresor-com'); ?></label>
                             <?php
                         },
-                        'content'  => function () use ($date_debut_iso, $peut_editer) {
+                        'content'  => function () use ($date_debut_iso, $peut_editer, $debut_differe) {
                             ?>
-                            <input type="datetime-local"
-                                id="chasse-date-debut"
-                                name="chasse-date-debut"
-                                value="<?= esc_attr($date_debut_iso); ?>"
-                                class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> required />
-                            <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                            <div class="champ-mode-options">
+                                <span class="toggle-option"><?= esc_html__('Now', 'chassesautresor-com'); ?></span>
+                                <label class="switch-control">
+                                    <input
+                                        id="date-debut-differee"
+                                        type="checkbox"
+                                        <?= $debut_differe ? 'checked' : ''; ?>
+                                        <?= $peut_editer ? '' : 'disabled'; ?>
+                                    >
+                                    <span class="switch-slider"></span>
+                                </label>
+                                <span class="toggle-option"><?= esc_html__('Later', 'chassesautresor-com'); ?></span>
+                                <div class="date-debut-actions" style="<?= $debut_differe ? '' : 'display:none;'; ?>">
+                                    <input type="datetime-local"
+                                        id="chasse-date-debut"
+                                        name="chasse-date-debut"
+                                        value="<?= esc_attr($date_debut_iso); ?>"
+                                        class="champ-inline-date champ-date-edit" <?= ($peut_editer && $debut_differe) ? '' : 'disabled'; ?> required />
+                                    <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                </div>
+                            </div>
                             <?php
                         },
                     ]


### PR DESCRIPTION
## Résumé
- Ajout d'un commutateur Illimité/Limité pour définir le nombre de gagnants d'une chasse
- Mise à jour du script d'édition pour gérer l'affichage et l'enregistrement du nombre de gagnants
- Ajustements des tests et de la documentation associés

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acc62875b08332a74c642c0446df52