### PR TITLE
Ajoute un conteneur boxed au header organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -35,10 +35,11 @@ $url_contact = esc_url($base_url . 'contact?email_organisateur=' . urlencode($em
 $est_complet = organisateur_est_complet($organisateur_id);
 $classes_header = 'header-organisateur';
 if ($peut_modifier && !$est_complet) {
-  $classes_header .= ' champ-organisateur champ-vide-obligatoire';
+    $classes_header .= ' champ-organisateur champ-vide-obligatoire';
 }
+$classes_header .= ' container container--boxed';
 ?>
-<div class="header-organisateur-wrapper">
+<div class="header-organisateur-wrapper container fullwidth">
   <div class="ligne-morse" aria-hidden="true">
     <div class="morse-wrapper" data-morse="<?= esc_attr($titre_organisateur); ?>"></div>
   </div>


### PR DESCRIPTION
## Résumé
- Encapsule le header organisateur dans un conteneur plein écran avec contenu limité

## Changements notables
- Ajout des classes `container` et `container--boxed` sur le header organisateur
- Wrapper du header organisé avec un conteneur `fullwidth`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68ae805f6de083329c89ea19037a242a