### PR TITLE
Ajuste le responsive du panneau d’édition chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1473,6 +1473,18 @@ body.panneau-ouvert::before {
   border-bottom: 3px solid var(--color-primary);
 }
 
+@media not all and (--bp-mobile) {
+  .edition-tab {
+    font-size: 90%;
+  }
+}
+
+@media not all and (--bp-small) {
+  .edition-tab {
+    font-size: 80%;
+  }
+}
+
 
 .edition-tab-content {
   display: none;

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1176,7 +1176,8 @@ li.ligne-email .champ-affichage {
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
 @media not all and (--bp-tablet) {
   .edition-tab-content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .edition-panel-body {

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -988,7 +988,19 @@ body.edition-active .edition-panel {
 
 .edition-panel label {
   color: var(--color-editor-text-muted);
-  font-size: 16px;
+  font-size: 1rem;
+}
+
+@media not all and (--bp-mobile) {
+  .edition-panel label {
+    font-size: 0.9rem;
+  }
+}
+
+@media not all and (--bp-small) {
+  .edition-panel label {
+    font-size: 0.8rem;
+  }
 }
 
 /* ========== 🧪 PLACEHOLDER ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -532,6 +532,12 @@ span.champ-obligatoire {
   }
 }
 
+@media not all and (--bp-small) {
+  .mode-edition {
+    --editor-label-width: 150px;
+  }
+}
+
 
 /* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */
 .mode-edition {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3121,6 +3121,16 @@ body.panneau-ouvert::before {
   border-bottom: 3px solid var(--color-primary);
 }
 
+@media not all and (min-width: 600px) {
+  .edition-tab {
+    font-size: 90%;
+  }
+}
+@media not all and (min-width: 480px) {
+  .edition-tab {
+    font-size: 80%;
+  }
+}
 .edition-tab-content {
   display: none;
   min-height: 180px;
@@ -5921,6 +5931,11 @@ span.champ-obligatoire {
 @media not all and (min-width: 768px) {
   .mode-edition {
     --editor-label-width: 200px;
+  }
+}
+@media not all and (min-width: 480px) {
+  .mode-edition {
+    --editor-label-width: 150px;
   }
 }
 /* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2835,7 +2835,8 @@ li.ligne-email .champ-affichage {
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
 @media not all and (min-width: 768px) {
   .edition-tab-content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
   .edition-panel-body {
     flex-direction: column;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2657,9 +2657,19 @@ body.edition-active .edition-panel {
 
 .edition-panel label {
   color: var(--color-editor-text-muted);
-  font-size: 16px;
+  font-size: 1rem;
 }
 
+@media not all and (min-width: 600px) {
+  .edition-panel label {
+    font-size: 0.9rem;
+  }
+}
+@media not all and (min-width: 480px) {
+  .edition-panel label {
+    font-size: 0.8rem;
+  }
+}
 /* ========== 🧪 PLACEHOLDER ========== */
 .edition-placeholder {
   border: 1px dashed var(--color-editor-border);


### PR DESCRIPTION
## Résumé
- Affine la largeur des labels du panneau de chasse pour les très petits écrans
- Réduit la taille de police des onglets d’édition sur mobile

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acd49a32a083329b530dd33d102638