### PR TITLE
Corriger la création de solutions pour une énigme

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -9,10 +9,11 @@
 
 defined('ABSPATH') || exit;
 
-$args       = $args ?? [];
-$objet_id   = $args['objet_id'] ?? $chasse_id ?? 0;
-$objet_type = $args['objet_type'] ?? 'chasse';
+$args           = $args ?? [];
+$objet_id       = $args['objet_id'] ?? 0;
+$objet_type     = $args['objet_type'] ?? 'chasse';
 $default_enigme = $args['default_enigme'] ?? null;
+$chasse_id      = $args['chasse_id'] ?? ($objet_type === 'chasse' ? $objet_id : 0);
 
 $objet_titre = get_the_title($objet_id);
 $indice_rang = prochain_rang_indice($objet_id, $objet_type);
@@ -29,13 +30,7 @@ $has_enigmes = !empty($enigmes_disponibles);
     <h3><?= esc_html__('Ajouter un indice', 'chassesautresor-com'); ?></h3>
 <?php if ($peut_ajouter) : ?>
     <div class="stat-value">
-        <button
-            type="button"
-            class="bouton-cta cta-indice-pour"
-        >
-            <?= esc_html__('Pour…', 'chassesautresor-com'); ?>
-        </button>
-        <div class="cta-indice-options">
+        <?php if ($objet_type === 'chasse') : ?>
             <button
                 type="button"
                 class="bouton-cta cta-creer-indice cta-indice-chasse"
@@ -59,7 +54,17 @@ $has_enigmes = !empty($enigmes_disponibles);
                     <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
                 </button>
             <?php endif; ?>
-        </div>
+        <?php else : ?>
+            <button
+                type="button"
+                class="bouton-cta cta-indice-enigme"
+                data-objet-type="<?= esc_attr($objet_type); ?>"
+                data-chasse-id="<?= esc_attr($chasse_id); ?>"
+                data-default-enigme="<?= esc_attr($default_enigme); ?>"
+            >
+                <?= esc_html__('Cette énigme', 'chassesautresor-com'); ?>
+            </button>
+        <?php endif; ?>
     </div>
 <?php else : ?>
     <span class="stat-value">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-solutions.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-solutions.php
@@ -33,14 +33,14 @@ $state_class         = $has_solutions ? 'champ-rempli' : 'champ-vide';
     <h3><?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?></h3>
 <?php if ($peut_ajouter) : ?>
     <div class='stat-value'>
-        <?php if ($objet_type === 'chasse') : ?>
-            <button
-                type='button'
-                class='bouton-cta cta-solution-pour'
-            >
-                <?= esc_html__('Pour…', 'chassesautresor-com'); ?>
-            </button>
-            <div class='cta-solution-options'>
+        <button
+            type='button'
+            class='bouton-cta cta-solution-pour'
+        >
+            <?= esc_html__('Pour…', 'chassesautresor-com'); ?>
+        </button>
+        <div class='cta-solution-options'>
+            <?php if ($objet_type === 'chasse') : ?>
                 <button
                     type='button'
                     class='bouton-cta cta-solution-chasse ajouter-solution<?= $has_solution_chasse ? ' disabled' : ''; ?>'
@@ -69,18 +69,18 @@ $state_class         = $has_solutions ? 'champ-rempli' : 'champ-vide';
                 >
                     <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
                 </button>
-            </div>
-        <?php else : ?>
-            <button
-                type='button'
-                class='bouton-cta cta-solution-enigme ajouter-solution'
-                data-objet-type='<?= esc_attr($objet_type); ?>'
-                data-chasse-id='<?= esc_attr($chasse_id); ?>'
-                data-default-enigme='<?= esc_attr($default_enigme); ?>'
-            >
-                <?= esc_html__('Cette énigme', 'chassesautresor-com'); ?>
-            </button>
-        <?php endif; ?>
+            <?php else : ?>
+                <button
+                    type='button'
+                    class='bouton-cta cta-solution-enigme ajouter-solution'
+                    data-objet-type='<?= esc_attr($objet_type); ?>'
+                    data-chasse-id='<?= esc_attr($chasse_id); ?>'
+                    data-default-enigme='<?= esc_attr($default_enigme); ?>'
+                >
+                    <?= esc_html__('Cette énigme', 'chassesautresor-com'); ?>
+                </button>
+            <?php endif; ?>
+        </div>
     </div>
 <?php else : ?>
     <span class='stat-value'>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-solutions.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-solutions.php
@@ -9,66 +9,78 @@
 
 defined('ABSPATH') || exit;
 
