### PR TITLE
feat: keep hunt image visible while scrolling

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -92,6 +92,8 @@
   }
   .champ-chasse.champ-img {
     margin: 0;
+    position: sticky;
+    top: 0;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -343,6 +343,8 @@
   }
   .champ-chasse.champ-img {
     margin: 0;
+    position: sticky;
+    top: 0;
   }
 }
 @media (min-width: 1440px) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -343,6 +343,8 @@
   }
   .champ-chasse.champ-img {
     margin: 0;
+    position: sticky;
+    top: 0;
   }
 }
 @media (min-width: 1440px) {


### PR DESCRIPTION
### Résumé
- Maintient l’image de la chasse visible lors du défilement des détails

### Changements notables
- Ajout d’un positionnement `sticky` sur l’image principale pour qu’elle reste à l’écran pendant la lecture des informations

### Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afca101b58833297407a10cfe76a94