### PR TITLE
Déplace la récompense dans la fiche chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -294,24 +294,21 @@ if ($edition_active && !$est_complet) {
       </div>
 
         <?php if (!empty($titre_recompense) || (float) $valeur_recompense > 0 || !empty($lot)) : ?>
-          <div class="chasse-lot" aria-live="polite">
-            <h2 class="lot-title"><?= esc_html__('lot à gagner', 'chassesautresor-com'); ?></h2>
-            <?php
-            $subtitle_parts = [];
-            if (!empty($titre_recompense)) {
-                $subtitle_parts[] = esc_html($titre_recompense);
-            }
-            if ((float) $valeur_recompense > 0) {
-                $subtitle_parts[] = esc_html(number_format_i18n((float) $valeur_recompense, 0)) . ' €';
-            }
-            if (!empty($subtitle_parts)) :
-            ?>
-              <div class="lot-subtitle"><?= implode(' — ', $subtitle_parts); ?></div>
-            <?php endif; ?>
-            <?php if (!empty($lot)) : ?>
-              <div class="lot-description"><?= wp_kses_post($lot); ?></div>
-            <?php endif; ?>
-          </div>
+            <div class="chasse-lot-complet" style="margin-top: 30px;">
+                <h3><?= '🏆 ' . esc_html__('Récompense de la chasse', 'chassesautresor-com'); ?></h3>
+
+                <?php if (!empty($titre_recompense)) : ?>
+                    <p><strong><?= esc_html__('Titre :', 'chassesautresor-com'); ?></strong> <?= esc_html($titre_recompense); ?></p>
+                <?php endif; ?>
+
+                <?php if ((float) $valeur_recompense > 0) : ?>
+                    <p><strong><?= esc_html__('Valeur :', 'chassesautresor-com'); ?></strong> <?= esc_html($valeur_recompense); ?> €</p>
+                <?php endif; ?>
+
+                <?php if (!empty($lot)) : ?>
+                    <p><strong><?= esc_html__('Description complète :', 'chassesautresor-com'); ?></strong><br><?= wp_kses_post($lot); ?></p>
+                <?php endif; ?>
+            </div>
         <?php endif; ?>
 
         <?php

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -2,38 +2,13 @@
 defined('ABSPATH') || exit;
 
 $description = $args['description'] ?? '';
-$titre_recompense = $args['titre_recompense'] ?? '';
-$lot = $args['lot'] ?? '';
-$valeur_recompense = $args['valeur_recompense'] ?? '';
-$chasse_id = $args['chasse_id'] ?? 0;
-$nb_max = $args['nb_max'] ?? 0;
-$mode = $args['mode'] ?? 'complet'; // 'complet' ou 'compact'
 ?>
 
 
 <section class="chasse-description-section bloc-elegant" id="chasse-description">
-  <?php if (!empty($description)) : ?>
-    <div class="chasse-description">
-      <?= wp_kses_post($description); ?>
-    </div>
-  <?php endif; ?>
-
-  <?php if (!empty($titre_recompense) || (float) $valeur_recompense > 0 || !empty($lot)) : ?>
-    <div class="chasse-lot-complet" style="margin-top: 30px;">
-      <h3>🏆 Récompense de la chasse</h3>
-
-      <?php if (!empty($titre_recompense)) : ?>
-        <p><strong>Titre :</strong> <?= esc_html($titre_recompense); ?></p>
-      <?php endif; ?>
-
-      <?php if ((float) $valeur_recompense > 0) : ?>
-        <p><strong>Valeur :</strong> <?= esc_html($valeur_recompense); ?> €</p>
-      <?php endif; ?>
-
-      <?php if (!empty($lot)) : ?>
-        <p><strong>Description complète :</strong><br><?= wp_kses_post($lot); ?></p>
-      <?php endif; ?>
-
-    </div>
-  <?php endif; ?>
+    <?php if (!empty($description)) : ?>
+        <div class="chasse-description">
+            <?= wp_kses_post($description); ?>
+        </div>
+    <?php endif; ?>
 </section>


### PR DESCRIPTION
## Résumé
- déplace la section de récompense depuis la description vers la fiche chasse

## Changements
- supprime l'affichage de la récompense de la section de description
- insère le bloc de récompense complet dans la fiche chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68afc91e970883328a619adbe26ddeb2