### PR TITLE
Affiche le détail de la récompense sur la page de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -120,18 +120,13 @@
     color: white;
 }
 .page-chasse-wrapper .chasse-lot {
-    display: flex;
-    gap: 0.7rem;
-    align-items: flex-start;
     margin-bottom: var(--space-md);
     font-size: 20px;
-}
-.page-chasse-wrapper .chasse-lot svg {
-    color: var(--color-secondary);
 }
 
 .page-chasse-wrapper .chasse-lot .lot-title {
     font-weight: 600;
+    margin: 0;
 }
 
 .page-chasse-wrapper .chasse-lot .lot-subtitle {

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -373,19 +373,13 @@
 }
 
 .page-chasse-wrapper .chasse-lot {
-  display: flex;
-  gap: 0.7rem;
-  align-items: flex-start;
   margin-bottom: var(--space-md);
   font-size: 20px;
 }
 
-.page-chasse-wrapper .chasse-lot svg {
-  color: var(--color-secondary);
-}
-
 .page-chasse-wrapper .chasse-lot .lot-title {
   font-weight: 600;
+  margin: 0;
 }
 
 .page-chasse-wrapper .chasse-lot .lot-subtitle {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -373,19 +373,13 @@
 }
 
 .page-chasse-wrapper .chasse-lot {
-  display: flex;
-  gap: 0.7rem;
-  align-items: flex-start;
   margin-bottom: var(--space-md);
   font-size: 20px;
 }
 
-.page-chasse-wrapper .chasse-lot svg {
-  color: var(--color-secondary);
-}
-
 .page-chasse-wrapper .chasse-lot .lot-title {
   font-weight: 600;
+  margin: 0;
 }
 
 .page-chasse-wrapper .chasse-lot .lot-subtitle {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -289,25 +289,22 @@ if ($edition_active && !$est_complet) {
 
         <?php if (!empty($titre_recompense) || (float) $valeur_recompense > 0 || !empty($lot)) : ?>
           <div class="chasse-lot" aria-live="polite">
-            <?php echo get_svg_icon('trophee'); ?>
-            <div>
-              <div class="lot-title"><?= esc_html__('lot à gagner', 'chassesautresor-com'); ?></div>
-              <?php
-              $subtitle_parts = [];
-              if (!empty($titre_recompense)) {
-                  $subtitle_parts[] = esc_html($titre_recompense);
-              }
-              if ((float) $valeur_recompense > 0) {
-                  $subtitle_parts[] = esc_html(number_format_i18n((float) $valeur_recompense, 0)) . ' €';
-              }
-              if (!empty($subtitle_parts)) :
-              ?>
-                <div class="lot-subtitle"><?= implode(' — ', $subtitle_parts); ?></div>
-              <?php endif; ?>
-              <?php if (!empty($lot)) : ?>
-                <div class="lot-description"><?= wp_kses_post($lot); ?></div>
-              <?php endif; ?>
-            </div>
+            <h2 class="lot-title"><?= esc_html__('lot à gagner', 'chassesautresor-com'); ?></h2>
+            <?php
+            $subtitle_parts = [];
+            if (!empty($titre_recompense)) {
+                $subtitle_parts[] = esc_html($titre_recompense);
+            }
+            if ((float) $valeur_recompense > 0) {
+                $subtitle_parts[] = esc_html(number_format_i18n((float) $valeur_recompense, 0)) . ' €';
+            }
+            if (!empty($subtitle_parts)) :
+            ?>
+              <div class="lot-subtitle"><?= implode(' — ', $subtitle_parts); ?></div>
+            <?php endif; ?>
+            <?php if (!empty($lot)) : ?>
+              <div class="lot-description"><?= wp_kses_post($lot); ?></div>
+            <?php endif; ?>
           </div>
         <?php endif; ?>
 


### PR DESCRIPTION
## Résumé
- affiche le lot avec un titre, un sous-titre formatté et sa description sur la page chasse

## Changements notables
- restructure la section `.chasse-lot` pour inclure titre, valeur formatée et description
- ajuste les styles CSS associés

## Testing
- `node build-css.js`
- `composer install --no-interaction`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aeec2cfe3883329dc41222344ff3b5