### PR TITLE
Basculer la page chasse sur la grille responsive

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -7,10 +7,8 @@
 
 .chasse-fiche-container {
   margin-top: var(--space-2xl);
-  display: flex;
-  gap: 2.6rem;
-  align-items: flex-start;
-  flex-wrap: wrap; /* utile si largeur écran réduite */
+  --grid-gap: 2.6rem;
+  align-items: start;
   position: relative;
 }
 
@@ -27,7 +25,6 @@
 
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
 .chasse-details-wrapper {
-  flex: 1;
   min-width: 240px;
 }
 .header-chasse {
@@ -98,14 +95,6 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
 @media not all and (--bp-tablet) {
-  .chasse-fiche-container {
-    flex-direction: column;
-  }
-
-  .chasse-image-wrapper,
-  .chasse-details-wrapper {
-    width: 100%;
-  }
   .header-chasse {
     font-size: 22px;
   }
@@ -124,4 +113,14 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
   border-radius: 999px;
   font-size: 0.8em;
   font-weight: 500;
+}
+
+@media (--bp-tablet) {
+  .chasse-section-intro .col-image { --col-span: 4; }
+  .chasse-section-intro .col-details { --col-span: 8; }
+}
+
+@media (--bp-desktop) {
+  .chasse-section-intro .col-image { --col-span: 5; }
+  .chasse-section-intro .col-details { --col-span: 7; }
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -257,10 +257,8 @@
    ================================================== */
 .chasse-fiche-container {
   margin-top: var(--space-2xl);
-  display: flex;
-  gap: 2.6rem;
-  align-items: flex-start;
-  flex-wrap: wrap; /* utile si largeur écran réduite */
+  --grid-gap: 2.6rem;
+  align-items: start;
   position: relative;
 }
 
@@ -277,7 +275,6 @@
 
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
 .chasse-details-wrapper {
-  flex: 1;
   min-width: 240px;
 }
 
@@ -351,13 +348,6 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
 @media not all and (min-width: 768px) {
-  .chasse-fiche-container {
-    flex-direction: column;
-  }
-  .chasse-image-wrapper,
-  .chasse-details-wrapper {
-    width: 100%;
-  }
   .header-chasse {
     font-size: 22px;
   }
@@ -377,6 +367,22 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   font-weight: 500;
 }
 
+@media (min-width: 768px) {
+  .chasse-section-intro .col-image {
+    --col-span: 4;
+  }
+  .chasse-section-intro .col-details {
+    --col-span: 8;
+  }
+}
+@media (min-width: 1024px) {
+  .chasse-section-intro .col-image {
+    --col-span: 5;
+  }
+  .chasse-section-intro .col-details {
+    --col-span: 7;
+  }
+}
 /* ========== 🛒 AJOUT AU PANIER ========== */
 .woocommerce a.button.add_to_cart_button {
   font-weight: 500;

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -97,5 +97,5 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
 
 	
         <div id="content" class="site-content">
-                <div class="ast-container<?php echo is_singular('enigme') ? ' container--xl-full' : ''; ?>">
+                <div class="ast-container<?php echo ( is_singular('enigme') || is_singular('chasse') ) ? ' container--xl-full' : ''; ?>">
                 <?php astra_content_top(); ?>

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -95,7 +95,7 @@ cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NO
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
 ?>
 
-<div id="primary" class="content-area">
+<div id="primary" class="content-area container fullwidth page-chasse-wrapper">
   <main id="main" class="site-main">
 
     <?php

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -80,7 +80,7 @@ if ($edition_active && !$est_complet) {
 
 <section class="<?= esc_attr($classe_intro); ?>">
 
-  <div class="chasse-fiche-container flex-row">
+  <div class="chasse-fiche-container row">
     <?php
     $statut = $infos_chasse['statut'];
     $statut_validation = $infos_chasse['statut_validation'];
@@ -117,7 +117,7 @@ if ($edition_active && !$est_complet) {
     <?php endif; ?>
 
     <!-- 📷 Image principale -->
-    <div class="champ-chasse champ-img <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
+    <div class="champ-chasse champ-img col-image col-12 <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
       data-champ="chasse_principale_image"
       data-cpt="chasse"
       data-post-id="<?= esc_attr($chasse_id); ?>">
@@ -139,7 +139,7 @@ if ($edition_active && !$est_complet) {
 
 
     <!-- 📟 Informations -->
-    <div class="chasse-details-wrapper">
+    <div class="chasse-details-wrapper col-details col-12">
 
       <!-- Titre dynamique -->
       <h1 class="titre-objet header-chasse"


### PR DESCRIPTION
## Résumé
- utilise le conteneur `fullwidth` et la grille du thème pour la page chasse
- répartit l’image et les détails en colonnes adaptatives
- ajuste les styles SCSS pour les points de rupture

## Changements notables
- enveloppe `single-chasse.php` dans un `container fullwidth`
- refonte de `chasse-affichage-complet.php` en `row` avec `col-*`
- mise à jour de `_chasse.scss` et génération de `dist/style.css`

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68adcdd58bdc83329c936c791123e1ec