### PR TITLE
Réduire la police de la colonne date en mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -376,6 +376,7 @@ tbody tr:nth-child(even) {
   .indices-table th:first-child,
   .indices-table td:first-child {
     width: 25%;
+    font-size: 12px;
   }
 
   .indices-table th:nth-child(2),
@@ -391,6 +392,11 @@ tbody tr:nth-child(even) {
   .indices-table th:nth-child(5),
   .indices-table td:nth-child(5) {
     width: 10%;
+  }
+
+  .solutions-table th:first-child,
+  .solutions-table td:first-child {
+    font-size: 12px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5860,6 +5860,7 @@ tbody tr:nth-child(even) {
   .indices-table th:first-child,
   .indices-table td:first-child {
     width: 25%;
+    font-size: 12px;
   }
   .indices-table th:nth-child(2),
   .indices-table td:nth-child(2) {
@@ -5872,6 +5873,10 @@ tbody tr:nth-child(even) {
   .indices-table th:nth-child(5),
   .indices-table td:nth-child(5) {
     width: 10%;
+  }
+  .solutions-table th:first-child,
+  .solutions-table td:first-child {
+    font-size: 12px;
   }
 }
 .solutions-table {


### PR DESCRIPTION
## Résumé
- Ajuste la taille de police de la colonne date des tableaux d'indices et solutions pour les écrans mobiles
- Compile les styles mis à jour

## Changements notables
- Colonne des dates des tableaux *indices* et *solutions* à 12px en dessous de la largeur tablette

## Testing
- `node build-css.js`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad40fd41ac83329d67469330758823