### PR TITLE
Affiner le panneau d’édition sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1163,8 +1163,22 @@ li.ligne-email .champ-affichage {
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
 @media not all and (--bp-tablet) {
+  .edition-tab-content {
+    padding: 0;
+  }
+
   .edition-panel-body {
     flex-direction: column;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .edition-panel-section {
+    border: 0;
+  }
+
+  .mode-edition {
+    --editor-label-width: 200px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2824,8 +2824,19 @@ li.ligne-email .champ-affichage {
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
 @media not all and (min-width: 768px) {
+  .edition-tab-content {
+    padding: 0;
+  }
   .edition-panel-body {
     flex-direction: column;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .edition-panel-section {
+    border: 0;
+  }
+  .mode-edition {
+    --editor-label-width: 200px;
   }
 }
 @media not all and (min-width: 480px) {


### PR DESCRIPTION
### Résumé
Ajuste l'affichage du panneau d'édition pour les résolutions inférieures à la tablette.

### Changements
- Retrait du padding de `.edition-tab-content` et du padding horizontal de `edition-panel-body`.
- Suppression de la bordure des sections du panneau.
- Largeur minimale des labels réduite à 200 px.

### Testing
- `npm ci`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68accbb1018883329bde3c886febddac