### PR TITLE
Rendre la largeur des labels du panneau d’édition responsive

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1176,10 +1176,6 @@ li.ligne-email .champ-affichage {
   .edition-panel-section {
     border: 0;
   }
-
-  .mode-edition {
-    --editor-label-width: 200px;
-  }
 }
 
 @media not all and (--bp-small) {

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -74,7 +74,7 @@
 .resume-infos > li > label,
 .resume-infos > li > .champ-edition > label,
 .resume-infos > li > .champ-affichage > label {
-  width: var(--editor-label-width);
+  min-width: var(--editor-label-width);
   flex-shrink: 0;
 }
 
@@ -107,7 +107,7 @@
 }
 
 .edition-row-label {
-  width: var(--editor-label-width);
+  min-width: var(--editor-label-width);
   display: flex;
   align-items: center;
   gap: var(--space-xs);

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -526,6 +526,12 @@ span.champ-obligatoire {
   --editor-icon-width:            1rem;      /* 📏 Largeur des icônes dans les panneaux */
 }
 
+@media not all and (--bp-tablet) {
+  .mode-edition {
+    --editor-label-width: 200px;
+  }
+}
+
 
 /* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */
 .mode-edition {

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -32,12 +32,12 @@
   gap: var(--space-xl);
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .grille-3 {
     grid-template-columns: repeat(2, 1fr);
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .grille-3 {
     grid-template-columns: 1fr;
   }
@@ -136,8 +136,10 @@
 .carte-ligne__image img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  object-position: center;
+  -o-object-fit: cover;
+     object-fit: cover;
+  -o-object-position: center;
+     object-position: center;
   display: block;
   max-height: 350px;
 }
@@ -348,7 +350,7 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
 }
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .chasse-fiche-container {
     flex-direction: column;
   }
@@ -498,6 +500,7 @@ button,
   margin-top: 10px;
   transition: var(--transition-medium);
   text-align: center;
+  width: -moz-fit-content;
   width: fit-content;
 }
 
