### PR TITLE
Fix duplicate translation entries

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1338,6 +1338,7 @@ msgid "Trier par énigmes trouvées"
 msgstr "Sort by found riddles"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:70
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
 msgid "Trouvées"
 msgstr "Found"
 
@@ -2568,8 +2569,4 @@ msgstr "Players"
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:31
 msgid "% total joueurs"
 msgstr "% of total players"
-
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvées"
-msgstr "Found"
 

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1338,6 +1338,7 @@ msgid "Trier par énigmes trouvées"
 msgstr "Trier par énigmes trouvées"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:70
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
 msgid "Trouvées"
 msgstr "Trouvées"
 
@@ -2542,8 +2543,4 @@ msgstr "Nb joueurs"
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:31
 msgid "% total joueurs"
 msgstr "% total joueurs"
-
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvées"
-msgstr "Trouvées"
 


### PR DESCRIPTION
## Résumé
- supprime un doublon de la chaîne `Trouvées` dans les fichiers de traduction

## Changements notables
- fusion des références de fichier pour la chaîne partagée
- suppression des entrées de traduction en double

## Testing
- `msgfmt wp-content/themes/chassesautresor/languages/fr_FR.po -o /tmp/fr_FR.mo`
- `msgfmt wp-content/themes/chassesautresor/languages/en_US.po -o /tmp/en_US.mo`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ad5164a5d083329d0683a9c14f257c