### PR TITLE
Adaptation de la fiche chasse à la largeur de l'image

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -16,8 +16,11 @@
 .chasse-fiche-container {
   margin-top: var(--space-2xl);
   --grid-gap: 2.6rem;
-  align-items: start;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--grid-gap);
   /* Image container max height (mobile first) */
   --hunt-img-max-height: 200px;
 }
@@ -25,8 +28,11 @@
 
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
-  /* flex: 0 0 400px; /* largeur fixe raisonnable */
+  flex: 0 0 auto;
+  padding: var(--space-xs);
+  width: fit-content;
   max-width: 100%;
+  margin: 0 auto;
 }
 /* Image container handling full width and limited height */
 .chasse-fiche-container .champ-img .champ-affichage {
@@ -81,7 +87,11 @@
 
 @media (--bp-tablet) {
   .chasse-fiche-container {
+    flex-direction: row;
     --hunt-img-max-height: 400px;
+  }
+  .champ-chasse.champ-img {
+    margin: 0;
   }
 }
 
@@ -94,6 +104,7 @@
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
 .chasse-details-wrapper {
   min-width: 240px;
+  flex: 1;
 }
 .header-chasse {
   font-size: 30px;
@@ -195,28 +206,4 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
   border-radius: 999px;
   font-size: 0.8em;
   font-weight: 500;
-}
-
-// Layout responsive: stack on small screens, ~40/60 from tablet upward
-.chasse-section-intro .col-image,
-.chasse-section-intro .col-details {
-  --col-span: 12;
-}
-
-@media (--bp-tablet) {
-  .chasse-section-intro .col-image {
-    --col-span: 3;
-  }
-  .chasse-section-intro .col-details {
-    --col-span: 5;
-  }
-}
-
-@media (--bp-desktop) {
-  .chasse-section-intro .col-image {
-    --col-span: 5;
-  }
-  .chasse-section-intro .col-details {
-    --col-span: 7;
-  }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -267,16 +267,23 @@
 .chasse-fiche-container {
   margin-top: var(--space-2xl);
   --grid-gap: 2.6rem;
-  align-items: start;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--grid-gap);
   /* Image container max height (mobile first) */
   --hunt-img-max-height: 200px;
 }
 
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
-  /* flex: 0 0 400px; /* largeur fixe raisonnable */
+  flex: 0 0 auto;
+  padding: var(--space-xs);
+  width: -moz-fit-content;
+  width: fit-content;
   max-width: 100%;
+  margin: 0 auto;
 }
 
 /* Image container handling full width and limited height */
@@ -331,7 +338,11 @@
 }
 @media (min-width: 768px) {
   .chasse-fiche-container {
+    flex-direction: row;
     --hunt-img-max-height: 400px;
+  }
+  .champ-chasse.champ-img {
+    margin: 0;
   }
 }
 @media (min-width: 1440px) {
@@ -342,6 +353,7 @@
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
 .chasse-details-wrapper {
   min-width: 240px;
+  flex: 1;
 }
 
 .header-chasse {
@@ -450,27 +462,6 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   font-weight: 500;
 }
 
-.chasse-section-intro .col-image,
-.chasse-section-intro .col-details {
-  --col-span: 12;
-}
-
-@media (min-width: 768px) {
-  .chasse-section-intro .col-image {
-    --col-span: 3;
-  }
-  .chasse-section-intro .col-details {
-    --col-span: 5;
-  }
-}
-@media (min-width: 1024px) {
-  .chasse-section-intro .col-image {
-    --col-span: 5;
-  }
-  .chasse-section-intro .col-details {
-    --col-span: 7;
-  }
-}
 /* ========== 🛒 AJOUT AU PANIER ========== */
 .woocommerce a.button.add_to_cart_button {
   font-weight: 500;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -267,16 +267,23 @@
 .chasse-fiche-container {
   margin-top: var(--space-2xl);
   --grid-gap: 2.6rem;
-  align-items: start;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--grid-gap);
   /* Image container max height (mobile first) */
   --hunt-img-max-height: 200px;
 }
 
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
-  /* flex: 0 0 400px; /* largeur fixe raisonnable */
+  flex: 0 0 auto;
+  padding: var(--space-xs);
+  width: -moz-fit-content;
+  width: fit-content;
   max-width: 100%;
+  margin: 0 auto;
 }
 
 /* Image container handling full width and limited height */
@@ -331,7 +338,11 @@
 }
 @media (min-width: 768px) {
   .chasse-fiche-container {
+    flex-direction: row;
     --hunt-img-max-height: 400px;
+  }
+  .champ-chasse.champ-img {
+    margin: 0;
   }
 }
 @media (min-width: 1440px) {
@@ -342,6 +353,7 @@
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
 .chasse-details-wrapper {
   min-width: 240px;
+  flex: 1;
 }
 
 .header-chasse {
@@ -450,27 +462,6 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   font-weight: 500;
 }
 
-.chasse-section-intro .col-image,
-.chasse-section-intro .col-details {
-  --col-span: 12;
-}
-
-@media (min-width: 768px) {
-  .chasse-section-intro .col-image {
-    --col-span: 3;
-  }
-  .chasse-section-intro .col-details {
-    --col-span: 5;
-  }
-}
-@media (min-width: 1024px) {
-  .chasse-section-intro .col-image {
-    --col-span: 5;
-  }
-  .chasse-section-intro .col-details {
-    --col-span: 7;
-  }
-}
 /* ========== 🛒 AJOUT AU PANIER ========== */
 .woocommerce a.button.add_to_cart_button {
   font-weight: 500;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -81,7 +81,7 @@ if ($edition_active && !$est_complet) {
 
 <section class="<?= esc_attr($classe_intro); ?>">
 
-  <div class="chasse-fiche-container row">
+  <div class="chasse-fiche-container">
     <?php
     $statut = $infos_chasse['statut'];
     $statut_validation = $infos_chasse['statut_validation'];
@@ -118,7 +118,7 @@ if ($edition_active && !$est_complet) {
     <?php endif; ?>
 
     <!-- 📷 Image principale -->
-    <div class="champ-chasse champ-img col-image <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
+    <div class="champ-chasse champ-img <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
       data-champ="chasse_principale_image"
       data-cpt="chasse"
       data-post-id="<?= esc_attr($chasse_id); ?>">
@@ -176,7 +176,7 @@ if ($edition_active && !$est_complet) {
 
 
     <!-- 📟 Informations -->
-    <div class="chasse-details-wrapper col-details">
+    <div class="chasse-details-wrapper">
 
       <!-- Titre dynamique -->
       <h1 class="titre-objet header-chasse"


### PR DESCRIPTION
## Résumé
- ajuste la fiche chasse pour que l'image et le descriptif ne dépendent plus de la grille
- le conteneur de l'image épouse la largeur du visuel avec un léger padding

## Changements notables
- conteneur flex permettant d'empiler sur mobile et d'aligner sur tablette et plus
- retrait des classes de grille dans le template de la chasse

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68af51304c648332b4f27657e98e8cae