### PR TITLE
Harmonise les couleurs des badges de statut

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -594,7 +594,7 @@ a.ajout-link:focus-visible {
 
 /* Couleurs par statut (alignées sur le nuancier) */
 .badge-statut.statut-en_cours {
-  background-color: var(--color-editor-success);
+  background-color: var(--color-success);
 }
 
 .badge-statut.statut-payante {
@@ -603,7 +603,7 @@ a.ajout-link:focus-visible {
 }
 
 .badge-statut.statut-a_venir {
-  background-color: var(--color-editor-placeholder);
+  background-color: var(--color-grey-medium);
 }
 
 .badge-statut.statut-termine {
@@ -611,7 +611,7 @@ a.ajout-link:focus-visible {
 }
 
 .badge-statut.statut-revision {
-  background-color: var(--color-editor-error);
+  background-color: var(--color-error);
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -963,7 +963,7 @@ a.ajout-link:focus-visible {
 
 /* Couleurs par statut (alignées sur le nuancier) */
 .badge-statut.statut-en_cours {
-  background-color: var(--color-editor-success);
+  background-color: var(--color-success);
 }
 
 .badge-statut.statut-payante {
@@ -972,7 +972,7 @@ a.ajout-link:focus-visible {
 }
 
 .badge-statut.statut-a_venir {
-  background-color: var(--color-editor-placeholder);
+  background-color: var(--color-grey-medium);
 }
 
 .badge-statut.statut-termine {
@@ -980,7 +980,7 @@ a.ajout-link:focus-visible {
 }
 
 .badge-statut.statut-revision {
-  background-color: var(--color-editor-error);
+  background-color: var(--color-error);
 }
 
 /* ========== 🎁 BADGE RÉCOMPENSE ========== */


### PR DESCRIPTION
## Résumé
- remplace les variables de couleurs spécifiques à l’éditeur par les équivalents globaux pour les badges de statut
- recompile la feuille `dist/style.css`

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9e5c68d08332a981d80c07da7c59