### PR TITLE
feat: add chasse-fiche image size for responsive display

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -23,6 +23,17 @@ add_action( 'after_setup_theme', 'cta_load_textdomain' );
 
 
 /**
+ * Adds custom image sizes.
+ *
+ * @return void
+ */
+function cta_register_image_sizes() {
+    add_image_size( 'chasse-fiche', 1024, 600, false );
+}
+add_action( 'after_setup_theme', 'cta_register_image_sizes' );
+
+
+/**
  * Retrieves the locale from the cookie.
  *
  * @return string

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1260,7 +1260,7 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
 
     $image_raw = get_field('chasse_principale_image', $chasse_id);
     $image_id  = is_array($image_raw) ? ($image_raw['ID'] ?? null) : $image_raw;
-    $image_url = $image_id ? wp_get_attachment_image_src($image_id, 'large')[0] : null;
+    $image_url = $image_id ? wp_get_attachment_image_src( $image_id, 'chasse-fiche' )[0] : null;
 
     $liens = get_field('chasse_principale_liens', $chasse_id);
     $liens = is_array($liens) ? $liens : [];

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -118,11 +118,19 @@ if ($edition_active && !$est_complet) {
 
       <div class="champ-affichage">
         <div class="header-chasse__image">
-          <img src="<?= esc_url($image_url); ?>"
-            alt="Image de la chasse"
-            class="chasse-image visuel-cpt"
-            data-cpt="chasse"
-            data-post-id="<?= esc_attr($chasse_id); ?>" />
+          <?php
+          echo wp_get_attachment_image(
+              $image_id,
+              'chasse-fiche',
+              false,
+              [
+                  'class'      => 'chasse-image visuel-cpt',
+                  'data-cpt'   => 'chasse',
+                  'data-post-id' => $chasse_id,
+                  'alt'        => __( 'Image de la chasse', 'chassesautresor-com' ),
+              ]
+          );
+          ?>
         </div>
       </div>
 


### PR DESCRIPTION
## Résumé
- ajoute la taille d’image `chasse-fiche`
- remplace l’`img` de la chasse par `wp_get_attachment_image`

## Changements notables
- définition de la taille d’image et son utilisation dans les données de chasse
- génération automatique des balises `srcset`

## Testing
- `npm run build:css`
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aeb16df7508332bf60ba39198358b5