### PR TITLE
Retire les icônes des réglages de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -445,6 +445,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             'data-cpt'     => 'chasse',
                             'data-post-id' => $chasse_id,
                         ],
+                        'no_icon'   => true,
                         'label'    => function () {
                             ?>
                             <label for="chasse-nb-gagnants"><?= esc_html__('Nb gagnants', 'chassesautresor-com'); ?></label>
@@ -503,6 +504,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             'data-cpt'     => 'chasse',
                             'data-post-id' => $chasse_id,
                         ],
+                        'no_icon'   => true,
                         'label'    => function () {
                             ?>
                             <label for="chasse-date-debut"><?= esc_html__('Début', 'chassesautresor-com'); ?></label>
@@ -549,6 +551,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             'data-cpt'     => 'chasse',
                             'data-post-id' => $chasse_id,
                         ],
+                        'no_icon'   => true,
                         'label'    => function () {
                             ?>
                             <label for="chasse-date-fin"><?= esc_html__('Date de fin', 'chassesautresor-com'); ?></label>
@@ -595,6 +598,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             'data-cpt'     => 'chasse',
                             'data-post-id' => $chasse_id,
                         ],
+                        'no_icon'   => true,
                         'label'    => function () {
                             ?>
                             <label>

--- a/wp-content/themes/chassesautresor/template-parts/common/edition-row.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/edition-row.php
@@ -26,27 +26,29 @@ foreach ($attributes as $key => $value) {
 }
 ?>
 <li class="edition-row <?php echo esc_attr($class); ?>" <?php echo implode(' ', $attr_strings); ?><?php echo $no_icon ? ' data-no-icon="1"' : ''; ?>>
-  <div class="edition-row-label">
-    <span class="edition-row-icon">
-      <?php if (!$no_icon && !empty($icon)) : ?>
-        <i class="<?php echo esc_attr($icon); ?>" aria-hidden="true"></i>
-      <?php endif; ?>
-    </span>
-    <?php
-    if (is_callable($label)) {
-        $label();
-    } else {
-        echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    }
-    ?>
-  </div>
-  <div class="edition-row-content">
-    <?php
-    if (is_callable($content)) {
-        $content();
-    } else {
-        echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    }
-    ?>
-  </div>
+    <div class="edition-row-label">
+        <?php if (!$no_icon) : ?>
+            <span class="edition-row-icon">
+                <?php if (!empty($icon)) : ?>
+                    <i class="<?php echo esc_attr($icon); ?>" aria-hidden="true"></i>
+                <?php endif; ?>
+            </span>
+        <?php endif; ?>
+        <?php
+        if (is_callable($label)) {
+            $label();
+        } else {
+            echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
+        ?>
+    </div>
+    <div class="edition-row-content">
+        <?php
+        if (is_callable($content)) {
+            $content();
+        } else {
+            echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
+        ?>
+    </div>
 </li>


### PR DESCRIPTION
Supprime les espaces réservés d'icône au début des lignes de la section Réglages du panneau d'édition d'une chasse.

- retire le span `edition-row-icon` lorsque l'option `no_icon` est activée
- applique `no_icon` à chaque champ de la section Réglages

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acd9d490d88332a9082a9766ee67f2