### PR TITLE
Déplace la description dans la fiche chasse

### DIFF
--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -184,19 +184,6 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
 
     <div class="separateur-avec-icone"></div>
 
-    <!-- 📜 Description finale -->
-    <?php
-    get_template_part('template-parts/chasse/chasse-partial-description', null, [
-      'description' => $description,
-      'titre_recompense' => $titre_recompense,
-      'lot' => $lot,
-      'valeur_recompense' => $valeur_recompense,
-      'nb_max' => $nb_max,
-      'chasse_id' => $chasse_id,
-      'mode' => 'complet'
-    ]);
-    ?>
-
       <!-- 🧩 Liste des énigmes -->
       <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">
       <header class="chasse-enigmes-header">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -217,6 +217,15 @@ if ($edition_active && !$est_complet) {
         <div class="icone-svg"></div>
         <div class="trait-droite"></div>
       </div>
+      <?php
+      get_template_part(
+          'template-parts/chasse/chasse-partial-description',
+          null,
+          [
+              'description' => $infos_chasse['description'] ?? '',
+          ]
+      );
+      ?>
 
       <div class="chasse-caracteristiques">
         <?php if ($mode_fin === 'automatique' && (int) $nb_max > 0) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -2,13 +2,11 @@
 defined('ABSPATH') || exit;
 
 $description = $args['description'] ?? '';
-?>
 
-
-<section class="chasse-description-section bloc-elegant" id="chasse-description">
-    <?php if (!empty($description)) : ?>
-        <div class="chasse-description">
-            <?= wp_kses_post($description); ?>
-        </div>
-    <?php endif; ?>
-</section>
+if (!empty($description)) :
+    ?>
+    <div class="chasse-description" id="chasse-description">
+        <?= wp_kses_post($description); ?>
+    </div>
+    <?php
+endif;


### PR DESCRIPTION
## Résumé
- Intégration de la description directement dans la fiche chasse
- Nettoyage de l'ancien bloc de description séparé

## Changements notables
- Déplacement du bloc `chasse-description` avant les caractéristiques
- Suppression de l'appel inutile au template de description sur la page chasse

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68afce02d9b483328b446cfe90e0a061