### PR TITLE
Allow responsive tables on small screens

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -278,7 +278,6 @@ tbody tr:nth-child(even) {
 
 /* Indices table */
 .indices-table {
-  table-layout: fixed;
   width: 100%;
 }
 
@@ -363,7 +362,6 @@ tbody tr:nth-child(even) {
 }
 
 .solutions-table {
-  table-layout: fixed;
   width: 100%;
 }
 
@@ -431,6 +429,13 @@ tbody tr:nth-child(even) {
 
 .solutions-table .badge-action + .badge-action {
   margin-left: 0.25rem;
+}
+
+@media (--bp-tablet) {
+  .indices-table,
+  .solutions-table {
+    table-layout: fixed;
+  }
 }
 
 /* Labels */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5705,7 +5705,6 @@ tbody tr:nth-child(even) {
 
 /* Indices table */
 .indices-table {
-  table-layout: fixed;
   width: 100%;
 }
 
@@ -5791,7 +5790,6 @@ tbody tr:nth-child(even) {
 }
 
 .solutions-table {
-  table-layout: fixed;
   width: 100%;
 }
 
@@ -5861,6 +5859,12 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
+@media (min-width: 768px) {
+  .indices-table,
+  .solutions-table {
+    table-layout: fixed;
+  }
+}
 /* Labels */
 .etiquette {
   display: inline-block;


### PR DESCRIPTION
### Résumé
- Désactive `table-layout: fixed` pour les tableaux d'indices et de solutions en dessous de 768px
- Applique une règle média pour rétablir la mise en page fixe à partir de la tablette
- Recompile la feuille de style du thème

### Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad31fca9fc8332ac02eb069bf57980