### PR TITLE
Adapte les SCSS aux règles mobile-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Keep function and variable names in English when possible.
 - Place opening braces on the same line as declarations.
 - Wrap all user-facing strings in WordPress internationalization functions and use the `chassesautresor-com` text domain.
+- Write CSS and SCSS using a mobile-first approach: base styles for small screens, then extend via media queries.
 
 ## Testing
 - Before committing any change, run the project tests.

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -120,7 +120,7 @@ button,
 
 .bouton-cta {
     display: inline-block;
-    padding: 10px 15px;
+    padding: 6px 10px;
     background-color: var(--color-gris-3);
     color: var(--color-text-secondary);
     border-radius: 5px;
@@ -172,35 +172,39 @@ button,
     display: flex;
     justify-content: center;
     margin-top: var(--space-sm);
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.bloc-reponse .reponse-cta-row .bouton-cta {
+    width: 100%;
 }
 
 .bloc-reponse .points-sousligne {
     text-align: center;
-    margin-top: var(--space-xxs);
+    margin-top: var(--space-xs);
     font-size: 0.75rem;
     opacity: 0.7;
 }
 
-@media not all and (--bp-small) {
+@media (--bp-small) {
     .bloc-reponse .reponse-cta-row {
-        flex-direction: column;
-        align-items: stretch;
+        flex-direction: row;
     }
     .bloc-reponse .reponse-cta-row .bouton-cta {
-        width: 100%;
+        width: auto;
     }
     .bloc-reponse .points-sousligne {
-        margin-top: var(--space-xs);
+        margin-top: var(--space-xxs);
     }
-}
-@media not all and (--bp-tablet) {
     .bouton-cta {
         padding: 8px 13px;
     }
 }
-@media not all and (--bp-small) {
+
+@media (--bp-tablet) {
     .bouton-cta {
-        padding: 6px 10px;
+        padding: 10px 15px;
     }
 }
 
@@ -420,6 +424,7 @@ a.ajout-link:focus-visible {
   background-color: var(--color-background-button);
   color: var(--color-text-primary);
   margin-top: 10px;
+  width: 100%;
 }
 
 .btn-lire-plus:hover {
@@ -432,9 +437,9 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media not all and (--bp-tablet) {
+@media (--bp-tablet) {
   .btn-lire-plus {
-    width: 100%;
+    width: auto;
   }
 }
 
@@ -452,7 +457,7 @@ a.ajout-link:focus-visible {
   padding: 0;
   border: none;
   box-shadow: none;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   line-height: 1;
 }
 
@@ -472,9 +477,9 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media not all and (--bp-small) {
+@media (--bp-small) {
   .bouton-retour {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
   }
 }
 
@@ -506,7 +511,7 @@ a.ajout-link:focus-visible {
 .bloc-metas-inline {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.7rem;
+  gap: 0.8rem;
   margin: 0.4rem 0;
   font-size: 0.95rem;
   opacity: 0.9;
@@ -519,6 +524,7 @@ a.ajout-link:focus-visible {
   padding: 0.3em 0.8em;
   border-radius: 1.2em;
   white-space: nowrap;
+  font-size: 85%;
 }
 .meta-etiquette svg {
   margin-bottom: -5px;
@@ -530,25 +536,23 @@ a.ajout-link:focus-visible {
   font-weight: 600;
 }
 .bloc-metas-inline--compact {
-  gap: 0.5rem;
+  gap: 0.4rem;
   font-size: 0.75rem;
 }
 
 .bloc-metas-inline--compact .meta-etiquette {
   padding: 0.2em 0.6em;
+  font-size: 100%;
 }
-@media not all and (--bp-small) {
+@media (--bp-small) {
     .bloc-metas-inline {
-        gap:0.8rem;
+        gap:0.7rem;
     }
     .meta-etiquette {
-        font-size:85%;
+        font-size:100%;
     }
     .bloc-metas-inline--compact {
-        gap:0.4rem;
-    }
-    .bloc-metas-inline--compact .meta-etiquette {
-        font-size:100%;
+        gap:0.5rem;
     }
 }
 
@@ -701,7 +705,7 @@ a.ajout-link:focus-visible {
   height: 2px;
   width: 40px;
   background-color: var(--color-accent);
-  margin: var(--space-xs) 0 var(--space-xl);
+  margin: 0 auto;
 }
 
 
@@ -715,9 +719,9 @@ a.ajout-link:focus-visible {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-small) {
+@media (--bp-small) {
     .separateur-2 {
-        margin: 0 auto;
+        margin: var(--space-xs) 0 var(--space-xl);
     }
 }
 
@@ -732,6 +736,8 @@ a.ajout-link:focus-visible {
 .formulaire-contact-wrapper {
   margin:var(--space-2xl) auto;
   max-width: 600px;
+  padding-left: var(--space-md);
+  padding-right: var(--space-md);
 }
 .titre-contact {
   margin-bottom: 0.8rem;
@@ -739,10 +745,10 @@ a.ajout-link:focus-visible {
 body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     color: var(--color-text-primary);
 }
-@media not all and (--bp-small) {
+@media (--bp-small) {
   .formulaire-contact-wrapper {
-    padding-left: var(--space-md);
-    padding-right: var(--space-md);
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 #wpforms-8792-field_6-container {
@@ -820,15 +826,15 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
     background: rgba(0, 0, 0, 0.7);
     color: var(--color-primary);
     font-weight: bold;
-    font-size: 1.2rem;
+    font-size: 1rem;
     padding: 10px 20px;
     margin-top: 15px;
     border-radius: 8px;
     text-align: center;
 }
 
-@media not all and (--bp-tablet) {
-    .countdown-container { font-size: 1rem; }
+@media (--bp-tablet) {
+    .countdown-container { font-size: 1.2rem; }
 }
 
 

--- a/wp-content/themes/chassesautresor/assets/scss/_grid.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_grid.scss
@@ -32,6 +32,7 @@
   display: grid;
   gap: var(--grid-gap);
   grid-template-columns: repeat(var(--grid-columns), 1fr);
+  --grid-columns: 4;
 }
 
 [class^="col-"], [class*=" col-"] {
@@ -52,14 +53,14 @@
 .col-11 { --col-span: 11; }
 .col-12 { --col-span: 12; }
 
-@media not all and (--bp-desktop) {
-  .row { --grid-columns: 8; }
-}
-
-@media not all and (--bp-tablet) {
+@media (--bp-small) {
   .row { --grid-columns: 6; }
 }
 
-@media not all and (--bp-small) {
-  .row { --grid-columns: 4; }
+@media (--bp-tablet) {
+  .row { --grid-columns: 8; }
+}
+
+@media (--bp-desktop) {
+  .row { --grid-columns: 12; }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -36,8 +36,8 @@
     background-color: rgba(0, 0, 0, 0.2);
     width: 100%;
     max-width: 100%;
-    padding-left: var(--space-lg);
-    padding-right: var(--space-lg);
+    padding-left: 7px;
+    padding-right: 7px;
 }
 .site-above-header-wrap .site-branding{
     padding:0;
@@ -58,24 +58,29 @@
 .site-above-header-wrap .ast-builder-layout-element {
     margin-left:10px;
 }
- @media not all and (--bp-desktop) {
-     header.site-header   {
-         padding: 0 10px ;
-     }
-     .site-above-header-wrap {
-         padding-left: 10px;
-         padding-right: 10px;
-     }
- }
- @media not all and (--bp-small) {
+header.site-header {
+    padding: 0 7px;
+}
+
+@media (--bp-small) {
     header.site-header {
-        padding: 0 7px;
+        padding: 0 10px;
     }
     .site-above-header-wrap {
-        padding-left: 7px;
-        padding-right: 7px;
+        padding-left: 10px;
+        padding-right: 10px;
     }
- }
+}
+
+@media (--bp-desktop) {
+    header.site-header {
+        padding: 0;
+    }
+    .site-above-header-wrap {
+        padding-left: var(--space-lg);
+        padding-right: var(--space-lg);
+    }
+}
 
 /* ========== 🧭 HERO  ========== */
 .hero-overlay--default {
@@ -138,7 +143,7 @@
   }
 }
 .hero-title {
-  font-size: 2.6rem;
+  font-size: 1.5rem;
   font-weight: 700;
   text-transform: uppercase;
   color: var(--color-primary);
@@ -147,16 +152,23 @@
   text-shadow: 1px 1px 4px rgba(0,0,0,0.7);
 }
 .hero-subtitle {
-  font-size: 1.3rem;
+  font-size: 1rem;
   color: var(--color-text-primary);
   opacity: 0.95;
-  margin-bottom: var(--space-2xl);
+  margin-bottom: var(--space-xs);
   max-width: 700px;
   margin-left: auto;
   margin-right: auto;
   text-shadow: 1px 1px 4px rgba(0,0,0,0.7);
 }
-@media not all and (--bp-tablet) {
+.has-hero .hero-overlay {
+  height: 220px;
+}
+.has-hero #content {
+  padding-top: 235px;
+}
+
+@media (--bp-small) {
   .hero-title {
     font-size: 1.8rem;
   }
@@ -171,19 +183,20 @@
     padding-top: 300px;
   }
 }
-@media not all and (--bp-small) {
+
+@media (--bp-tablet) {
   .hero-title {
-    font-size: 1.5rem;
+    font-size: 2.6rem;
   }
   .hero-subtitle {
-    font-size: 1rem;
-    margin-bottom: var(--space-xs);
+    font-size: 1.3rem;
+    margin-bottom: var(--space-2xl);
   }
   .has-hero .hero-overlay {
-    height: 220px;
+    height: 475px;
   }
   .has-hero #content {
-    padding-top: 235px;
+    padding-top: 475px;
   }
 }
 
@@ -211,12 +224,19 @@ body #primary {
   align-items: flex-start; /* ✅ important : alignement haut */
   flex-wrap: wrap; /* ✅ si l’un est trop large */
 }
-@media not all and (--bp-desktop) {
-    .ast-container, .ast-container-fluid {
-        margin-left: auto;
-        margin-right: auto;
-        padding-left: 13px;
-        padding-right: 13px;
+.ast-container,
+.ast-container-fluid {
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 13px;
+    padding-right: 13px;
+}
+
+@media (--bp-desktop) {
+    .ast-container,
+    .ast-container-fluid {
+        padding-left: var(--space-md);
+        padding-right: var(--space-md);
     }
 }
 .deux-col-wrapper {
@@ -253,7 +273,9 @@ body #primary {
   gap: var(--space-2xl);
   justify-content: center;
   margin-top: var(--space-2xl);
-}
+  flex-direction: column;
+  align-items: center;
+ }
 
 .bloc-temoignages .temoignage-colonne {
   background-color: rgba(255, 255, 255, 0.02);
@@ -293,10 +315,11 @@ body #primary {
   opacity: 0.9;
   line-height: 1.5;
 }
-@media not all and (--bp-tablet) {
+
+@media (--bp-tablet) {
   .bloc-temoignages .temoignage-colonnes {
-    flex-direction: column;
-    align-items: center;
+    flex-direction: row;
+    align-items: stretch;
   }
 }
 
@@ -471,25 +494,44 @@ footer .ast-footer-widget a {
 }
 
 
-@media not all and (--bp-mobile) {
-  .site-footer-primary-section-1 {
-    order: 2;
-    margin: 30px 0;
-  }
+.site-footer-primary-section-1 {
+  order: 2;
+  margin: 30px 0;
+}
 
+.site-footer-primary-section-2 {
+  order: 3;
+}
+footer .site-footer-primary-section-3 {
+  order: 1;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 15px;
+  margin-bottom: 15px;
+  display: block;
+}
+.ast-builder-footer-grid-columns {
+  column-gap: 20px;
+  padding-inline: 10px;
+}
+
+@media (--bp-mobile) {
+  .site-footer-primary-section-1 {
+    order: 1;
+    margin: 0;
+  }
   .site-footer-primary-section-2 {
-    order: 3;
+    order: 2;
   }
   footer .site-footer-primary-section-3 {
-    order: 1;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    padding-bottom: 15px;
-    margin-bottom: 15px;
-    display: block;
+    order: 3;
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+    display: flex;
   }
   .ast-builder-footer-grid-columns {
     column-gap: 20px;
-    padding-inline: 10px;
+    padding-inline: 0;
   }
 }
 .bandeau-info-chasse {

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -218,38 +218,61 @@ a.bouton-edition-attention {
 
 /* ========== 📱 RESPONSIVE – TABLETTES (≤ 768PX) ========== */
 
-@media not all and (--bp-tablet) {
-    .conteneur-organisateur {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-    }
-    .champ-organisateur .champ-affichage {
-        position: relative;
-    }
-
-    /* 🔹 Titre  */
-    .header-organisateur__nom {
-        margin-bottom: 0.7rem;
-    }
-    .colonne-logo .champ-modifier{
-        position: relative;
-    }
-    .champ-organisateur .champ-modifier {
-        font-size: 0.85rem;
-    }
-    .colonne-logo {
-        max-width: none;
-        margin: 0 auto;
-    }
-
-  .colonne-texte {
+.conteneur-organisateur {
+    flex-direction: column;
     align-items: center;
     text-align: center;
+}
+.champ-organisateur .champ-affichage {
+    position: relative;
+}
+
+/* 🔹 Titre  */
+.header-organisateur__nom {
+    margin-bottom: 0.7rem;
+    font-size: 1.2rem;
+}
+.colonne-logo .champ-modifier{
+    position: relative;
+}
+.champ-organisateur .champ-modifier {
+    font-size: 0.85rem;
+}
+.colonne-logo {
+    max-width: none;
     margin: 0 auto;
-  }
+}
+
+.colonne-texte {
+  align-items: center;
+  text-align: center;
+  margin: 0 auto;
+}
+
+@media (--bp-tablet) {
+    .conteneur-organisateur {
+        flex-direction: row;
+        align-items: center;
+        text-align: left;
+    }
+    .champ-organisateur .champ-affichage {
+        position: static;
+    }
     .header-organisateur__nom {
-        font-size: 1.2rem;
+        margin-bottom: 0;
+        font-size: 1.6rem;
+    }
+    .champ-organisateur .champ-modifier {
+        font-size: inherit;
+    }
+    .colonne-logo {
+        max-width: 100px;
+        margin: 0;
+    }
+    .colonne-texte {
+        align-items: flex-start;
+        text-align: left;
+        margin: 0;
     }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_variables.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_variables.scss
@@ -86,7 +86,6 @@
   --container-max-width: var(--container-max-width-default);
   --container-max-width-narrow: 800px;
   --grid-gap: 1rem;
-  --mobile-first: 1; /* active le mode mobile-first */
   --grid-columns: 4;
   --dashboard-card-max-width: 420px; /* 🔲 Largeur max des dashboard-card isolées */
 

--- a/wp-content/themes/chassesautresor/assets/scss/_variables.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_variables.scss
@@ -86,7 +86,8 @@
   --container-max-width: var(--container-max-width-default);
   --container-max-width-narrow: 800px;
   --grid-gap: 1rem;
-  --grid-columns: 12;
+  --mobile-first: 1; /* active le mode mobile-first */
+  --grid-columns: 4;
   --dashboard-card-max-width: 420px; /* 🔲 Largeur max des dashboard-card isolées */
 
   /* Espacements */

--- a/wp-content/themes/chassesautresor/docs/systeme-grille.md
+++ b/wp-content/themes/chassesautresor/docs/systeme-grille.md
@@ -9,7 +9,7 @@ La grille générique repose sur un conteneur `.row` utilisant **CSS Grid**. Cha
 - 4 colonnes par défaut sur mobile.
 - 6 colonnes à partir de `--bp-small`, 8 à partir de `--bp-tablet` et 12 à partir de `--bp-desktop`.
 - Espacement configurable via la variable `--grid-gap`.
-- La variable `--mobile-first` (valeur `1`) rappelle que les styles de base ciblent les petits écrans.
+- Les styles de base ciblent les petits écrans : la grille suit une approche mobile-first.
 
 ```html
 <div class="row">

--- a/wp-content/themes/chassesautresor/docs/systeme-grille.md
+++ b/wp-content/themes/chassesautresor/docs/systeme-grille.md
@@ -6,9 +6,10 @@ Ce document décrit les grilles disponibles dans le thème afin de faciliter leu
 
 La grille générique repose sur un conteneur `.row` utilisant **CSS Grid**. Chaque élément enfant reçoit une classe `.col-X` pour définir le nombre de colonnes occupées (de `1` à `12`).
 
-- Largeur par défaut : `12` colonnes.
+- 4 colonnes par défaut sur mobile.
+- 6 colonnes à partir de `--bp-small`, 8 à partir de `--bp-tablet` et 12 à partir de `--bp-desktop`.
 - Espacement configurable via la variable `--grid-gap`.
-- Les colonnes se réorganisent automatiquement en fonction des points de rupture (`--bp-desktop`, `--bp-tablet`, `--bp-small`).
+- La variable `--mobile-first` (valeur `1`) rappelle que les styles de base ciblent les petits écrans.
 
 ```html
 <div class="row">


### PR DESCRIPTION
## Résumé
- Passage progressif des feuilles de style vers une logique mobile-first
- Ajustements des marges et paddings pour les petits écrans

## Changements notables
- Conversion des grilles CSS pour définir 4 colonnes par défaut et n'augmenter qu'aux ruptures supérieures
- Refonte des composants CTA et formulaires pour appliquer les styles mobiles en dehors des media queries
- Simplification des styles du header et du footer pour qu'ils s'adaptent d'abord aux écrans étroits

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ae948f5a0083328d10f878858da015