### PR TITLE
Nettoyage des surcharges fullwidth

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -93,7 +93,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   background-image: url(...);
   background-size: cover;
   z-index: 10;

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -6401,7 +6401,7 @@ body.accueil-fullscreen {
   position: absolute;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   background-image: url(...);
   background-size: cover;
   z-index: 10;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6486,7 +6486,7 @@ body.accueil-fullscreen {
   position: absolute;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   background-image: url(...);
   background-size: cover;
   z-index: 10;

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -39,7 +39,7 @@ if ($peut_modifier && !$est_complet) {
 }
 $classes_header .= ' container container--boxed';
 ?>
-<div class="header-organisateur-wrapper container fullwidth">
+<div class="header-organisateur-wrapper">
   <div class="ligne-morse" aria-hidden="true">
     <div class="morse-wrapper" data-morse="<?= esc_attr($titre_organisateur); ?>"></div>
   </div>


### PR DESCRIPTION
## Résumé
- nettoyage des styles fullwidth obsolètes sur la page de chasse
- simplification du header organisateur avec `container--boxed`

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d7608308332b140f492c1cb0b39