### PR TITLE
Affiche ratios de participation et énigmes trouvées

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1270,19 +1270,19 @@ msgid "Inscription"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:58
-msgid "Trier par taux de participation"
+msgid "Trier par participation"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:60
-msgid "Tx participation"
+msgid "Participation"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:68
-msgid "Trier par taux de résolution"
+msgid "Trier par énigmes trouvées"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:70
-msgid "Tx résolution"
+msgid "Trouvées"
 msgstr ""
 
 #: template-parts/common/stat-histogram-card.php:38
@@ -2364,6 +2364,6 @@ msgid "% total joueurs"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvé"
+msgid "Trouvées"
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1326,20 +1326,20 @@ msgid "Inscription"
 msgstr "Registration"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:58
-msgid "Trier par taux de participation"
-msgstr "Sort by participation rate"
+msgid "Trier par participation"
+msgstr "Sort by participation"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:60
-msgid "Tx participation"
-msgstr "Participation rate"
+msgid "Participation"
+msgstr "Participation"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:68
-msgid "Trier par taux de résolution"
-msgstr "Sort by resolution rate"
+msgid "Trier par énigmes trouvées"
+msgstr "Sort by found riddles"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:70
-msgid "Tx résolution"
-msgstr "Resolution rate"
+msgid "Trouvées"
+msgstr "Found"
 
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:36
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:38
@@ -2570,6 +2570,6 @@ msgid "% total joueurs"
 msgstr "% of total players"
 
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvé"
-msgstr "Solved"
+msgid "Trouvées"
+msgstr "Found"
 

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1191,9 +1191,8 @@ msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:568
 #: template-parts/enigme/enigme-edition-main.php:533
-#, fuzzy
 msgid "Participants"
-msgstr "Tx participation"
+msgstr "Participants"
 
 #: template-parts/chasse/chasse-edition-main.php:575
 #: template-parts/enigme/enigme-edition-main.php:97
@@ -1327,20 +1326,20 @@ msgid "Inscription"
 msgstr "Inscription"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:58
-msgid "Trier par taux de participation"
-msgstr "Trier par taux de participation"
+msgid "Trier par participation"
+msgstr "Trier par participation"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:60
-msgid "Tx participation"
-msgstr "Tx participation"
+msgid "Participation"
+msgstr "Participation"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:68
-msgid "Trier par taux de résolution"
-msgstr "Trier par taux de résolution"
+msgid "Trier par énigmes trouvées"
+msgstr "Trier par énigmes trouvées"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:70
-msgid "Tx résolution"
-msgstr "Tx résolution"
+msgid "Trouvées"
+msgstr "Trouvées"
 
 #: template-parts/common/stat-histogram-card.php:38
 msgid "Aucune donnée."
@@ -1783,9 +1782,8 @@ msgid "Aucun participant engagé."
 msgstr "Aucun participant engagé."
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:47
-#, fuzzy
 msgid "Liste participants"
-msgstr "Tx participation"
+msgstr "Liste participants"
 
 #: template-parts/enigme/partials/enigme-partial-participants.php:51
 msgid "Nom"
@@ -2546,6 +2544,6 @@ msgid "% total joueurs"
 msgstr "% total joueurs"
 
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvé"
-msgstr "Trouvé"
+msgid "Trouvées"
+msgstr "Trouvées"
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-enigmes.php
@@ -31,7 +31,7 @@ if ($title !== '') {
       <th scope="col"<?= in_array(3, $cols_etiquette, true) ? ' data-format="etiquette" data-col="3"' : ''; ?>><?= esc_html__('% total joueurs', 'chassesautresor-com'); ?></th>
       <th scope="col"<?= in_array(4, $cols_etiquette, true) ? ' data-format="etiquette" data-col="4"' : ''; ?>><?= esc_html__('Tentatives', 'chassesautresor-com'); ?></th>
       <th scope="col"<?= in_array(5, $cols_etiquette, true) ? ' data-format="etiquette" data-col="5"' : ''; ?>><?= esc_html__('Points', 'chassesautresor-com'); ?></th>
-      <th scope="col"<?= in_array(6, $cols_etiquette, true) ? ' data-format="etiquette" data-col="6"' : ''; ?>><?= esc_html__('Trouvé', 'chassesautresor-com'); ?></th>
+      <th scope="col"<?= in_array(6, $cols_etiquette, true) ? ' data-format="etiquette" data-col="6"' : ''; ?>><?= esc_html__('Trouvées', 'chassesautresor-com'); ?></th>
     </tr>
   </thead>
   <tbody>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-participants.php
@@ -55,9 +55,9 @@ if (empty($participants)) {
         <button
           class="sort"
           data-orderby="participation"
-          aria-label="<?= esc_attr__('Trier par taux de participation', 'chassesautresor-com'); ?>"
+          aria-label="<?= esc_attr__('Trier par participation', 'chassesautresor-com'); ?>"
         >
-          <?= esc_html__('Tx participation', 'chassesautresor-com'); ?>
+          <?= esc_html__('Participation', 'chassesautresor-com'); ?>
           <i class="fa-solid <?= esc_attr($icon_participation); ?>"></i>
         </button>
       </th>
@@ -65,9 +65,9 @@ if (empty($participants)) {
         <button
           class="sort"
           data-orderby="resolution"
-          aria-label="<?= esc_attr__('Trier par taux de résolution', 'chassesautresor-com'); ?>"
+          aria-label="<?= esc_attr__('Trier par énigmes trouvées', 'chassesautresor-com'); ?>"
         >
-          <?= esc_html__('Tx résolution', 'chassesautresor-com'); ?>
+          <?= esc_html__('Trouvées', 'chassesautresor-com'); ?>
           <i class="fa-solid <?= esc_attr($icon_resolution); ?>"></i>
         </button>
       </th>
@@ -79,8 +79,8 @@ if (empty($participants)) {
     foreach ($p['enigmes'] as $e) {
         $titles[] = esc_html($e['title']);
     }
-    $taux_participation = $total_enigmes > 0 ? (100 * $p['nb_engagees'] / $total_enigmes) : 0;
-    $taux_resolution    = $total_enigmes > 0 ? (100 * $p['nb_resolues'] / $total_enigmes) : 0;
+    $participation_ratio = sprintf('%d/%d', (int) $p['nb_engagees'], (int) $total_enigmes);
+    $trouvees_ratio      = sprintf('%d/%d', (int) $p['nb_resolues'], (int) $total_enigmes);
 ?>
     <tr>
       <td><?= esc_html($p['username']); ?></td>
@@ -96,8 +96,8 @@ if (empty($participants)) {
         echo implode(' ', $etiquettes);
         ?>
       </td>
-      <td><?= esc_html(number_format_i18n($taux_participation, 0)); ?>%</td>
-      <td><?= esc_html(number_format_i18n($taux_resolution, 0)); ?>%</td>
+      <td><?= esc_html($participation_ratio); ?></td>
+      <td><?= esc_html($trouvees_ratio); ?></td>
     </tr>
     <?php endforeach; ?>
   </tbody>


### PR DESCRIPTION
## Résumé
- affiche la participation et les énigmes trouvées sous forme de ratios x/y
- pluralise l'en-tête "Trouvées" dans les statistiques des énigmes
- met à jour les fichiers de traduction correspondants

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad4e43880c8332a91e8dde9b3ba5f4