### PR TITLE
Ajout de la classe img-h-max à l'image de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -124,7 +124,7 @@ if ($edition_active && !$est_complet) {
               'chasse-fiche',
               false,
               [
-                  'class'      => 'chasse-image visuel-cpt',
+                  'class'      => 'chasse-image visuel-cpt img-h-max',
                   'data-cpt'   => 'chasse',
                   'data-post-id' => $chasse_id,
                   'alt'        => __( 'Image de la chasse', 'chassesautresor-com' ),


### PR DESCRIPTION
## Résumé
- ajoute la classe `img-h-max` sur l'image principale des chasses

## Changements notables
- applique la classe `img-h-max` dans `wp_get_attachment_image`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm run build:css` *(échoue : Cannot find module 'sass')*


------
https://chatgpt.com/codex/tasks/task_e_68aeb3f97b4c8332b65fad77a76e3ff2