### PR TITLE
feat: bascule solutions énigme/chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -321,11 +321,13 @@ tbody tr:nth-child(even) {
   flex-wrap: nowrap;
 }
 
-.indices-table-header {
+.indices-table-header,
+.solutions-table-header {
   margin-bottom: 0.5rem;
 }
 
-.indices-table-header .etiquette + .etiquette {
+.indices-table-header .etiquette + .etiquette,
+.solutions-table-header .etiquette + .etiquette {
   margin-left: 0.25rem;
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -5796,11 +5796,13 @@ tbody tr:nth-child(even) {
   flex-wrap: nowrap;
 }
 
-.indices-table-header {
+.indices-table-header,
+.solutions-table-header {
   margin-bottom: 0.5rem;
 }
 
-.indices-table-header .etiquette + .etiquette {
+.indices-table-header .etiquette + .etiquette,
+.solutions-table-header .etiquette + .etiquette {
   margin-left: 0.25rem;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5873,11 +5873,13 @@ tbody tr:nth-child(even) {
   flex-wrap: nowrap;
 }
 
-.indices-table-header {
+.indices-table-header,
+.solutions-table-header {
   margin-bottom: 0.5rem;
 }
 
-.indices-table-header .etiquette + .etiquette {
+.indices-table-header .etiquette + .etiquette,
+.solutions-table-header .etiquette + .etiquette {
   margin-left: 0.25rem;
 }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -61,6 +61,8 @@ function enqueue_script_enigme_edit()
       'scrollTarget'  => '#enigme-section-solutions',
       'tooltipChasse' => __('Il existe déjà une solution pour cette chasse', 'chassesautresor-com'),
       'tooltipEnigme' => __('Il existe déjà une solution pour cette énigme', 'chassesautresor-com'),
+      'toggleChasse'  => __('Voir toutes les solutions de la chasse', 'chassesautresor-com'),
+      'toggleEnigme'  => __('Voir la solution de cette énigme', 'chassesautresor-com'),
     ]
   );
 

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1296,6 +1296,23 @@ msgstr ""
 msgid "Trouvées"
 msgstr ""
 
+#: template-parts/common/edition-animation.php:512
+msgid "Solutions pour toute la chasse %s"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:514
+msgid "Solutions pour %s"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:521
+#: inc/edition/edition-enigme.php:64
+msgid "Voir toutes les solutions de la chasse"
+msgstr ""
+
+#: inc/edition/edition-enigme.php:65
+msgid "Voir la solution de cette énigme"
+msgstr ""
+
 #: template-parts/common/stat-histogram-card.php:38
 msgid "Aucune donnée."
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2598,3 +2598,20 @@ msgstr "Edit logo"
 msgid "Logo de l’organisateur"
 msgstr "Organizer logo"
 
+#: template-parts/common/edition-animation.php:512
+msgid "Solutions pour toute la chasse %s"
+msgstr "Solutions for the whole hunt %s"
+
+#: template-parts/common/edition-animation.php:514
+msgid "Solutions pour %s"
+msgstr "Solutions for %s"
+
+#: template-parts/common/edition-animation.php:521
+#: inc/edition/edition-enigme.php:64
+msgid "Voir toutes les solutions de la chasse"
+msgstr "See all hunt solutions"
+
+#: inc/edition/edition-enigme.php:65
+msgid "Voir la solution de cette énigme"
+msgstr "See this riddle's solution"
+

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2585,3 +2585,20 @@ msgstr "Modifier le logo"
 msgid "Logo de l’organisateur"
 msgstr "Logo de l’organisateur"
 
+#: template-parts/common/edition-animation.php:512
+msgid "Solutions pour toute la chasse %s"
+msgstr "Solutions pour toute la chasse %s"
+
+#: template-parts/common/edition-animation.php:514
+msgid "Solutions pour %s"
+msgstr "Solutions pour %s"
+
+#: template-parts/common/edition-animation.php:521
+#: inc/edition/edition-enigme.php:64
+msgid "Voir toutes les solutions de la chasse"
+msgstr "Voir toutes les solutions de la chasse"
+
+#: inc/edition/edition-enigme.php:65
+msgid "Voir la solution de cette énigme"
+msgstr "Voir la solution de cette énigme"
+


### PR DESCRIPTION
## Résumé
- ajout d'une entête et d'un bouton pour afficher toutes les solutions de la chasse depuis une énigme
- mise à jour dynamique du titre et du contenu du tableau des solutions
- expose le nombre total de solutions via l'API d'état

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68addc6a0f5883329014586a992f4721