### PR TITLE
feat: add sidebar back link for enigma

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -38,6 +38,28 @@
   padding: var(--space-sm) var(--space-md);
   position: relative;
   border-radius: 8px 8px 0 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.menu-lateral__back {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: var(--space-xs);
+  color: inherit;
+  text-decoration: none;
+  background: none;
+  border: 1px solid rgba(var(--color-white-rgb, 255, 255, 255), 0.5);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menu-lateral__back svg {
+  width: 1rem;
+  height: 1rem;
 }
 
 .menu-lateral__title {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1382,6 +1382,28 @@ a[aria-disabled=true] {
   padding: var(--space-sm) var(--space-md);
   position: relative;
   border-radius: 8px 8px 0 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.menu-lateral__back {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: var(--space-xs);
+  color: inherit;
+  text-decoration: none;
+  background: none;
+  border: 1px solid rgba(var(--color-white-rgb, 255, 255, 255), 0.5);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menu-lateral__back svg {
+  width: 1rem;
+  height: 1rem;
 }
 
 .menu-lateral__title {

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -530,8 +530,10 @@ defined('ABSPATH') || exit;
 
         echo '<div class="menu-lateral__header">';
         if ($chasse_id) {
-            $url_chasse = get_permalink($chasse_id);
-            $titre      = get_the_title($chasse_id);
+            $url_chasse  = get_permalink($chasse_id);
+            $titre       = get_the_title($chasse_id);
+            $retour_icon = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>';
+            echo '<a class="menu-lateral__back" href="' . esc_url($url_chasse) . '"><span class="screen-reader-text">' . esc_html__("Retour", "chassesautresor-com") . '</span>' . $retour_icon . '</a>';
             echo '<h2 class="menu-lateral__title"><a href="' . esc_url($url_chasse) . '">' . esc_html($titre) . '</a></h2>';
         }
         echo '</div>';


### PR DESCRIPTION
Ajout d'une icône de retour dans l'aside des énigmes.

- Affiche une icône de retour vers la chasse associée dans l'en-tête de l'aside.
- Met en forme l'en-tête et l'icône pour un alignement horizontal.
- Recompile la feuille de style.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68adb2960ad4833294e5bcf9c4efff93