### PR TITLE
Ajout d'un bouton d'indice pour l'énigme active

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -1,5 +1,5 @@
 (function () {
-  function openModal(btn) {
+  function openModal(btn, defaultEnigme) {
     var overlay = document.createElement('div');
     overlay.className = 'indice-modal-overlay';
     var titre = indicesCreate.texts.indiceTitre.replace('%d', btn.dataset.indiceRang || '');
@@ -273,7 +273,7 @@
             }
             select.appendChild(opt);
           });
-          var def = btn.dataset.defaultEnigme || btn.dataset.objetId;
+      var def = defaultEnigme || btn.dataset.defaultEnigme || btn.dataset.objetId;
           if (def) select.value = def;
           if (!select.value) select.value = select.options[0].value;
           var selected = select.options[select.selectedIndex];
@@ -310,7 +310,8 @@
         enigmeBtn.dataset.objetType = 'enigme';
       }
       enigmeBtn.dataset.indiceRang = '';
-      openModal(enigmeBtn);
+      var def = enigmeBtn.dataset.objetId || enigmeBtn.dataset.defaultEnigme || '';
+      openModal(enigmeBtn, def);
       return;
     }
     var btn = target && target.closest ? target.closest('.cta-creer-indice, .badge-action.edit') : null;

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -411,7 +411,6 @@ msgstr ""
 
 #: inc/enigme/affichage.php:649
 #: template-parts/chasse/chasse-edition-main.php:708
-#: template-parts/chasse/partials/chasse-partial-indices.php:32
 msgid "Indices"
 msgstr ""
 
@@ -421,19 +420,24 @@ msgstr ""
 msgid "Indices pour %s"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:26
+#: template-parts/chasse/partials/chasse-partial-indices.php:35
 msgid "Ajouter un indice"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:33
+#: template-parts/chasse/partials/chasse-partial-indices.php:42
 msgid "Pour…"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:44
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+msgid "Cette énigme"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:66
+#: template-parts/chasse/partials/chasse-partial-indices.php:77
 msgid "La chasse entière"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:56
+#: template-parts/chasse/partials/chasse-partial-indices.php:89
 msgid "Une énigme de la chasse"
 msgstr ""
 
@@ -741,8 +745,7 @@ msgstr ""
 
 #: inc/organisateur-functions.php:231
 #: template-parts/chasse/chasse-edition-main.php:673
-#: template-parts/chasse/partials/chasse-partial-indices.php:46
-#: template-parts/chasse/partials/chasse-partial-indices.php:50
+#: template-parts/chasse/partials/chasse-partial-indices.php:97
 #: template-parts/organisateur/organisateur-edition-main.php:305
 #: template-parts/organisateur/organisateur-edition-main.php:319
 #: template-parts/organisateur/organisateur-edition-main.php:360

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -437,7 +437,8 @@ msgstr "View Stats"
 
 #: inc/enigme/affichage.php:649
 #: template-parts/chasse/chasse-edition-main.php:708
-#: template-parts/chasse/partials/chasse-partial-indices.php:32
+#: inc/enigme/affichage.php:649
+#: template-parts/chasse/chasse-edition-main.php:708
 msgid "Indices"
 msgstr "Hints"
 
@@ -447,19 +448,24 @@ msgstr "Hints"
 msgid "Indices pour %s"
 msgstr "Hints for %s"
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:26
+#: template-parts/chasse/partials/chasse-partial-indices.php:35
 msgid "Ajouter un indice"
 msgstr "Add a hint"
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:33
+#: template-parts/chasse/partials/chasse-partial-indices.php:42
 msgid "Pour…"
 msgstr "For…"
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:44
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+msgid "Cette énigme"
+msgstr "This riddle"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:66
+#: template-parts/chasse/partials/chasse-partial-indices.php:77
 msgid "La chasse entière"
 msgstr "The entire hunt"
 
-#: template-parts/chasse/partials/chasse-partial-indices.php:56
+#: template-parts/chasse/partials/chasse-partial-indices.php:89
 msgid "Une énigme de la chasse"
 msgstr "A riddle from the hunt"
 
@@ -772,8 +778,7 @@ msgstr "Add bank details"
 
 #: inc/organisateur-functions.php:231
 #: template-parts/chasse/chasse-edition-main.php:673
-#: template-parts/chasse/partials/chasse-partial-indices.php:46
-#: template-parts/chasse/partials/chasse-partial-indices.php:50
+#: template-parts/chasse/partials/chasse-partial-indices.php:97
 #: template-parts/organisateur/organisateur-edition-main.php:305
 #: template-parts/organisateur/organisateur-edition-main.php:319
 #: template-parts/organisateur/organisateur-edition-main.php:360

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -437,7 +437,6 @@ msgstr "Afficher les statistiques"
 
 #: inc/enigme/affichage.php:649
 #: template-parts/chasse/chasse-edition-main.php:708
-#: template-parts/chasse/partials/chasse-partial-indices.php:32
 msgid "Indices"
 msgstr "Indices"
 
@@ -446,6 +445,27 @@ msgstr "Indices"
 #, php-format
 msgid "Indices pour %s"
 msgstr "Indices pour %s"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:35
+msgid "Ajouter un indice"
+msgstr "Ajouter un indice"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:42
+msgid "Pour…"
+msgstr "Pour…"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+msgid "Cette énigme"
+msgstr "Cette énigme"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:66
+#: template-parts/chasse/partials/chasse-partial-indices.php:77
+msgid "La chasse entière"
+msgstr "La chasse entière"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:89
+msgid "Une énigme de la chasse"
+msgstr "Une énigme de la chasse"
 
 #: inc/enigme/affichage.php:677
 #, fuzzy
