### PR TITLE
Ajuste la taille du logo des organisateurs

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -145,9 +145,10 @@ a.bouton-edition-attention {
 
 
 .header-organisateur__logo img {
-    max-height: 50px;
-    width: auto;
+    width: 50px;
+    height: 50px;
     object-fit: contain;
+    border-radius: 50%;
 }
 
 

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -145,7 +145,9 @@ a.bouton-edition-attention {
 
 
 .header-organisateur__logo img {
-    width: 100px;
+    max-height: 50px;
+    width: auto;
+    object-fit: contain;
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7928,10 +7928,11 @@ a.bouton-edition-attention {
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */
 .header-organisateur__logo img {
-  max-height: 50px;
-  width: auto;
+  width: 50px;
+  height: 50px;
   -o-object-fit: contain;
      object-fit: contain;
+  border-radius: 50%;
 }
 
 /* ========== 🧭 MODAL BIENVENUE ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7928,7 +7928,10 @@ a.bouton-edition-attention {
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */
 .header-organisateur__logo img {
-  width: 100px;
+  max-height: 50px;
+  width: auto;
+  -o-object-fit: contain;
+     object-fit: contain;
 }
 
 /* ========== 🧭 MODAL BIENVENUE ========== */

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -5,8 +5,8 @@ $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
 
 
 $logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
-$logo = wp_get_attachment_image_src($logo_id, 'medium');
-$logo_url = $logo ? $logo[0] : esc_url(wp_get_attachment_image_src(3927, 'medium')[0]);
+$logo = wp_get_attachment_image_src($logo_id, 'thumbnail');
+$logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
 
 $titre_organisateur = get_post_field('post_title', $organisateur_id);
 
@@ -54,13 +54,13 @@ if ($peut_modifier && !$est_complet) {
 
           <div class="champ-affichage">
             <div class="header-organisateur__logo">
-              <a href="<?= esc_url(get_permalink($organisateur_id)); ?>" aria-label="Voir la page de l’organisateur">
+              <a href="<?= esc_url(get_permalink($organisateur_id)); ?>"
+                aria-label="<?= esc_attr__('Voir la page de l\u2019organisateur', 'chassesautresor-com'); ?>">
                 <img src="<?= esc_url($logo_url); ?>"
-                  alt="Logo de l’organisateur"
+                  alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
                   class="header-organisateur__logo visuel-cpt"
                   data-cpt="organisateur"
-                  data-post-id="<?= esc_attr($organisateur_id); ?>"
-                  style="max-width:100%; height:auto;" />
+                  data-post-id="<?= esc_attr($organisateur_id); ?>" />
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Résumé
- adapte les dimensions du logo dans l’en-tête organisateur
- recompile les styles du thème

## Testing
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ae7cae3b0c83329af99c5c76fe2e3d