### PR TITLE
Supprime les min-width spécifiques des labels de résumé

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1074,10 +1074,6 @@ li.ligne-logo .champ-modifier {
   gap: var(--space-xs);
 }
 
-.resume-infos li.champ-description label,
-.resume-infos li.champ-wysiwyg label {
-  min-width: var(--editor-label-width);
-}
 
 .resume-infos li.champ-description .champ-texte,
 .resume-infos li.champ-wysiwyg .champ-texte {
@@ -1123,9 +1119,6 @@ li.ligne-logo .champ-modifier {
   gap: var(--space-xs);
 }
 
-.resume-infos li.champ-recompense label {
-  min-width: var(--editor-label-width);
-}
 
 .resume-infos li.champ-recompense .champ-texte {
   flex: 1;

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -2711,10 +2711,6 @@ li.ligne-logo .champ-modifier {
   gap: var(--space-xs);
 }
 
-.resume-infos li.champ-description label,
-.resume-infos li.champ-wysiwyg label {
-  min-width: var(--editor-label-width);
-}
 
 .resume-infos li.champ-description .champ-texte,
 .resume-infos li.champ-wysiwyg .champ-texte {
@@ -2759,9 +2755,6 @@ li.ligne-logo .champ-modifier {
   gap: var(--space-xs);
 }
 
-.resume-infos li.champ-recompense label {
-  min-width: var(--editor-label-width);
-}
 
 .resume-infos li.champ-recompense .champ-texte {
   flex: 1;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2734,11 +2734,6 @@ li.ligne-logo .champ-modifier {
   gap: var(--space-xs);
 }
 
-.resume-infos li.champ-description label,
-.resume-infos li.champ-wysiwyg label {
-  min-width: var(--editor-label-width);
-}
-
 .resume-infos li.champ-description .champ-texte,
 .resume-infos li.champ-wysiwyg .champ-texte {
   flex: 1;
@@ -2780,10 +2775,6 @@ li.ligne-logo .champ-modifier {
   display: flex;
   align-items: baseline;
   gap: var(--space-xs);
-}
-
-.resume-infos li.champ-recompense label {
-  min-width: var(--editor-label-width);
 }
 
 .resume-infos li.champ-recompense .champ-texte {


### PR DESCRIPTION
## Résumé
- retire les déclarations `min-width` spécifiques aux labels des panneaux de résumé

## Changements
- supprime les règles visant `.champ-description` et `.champ-wysiwyg`
- supprime la règle pour `.champ-recompense`
- régénère la feuille de style compilée

## Testing
- `node build-css.js`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad28693bfc8332a206a8f0dc2e8d02