### PR TITLE
feat: make container fullwidth on xxl screens by default

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_grid.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_grid.scss
@@ -4,7 +4,7 @@
 .ast-container,
 .ast-container-fluid {
   width: 100%;
-  max-width: none;
+  max-width: var(--container-max-width);
   margin-left: auto;
   margin-right: auto;
   padding-left: var(--space-md);
@@ -19,6 +19,29 @@
 .container--narrow,
 .ast-container--narrow {
   --container-max-width: var(--container-max-width-narrow);
+}
+
+.container.fullwidth,
+.ast-container.fullwidth {
+  max-width: none;
+}
+
+@media (--bp-xxl) {
+  .container,
+  .ast-container,
+  .ast-container-fluid {
+    max-width: none;
+  }
+
+  .container--boxed,
+  .ast-container--boxed {
+    max-width: var(--container-max-width);
+  }
+
+  .container.fullwidth-xl,
+  .ast-container.fullwidth-xl {
+    max-width: none;
+  }
 }
 
 .row {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6281,7 +6281,7 @@ span.champ-obligatoire {
 .ast-container,
 .ast-container-fluid {
   width: 100%;
-  max-width: none;
+  max-width: var(--container-max-width);
   margin-left: auto;
   margin-right: auto;
   padding-left: var(--space-md);
@@ -6298,6 +6298,26 @@ span.champ-obligatoire {
   --container-max-width: var(--container-max-width-narrow);
 }
 
+.container.fullwidth,
+.ast-container.fullwidth {
+  max-width: none;
+}
+
+@media (min-width: 1440px) {
+  .container,
+  .ast-container,
+  .ast-container-fluid {
+    max-width: none;
+  }
+  .container--boxed,
+  .ast-container--boxed {
+    max-width: var(--container-max-width);
+  }
+  .container.fullwidth-xl,
+  .ast-container.fullwidth-xl {
+    max-width: none;
+  }
+}
 .row {
   display: grid;
   gap: var(--grid-gap);


### PR DESCRIPTION
## Summary
- Par défaut, les conteneurs deviennent plein écran au-dessus de 1440px.
- Ajout d’une classe pour conserver une largeur limitée sur les très grands écrans.

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ae82cdeed48332ae756bb7add42d47