### PR TITLE
feat: use segmented control for validation mode

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -2092,6 +2092,46 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
+.champ-mode-options.segmented-control {
+  gap: 0;
+  border: 1px solid var(--color-editor-border);
+  border-radius: var(--space-xs);
+  overflow: hidden;
+}
+
+.champ-mode-options.segmented-control input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+}
+
+.champ-mode-options.segmented-control label {
+  flex: 1;
+  padding: var(--space-xs) var(--space-sm);
+  text-align: center;
+  cursor: pointer;
+  background: var(--color-editor-background);
+  border-right: 1px solid var(--color-editor-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xxs);
+  user-select: none;
+}
+
+.champ-mode-options.segmented-control label:last-of-type {
+  border-right: none;
+}
+
+.champ-mode-options.segmented-control input[type="radio"]:checked + label {
+  background: var(--color-editor-accent);
+  color: var(--color-editor-background);
+}
+
+.champ-mode-options.segmented-control input[type="radio"]:disabled + label {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .champ-mode-fin label {
   display: flex;
   align-items: center;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3721,6 +3721,48 @@ body.panneau-ouvert::before {
   align-items: center;
 }
 
+.champ-mode-options.segmented-control {
+  gap: 0;
+  border: 1px solid var(--color-editor-border);
+  border-radius: var(--space-xs);
+  overflow: hidden;
+}
+
+.champ-mode-options.segmented-control input[type=radio] {
+  position: absolute;
+  opacity: 0;
+}
+
+.champ-mode-options.segmented-control label {
+  flex: 1;
+  padding: var(--space-xs) var(--space-sm);
+  text-align: center;
+  cursor: pointer;
+  background: var(--color-editor-background);
+  border-right: 1px solid var(--color-editor-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xxs);
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.champ-mode-options.segmented-control label:last-of-type {
+  border-right: none;
+}
+
+.champ-mode-options.segmented-control input[type=radio]:checked + label {
+  background: var(--color-editor-accent);
+  color: var(--color-editor-background);
+}
+
+.champ-mode-options.segmented-control input[type=radio]:disabled + label {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .champ-mode-fin label {
   display: flex;
   align-items: center;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -309,9 +309,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     },
                     'content' => function () use ($mode_validation, $peut_editer, $enigme_id) {
                         ?>
-                        <div class="champ-mode-options">
-                            <label>
-                                <input id="enigme_mode_validation" type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                        <div class="champ-mode-options segmented-control">
+                            <input id="enigme_mode_validation_auto" type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                            <label for="enigme_mode_validation_auto">
                                 <?= esc_html__('Automatique', 'chassesautresor-com'); ?>
                                 <?php
                                 get_template_part(
@@ -327,8 +327,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                 );
                                 ?>
                             </label>
-                            <label>
-                                <input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+
+                            <input id="enigme_mode_validation_manuelle" type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                            <label for="enigme_mode_validation_manuelle">
                                 <?= esc_html__('Manuelle', 'chassesautresor-com'); ?>
                                 <?php
                                 get_template_part(
@@ -344,8 +345,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                 );
                                 ?>
                             </label>
-                            <label>
-                                <input type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+
+                            <input id="enigme_mode_validation_aucune" type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
+                            <label for="enigme_mode_validation_aucune">
                                 <?= esc_html__('Aucune', 'chassesautresor-com'); ?>
                             </label>
                         </div>


### PR DESCRIPTION
## Summary
- remplace les radios du mode de validation par un segmented control
- style Orgy pour le contrôle segmenté

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb211372c833287b8e28dbd542e80