### PR TITLE
Ajout d'un badge de points sur la fiche chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -726,6 +726,30 @@ function afficherErreurGlobale(message) {
   }, 4000); // Disparition après 4 secondes
 }
 
+function mettreAJourBadgeCoutChasse(postId, cout) {
+  const container = document.querySelector('.header-chasse__image');
+  if (!container) return;
+  const labelTpl = container.dataset.coutLabel || '';
+  const ptsLabel = container.dataset.ptsLabel || 'pts';
+  let badge = container.querySelector('.badge-cout');
+  if (cout > 0) {
+    if (!badge) {
+      badge = document.createElement('span');
+      badge.className = 'badge-cout';
+      badge.dataset.postId = postId;
+      container.appendChild(badge);
+    }
+    badge.textContent = `${cout} ${ptsLabel}`;
+    if (labelTpl) {
+      badge.setAttribute('aria-label', labelTpl.replace('%d', cout));
+    }
+  } else if (badge) {
+    badge.remove();
+  }
+}
+
+window.mettreAJourBadgeCoutChasse = mettreAJourBadgeCoutChasse;
+
 // ================================
 // 💾 Enregistrement du coût en points après clic bouton "✓"
 // ================================
@@ -746,6 +770,7 @@ document.querySelectorAll('.champ-cout-points .champ-enregistrer').forEach(bouto
 
     if (champ === 'chasse_infos_cout_points') {
       rafraichirStatutChasse(postId);
+      mettreAJourBadgeCoutChasse(postId, parseInt(valeur, 10));
     }
 
     // Cache les boutons après envoi

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -239,6 +239,9 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
     ];
     if (champsStatut.includes(champ)) {
       rafraichirStatutChasse(postId);
+      if (champ === 'chasse_infos_cout_points' && typeof window.mettreAJourBadgeCoutChasse === 'function') {
+        window.mettreAJourBadgeCoutChasse(postId, parseInt(valeur, 10));
+      }
     }
     const champsResume = ['post_title'];
     if (champsResume.includes(champ) && typeof window.mettreAJourResumeInfos === 'function') {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -40,6 +40,12 @@
   --img-max-height: var(--hunt-img-max-height);
 }
 
+.header-chasse__image .badge-cout {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .header-chasse__image img {
   display: block;
   max-width: 100%;

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -282,21 +282,24 @@
 /* Image container handling full width and limited height */
 .chasse-fiche-container .champ-img .champ-affichage {
   display: block;
+  text-align: center;
 }
 
 .header-chasse__image {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: var(--hunt-img-max-height);
+  display: inline-block;
   position: relative;
+  --img-max-height: var(--hunt-img-max-height);
+}
+
+.header-chasse__image .badge-cout {
+  position: absolute;
+  top: 10px;
+  right: 10px;
 }
 
 .header-chasse__image img {
+  display: block;
   max-width: 100%;
-  max-height: 100%;
-  width: auto;
   height: auto;
   box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -291,6 +291,12 @@
   --img-max-height: var(--hunt-img-max-height);
 }
 
+.header-chasse__image .badge-cout {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .header-chasse__image img {
   display: block;
   max-width: 100%;

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -471,6 +471,12 @@ msgstr ""
 msgid "Coût par tentative : %d points."
 msgstr ""
 
+#: template-parts/chasse/chasse-affichage-complet.php:120
+#: template-parts/chasse/chasse-affichage-complet.php:130
+#, php-format
+msgid "Coût de participation : %d points."
+msgstr ""
+
 #: inc/enigme/affichage.php:741
 #: assets/js/reponse-automatique.js:76
 #: assets/js/reponse-automatique.js:98

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -499,6 +499,12 @@ msgstr "Daily Attempts: %1$d/%2$s"
 msgid "Coût par tentative : %d points."
 msgstr "Attempt cost"
 
+#: template-parts/chasse/chasse-affichage-complet.php:120
+#: template-parts/chasse/chasse-affichage-complet.php:130
+#, php-format
+msgid "Coût de participation : %d points."
+msgstr "Participation cost: %d points."
+
 #: inc/enigme/affichage.php:741 assets/js/reponse-automatique.js:76
 #: assets/js/reponse-automatique.js:98
 msgid "pts"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -499,6 +499,12 @@ msgstr "Tentatives quotidiennes"
 msgid "Coût par tentative : %d points."
 msgstr ""
 
+#: template-parts/chasse/chasse-affichage-complet.php:120
+#: template-parts/chasse/chasse-affichage-complet.php:130
+#, php-format
+msgid "Coût de participation : %d points."
+msgstr "Coût de participation : %d points."
+
 #: inc/enigme/affichage.php:741 assets/js/reponse-automatique.js:76
 #: assets/js/reponse-automatique.js:98
 msgid "pts"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -23,6 +23,7 @@ $date_debut        = $champs['date_debut'];
 $date_fin          = $champs['date_fin'];
 $illimitee         = $champs['illimitee'];
 $nb_max            = $champs['nb_max'];
+$cout_points       = (int) ($champs['cout_points'] ?? 0);
 
 // Champs cachés
 $date_decouverte      = $champs['date_decouverte'];
@@ -114,20 +115,33 @@ if ($edition_active && !$est_complet) {
       data-post-id="<?= esc_attr($chasse_id); ?>">
 
       <div class="champ-affichage">
-        <div class="header-chasse__image">
+        <div
+            class="header-chasse__image"
+            data-cout-label="<?= esc_attr__('Coût de participation : %d points.', 'chassesautresor-com'); ?>"
+            data-pts-label="<?= esc_attr__('pts', 'chassesautresor-com'); ?>"
+        >
           <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
             <?= esc_html($statut_label); ?>
           </span>
+          <?php if ($cout_points > 0) : ?>
+            <span
+                class="badge-cout"
+                data-post-id="<?= esc_attr($chasse_id); ?>"
+                aria-label="<?= esc_attr(sprintf(__('Coût de participation : %d points.', 'chassesautresor-com'), $cout_points)); ?>"
+            >
+              <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
+            </span>
+          <?php endif; ?>
           <?php
           echo wp_get_attachment_image(
               $image_id,
               'chasse-fiche',
               false,
               [
-                  'class'      => 'chasse-image visuel-cpt img-h-max',
-                  'data-cpt'   => 'chasse',
+                  'class'       => 'chasse-image visuel-cpt img-h-max',
+                  'data-cpt'    => 'chasse',
                   'data-post-id' => $chasse_id,
-                  'alt'        => __( 'Image de la chasse', 'chassesautresor-com' ),
+                  'alt'         => __('Image de la chasse', 'chassesautresor-com'),
               ]
           );
           ?>


### PR DESCRIPTION
### Résumé
- Affiche le coût en points directement sur l’image de la chasse
- Met à jour dynamiquement ce badge lors de l’édition du coût
- Ajoute les chaînes de traduction associées

### Testing
- `npm install`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aec405135c8332869681fa401015d3