### PR TITLE
Corrige le débordement des cartes d'animation sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1718,6 +1718,7 @@ body.panneau-ouvert::before {
   color: var(--color-editor-text);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   position: relative;
+  box-sizing: border-box;
 }
 
 .carte-orgy {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3350,6 +3350,7 @@ body.panneau-ouvert::before {
   color: var(--color-editor-text);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   position: relative;
+  box-sizing: border-box;
 }
 
 .carte-orgy .bouton-cta {


### PR DESCRIPTION
## Résumé
- empêche les cartes du panneau d'édition de dépasser sur les petits écrans

## Changements notables
- ajoute `box-sizing: border-box` aux cartes du tableau de bord pour inclure le padding dans la largeur

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad421583b483328e7269937592829b