### PR TITLE
Fix duplicate translation entries

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1165,7 +1165,7 @@ msgstr "Learn more about loyalty points"
 msgid "Coût d’accès à une chasse"
 msgstr "Hunt access cost"
 
-#: template-parts/chasse/chasse-edition-main.php:601
+#: template-parts/chasse/chasse-edition-main.php:601 template-parts/enigme/enigme-edition-main.php:434
 msgid "Accès"
 msgstr "Access"
 
@@ -1559,10 +1559,6 @@ msgstr ""
 #: template-parts/enigme/enigme-edition-main.php:418
 msgid "max par jour"
 msgstr "max per day"
-
-#: template-parts/enigme/enigme-edition-main.php:434
-msgid "Accès"
-msgstr "Access"
 
 #: template-parts/enigme/enigme-edition-main.php:438
 msgid "Libre"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1162,7 +1162,7 @@ msgstr "En savoir plus sur les points"
 msgid "Coût d’accès à une chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:601
+#: template-parts/chasse/chasse-edition-main.php:601 template-parts/enigme/enigme-edition-main.php:434
 msgid "Accès"
 msgstr "Accès"
 
@@ -1549,10 +1549,6 @@ msgstr ""
 #: template-parts/enigme/enigme-edition-main.php:418
 msgid "max par jour"
 msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:434
-msgid "Accès"
-msgstr "Accès"
 
 #: template-parts/enigme/enigme-edition-main.php:438
 msgid "Libre"


### PR DESCRIPTION
Supprime les doublons de la chaîne "Accès" dans les traductions.

- Fusion des références pour "Accès" dans fr_FR.po
- Fusion des références pour "Accès" dans en_US.po

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `msgfmt wp-content/themes/chassesautresor/languages/fr_FR.po -o /tmp/fr_FR.mo`
- `msgfmt wp-content/themes/chassesautresor/languages/en_US.po -o /tmp/en_US.mo`


------
https://chatgpt.com/codex/tasks/task_e_68acdcd8713c8332b3afe29a1970af3b