### PR TITLE
Supprime l'étiquette de coût des fiches de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -99,7 +99,6 @@ function rafraichirCarteSolutions() {
 
 window.rafraichirCarteSolutions = rafraichirCarteSolutions;
 
-
   function initChasseEdit() {
   if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
   inputDateDebut = document.getElementById('chasse-date-debut');
@@ -107,7 +106,6 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
   erreurDebut = document.getElementById('erreur-date-debut');
   erreurFin = document.getElementById('erreur-date-fin');
   toggleDateFin = document.getElementById('date-fin-limitee');
-
 
   // ==============================
   // 🟢 Initialisation des champs
@@ -232,8 +230,6 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
     // Ce fichier ne fait que fournir les messages d'erreur via
     // `validerDatesAvantEnvoi` appelé par `initChampDate()`.
   }
-
-
 
   // ================================
   // 🏆 Gestion de l'enregistrement de la récompense (titre, texte, valeur)
@@ -365,7 +361,6 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
     });
 
   }
-
 
   if (boutonRecompense && inputTitreRecompense && inputTexteRecompense && inputValeurRecompense) {
     boutonRecompense.addEventListener('click', () => {
@@ -626,7 +621,6 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
 
   window.addEventListener('liens-publics-updated', rafraichirCarteLiens);
 
-
 // ==============================
 // 🔗 Initialisation des liens chasse
 // ==============================
@@ -639,7 +633,6 @@ function initLiensChasse(bloc) {
     });
   }
 }
-
 
 // ==============================
 // 🔎 Validation logique entre date de début et date de fin
@@ -712,7 +705,6 @@ function validerDatesAvantEnvoi(champModifie) {
   return true;
 }
 
-
 // ==============================
 // 🔥 Affichage d'un message global temporaire
 // ==============================
@@ -734,36 +726,6 @@ function afficherErreurGlobale(message) {
   }, 4000); // Disparition après 4 secondes
 }
 
-
-// ================================
-// 💰 Mise à jour dynamique de l'affichage du coût (Gratuit / Payant)
-// ================================
-function mettreAJourAffichageCout(postId, cout) {
-  const coutAffichage = document.querySelector(`.chasse-prix[data-post-id="${postId}"] .cout-affichage`);
-  if (!coutAffichage) return;
-
-  coutAffichage.dataset.cout = cout; // Met à jour data-cout
-  coutAffichage.innerHTML = ''; // Vide l'affichage
-
-  const templateId = parseInt(cout, 10) === 0 ? 'icon-free' : 'icon-unlock';
-  const template = document.getElementById(templateId);
-
-  if (template) {
-    coutAffichage.appendChild(template.content.cloneNode(true));
-  }
-
-  if (parseInt(cout, 10) === 0) {
-    coutAffichage.insertAdjacentText('beforeend', ' Gratuit');
-  } else {
-    coutAffichage.insertAdjacentText('beforeend', ` ${cout}`);
-    const devise = document.createElement('span');
-    devise.className = 'prix-devise';
-    devise.textContent = 'pts';
-    coutAffichage.appendChild(devise);
-  }
-}
-
-
 // ================================
 // 💾 Enregistrement du coût en points après clic bouton "✓"
 // ================================
@@ -783,7 +745,6 @@ document.querySelectorAll('.champ-cout-points .champ-enregistrer').forEach(bouto
     modifierChampSimple(champ, valeur, postId, 'chasse');
 
     if (champ === 'chasse_infos_cout_points') {
-      mettreAJourAffichageCout(postId, valeur);
       rafraichirStatutChasse(postId);
     }
 
@@ -796,8 +757,6 @@ document.querySelectorAll('.champ-cout-points .champ-enregistrer').forEach(bouto
     }
   });
 });
-
-
 
 // ================================
 // 💰 Gestion de l'enregistrement du coût en points
@@ -820,8 +779,6 @@ document.querySelectorAll('.champ-cout-points .champ-annuler').forEach(bouton =>
     }
   });
 });
-
-
 
 // ================================
 // 🎯 Gestion du champ Nombre de gagnants + Illimité (avec debounce)
@@ -1114,7 +1071,6 @@ window.mettreAJourEtatIntroChasse = function () {
   section.classList.toggle('champ-vide-obligatoire', incomplets.length > 0);
 };
 
-
 // ================================
 // 👥 Mise à jour dynamique de l'affichage du nombre de gagnants
 // ================================
@@ -1129,15 +1085,12 @@ function mettreAJourAffichageNbGagnants(postId, nb) {
   }
 }
 
-
-
 document.addEventListener('acf/submit_success', function (e) {
   DEBUG && console.log('✅ Formulaire ACF soumis avec succès', e);
   if (typeof window.mettreAJourResumeInfos === 'function') {
     window.mettreAJourResumeInfos();
   }
 });
