### PR TITLE
Fix cost toggle logic

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -231,6 +231,16 @@ describe('chasse-edit UI', () => {
     expect(input.min).toBe('1');
   });
 
+  test('points input hidden and disabled initially when gratuit selected', () => {
+    const toggle = document.getElementById('cout-payant');
+    const actions = document.querySelector('.cout-points-actions');
+    const input = document.querySelector('.champ-cout');
+    expect(toggle.checked).toBe(false);
+    expect(actions.style.display).toBe('none');
+    expect(input.disabled).toBe(true);
+    expect(input.value).toBe('0');
+  });
+
   test('access toggle hides points input when unchecked', () => {
     const toggle = document.getElementById('cout-payant');
     const actions = document.querySelector('.cout-points-actions');

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -395,23 +395,23 @@ function initChampCoutPoints() {
     const valeurInitiale = parseInt(input.value.trim(), 10);
     if (valeurInitiale === 0) {
       input.disabled = true;
-      checkbox.checked = true;
+      checkbox.checked = false;
     } else {
       input.disabled = false;
-      checkbox.checked = false;
+      checkbox.checked = true;
     }
 
     input.addEventListener('input', enregistrerCout);
 
     checkbox.addEventListener('change', () => {
       if (checkbox.checked) {
-        ancienneValeur = input.value.trim();
-        input.value = 0;
-        input.disabled = true;
-      } else {
         const valeur = parseInt(ancienneValeur, 10);
         input.value = valeur > 0 ? valeur : 10;
         input.disabled = false;
+      } else {
+        ancienneValeur = input.value.trim();
+        input.value = 0;
+        input.disabled = true;
       }
       enregistrerCout();
     });


### PR DESCRIPTION
## Summary
- corrige la logique du commutateur gratuit/points
- ajoute un test pour l'état initial du coût en points

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acd898b07c833288da6390bc627650