### PR TITLE
feat: load solutions scripts for enigme editing

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -32,7 +32,17 @@ function enqueue_script_enigme_edit()
   if (!utilisateur_peut_modifier_post($enigme_id)) return;
 
   // 📦 Modules JS partagés + scripts spécifiques
-  enqueue_core_edit_scripts(['organisateur-edit', 'enigme-edit', 'enigme-stats', 'table-etiquette', 'tentatives-toggle', 'indices-pager', 'indices-create']);
+  enqueue_core_edit_scripts([
+    'organisateur-edit',
+    'enigme-edit',
+    'enigme-stats',
+    'table-etiquette',
+    'tentatives-toggle',
+    'solutions-pager',
+    'solutions-create',
+    'indices-pager',
+    'indices-create',
+  ]);
 
   wp_localize_script(
     'enigme-stats',


### PR DESCRIPTION
### Résumé
Ajout du chargement des modules `solutions-pager` et `solutions-create` lors de l’édition d’une énigme.

### Changements
- Charge les scripts de gestion des solutions pour l’édition d’énigme

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68adb2a65a088332b4268436ada5a420