-$args = $args ?? [];
-$objet_id = $args['objet_id'] ?? $chasse_id ?? 0;
-$objet_type = $args['objet_type'] ?? 'chasse';
+$args           = $args ?? [];
+$objet_id       = $args['objet_id'] ?? $chasse_id ?? 0;
+$objet_type     = $args['objet_type'] ?? 'chasse';
 $default_enigme = $args['default_enigme'] ?? null;
+$chasse_id      = $args['chasse_id'] ?? ($objet_type === 'chasse' ? $objet_id : 0);
 
-$peut_ajouter = solution_action_autorisee('create', $objet_type, $objet_id);
+$peut_ajouter       = solution_action_autorisee('create', $objet_type, $objet_id);
 $has_solution_chasse = $objet_type === 'chasse' && solution_existe_pour_objet($objet_id, 'chasse');
-$toutes_enigmes = $objet_type === 'chasse' ? recuperer_enigmes_pour_chasse($objet_id) : [];
+$toutes_enigmes      = $objet_type === 'chasse' ? recuperer_enigmes_pour_chasse($objet_id) : [];
 $enigmes_disponibles = array_filter(
     $toutes_enigmes,
     static fn($e) => !solution_existe_pour_objet($e->ID, 'enigme')
 );
-$has_enigmes = !empty($enigmes_disponibles);
+$has_enigmes         = !empty($enigmes_disponibles);
 $has_enigme_solution = count($toutes_enigmes) > count($enigmes_disponibles);
-$has_solutions = $has_solution_chasse || $has_enigme_solution;
-$state_class = $has_solutions ? 'champ-rempli' : 'champ-vide';
+$has_solutions       = $has_solution_chasse || $has_enigme_solution;
+$state_class         = $has_solutions ? 'champ-rempli' : 'champ-vide';
 ?>
-<div class='dashboard-card carte-orgy champ-<?= esc_attr($objet_type); ?> champ-solutions<?= $peut_ajouter ? '' : ' disabled'; ?> <?= esc_attr($state_class); ?>'
->
+<div class='dashboard-card carte-orgy champ-<?= esc_attr($objet_type); ?> champ-solutions<?= $peut_ajouter ? '' : ' disabled'; ?> <?= esc_attr($state_class); ?>'>
     <span class="carte-check" aria-hidden='true'><i class='fa-solid fa-check'></i></span>
     <i class='fa-solid fa-lightbulb icone-defaut' aria-hidden='true'></i>
     <h3><?= esc_html__('Ajouter une solution', 'chassesautresor-com'); ?></h3>
 <?php if ($peut_ajouter) : ?>
     <div class='stat-value'>
-        <button
-            type='button'
-            class='bouton-cta cta-solution-pour'
-        >
-            <?= esc_html__('Pour…', 'chassesautresor-com'); ?>
-        </button>
-        <div class='cta-solution-options'>
+        <?php if ($objet_type === 'chasse') : ?>
             <button
                 type='button'
-                class='bouton-cta cta-solution-chasse ajouter-solution<?= $has_solution_chasse ? ' disabled' : ''; ?>'
-                data-objet-type='chasse'
-                data-objet-id='<?= esc_attr($objet_id); ?>'
-                data-objet-titre='<?= esc_attr(get_the_title($objet_id)); ?>'
-                <?php if ($has_solution_chasse) : ?>
-                    aria-disabled="true"
-                    title="<?= esc_attr__('Il existe déjà une solution pour cette chasse', 'chassesautresor-com'); ?>"
-                <?php endif; ?>
+                class='bouton-cta cta-solution-pour'
             >
-                <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
+                <?= esc_html__('Pour…', 'chassesautresor-com'); ?>
             </button>
+            <div class='cta-solution-options'>
+                <button
+                    type='button'
+                    class='bouton-cta cta-solution-chasse ajouter-solution<?= $has_solution_chasse ? ' disabled' : ''; ?>'
+                    data-objet-type='<?= esc_attr($objet_type); ?>'
+                    data-objet-id='<?= esc_attr($objet_id); ?>'
+                    data-objet-titre='<?= esc_attr(get_the_title($objet_id)); ?>'
+                    <?php if ($has_solution_chasse) : ?>
+                        aria-disabled="true"
+                        title="<?= esc_attr__('Il existe déjà une solution pour cette chasse', 'chassesautresor-com'); ?>"
+                    <?php endif; ?>
+                >
+                    <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
+                </button>
+                <button
+                    type='button'
+                    class='bouton-cta cta-solution-enigme ajouter-solution<?= $has_enigmes ? '' : ' disabled'; ?>'
+                    data-objet-type='enigme'
+                    data-chasse-id='<?= esc_attr($chasse_id); ?>'
+                    <?php if ($default_enigme) : ?>
+                        data-default-enigme='<?= esc_attr($default_enigme); ?>'
+                    <?php endif; ?>
+                    <?php if (!$has_enigmes) : ?>
+                        aria-disabled="true"
+                        title="<?= esc_attr__('Toutes les énigmes de la chasse ont déjà une solution', 'chassesautresor-com'); ?>"
+                    <?php endif; ?>
+                >
+                    <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
+                </button>
+            </div>
+        <?php else : ?>
             <button
                 type='button'
