### PR TITLE
feat: update chasse badges dynamically

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -261,4 +261,45 @@ describe('chasse-edit UI', () => {
     expect(input.disabled).toBe(true);
     expect(input.value).toBe('0');
   });
+
+  test('cost badge updates on input change', () => {
+    const container = document.createElement('div');
+    container.className = 'header-chasse__image';
+    container.dataset.coutLabel = 'Coût de participation : %d points.';
+    container.dataset.ptsLabel = 'pts';
+    document.body.appendChild(container);
+
+    const input = document.querySelector('.champ-cout');
+    input.value = '25';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const badge = container.querySelector('.badge-cout');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe('25 pts');
+    expect(badge.getAttribute('aria-label')).toBe('Coût de participation : 25 points.');
+  });
+
+  test('mode badge updates on toggle change', () => {
+    const container = document.createElement('div');
+    container.className = 'header-chasse__image';
+    container.dataset.modeAutoLabel = 'mode de fin de chasse : automatique';
+    container.dataset.modeManuelLabel = 'mode de fin de chasse : manuelle';
+    container.dataset.modeAutoIcon = '<i class="fa-solid fa-bolt"></i>';
+    container.dataset.modeManuelIcon = '<i class="hand"></i>';
+    const icone = document.createElement('span');
+    icone.className = 'mode-fin-icone';
+    container.appendChild(icone);
+    document.body.appendChild(container);
+
+    const toggle = document.getElementById('chasse_mode_fin');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(icone.innerHTML).toBe('<i class="hand"></i>');
+    expect(icone.getAttribute('title')).toBe('mode de fin de chasse : manuelle');
+
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(icone.innerHTML).toBe('<i class="fa-solid fa-bolt"></i>');
+    expect(icone.getAttribute('title')).toBe('mode de fin de chasse : automatique');
+  });
 });

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -750,6 +750,32 @@ function mettreAJourBadgeCoutChasse(postId, cout) {
 
 window.mettreAJourBadgeCoutChasse = mettreAJourBadgeCoutChasse;
 
+function mettreAJourBadgeModeFinChasse(mode) {
+  const container = document.querySelector('.header-chasse__image');
+  if (!container) return;
+  const icone = container.querySelector('.mode-fin-icone');
+  if (!icone) return;
+  const autoLabel = container.dataset.modeAutoLabel || '';
+  const manuelLabel = container.dataset.modeManuelLabel || '';
+  const autoIcon = container.dataset.modeAutoIcon || '';
+  const manuelIcon = container.dataset.modeManuelIcon || '';
+  if (mode === 'automatique') {
+    icone.innerHTML = autoIcon;
+    if (autoLabel) {
+      icone.setAttribute('title', autoLabel);
+      icone.setAttribute('aria-label', autoLabel);
+    }
+  } else {
+    icone.innerHTML = manuelIcon;
+    if (manuelLabel) {
+      icone.setAttribute('title', manuelLabel);
+      icone.setAttribute('aria-label', manuelLabel);
+    }
+  }
+}
+
+window.mettreAJourBadgeModeFinChasse = mettreAJourBadgeModeFinChasse;
+
 // ================================
 // 💾 Enregistrement du coût en points après clic bouton "✓"
 // ================================
@@ -792,9 +818,11 @@ document.querySelectorAll('.champ-cout-points .champ-annuler').forEach(bouton =>
     const li = bouton.closest('li');
     const input = li.querySelector('.champ-input');
     if (!li || !input) return;
+    const postId = li.dataset.postId;
 
     // Restaure l'ancienne valeur
     input.value = input.dataset.valeurInitiale || '0';
+    mettreAJourBadgeCoutChasse(postId, parseInt(input.value.trim(), 10) || 0);
 
     // Cache les boutons
     const boutons = li.querySelector('.champ-inline-actions');
@@ -940,8 +968,9 @@ function initChampCoutPoints() {
   const input = document.querySelector('.champ-cout-points .champ-cout');
   const toggle = document.getElementById('cout-payant');
   const actions = input?.closest('.cout-points-actions');
+  const postId = input?.closest('li')?.dataset.postId;
 
-  if (!input || !toggle || !actions) return;
+  if (!input || !toggle || !actions || !postId) return;
 
   function updateVisibility() {
     if (toggle.checked) {
@@ -959,6 +988,11 @@ function initChampCoutPoints() {
 
     input.dispatchEvent(new Event('input', { bubbles: true }));
   }
+
+  input.addEventListener('input', () => {
+    const valeur = parseInt(input.value.trim(), 10) || 0;
+    mettreAJourBadgeCoutChasse(postId, valeur);
+  });
 
   toggle.addEventListener('change', updateVisibility);
   updateVisibility();
@@ -1012,6 +1046,8 @@ function initModeFinChasse() {
 
       mettreAJourAffichageNbGagnants(postId, 0);
     }
+
+    mettreAJourBadgeModeFinChasse(selected);
   }
 
   toggle.addEventListener('change', () => update(true));

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -128,6 +128,10 @@ if ($edition_active && !$est_complet) {
             class="header-chasse__image"
             data-cout-label="<?= esc_attr__('Coût de participation : %d points.', 'chassesautresor-com'); ?>"
             data-pts-label="<?= esc_attr__('pts', 'chassesautresor-com'); ?>"
+            data-mode-auto-label="<?= esc_attr__('mode de fin de chasse : automatique', 'chassesautresor-com'); ?>"
+            data-mode-manuel-label="<?= esc_attr__('mode de fin de chasse : manuelle', 'chassesautresor-com'); ?>"
+            data-mode-auto-icon="<?= esc_attr('<i class="fa-solid fa-bolt"></i>'); ?>"
+            data-mode-manuel-icon="<?= esc_attr(get_svg_icon('hand')); ?>"
         >
             <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>"
               data-post-id="<?= esc_attr($chasse_id); ?>">
@@ -147,7 +151,7 @@ if ($edition_active && !$est_complet) {
                 <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
               </span>
             <?php endif; ?>
-            <span class="mode-fin-icone" title="<?= esc_attr($title_mode); ?>">
+            <span class="mode-fin-icone" title="<?= esc_attr($title_mode); ?>" aria-label="<?= esc_attr($title_mode); ?>">
               <?php if ($mode_fin === 'automatique') : ?>
                 <i class="fa-solid fa-bolt"></i>
               <?php else : ?>


### PR DESCRIPTION
### Résumé
Actualise en temps réel les badges de coût et de mode de fin sur l’image de la chasse pendant l’édition.

### Changements
- Rafraîchissement immédiat du badge de coût lors des modifications et annulations
- Mise à jour dynamique de l’icône de mode de fin via de nouveaux attributs de données
- Tests Jest ajoutés pour vérifier la mise à jour des badges

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afc8bb4f3c83328063a5a898a1515e