### PR TITLE
Masquer la colonne date des tableaux d'animation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -374,9 +374,10 @@ tbody tr:nth-child(even) {
   }
 
   .indices-table th:first-child,
-  .indices-table td:first-child {
-    width: 25%;
-    font-size: 12px;
+  .indices-table td:first-child,
+  .solutions-table th:first-child,
+  .solutions-table td:first-child {
+    display: none;
   }
 
   .indices-table th:nth-child(2),
@@ -394,9 +395,24 @@ tbody tr:nth-child(even) {
     width: 10%;
   }
 
-  .solutions-table th:first-child,
-  .solutions-table td:first-child {
-    font-size: 12px;
+  .solutions-table th:nth-child(2),
+  .solutions-table td:nth-child(2) {
+    width: 35%;
+  }
+
+  .solutions-table th:nth-child(3),
+  .solutions-table td:nth-child(3) {
+    width: 25%;
+  }
+
+  .solutions-table th:nth-child(4),
+  .solutions-table td:nth-child(4) {
+    width: 30%;
+  }
+
+  .solutions-table th:nth-child(5),
+  .solutions-table td:nth-child(5) {
+    width: 10%;
   }
 }
 
@@ -481,6 +497,12 @@ tbody tr:nth-child(even) {
   .indices-table,
   .solutions-table {
     table-layout: fixed;
+  }
+
+  .indices-table td:first-child,
+  .solutions-table td:first-child {
+    font-size: 14px;
+    font-weight: 400;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5864,9 +5864,10 @@ tbody tr:nth-child(even) {
     display: none;
   }
   .indices-table th:first-child,
-  .indices-table td:first-child {
-    width: 25%;
-    font-size: 12px;
+  .indices-table td:first-child,
+  .solutions-table th:first-child,
+  .solutions-table td:first-child {
+    display: none;
   }
   .indices-table th:nth-child(2),
   .indices-table td:nth-child(2) {
@@ -5880,9 +5881,21 @@ tbody tr:nth-child(even) {
   .indices-table td:nth-child(5) {
     width: 10%;
   }
-  .solutions-table th:first-child,
-  .solutions-table td:first-child {
-    font-size: 12px;
+  .solutions-table th:nth-child(2),
+  .solutions-table td:nth-child(2) {
+    width: 35%;
+  }
+  .solutions-table th:nth-child(3),
+  .solutions-table td:nth-child(3) {
+    width: 25%;
+  }
+  .solutions-table th:nth-child(4),
+  .solutions-table td:nth-child(4) {
+    width: 30%;
+  }
+  .solutions-table th:nth-child(5),
+  .solutions-table td:nth-child(5) {
+    width: 10%;
   }
 }
 .solutions-table {
@@ -5965,6 +5978,11 @@ tbody tr:nth-child(even) {
   .indices-table,
   .solutions-table {
     table-layout: fixed;
+  }
+  .indices-table td:first-child,
+  .solutions-table td:first-child {
+    font-size: 14px;
+    font-weight: 400;
   }
 }
 /* Labels */


### PR DESCRIPTION
## Résumé
- Masque la colonne de date des tableaux "indices" et "solutions" sur les petits écrans
- Normalise l'affichage des dates (14px, graisse normale) pour les écrans ≥ tablette
- Recompile la feuille de style du thème

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad48d23908833299662a87785608fa