-
 
 // ================================
 // 🔁 Rafraîchissement dynamique du statut de la chasse

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -377,14 +377,6 @@ function initChampCoutPoints() {
         input.value = valeur;
         modifierChampSimple(champ, valeur, postId, cpt);
 
-        // ✅ Mise à jour visuelle du badge coût pour la chasse
-        if (
-          champ === 'chasse_infos_cout_points' &&
-          typeof mettreAJourAffichageCout === 'function'
-        ) {
-          mettreAJourAffichageCout(postId, valeur);
-        }
-
         if (typeof window.onCoutPointsUpdated === 'function') {
           window.onCoutPointsUpdated(bloc, champ, valeur, postId, cpt);
         }

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -87,12 +87,6 @@
     margin: var(--space-xl) 0;
     color: white;
 }
-.chasse-prix {
-    font-size: 2.3rem;
-}
-.chasse-prix svg {
-    vertical-align: middle;
-}
 .page-chasse-wrapper .chasse-lot {
     display: flex;
     gap: 0.7rem;

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -337,14 +337,6 @@
   color: white;
 }
 
-.chasse-prix {
-  font-size: 2.3rem;
-}
-
-.chasse-prix svg {
-  vertical-align: middle;
-}
-
 .page-chasse-wrapper .chasse-lot {
   display: flex;
   gap: 0.7rem;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -339,14 +339,6 @@
   color: white;
 }
 
-.chasse-prix {
-  font-size: 2.3rem;
-}
-
-.chasse-prix svg {
-  vertical-align: middle;
-}
-
 .page-chasse-wrapper .chasse-lot {
   display: flex;
   gap: 0.7rem;

--- a/wp-content/themes/chassesautresor/notices/fields/cout-points.md
+++ b/wp-content/themes/chassesautresor/notices/fields/cout-points.md
@@ -104,12 +104,6 @@ document.addEventListener('DOMContentLoaded', initChampCoutPoints);
 
 ```js
 window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
-  if (champ === 'chasse_infos_cout_points') {
-    if (typeof mettreAJourAffichageCout === 'function') {
-      mettreAJourAffichageCout(postId, valeur);
-    }
-  }
-
   if (champ === 'enigme_tentative_cout_points') {
     const champMaxBloc = document.querySelector('[data-champ="enigme_tentative_max"]');
     const champMaxInput = champMaxBloc?.querySelector('.champ-input');

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -827,9 +827,6 @@ initChampNbGagnants()
 mettreAJourResumeInfos()
 → Met à jour dynamiquement les indicateurs "champ-vide" / "champ-rempli" dans le résumé
 
-mettreAJourAffichageCout(postId, cout)
-→ Met à jour dynamiquement l’affichage du prix (ex : badge Gratuit / X pts)
-
 validerDatesAvantEnvoi(champModifie)
 → Contrôle logique cohérent entre date de début / fin d’une chasse
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -19,11 +19,10 @@ $champs = $infos_chasse['champs'];
 $lot               = $champs['lot'];
 $titre_recompense  = $champs['titre_recompense'];
 $valeur_recompense = $champs['valeur_recompense'];
-$cout_points       = $champs['cout_points'];
 $date_debut        = $champs['date_debut'];
 $date_fin          = $champs['date_fin'];
 $illimitee         = $champs['illimitee'];
-$nb_max            = $champs['nb_max'];   
+$nb_max            = $champs['nb_max'];
 
 // Champs cachés
 $date_decouverte      = $champs['date_decouverte'];
@@ -169,21 +168,6 @@ if ($edition_active && !$est_complet) {
         <div class="trait-droite"></div>
       </div>
 
-      <div class="bloc-metas-inline">
-
-        <div class="prix chasse-prix" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
-          <span class="cout-affichage" data-cout="<?= esc_attr((int)$cout_points); ?>">
-            <?php if ((int)$cout_points === 0) : ?>
-              <?php echo get_svg_icon('free'); ?>
-              <span class="texte-cout">Gratuit</span>
-            <?php else : ?>
-              <?php echo get_svg_icon('unlock'); ?>
-              <span class="valeur-cout"><?= esc_html($cout_points); ?></span>
-              <span class="prix-devise">pts</span>
-            <?php endif; ?>
-          </span>
-        </div>
-      </div>
       <?php if (!empty($titre_recompense) && (float) $valeur_recompense > 0) : ?>
         <div class="chasse-lot" aria-live="polite">
           <?php echo get_svg_icon('trophee'); ?>


### PR DESCRIPTION
## Résumé
- suppression de l'affichage du coût sur la fiche de chasse
- nettoyage du JavaScript, des styles et de la documentation associés

## Changements notables
- retrait du bloc d'étiquette de coût dans le template de chasse
- simplification des scripts d'édition de chasse et des helpers
- suppression des styles liés au prix dans les fichiers SCSS/CSS

## Testing
- `source ./setup-env.sh`
- `composer install --no-interaction`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeaa6ab54083328f93e29a6fb27598