@@ -760,8 +780,7 @@ msgstr "Ajouter des coordonnées bancaires"
 
 #: inc/organisateur-functions.php:231
 #: template-parts/chasse/chasse-edition-main.php:673
-#: template-parts/chasse/partials/chasse-partial-indices.php:46
-#: template-parts/chasse/partials/chasse-partial-indices.php:50
+#: template-parts/chasse/partials/chasse-partial-indices.php:97
 #: template-parts/organisateur/organisateur-edition-main.php:305
 #: template-parts/organisateur/organisateur-edition-main.php:319
 #: template-parts/organisateur/organisateur-edition-main.php:360

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-partial-indices.php
@@ -22,6 +22,12 @@ $state_class = $has_indices ? 'champ-rempli' : 'champ-vide';
 $peut_ajouter = indice_action_autorisee('create', $objet_type, $objet_id);
 $enigmes_disponibles = $objet_type === 'chasse' ? recuperer_enigmes_pour_chasse($objet_id) : [];
 $has_enigmes = !empty($enigmes_disponibles);
+
+if ($objet_type === 'enigme') {
+    $chasse_id           = (int) recuperer_id_chasse_associee($objet_id);
+    $chasse_titre        = get_the_title($chasse_id);
+    $chasse_indice_rang  = prochain_rang_indice($chasse_id, 'chasse');
+}
 ?>
 <div class="dashboard-card carte-orgy champ-<?= esc_attr($objet_type); ?> champ-indices<?= $peut_ajouter ? '' : ' disabled'; ?> <?= esc_attr($state_class); ?>">
     <span class="carte-check" aria-hidden="true"><i class="fa-solid fa-check"></i></span>
@@ -36,28 +42,53 @@ $has_enigmes = !empty($enigmes_disponibles);
             <?= esc_html__('Pour…', 'chassesautresor-com'); ?>
         </button>
         <div class="cta-indice-options">
-            <button
-                type="button"
-                class="bouton-cta cta-creer-indice cta-indice-chasse"
-                data-objet-type="<?= esc_attr($objet_type); ?>"
-                data-objet-id="<?= esc_attr($objet_id); ?>"
-                data-objet-titre="<?= esc_attr($objet_titre); ?>"
-                data-indice-rang="<?= esc_attr($indice_rang); ?>"
-            >
-                <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
-            </button>
-            <?php if ($has_enigmes) : ?>
+            <?php if ($objet_type === 'enigme') : ?>
                 <button
                     type="button"
                     class="bouton-cta cta-indice-enigme"
                     data-objet-type="enigme"
-                    data-chasse-id="<?= esc_attr($objet_id); ?>"
-                    <?php if ($default_enigme) : ?>
-                        data-default-enigme="<?= esc_attr($default_enigme); ?>"
-                    <?php endif; ?>
+                    data-objet-id="<?= esc_attr($objet_id); ?>"
+                    data-objet-titre="<?= esc_attr($objet_titre); ?>"
+                    data-chasse-id="<?= esc_attr($chasse_id); ?>"
+                    data-default-enigme="<?= esc_attr($objet_id); ?>"
+                    data-indice-rang="<?= esc_attr($indice_rang); ?>"
                 >
-                    <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
+                    <?= esc_html__('Cette énigme', 'chassesautresor-com'); ?>
                 </button>
+                <button
+                    type="button"
+                    class="bouton-cta cta-creer-indice cta-indice-chasse"
+                    data-objet-type="chasse"
+                    data-objet-id="<?= esc_attr($chasse_id); ?>"
+                    data-objet-titre="<?= esc_attr($chasse_titre); ?>"
+                    data-indice-rang="<?= esc_attr($chasse_indice_rang); ?>"
+                >
+                    <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
+                </button>
+            <?php else : ?>
+                <button
+                    type="button"
+                    class="bouton-cta cta-creer-indice cta-indice-chasse"
+                    data-objet-type="<?= esc_attr($objet_type); ?>"
+                    data-objet-id="<?= esc_attr($objet_id); ?>"
+                    data-objet-titre="<?= esc_attr($objet_titre); ?>"
+                    data-indice-rang="<?= esc_attr($indice_rang); ?>"
+                >
+                    <?= esc_html__('La chasse entière', 'chassesautresor-com'); ?>
+                </button>
+                <?php if ($has_enigmes) : ?>
+                    <button
+                        type="button"
+                        class="bouton-cta cta-indice-enigme"
+                        data-objet-type="enigme"
+                        data-chasse-id="<?= esc_attr($objet_id); ?>"
+                        <?php if ($default_enigme) : ?>
+                            data-default-enigme="<?= esc_attr($default_enigme); ?>"
+                        <?php endif; ?>
+                    >
+                        <?= esc_html__('Une énigme de la chasse', 'chassesautresor-com'); ?>
+                    </button>
+                <?php endif; ?>
             <?php endif; ?>
         </div>
     </div>


### PR DESCRIPTION
## Résumé
- Permet d'ajouter un indice soit pour l'énigme en cours soit pour la chasse associée
- Pré-sélectionne l'énigme active lors de l'ouverture de la modale d'ajout
- Met à jour les fichiers de traduction correspondants

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68adb7dda8408332bfbc2f3d1f2b2385