-                class='bouton-cta cta-solution-enigme ajouter-solution<?= $has_enigmes ? '' : ' disabled'; ?>'
-                data-objet-type='enigme'
-                data-chasse-id='<?= esc_attr($objet_id); ?>'
-                <?php if ($default_enigme) : ?>
-                    data-default-enigme='<?= esc_attr($default_enigme); ?>'
-                <?php endif; ?>
-                <?php if (!$has_enigmes) : ?>
-                    aria-disabled="true"
-                    title="<?= esc_attr__('Toutes les énigmes de la chasse ont déjà une solution', 'chassesautresor-com'); ?>"
-                <?php endif; ?>
+                class='bouton-cta cta-solution-enigme ajouter-solution'
+                data-objet-type='<?= esc_attr($objet_type); ?>'
+                data-chasse-id='<?= esc_attr($chasse_id); ?>'
+                data-default-enigme='<?= esc_attr($default_enigme); ?>'
             >
-                <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
+                <?= esc_html__('Cette énigme', 'chassesautresor-com'); ?>
             </button>
-        </div>
+        <?php endif; ?>
     </div>
 <?php else : ?>
     <span class='stat-value'>
@@ -76,3 +88,4 @@ $state_class = $has_solutions ? 'champ-rempli' : 'champ-vide';
     </span>
 <?php endif; ?>
 </div>
+

--- a/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
@@ -121,10 +121,19 @@ $solution_prefill = apply_filters('chassesautresor/edition_animation_solution_pr
                   'objet_id'   => $objet_id,
                   'objet_type' => $objet_type,
               ]);
-              get_template_part('template-parts/chasse/partials/chasse-partial-solutions', null, [
+
+              $solutions_args = [
                   'objet_id'   => $objet_id,
                   'objet_type' => $objet_type,
-              ]);
+              ];
+
+              if ($objet_type === 'enigme') {
+                  $chasse_id                    = recuperer_id_chasse_associee($objet_id);
+                  $solutions_args['chasse_id']   = $chasse_id;
+                  $solutions_args['default_enigme'] = $objet_id;
+              }
+
+              get_template_part('template-parts/chasse/partials/chasse-partial-solutions', null, $solutions_args);
           }
           ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
@@ -117,10 +117,10 @@ $solution_prefill = apply_filters('chassesautresor/edition_animation_solution_pr
 
           <?php
           if ($objet_type !== 'organisateur') {
-              get_template_part('template-parts/chasse/partials/chasse-partial-indices', null, [
+              $indices_args = [
                   'objet_id'   => $objet_id,
                   'objet_type' => $objet_type,
-              ]);
+              ];
 
               $solutions_args = [
                   'objet_id'   => $objet_id,
@@ -128,11 +128,14 @@ $solution_prefill = apply_filters('chassesautresor/edition_animation_solution_pr
               ];
 
               if ($objet_type === 'enigme') {
-                  $chasse_id                    = recuperer_id_chasse_associee($objet_id);
-                  $solutions_args['chasse_id']   = $chasse_id;
+                  $chasse_id                      = recuperer_id_chasse_associee($objet_id);
+                  $indices_args['chasse_id']      = $chasse_id;
+                  $indices_args['default_enigme'] = $objet_id;
+                  $solutions_args['chasse_id']    = $chasse_id;
                   $solutions_args['default_enigme'] = $objet_id;
               }
 
+              get_template_part('template-parts/chasse/partials/chasse-partial-indices', null, $indices_args);
               get_template_part('template-parts/chasse/partials/chasse-partial-solutions', null, $solutions_args);
           }
           ?>


### PR DESCRIPTION
## Résumé
- Assure la transmission de la chasse parente et de l’énigme par défaut lors de l’édition d’une énigme
- Ajuste l’interface d’ajout de solutions pour différencier chasse et énigme

## Changements notables
- Passage du `chasse_id` et de `default_enigme` au partial des solutions
- Bouton « La chasse entière » visible uniquement pour les chasses, ajout du bouton « Cette énigme » pour les énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68adb7c6a9648332a05acbdf8c6ffef5