### PR TITLE
Remove horizontal padding from edition panel section on small screens

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1175,6 +1175,8 @@ li.ligne-email .champ-affichage {
 
   .edition-panel-section {
     border: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2834,6 +2834,8 @@ li.ligne-email .champ-affichage {
   }
   .edition-panel-section {
     border: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 @media not all and (min-width: 480px) {


### PR DESCRIPTION
## Résumé
- Supprime le padding horizontal des sections du panneau d'édition sur mobile

## Changements notables
- Ajustement du SCSS pour retirer le padding gauche/droite sous `--bp-tablet`
- Compilation du CSS distribué pour refléter la modification

## Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acd2890c248332b091e50e854ebf0d