### PR TITLE
Add lightbox to chasse image

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -158,21 +158,28 @@ if ($edition_active && !$est_complet) {
                 <?= get_svg_icon('hand'); ?>
               <?php endif; ?>
             </span>
-          <?php
-          echo wp_get_attachment_image(
-              $image_id,
-              'chasse-fiche',
-              false,
-              [
-                  'class'       => 'chasse-image visuel-cpt img-h-max',
-                  'data-cpt'    => 'chasse',
-                  'data-post-id' => $chasse_id,
-                  'alt'         => __('Image de la chasse', 'chassesautresor-com'),
-              ]
-          );
-          ?>
+            <?php if ($image_id) : ?>
+              <a
+                href="<?= esc_url(wp_get_attachment_image_url($image_id, 'full')); ?>"
+                class="fancybox"
+              >
+                <?php
+                echo wp_get_attachment_image(
+                    $image_id,
+                    'chasse-fiche',
+                    false,
+                    [
+                        'class'       => 'chasse-image visuel-cpt img-h-max',
+                        'data-cpt'    => 'chasse',
+                        'data-post-id' => $chasse_id,
+                        'alt'         => __('Image de la chasse', 'chassesautresor-com'),
+                    ]
+                );
+                ?>
+              </a>
+            <?php endif; ?>
+          </div>
         </div>
-      </div>
 
       <input type="hidden" class="champ-input" value="<?= esc_attr($image_id); ?>">
       <div class="champ-feedback"></div>


### PR DESCRIPTION
## Résumé
- Ajout de la lightbox Firelight sur l’image principale des chasses

## Changements notables
- L’image principale est désormais entourée d’un lien vers sa version originale pour l’ouvrir avec Firelight Lightbox

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68afd1aa7e3c83328bcee3bfa47deb68