### PR TITLE
Ajuste responsive des blocs QR code dans la configuration de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -160,7 +160,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  column-gap: calc(4 * var(--space-xl));
+  column-gap: var(--space-xl);
   row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
@@ -204,17 +204,17 @@
 @media not all and (--bp-desktop) {
   .dashboard-card.champ-protection-solutions .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image {
-    flex: 0 0 200px;
+    flex: 0 0 150px;
   }
 
   .dashboard-card.champ-protection-solutions .qr-code-image img,
   .dashboard-card.champ-qr-code .qr-code-image img {
-    width: 200px;
+    width: 150px;
   }
 
   .dashboard-card.champ-protection-solutions .qr-code-image i,
   .dashboard-card.champ-qr-code .qr-code-image i {
-    font-size: 200px;
+    font-size: 150px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -201,6 +201,23 @@
   margin-top: 0;
 }
 
+@media not all and (--bp-desktop) {
+  .dashboard-card.champ-protection-solutions .qr-code-image,
+  .dashboard-card.champ-qr-code .qr-code-image {
+    flex: 0 0 200px;
+  }
+
+  .dashboard-card.champ-protection-solutions .qr-code-image img,
+  .dashboard-card.champ-qr-code .qr-code-image img {
+    width: 200px;
+  }
+
+  .dashboard-card.champ-protection-solutions .qr-code-image i,
+  .dashboard-card.champ-qr-code .qr-code-image i {
+    font-size: 200px;
+  }
+}
+
 @media not all and (--bp-tablet) {
   .dashboard-card.champ-protection-solutions .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image {

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -201,6 +201,31 @@
   margin-top: 0;
 }
 
+@media not all and (--bp-tablet) {
+  .dashboard-card.champ-protection-solutions .qr-code-image,
+  .dashboard-card.champ-qr-code .qr-code-image {
+    flex: 0 0 100px;
+  }
+
+  .dashboard-card.champ-protection-solutions .qr-code-image i {
+    font-size: 100px;
+  }
+}
+
+@media not all and (--bp-mobile) {
+  .dashboard-card.champ-protection-solutions .qr-code-block,
+  .dashboard-card.champ-qr-code .qr-code-block {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .dashboard-card.champ-protection-solutions .qr-code-content,
+  .dashboard-card.champ-qr-code .qr-code-content {
+    align-items: center;
+    text-align: center;
+  }
+}
+
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */
 
 .champ-edition {

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -224,6 +224,22 @@
     align-items: center;
     text-align: center;
   }
+
+  .dashboard-card.champ-protection-solutions .qr-code-image,
+  .dashboard-card.champ-qr-code .qr-code-image {
+    width: 100px;
+    flex: none;
+  }
+
+  .dashboard-card.champ-protection-solutions .qr-code-image img,
+  .dashboard-card.champ-qr-code .qr-code-image img {
+    width: 100px;
+  }
+
+  .dashboard-card.champ-protection-solutions .qr-code-image i,
+  .dashboard-card.champ-qr-code .qr-code-image i {
+    font-size: 100px;
+  }
 }
 
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1907,6 +1907,30 @@ a[aria-disabled=true] {
   margin-top: 0;
 }
 
+@media not all and (min-width: 768px) {
+  .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
+  .dashboard-card.champ-qr-code .qr-code-image,
+  .champ-qr-code.carte-orgy .qr-code-image {
+    flex: 0 0 100px;
+  }
+  .dashboard-card.champ-protection-solutions .qr-code-image i, .champ-protection-solutions.carte-orgy .qr-code-image i {
+    font-size: 100px;
+  }
+}
+@media not all and (min-width: 600px) {
+  .dashboard-card.champ-protection-solutions .qr-code-block, .champ-protection-solutions.carte-orgy .qr-code-block,
+  .dashboard-card.champ-qr-code .qr-code-block,
+  .champ-qr-code.carte-orgy .qr-code-block {
+    flex-direction: column;
+    align-items: center;
+  }
+  .dashboard-card.champ-protection-solutions .qr-code-content, .champ-protection-solutions.carte-orgy .qr-code-content,
+  .dashboard-card.champ-qr-code .qr-code-content,
+  .champ-qr-code.carte-orgy .qr-code-content {
+    align-items: center;
+    text-align: center;
+  }
+}
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */
 .champ-edition {
   display: flex;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1865,8 +1865,8 @@ a[aria-disabled=true] {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  -moz-column-gap: calc(4 * var(--space-xl));
-       column-gap: calc(4 * var(--space-xl));
+  -moz-column-gap: var(--space-xl);
+       column-gap: var(--space-xl);
   row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
@@ -1911,17 +1911,17 @@ a[aria-disabled=true] {
   .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image,
   .champ-qr-code.carte-orgy .qr-code-image {
-    flex: 0 0 200px;
+    flex: 0 0 150px;
   }
   .dashboard-card.champ-protection-solutions .qr-code-image img, .champ-protection-solutions.carte-orgy .qr-code-image img,
   .dashboard-card.champ-qr-code .qr-code-image img,
   .champ-qr-code.carte-orgy .qr-code-image img {
-    width: 200px;
+    width: 150px;
   }
   .dashboard-card.champ-protection-solutions .qr-code-image i, .champ-protection-solutions.carte-orgy .qr-code-image i,
   .dashboard-card.champ-qr-code .qr-code-image i,
   .champ-qr-code.carte-orgy .qr-code-image i {
-    font-size: 200px;
+    font-size: 150px;
   }
 }
 @media not all and (min-width: 768px) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1930,6 +1930,22 @@ a[aria-disabled=true] {
     align-items: center;
     text-align: center;
   }
+  .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
+  .dashboard-card.champ-qr-code .qr-code-image,
+  .champ-qr-code.carte-orgy .qr-code-image {
+    width: 100px;
+    flex: none;
+  }
+  .dashboard-card.champ-protection-solutions .qr-code-image img, .champ-protection-solutions.carte-orgy .qr-code-image img,
+  .dashboard-card.champ-qr-code .qr-code-image img,
+  .champ-qr-code.carte-orgy .qr-code-image img {
+    width: 100px;
+  }
+  .dashboard-card.champ-protection-solutions .qr-code-image i, .champ-protection-solutions.carte-orgy .qr-code-image i,
+  .dashboard-card.champ-qr-code .qr-code-image i,
+  .champ-qr-code.carte-orgy .qr-code-image i {
+    font-size: 100px;
+  }
 }
 /* ========== 🖊️ CHAMPS ÉDITABLES ========== */
 .champ-edition {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1907,6 +1907,23 @@ a[aria-disabled=true] {
   margin-top: 0;
 }
 
+@media not all and (min-width: 1024px) {
+  .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
+  .dashboard-card.champ-qr-code .qr-code-image,
+  .champ-qr-code.carte-orgy .qr-code-image {
+    flex: 0 0 200px;
+  }
+  .dashboard-card.champ-protection-solutions .qr-code-image img, .champ-protection-solutions.carte-orgy .qr-code-image img,
+  .dashboard-card.champ-qr-code .qr-code-image img,
+  .champ-qr-code.carte-orgy .qr-code-image img {
+    width: 200px;
+  }
+  .dashboard-card.champ-protection-solutions .qr-code-image i, .champ-protection-solutions.carte-orgy .qr-code-image i,
+  .dashboard-card.champ-qr-code .qr-code-image i,
+  .champ-qr-code.carte-orgy .qr-code-image i {
+    font-size: 200px;
+  }
+}
 @media not all and (min-width: 768px) {
   .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image,


### PR DESCRIPTION
## Résumé
- Réduction de la taille des images QR code sous `--bp-tablet`
- Empilement vertical icône/texte et centrage sous `--bp-mobile`

## Changements notables
- Ajustement des media queries pour les cartes « Protection des solutions » et « QR code »
- Génération des CSS dist avec les nouvelles règles responsive

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad2a3e51588332938ce678541cb3a7