### PR TITLE
Move status badge outside hunt image

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -31,10 +31,14 @@
   align-items: center;
   justify-content: center;
   height: var(--hunt-img-max-height);
-  position: relative;
 }
 
-.header-chasse__image img {
+.header-chasse__image-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.header-chasse__image-wrapper img {
   max-width: 100%;
   max-height: 100%;
   width: auto;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -281,10 +281,14 @@
   align-items: center;
   justify-content: center;
   height: var(--hunt-img-max-height);
-  position: relative;
 }
 
-.header-chasse__image img {
+.header-chasse__image-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.header-chasse__image-wrapper img {
   max-width: 100%;
   max-height: 100%;
   width: auto;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -116,14 +116,16 @@ if ($edition_active && !$est_complet) {
 
         <div class="champ-affichage">
             <div class="header-chasse__image">
-                <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
-                    <?= esc_html($statut_label); ?>
-                </span>
-                <img src="<?= esc_url($image_url); ?>"
-                    alt="Image de la chasse"
-                    class="chasse-image visuel-cpt"
-                    data-cpt="chasse"
-                    data-post-id="<?= esc_attr($chasse_id); ?>" />
+                <div class="header-chasse__image-wrapper">
+                    <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
+                        <?= esc_html($statut_label); ?>
+                    </span>
+                    <img src="<?= esc_url($image_url); ?>"
+                        alt="Image de la chasse"
+                        class="chasse-image visuel-cpt"
+                        data-cpt="chasse"
+                        data-post-id="<?= esc_attr($chasse_id); ?>" />
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Résumé
- repositionne le badge de statut de la chasse en dehors de l’image
- ajuste les styles et régénère la feuille de style compilée

## Changements notables
- déplacé le badge de statut dans le conteneur de l’image de la chasse
- défini `position: relative` sur la colonne image et reconstruit `style.css`

## Testing
- `npm install`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aeab22d7d88332902e8d9e8a829b29