### PR TITLE
Corrige la largeur des labels d’édition sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -113,6 +113,13 @@
   gap: var(--space-xs);
 }
 
+@media not all and (--bp-tablet) {
+  .edition-row-label {
+    min-width: unset;
+    width: var(--editor-label-width);
+  }
+}
+
 .edition-row-icon {
   width: var(--editor-icon-width);
   flex: 0 0 var(--editor-icon-width);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1819,6 +1819,12 @@ a[aria-disabled=true] {
   gap: var(--space-xs);
 }
 
+@media not all and (min-width: 768px) {
+  .edition-row-label {
+    min-width: unset;
+    width: var(--editor-label-width);
+  }
+}
 .edition-row-icon {
   width: var(--editor-icon-width);
   flex: 0 0 var(--editor-icon-width);


### PR DESCRIPTION
## Résumé
- Rend la largeur des labels d’édition fixe sous la tablette
- Regénère la feuille de style compilée

## Testing
- `npm test`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acdc55e904833286c4f81f8bd6d116