### PR TITLE
Réduire la taille des champs sur mobiles

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -495,6 +495,14 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
+@media not all and (--bp-tablet) {
+  .edition-panel-body input.champ-input,
+  .edition-panel-body input[type="date"],
+  .edition-panel-body input[type="datetime-local"] {
+    font-size: 0.85rem;
+  }
+}
+
 .edition-panel-body input.champ-number {
   width: 100px;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2189,6 +2189,13 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
+@media not all and (min-width: 768px) {
+  .edition-panel-body input.champ-input,
+  .edition-panel-body input[type=date],
+  .edition-panel-body input[type=datetime-local] {
+    font-size: 0.85rem;
+  }
+}
 .edition-panel-body input.champ-number {
   width: 100px;
 }


### PR DESCRIPTION
## Summary
- ajuste la taille de police des champs de saisie pour les écrans en dessous de la tablette
- reconstruit la feuille de style du thème

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad1f6875908332b128ea1d9d62127b