### PR TITLE
Refactor riddle statistics table columns

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -252,12 +252,6 @@ tbody tr:nth-child(even) {
   font-size: 0.85em;
 }
 
-.stats-table thead tr:first-child th[colspan] {
-  text-align: center;
-  vertical-align: middle;
-  border-bottom: none;
-}
-
 .stats-table th button.sort {
   background: none;
   border: none;

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -5729,12 +5729,6 @@ tbody tr:nth-child(even) {
   font-size: 0.85em;
 }
 
-.stats-table thead tr:first-child th[colspan] {
-  text-align: center;
-  vertical-align: middle;
-  border-bottom: none;
-}
-
 .stats-table th button.sort {
   background: none;
   border: none;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5742,12 +5742,6 @@ tbody tr:nth-child(even) {
   font-size: 0.85em;
 }
 
-.stats-table thead tr:first-child th[colspan] {
-  text-align: center;
-  vertical-align: middle;
-  border-bottom: none;
-}
-
 .stats-table th button.sort {
   background: none;
   border: none;

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2355,3 +2355,15 @@ msgstr ""
 msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
 msgstr ""
 
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+msgid "Nb joueurs"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
+msgid "% total joueurs"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
+msgid "Trouvé"
+msgstr ""
+

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1593,7 +1593,6 @@ msgid "Mois"
 msgstr "Month"
 
 #: template-parts/enigme/enigme-edition-main.php:556
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:33
 msgid "Bonnes réponses"
 msgstr "Correct answers"
 
@@ -2561,4 +2560,16 @@ msgstr "They will only be released on the date you choose: "
 #: template-parts/chasse/chasse-edition-main.php:999
 msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
 msgstr "right after the hunt ends or after a configurable delay."
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+msgid "Nb joueurs"
+msgstr "Players"
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
+msgid "% total joueurs"
+msgstr "% of total players"
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
+msgid "Trouvé"
+msgstr "Solved"
 

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2537,3 +2537,15 @@ msgstr "Ils ne seront partagés qu'à la date que vous aurez choisie : "
 msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
 msgstr "immédiatement après la fin de la chasse ou après un délai paramétrable."
 
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+msgid "Nb joueurs"
+msgstr "Nb joueurs"
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
+msgid "% total joueurs"
+msgstr "% total joueurs"
+
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
+msgid "Trouvé"
+msgstr "Trouvé"
+

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -823,7 +823,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               'title'         => esc_html__('Énigmes', 'chassesautresor-com'),
               'enigmes'       => $enigmes_stats,
               'total'         => $total_engagements,
-              'cols_etiquette' => [2, 3, 4, 5, 6, 7],
+              'cols_etiquette' => [2, 3, 4, 5, 6],
           ]); ?>
           <div class="liste-participants" data-page="1" data-pages="<?= esc_attr($pages_participants); ?>" data-order="asc" data-orderby="inscription">
             <?php get_template_part('template-parts/chasse/partials/chasse-partial-participants', null, [

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -26,17 +26,12 @@ if ($title !== '') {
 <table class="stats-table compact">
   <thead>
     <tr>
-      <th scope="col" rowspan="2"><?= esc_html__('Titre', 'chassesautresor-com'); ?></th>
-      <th scope="col" colspan="2"><?= esc_html__('Participants', 'chassesautresor-com'); ?></th>
-      <th scope="col" rowspan="2"<?= in_array(4, $cols_etiquette, true) ? ' data-format="etiquette" data-col="4"' : ''; ?>><?= esc_html__('Tentatives', 'chassesautresor-com'); ?></th>
-      <th scope="col" rowspan="2"<?= in_array(5, $cols_etiquette, true) ? ' data-format="etiquette" data-col="5"' : ''; ?>><?= esc_html__('Points', 'chassesautresor-com'); ?></th>
-      <th scope="col" colspan="2"><?= esc_html__('Bonnes réponses', 'chassesautresor-com'); ?></th>
-    </tr>
-    <tr>
-      <th scope="col"<?= in_array(2, $cols_etiquette, true) ? ' data-format="etiquette" data-col="2"' : ''; ?>><?= esc_html__('Nombre', 'chassesautresor-com'); ?></th>
-      <th scope="col"<?= in_array(3, $cols_etiquette, true) ? ' data-format="etiquette" data-col="3"' : ''; ?>><?= esc_html__('Taux', 'chassesautresor-com'); ?></th>
-      <th scope="col"<?= in_array(6, $cols_etiquette, true) ? ' data-format="etiquette" data-col="6"' : ''; ?>><?= esc_html__('Nombre', 'chassesautresor-com'); ?></th>
-      <th scope="col"<?= in_array(7, $cols_etiquette, true) ? ' data-format="etiquette" data-col="7"' : ''; ?>><?= esc_html__('Taux', 'chassesautresor-com'); ?></th>
+      <th scope="col"><?= esc_html__('Titre', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(2, $cols_etiquette, true) ? ' data-format="etiquette" data-col="2"' : ''; ?>><?= esc_html__('Nb joueurs', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(3, $cols_etiquette, true) ? ' data-format="etiquette" data-col="3"' : ''; ?>><?= esc_html__('% total joueurs', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(4, $cols_etiquette, true) ? ' data-format="etiquette" data-col="4"' : ''; ?>><?= esc_html__('Tentatives', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(5, $cols_etiquette, true) ? ' data-format="etiquette" data-col="5"' : ''; ?>><?= esc_html__('Points', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(6, $cols_etiquette, true) ? ' data-format="etiquette" data-col="6"' : ''; ?>><?= esc_html__('Trouvé', 'chassesautresor-com'); ?></th>
     </tr>
   </thead>
   <tbody>
@@ -48,7 +43,6 @@ if ($title !== '') {
       <td><?= $e['tentatives'] ? esc_html($e['tentatives']) : ''; ?></td>
       <td><?= $e['points'] ? esc_html($e['points']) : ''; ?></td>
       <td><?= $e['resolutions'] ? esc_html($e['resolutions']) : ''; ?></td>
-      <td><?= $e['resolutions'] && $e['engagements'] > 0 ? esc_html(number_format((100 * $e['resolutions']) / $e['engagements'], 1, ',', ' ') . '%') : ''; ?></td>
     </tr>
     <?php endforeach; ?>
   </tbody>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -66,7 +66,7 @@ $points          = organisateur_compter_points_collectes($organisateur_id);
               [
                   'enigmes'       => $enigmes_stats,
                   'total'         => $participants,
-                  'cols_etiquette' => [2, 3, 4, 5, 6, 7],
+                  'cols_etiquette' => [2, 3, 4, 5, 6],
               ]
           );
       }


### PR DESCRIPTION
## Résumé
Simplifie l'entête du tableau des énigmes et ajuste les statistiques affichées.

## Changements notables
- Entête du tableau ramenée à une seule ligne et nouvelles colonnes « Nb joueurs », « % total joueurs » et « Trouvé »
- Suppression de la colonne « bonnes réponses - taux » et nettoyage du style associé
- Mise à jour des références `cols_etiquette` et des fichiers de traduction

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad4a8baa88833290e43eeefd4f3541