### PR TITLE
Ajuste les largeurs des labels en mode édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -528,13 +528,13 @@ span.champ-obligatoire {
 
 @media not all and (--bp-tablet) {
   .mode-edition {
-    --editor-label-width: 200px;
+    --editor-label-width: 175px;
   }
 }
 
 @media not all and (--bp-small) {
   .mode-edition {
-    --editor-label-width: 150px;
+    --editor-label-width: 135px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -2836,7 +2836,7 @@ li.ligne-email .champ-affichage {
     border: 0;
   }
   .mode-edition {
-    --editor-label-width: 200px;
+    --editor-label-width: 175px;
   }
 }
 @media not all and (min-width: 480px) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5949,12 +5949,12 @@ span.champ-obligatoire {
 
 @media not all and (min-width: 768px) {
   .mode-edition {
-    --editor-label-width: 200px;
+    --editor-label-width: 175px;
   }
 }
 @media not all and (min-width: 480px) {
   .mode-edition {
-    --editor-label-width: 150px;
+    --editor-label-width: 135px;
   }
 }
 /* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */


### PR DESCRIPTION
## Résumé
- Réduction des largeurs de label pour l'éditeur sur tablette et mobile

## Changements
- Fixe `--editor-label-width` à 175px pour les tablettes
- Fixe `--editor-label-width` à 135px pour les petits écrans

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b8ab6f48332b7da58c51861dd7b