### PR TITLE
feat: bascule des indices dans l’onglet animation des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -138,6 +138,28 @@ function initEnigmeEdit() {
   }
 
   // ==============================
+  // 🔀 Toggle indices table between enigme and chasse
+  // ==============================
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.indices-toggle');
+    if (!btn) return;
+    const wrapper = document.querySelector('.liste-indices');
+    if (!wrapper) return;
+    const isEnigme = wrapper.dataset.objetType === 'enigme';
+    wrapper.dataset.objetType = isEnigme ? 'chasse' : 'enigme';
+    wrapper.dataset.objetId = isEnigme
+      ? wrapper.dataset.chasseId
+      : wrapper.dataset.enigmeId;
+    wrapper.dataset.page = '1';
+    btn.textContent = isEnigme
+      ? wp.i18n.__('Voir les indices de cette énigme', 'chassesautresor-com')
+      : wp.i18n.__('Voir tous les indices de la chasse', 'chassesautresor-com');
+    if (typeof window.reloadIndicesTable === 'function') {
+      window.reloadIndicesTable(wrapper);
+    }
+  });
+
+  // ==============================
   // 🧩 Affichage conditionnel – Champs radio
   // ==============================
   initChampConditionnel('acf[enigme_mode_validation]', {

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -130,32 +130,51 @@ function initEnigmeEdit() {
   // ==============================
   const titreInput = document.querySelector('.champ-enigme[data-champ="post_title"] .champ-input');
   const indiceHeading = document.getElementById('enigme-section-indices');
+  const indicesWrapper = document.querySelector('.liste-indices');
+
+  function updateIndiceHeading(type) {
+    if (!indiceHeading) return;
+    const isEnigme = type === 'enigme';
+    const template = isEnigme
+      ? indiceHeading.dataset.titreEnigme
+      : indiceHeading.dataset.titreChasse;
+    const titre = isEnigme
+      ? indiceHeading.dataset.enigmeTitle
+      : indiceHeading.dataset.chasseTitle;
+    if (template && typeof titre === 'string') {
+      indiceHeading.textContent = template.replace('%s', titre);
+    }
+  }
+
   if (titreInput && indiceHeading) {
-    const template = indiceHeading.dataset.titreTemplate || 'Indices pour %s';
     titreInput.addEventListener('input', () => {
-      indiceHeading.textContent = template.replace('%s', titreInput.value.trim());
+      indiceHeading.dataset.enigmeTitle = titreInput.value.trim();
+      if (indicesWrapper?.dataset.objetType === 'enigme') {
+        updateIndiceHeading('enigme');
+      }
     });
   }
+
+  updateIndiceHeading(indicesWrapper?.dataset.objetType || 'enigme');
 
   // ==============================
   // 🔀 Toggle indices table between enigme and chasse
   // ==============================
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.indices-toggle');
-    if (!btn) return;
-    const wrapper = document.querySelector('.liste-indices');
-    if (!wrapper) return;
-    const isEnigme = wrapper.dataset.objetType === 'enigme';
-    wrapper.dataset.objetType = isEnigme ? 'chasse' : 'enigme';
-    wrapper.dataset.objetId = isEnigme
-      ? wrapper.dataset.chasseId
-      : wrapper.dataset.enigmeId;
-    wrapper.dataset.page = '1';
+    if (!btn || !indicesWrapper) return;
+    const isEnigme = indicesWrapper.dataset.objetType === 'enigme';
+    indicesWrapper.dataset.objetType = isEnigme ? 'chasse' : 'enigme';
+    indicesWrapper.dataset.objetId = isEnigme
+      ? indicesWrapper.dataset.chasseId
+      : indicesWrapper.dataset.enigmeId;
+    indicesWrapper.dataset.page = '1';
     btn.textContent = isEnigme
       ? wp.i18n.__('Voir les indices de cette énigme', 'chassesautresor-com')
       : wp.i18n.__('Voir tous les indices de la chasse', 'chassesautresor-com');
+    updateIndiceHeading(indicesWrapper.dataset.objetType);
     if (typeof window.reloadIndicesTable === 'function') {
-      window.reloadIndicesTable(wrapper);
+      window.reloadIndicesTable(indicesWrapper);
     }
   });
 

--- a/wp-content/themes/chassesautresor/assets/js/indices-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-pager.js
@@ -6,6 +6,12 @@
     formData.append('objet_id', wrapper.dataset.objetId);
     formData.append('objet_type', wrapper.dataset.objetType);
     formData.append('page', page);
+    if (wrapper.dataset.chasseId) {
+      formData.append('chasse_id', wrapper.dataset.chasseId);
+    }
+    if (wrapper.dataset.enigmeId) {
+      formData.append('enigme_id', wrapper.dataset.enigmeId);
+    }
 
     fetch(wrapper.dataset.ajaxUrl, {
       method: 'POST',

--- a/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
@@ -330,6 +330,15 @@ $solution_prefill = apply_filters('chassesautresor/edition_animation_solution_pr
               $count_total  = $count_enigme;
           }
 
+          $enigme_title = get_the_title($objet_id);
+          if ($enigme_title === TITRE_DEFAUT_ENIGME) {
+              $enigme_title = __('en création', 'chassesautresor-com');
+          }
+          $chasse_title = $chasse_id ? get_the_title($chasse_id) : '';
+          if ($chasse_title === TITRE_DEFAUT_CHASSE) {
+              $chasse_title = __('Nouvelle chasse', 'chassesautresor-com');
+          }
+
           $par_page_solutions = 5;
           $page_solutions     = 1;
 
@@ -393,25 +402,19 @@ $solution_prefill = apply_filters('chassesautresor/edition_animation_solution_pr
 
           <h3
             id="<?= esc_attr($objet_type); ?>-section-indices"
-            data-titre-template="<?= esc_attr__('Indices pour %s', 'chassesautresor-com'); ?>"
+            data-titre-enigme="<?= esc_attr__('Indices pour %s', 'chassesautresor-com'); ?>"
+            data-titre-chasse="<?= esc_attr__('Indices pour toute la chasse %s', 'chassesautresor-com'); ?>"
+            data-enigme-title="<?= esc_attr($enigme_title); ?>"
+            data-chasse-title="<?= esc_attr($chasse_title); ?>"
             style="margin-top: var(--space-xl);"
           >
-            <?php if ($indices_objet_type === 'enigme') : ?>
-              <?= esc_html(sprintf(__('Indices pour %s', 'chassesautresor-com'), get_the_title($objet_id))); ?>
+            <?php if ($indices_objet_type === 'chasse') : ?>
+              <?= esc_html(sprintf(__('Indices pour toute la chasse %s', 'chassesautresor-com'), $chasse_title)); ?>
             <?php else : ?>
-              <?= esc_html__('Indices', 'chassesautresor-com'); ?>
+              <?= esc_html(sprintf(__('Indices pour %s', 'chassesautresor-com'), $enigme_title)); ?>
             <?php endif; ?>
           </h3>
-          <?php if ($has_enigme_indices) : ?>
-          <div class="indices-table-toggle">
-            <span class="etiquette">
-              <button type="button" class="indices-toggle champ-modifier" data-chasse-id="<?= esc_attr($chasse_id); ?>" data-enigme-id="<?= esc_attr($objet_id); ?>">
-                <?= esc_html__('Voir tous les indices de la chasse', 'chassesautresor-com'); ?>
-              </button>
-            </span>
-          </div>
-          <?php endif; ?>
-          <div class="liste-indices" data-page="1" data-pages="<?= esc_attr($pages_indices); ?>" data-objet-type="<?= esc_attr($indices_objet_type); ?>" data-objet-id="<?= esc_attr($indices_objet_id); ?>" data-enigme-id="<?= esc_attr($objet_id); ?>" data-chasse-id="<?= esc_attr($chasse_id); ?>" data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>">
+          <div class="liste-indices" data-page="1" data-pages="<?= esc_attr($pages_indices); ?>" data-objet-type="<?= esc_attr($indices_objet_type); ?>" data-objet-id="<?= esc_attr($indices_objet_id); ?>" data-enigme-id="<?= esc_attr($objet_id); ?>" data-chasse-id="<?= esc_attr($chasse_id); ?>" data-ajax-url="<?= esc_url(admin_url('admin-ajax.php')); ?>" data-has-enigme-indices="<?= esc_attr($has_enigme_indices ? '1' : '0'); ?>">
             <?php
             get_template_part('template-parts/common/indices-table', null, [
                 'indices'      => $indices_list,
@@ -422,6 +425,11 @@ $solution_prefill = apply_filters('chassesautresor/edition_animation_solution_pr
                 'count_total'  => $count_total,
                 'count_chasse' => $count_chasse,
                 'count_enigme' => $count_enigme,
+                'toggle'       => $has_enigme_indices ? [
+                    'chasse_id' => $chasse_id,
+                    'enigme_id' => $objet_id,
+                    'label'     => __('Voir tous les indices de la chasse', 'chassesautresor-com'),
+                ] : null,
             ]);
             ?>
           </div>

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -22,6 +22,7 @@ $objet_titre  = get_the_title($objet_id);
 $count_total  = isset($args['count_total']) ? (int) $args['count_total'] : 0;
 $count_chasse = isset($args['count_chasse']) ? (int) $args['count_chasse'] : 0;
 $count_enigme = isset($args['count_enigme']) ? (int) $args['count_enigme'] : 0;
+$toggle       = $args['toggle'] ?? null;
 
 if (empty($indices)) {
     $titre = get_the_title($objet_id);
@@ -35,7 +36,7 @@ if (empty($indices)) {
 }
 ?>
 
-<?php if ($count_total || $count_chasse || $count_enigme) : ?>
+<?php if ($count_total || $count_chasse || $count_enigme || $toggle) : ?>
 <div class="indices-table-header">
     <?php if ($count_total) : ?>
         <span class="etiquette"><?php echo esc_html(sprintf(_n('%d indice au total', '%d indices au total', $count_total, 'chassesautresor-com'), $count_total)); ?></span>
@@ -45,6 +46,13 @@ if (empty($indices)) {
     <?php endif; ?>
     <?php if ($count_enigme) : ?>
         <span class="etiquette"><?php echo esc_html(sprintf(_n('%d indice énigme', '%d indices énigme', $count_enigme, 'chassesautresor-com'), $count_enigme)); ?></span>
+    <?php endif; ?>
+    <?php if ($toggle) : ?>
+        <span class="etiquette">
+            <button type="button" class="indices-toggle champ-modifier" data-chasse-id="<?= esc_attr($toggle['chasse_id']); ?>" data-enigme-id="<?= esc_attr($toggle['enigme_id']); ?>">
+                <?= esc_html($toggle['label']); ?>
+            </button>
+        </span>
     <?php endif; ?>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
## Résumé
- ajoute une détection des indices d’énigme pour afficher le tableau global si nécessaire
- permet de basculer entre les indices de l’énigme et ceux de la chasse
- rafraîchit dynamiquement le tableau d’indices lors de la bascule

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68add79b91d483329352490df5d80abb