@@ -554,7 +557,7 @@ button,
   opacity: 0.7;
 }
 
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .bloc-reponse .reponse-cta-row {
     flex-direction: column;
     align-items: stretch;
@@ -566,12 +569,12 @@ button,
     margin-top: var(--space-xs);
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .bouton-cta {
     padding: 8px 13px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .bouton-cta {
     padding: 6px 10px;
   }
@@ -636,6 +639,7 @@ button,
   cursor: not-allowed;
   pointer-events: none;
   text-align: center;
+  width: -moz-fit-content;
   width: fit-content;
   display: flex;
   align-items: center;
@@ -796,7 +800,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .btn-lire-plus {
     width: 100%;
   }
@@ -833,7 +837,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .bouton-retour {
     font-size: 1.25rem;
   }
@@ -898,7 +902,7 @@ a.ajout-link:focus-visible {
   padding: 0.2em 0.6em;
 }
 
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .bloc-metas-inline {
     gap: 0.8rem;
   }
@@ -1060,7 +1064,7 @@ a.ajout-link:focus-visible {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .separateur-2 {
     margin: 0 auto;
   }
@@ -1082,7 +1086,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   color: var(--color-text-primary);
 }
 
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .formulaire-contact-wrapper {
     padding-left: var(--space-md);
     padding-right: var(--space-md);
@@ -1169,7 +1173,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   text-align: center;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .countdown-container {
     font-size: 1rem;
   }
@@ -1315,6 +1319,7 @@ a[aria-disabled=true] {
   display: none;
   z-index: 10;
   min-width: 6rem;
+  width: -moz-max-content;
   width: max-content;
 }
 
@@ -1616,7 +1621,7 @@ a[aria-disabled=true] {
   padding-bottom: var(--space-sm);
 }
 
-@media (--bp-wide) {
+@media (min-width: 1280px) {
   .menu-lateral {
     position: fixed;
     top: 50%;
@@ -1775,7 +1780,7 @@ a[aria-disabled=true] {
 .resume-infos > li > label,
 .resume-infos > li > .champ-edition > label,
 .resume-infos > li > .champ-affichage > label {
-  width: var(--editor-label-width);
+  min-width: var(--editor-label-width);
   flex-shrink: 0;
 }
 
@@ -1808,7 +1813,7 @@ a[aria-disabled=true] {
 }
 
 .edition-row-label {
-  width: var(--editor-label-width);
+  min-width: var(--editor-label-width);
   display: flex;
   align-items: center;
   gap: var(--space-xs);
@@ -1854,7 +1859,8 @@ a[aria-disabled=true] {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  column-gap: calc(4 * var(--space-xl));
+  -moz-column-gap: calc(4 * var(--space-xl));
+       column-gap: calc(4 * var(--space-xl));
   row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
@@ -1874,6 +1880,12 @@ a[aria-disabled=true] {
   width: 100%;
   height: auto;
   display: block;
+}
+
+.qr-code-block .qr-code-image i {
+  display: block;
+  font-size: 200px;
+  line-height: 1;
 }
 
 .qr-code-block .qr-code-content {
@@ -2231,6 +2243,10 @@ body .header-img-modifiable .icone-modif {
   padding: 0.1rem var(--space-xs);
 }
 
+.champ-edition input.champ-input::-moz-placeholder {
+  color: var(--color-editor-placeholder);
+}
+
 .champ-edition input.champ-input::placeholder {
   color: var(--color-editor-placeholder);
 }
@@ -2402,7 +2418,7 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 /* ========== 📱 RESPONSIVE GLOBAL ========== */
 /* Empilage à partir de tablette */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -2450,7 +2466,7 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 /* ========== 📱 RESPONSIVE HEADER ========== */
 /* Empilage à partir de tablette */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -2807,12 +2823,23 @@ li.ligne-email .champ-affichage {
 }
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
+  .edition-tab-content {
+    padding: 0;
+  }
   .edition-panel-body {
     flex-direction: column;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .edition-panel-section {
+    border: 0;
+  }
+  .mode-edition {
+    --editor-label-width: 200px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -3294,14 +3321,19 @@ body.panneau-ouvert::before {
   height: 2rem;
 }
 
-.dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy {
+.dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy,
+.dashboard-card.champ-protection-solutions,
+.champ-protection-solutions.carte-orgy {
   width: 75%;
-  margin: 0 auto;
+  margin: var(--space-4xl) auto;
 }
 
-@media not all and (--bp-desktop) {
-  .dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy {
+@media not all and (min-width: 1024px) {
+  .dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy,
+  .dashboard-card.champ-protection-solutions,
+  .champ-protection-solutions.carte-orgy {
     width: 100%;
+    margin: var(--space-xl) auto;
   }
 }
 .dashboard-card.solution-option, .solution-option.carte-orgy {
@@ -3834,7 +3866,8 @@ body.panneau-ouvert::before {
 .champ-pre-requis .prerequis-mini img {
   width: 80px;
   height: 80px;
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
   border-radius: 4px;
 }
 
@@ -4136,7 +4169,7 @@ body.panneau-ouvert::before {
   grid-column: 1;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .enigme-layout .menu-lateral {
     position: sticky;
     top: var(--space-md);
@@ -4149,7 +4182,7 @@ body.panneau-ouvert::before {
   grid-template-columns: 1fr;
 }
 
-@media (--bp-wide) {
+@media (min-width: 1280px) {
   .enigme-layout {
     display: block;
     gap: 0;
@@ -4415,7 +4448,7 @@ li.active .enigme-menu__edit {
   margin-top: var(--space-md);
 }
 
-@media (--bp-desktop) and (hover: hover) {
+@media (min-width: 1024px) and (hover: hover) {
   body.single-enigme .page-enigme {
     margin-top: calc(var(--space-4xl) + var(--space-md));
   }
@@ -4443,7 +4476,7 @@ li.active .enigme-menu__edit {
   font-size: 32px;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .page-enigme {
     gap: var(--space-xl);
   }
@@ -4455,7 +4488,7 @@ li.active .enigme-menu__edit {
     font-size: 1rem;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .page-enigme {
     gap: var(--space-lg);
   }
@@ -4468,7 +4501,8 @@ li.active .enigme-menu__edit {
 }
 .hero-visuel img {
   /*width: 100%;*/
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
   /*max-height: 300px;*/
 }
 
@@ -4495,7 +4529,7 @@ li.active .enigme-menu__edit {
   margin-top: 0;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .participation {
     width: 70%;
   }
@@ -4569,7 +4603,7 @@ li.active .enigme-menu__edit {
   margin-inline: auto;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .enigme-layout {
     grid-template-columns: 1fr;
   }
@@ -4604,7 +4638,7 @@ body.topbar-visible .enigme-edit-toggle--desktop {
   top: calc(var(--space-md) + var(--space-4xl));
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .enigme-layout .menu-lateral {
     display: none;
   }
@@ -4763,7 +4797,7 @@ body.single-enigme.topbar-visible header.site-header {
   transform: translateY(0);
 }
 
-@media not all and (--bp-desktop), (hover: none) {
+@media not all and (min-width: 1024px), (hover: none) {
   body.single-enigme header.site-header {
     display: none;
   }
@@ -4819,7 +4853,8 @@ body.single-enigme.topbar-visible header.site-header {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
   box-shadow: inset 0 0 10px rgba(255, 215, 0, 0.8), 0 0 20px rgba(255, 215, 0, 0.5);
 }
 
@@ -5111,22 +5146,22 @@ header .points-link:hover {
 }
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .points-value {
     font-size: 16px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .points-value {
     font-size: 14px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .points-unite {
     display: none;
   }
 }
-@media not all and (--bp-xs) {
+@media not all and (min-width: 374px) {
   .points-unite {
     display: none;
   }
@@ -5402,7 +5437,7 @@ h1.h1-diff { /* variation couleur bronze, plus petite, centrée */
   color: var(--color-accent);
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   h1, .entry-content h1 {
     font-size: 36px;
   }
@@ -5410,7 +5445,7 @@ h1.h1-diff { /* variation couleur bronze, plus petite, centrée */
     font-size: 30px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   h1, .entry-content h1 {
     font-size: 30px;
   }
@@ -5429,12 +5464,12 @@ h2, .entry-content h2 {
   font-size: 32px;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   h2, .entry-content h2 {
     font-size: 28px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   h2, .entry-content h2 {
     font-size: 24px;
   }
@@ -5450,7 +5485,7 @@ h3, .entry-content h3 {
   margin-bottom: var(--space-sm);
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .page header.entry-header .entry-title {
     font-size: 36px;
   }
@@ -5458,7 +5493,7 @@ h3, .entry-content h3 {
     font-size: 22px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .page header.entry-header .entry-title {
     font-size: 30px;
   }
@@ -5686,7 +5721,8 @@ tbody tr:nth-child(even) {
 .indices-table td img {
   width: 80px;
   height: 80px;
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
 }
 
 .indices-table .badge-action {
@@ -5853,12 +5889,12 @@ span.champ-obligatoire {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
     font-size: 96%;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
     font-size: 93%;
   }
@@ -6064,17 +6100,17 @@ span.champ-obligatoire {
   --col-span: 12;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .row {
     --grid-columns: 8;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .row {
     --grid-columns: 6;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .row {
     --grid-columns: 4;
   }
@@ -6153,7 +6189,7 @@ body.accueil-fullscreen {
   margin-left: 10px;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   header.site-header {
     padding: 0 10px;
   }
@@ -6162,7 +6198,7 @@ body.accueil-fullscreen {
     padding-right: 10px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   header.site-header {
     padding: 0 7px;
   }
@@ -6257,7 +6293,7 @@ body.accueil-fullscreen {
   text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.7);
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .hero-title {
     font-size: 1.8rem;
   }
@@ -6272,7 +6308,7 @@ body.accueil-fullscreen {
     padding-top: 300px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .hero-title {
     font-size: 1.5rem;
   }
@@ -6308,7 +6344,7 @@ body #primary {
   flex-wrap: wrap; /* ✅ si l’un est trop large */
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .ast-container, .ast-container-fluid {
     margin-left: auto;
     margin-right: auto;
@@ -6389,7 +6425,7 @@ body #primary {
   line-height: 1.5;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .bloc-temoignages .temoignage-colonnes {
     flex-direction: column;
     align-items: center;
@@ -6486,6 +6522,10 @@ body #primary {
   box-sizing: border-box;
 }
 
+.newsletter-group input[type=email]::-moz-placeholder {
+  color: var(--color-gris-3);
+}
+
 .newsletter-group input[type=email]::placeholder {
   color: var(--color-gris-3);
 }
@@ -6562,7 +6602,7 @@ footer .ast-footer-widget a {
   text-decoration: none;
 }
 
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .site-footer-primary-section-1 {
     order: 2;
     margin: 30px 0;
@@ -6578,7 +6618,8 @@ footer .ast-footer-widget a {
     display: block;
   }
   .ast-builder-footer-grid-columns {
-    column-gap: 20px;
+    -moz-column-gap: 20px;
+         column-gap: 20px;
     padding-inline: 10px;
   }
 }
@@ -7030,7 +7071,7 @@ footer .ast-footer-widget a {
 }
 
 /* ✅ Mobile : Les éléments s'empilent */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .dashboard-profile-wrapper {
     flex-direction: column; /* ✅ Empile les éléments */
     justify-content: center; /* ✅ Centre les éléments verticalement */
@@ -7090,7 +7131,7 @@ footer .ast-footer-widget a {
   vertical-align: middle;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .menu-deroulant .submenu {
     left: -50px;
   }
@@ -7197,7 +7238,8 @@ footer .ast-footer-widget a {
 .dashboard-logo {
   width: 100%;
   height: 100%;
-  object-fit: cover; /* Ajuste l’image pour occuper tout l’espace sans déformation */
+  -o-object-fit: cover;
+     object-fit: cover; /* Ajuste l’image pour occuper tout l’espace sans déformation */
 }
 
 /* 🔥 Overlay du nombre de chasses */
@@ -7424,7 +7466,7 @@ footer .ast-footer-widget a {
 }
 
 /* Tablette : 2 colonnes */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .image-container {
     height: 260px;
   }
@@ -7695,7 +7737,7 @@ a.bouton-edition-attention {
 }
 
 /* ========== 📱 RESPONSIVE – TABLETTES (≤ 768PX) ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .conteneur-organisateur {
     flex-direction: column;
     align-items: center;
@@ -7728,7 +7770,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 RESPONSIVE – TABLETTES (600PX À 768PX) ========== */
-@media (min-width: 600px) and (--bp-tablet) {
+@media (min-width: 600px) and (min-width: 768px) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
@@ -7753,7 +7795,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 BASCULE EN COLONNE (≤ 600PX) ========== */
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .conteneur-organisateur {
     gap: var(--space-md);
   }
@@ -7764,7 +7806,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 RESPONSIVE – MOBILE (≤ 480PX) ========== */
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .conteneur-organisateur {
     gap: 0.2rem;
   }
@@ -7922,7 +7964,7 @@ section#presentation .presentation-fermer {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .lien-public .texte-lien {
     display: none;
   }
@@ -8025,7 +8067,7 @@ section#presentation .presentation-fermer {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .separateur-avec-icone {
     margin: 2.1rem 0;
   }
@@ -8041,7 +8083,7 @@ section#presentation .presentation-fermer {
     height: 50px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .separateur-avec-icone {
     margin: var(--space-xl) 0;
   }
@@ -8078,20 +8120,7 @@ section#presentation .presentation-fermer {
 }
 
 /* 🎨 Variables globales */
-@custom-media --bp-xs (min-width: 374px);
-@custom-media --bp-small (min-width: 480px);
-@custom-media --bp-mobile (min-width: 600px);
-@custom-media --bp-tablet (min-width: 768px);
-@custom-media --bp-desktop (min-width: 1024px);
-@custom-media --bp-wide (min-width: 1280px);
-@custom-media --bp-xxl (min-width: 1440px);
-@custom-media --bp-xxxl (min-width: 1920px);
 /* Legacy aliases */
-@custom-media --bp-sm (--bp-small);
-@custom-media --bp-600 (--bp-mobile);
-@custom-media --bp-md (--bp-tablet);
-@custom-media --bp-lg (--bp-desktop);
-@custom-media --bp-xl (--bp-wide);
 :root {
   /* Typographie et breakpoints */
   --font-main: "Poppins", sans-serif; /* Police principale */
@@ -8191,5 +8220,3 @@ section#presentation .presentation-fermer {
   --editor-button-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-button) */
   --editor-button-hover-hsl: 214 79% 39%; /* = #1558B0 → var(--color-editor-button-hover) */
 }
-
-/*# sourceMappingURL=main.css.map */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2835,9 +2835,6 @@ li.ligne-email .champ-affichage {
   .edition-panel-section {
     border: 0;
   }
-  .mode-edition {
-    --editor-label-width: 200px;
-  }
 }
 @media not all and (min-width: 480px) {
   .edition-panel-body {
@@ -5921,6 +5918,11 @@ span.champ-obligatoire {
   --editor-icon-width: 1rem; /* 📏 Largeur des icônes dans les panneaux */
 }
 
+@media not all and (min-width: 768px) {
+  .mode-edition {
+    --editor-label-width: 200px;
+  }
+}
 /* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */
 .mode-edition {
   /* dérivés HSL (triplets) de tes variables existantes */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1780,7 +1780,7 @@ a[aria-disabled=true] {
 .resume-infos > li > label,
 .resume-infos > li > .champ-edition > label,
 .resume-infos > li > .champ-affichage > label {
-  width: var(--editor-label-width);
+  min-width: var(--editor-label-width);
   flex-shrink: 0;
 }
 
@@ -1813,7 +1813,7 @@ a[aria-disabled=true] {
 }
 
 .edition-row-label {
-  width: var(--editor-label-width);
+  min-width: var(--editor-label-width);
   display: flex;
   align-items: center;
   gap: var(--space-xs);


### PR DESCRIPTION
## Résumé
La largeur minimale des labels du panneau d’édition s’adapte désormais aux petits écrans.

## Changements
- Utilisation de `min-width` basé sur `--editor-label-width` pour les labels
- Réduction de la largeur des labels à 200px sous `--bp-tablet`

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68accd568fd883329f202437f1b474e8