### PR TITLE
Affiche un CTA désactivé pour les admins

### DIFF
--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -1,0 +1,87 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($capability) {
+        return $capability === 'administrator';
+    }
+}
+
+if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+    function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) {
+        return false;
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($field, $post_id) {
+        return null;
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($id) {
+        return '';
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain) {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url) {
+        return $url;
+    }
+}
+
+if (!function_exists('get_user_points')) {
+    function get_user_points($user_id) {
+        return 0;
+    }
+}
+
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id() {
+        return 1;
+    }
+}
+
+if (!function_exists('wp_nonce_field')) {
+    function wp_nonce_field($action, $name, $referer = true, $echo = false) {
+        return '';
+    }
+}
+
+if (!function_exists('site_url')) {
+    function site_url($path = '') {
+        return $path;
+    }
+}
+
+if (!function_exists('date_i18n')) {
+    function date_i18n($format, $timestamp) {
+        return '';
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+class GenererCtaChasseTest extends TestCase
+{
+    public function test_admin_or_organizer_gets_disabled_button(): void
+    {
+        $cta = generer_cta_chasse(123, 5);
+        $this->assertSame(
+            [
+                'cta_html'    => '<button class="bouton-cta" disabled>Participer</button>',
+                'cta_message' => '',
+                'type'        => 'indisponible',
+            ],
+            $cta
+        );
+    }
+}
+

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -609,9 +609,16 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         ];
     }
 
-    // 🔐 Admin ou organisateur : pas de bouton
+    // 🔐 Admin or organiser: disabled participation button
     if (current_user_can('administrator') || utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
-        return ['cta_html' => '', 'cta_message' => '', 'type' => ''];
+        return [
+            'cta_html'    => sprintf(
+                '<button class="bouton-cta" disabled>%s</button>',
+                esc_html__( 'Participer', 'chassesautresor-com' )
+            ),
+            'cta_message' => '',
+            'type'        => 'indisponible',
+        ];
     }
 
     // ✅ Déjà engagé


### PR DESCRIPTION
## Résumé
- affiche un bouton "Participer" désactivé pour les administrateurs ou organisateurs
- couvre le comportement par un test unitaire

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68afd14ba3808332b3c61c6498a7e321