### PR TITLE
feat: restructure hunt CTA section

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -164,10 +164,36 @@
   line-height: 1.3;
 }
 
+
 .chasse-caracteristiques .caracteristique {
   display: flex;
-  gap: var(--space-md);
+  gap: var(--space-sm);
   margin-bottom: var(--space-xs);
+}
+
+.chasse-cta-section {
+  display: flex;
+  gap: var(--space-xl);
+  align-items: center;
+  text-align: left;
+  width: 100%;
+  max-width: 100%;
+}
+
+.chasse-cta-section .chasse-caracteristiques {
+  margin-top: 0;
+  flex: 1;
+}
+
+.chasse-cta-section .cta-chasse-row {
+  flex: 0 0 auto;
+  text-align: center;
+}
+
+@media (--bp-tablet) {
+  .chasse-cta-section {
+    max-width: 650px;
+  }
 }
 
 .chasse-caracteristiques .caracteristique-label {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -162,13 +162,16 @@
   margin-top: var(--space-lg);
   font-size: 0.8rem;
   line-height: 1.3;
+  color: var(--color-editor-text-muted);
+  text-align: left;
+  width: fit-content;
 }
 
 
 .chasse-caracteristiques .caracteristique {
   display: flex;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-xs);
+  gap: var(--space-xxs);
+  margin-bottom: var(--space-xxs);
 }
 
 .chasse-cta-section {
@@ -182,12 +185,14 @@
 
 .chasse-cta-section .chasse-caracteristiques {
   margin-top: 0;
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .chasse-cta-section .cta-chasse-row {
-  flex: 0 0 auto;
+  flex: 1;
   text-align: center;
+  display: flex;
+  justify-content: center;
 }
 
 @media (--bp-tablet) {
@@ -197,12 +202,12 @@
 }
 
 .chasse-caracteristiques .caracteristique-label {
-  flex: 0 0 9rem;
+  flex: 0 0 6rem;
   font-weight: 700;
 }
 
 .chasse-caracteristiques .caracteristique-valeur {
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 /* ========== 🧾 BLOC PRÉSENTATION DE LA CHASSE ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -417,12 +417,15 @@
   margin-top: var(--space-lg);
   font-size: 0.8rem;
   line-height: 1.3;
+  color: var(--color-editor-text-muted);
+  text-align: left;
+  width: fit-content;
 }
 
 .chasse-caracteristiques .caracteristique {
   display: flex;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-xs);
+  gap: var(--space-xxs);
+  margin-bottom: var(--space-xxs);
 }
 
 .chasse-cta-section {
@@ -436,12 +439,14 @@
 
 .chasse-cta-section .chasse-caracteristiques {
   margin-top: 0;
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .chasse-cta-section .cta-chasse-row {
-  flex: 0 0 auto;
+  flex: 1;
   text-align: center;
+  display: flex;
+  justify-content: center;
 }
 
 @media (min-width: 768px) {
@@ -450,12 +455,12 @@
   }
 }
 .chasse-caracteristiques .caracteristique-label {
-  flex: 0 0 9rem;
+  flex: 0 0 6rem;
   font-weight: 700;
 }
 
 .chasse-caracteristiques .caracteristique-valeur {
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 /* ========== 🧾 BLOC PRÉSENTATION DE LA CHASSE ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -421,10 +421,34 @@
 
 .chasse-caracteristiques .caracteristique {
   display: flex;
-  gap: var(--space-md);
+  gap: var(--space-sm);
   margin-bottom: var(--space-xs);
 }
 
+.chasse-cta-section {
+  display: flex;
+  gap: var(--space-xl);
+  align-items: center;
+  text-align: left;
+  width: 100%;
+  max-width: 100%;
+}
+
+.chasse-cta-section .chasse-caracteristiques {
+  margin-top: 0;
+  flex: 1;
+}
+
+.chasse-cta-section .cta-chasse-row {
+  flex: 0 0 auto;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .chasse-cta-section {
+    max-width: 650px;
+  }
+}
 .chasse-caracteristiques .caracteristique-label {
   flex: 0 0 9rem;
   font-weight: 700;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -417,12 +417,15 @@
   margin-top: var(--space-lg);
   font-size: 0.8rem;
   line-height: 1.3;
+  color: var(--color-editor-text-muted);
+  text-align: left;
+  width: fit-content;
 }
 
 .chasse-caracteristiques .caracteristique {
   display: flex;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-xs);
+  gap: var(--space-xxs);
+  margin-bottom: var(--space-xxs);
 }
 
 .chasse-cta-section {
@@ -436,12 +439,14 @@
 
 .chasse-cta-section .chasse-caracteristiques {
   margin-top: 0;
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .chasse-cta-section .cta-chasse-row {
-  flex: 0 0 auto;
+  flex: 1;
   text-align: center;
+  display: flex;
+  justify-content: center;
 }
 
 @media (min-width: 768px) {
@@ -450,12 +455,12 @@
   }
 }
 .chasse-caracteristiques .caracteristique-label {
-  flex: 0 0 9rem;
+  flex: 0 0 6rem;
   font-weight: 700;
 }
 
 .chasse-caracteristiques .caracteristique-valeur {
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 /* ========== 🧾 BLOC PRÉSENTATION DE LA CHASSE ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -421,10 +421,34 @@
 
 .chasse-caracteristiques .caracteristique {
   display: flex;
-  gap: var(--space-md);
+  gap: var(--space-sm);
   margin-bottom: var(--space-xs);
 }
 
+.chasse-cta-section {
+  display: flex;
+  gap: var(--space-xl);
+  align-items: center;
+  text-align: left;
+  width: 100%;
+  max-width: 100%;
+}
+
+.chasse-cta-section .chasse-caracteristiques {
+  margin-top: 0;
+  flex: 1;
+}
+
+.chasse-cta-section .cta-chasse-row {
+  flex: 0 0 auto;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .chasse-cta-section {
+    max-width: 650px;
+  }
+}
 .chasse-caracteristiques .caracteristique-label {
   flex: 0 0 9rem;
   font-weight: 700;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -224,23 +224,27 @@ if ($edition_active && !$est_complet) {
         <div class="icone-svg"></div>
         <div class="trait-droite"></div>
       </div>
-      <?php
-      get_template_part(
-          'template-parts/chasse/chasse-partial-description',
-          null,
-          [
-              'description' => $infos_chasse['description'] ?? '',
-          ]
-      );
-      ?>
+        <?php
+        get_template_part(
+            'template-parts/chasse/chasse-partial-description',
+            null,
+            [
+                'description' => $infos_chasse['description'] ?? '',
+            ]
+        );
+        ?>
 
-      <div class="chasse-caracteristiques">
-        <?php if ($mode_fin === 'automatique' && (int) $nb_max > 0) : ?>
-          <div class="caracteristique">
-            <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
-            <span class="caracteristique-valeur"><?= sprintf(esc_html__('%d gagnants', 'chassesautresor-com'), $nb_max); ?></span>
-          </div>
-        <?php endif; ?>
+        <?php
+        $cta_data = $infos_chasse['cta_data'] ?? [];
+        ?>
+        <div class="chasse-cta-section cta-chasse">
+          <div class="chasse-caracteristiques">
+          <?php if ($mode_fin === 'automatique' && (int) $nb_max > 0) : ?>
+            <div class="caracteristique">
+              <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
+              <span class="caracteristique-valeur"><?= sprintf(esc_html__('%d gagnants', 'chassesautresor-com'), $nb_max); ?></span>
+            </div>
+          <?php endif; ?>
 
           <div class="caracteristique">
             <span class="caracteristique-label"><?= esc_html__('Fin de chasse', 'chassesautresor-com'); ?></span>
@@ -310,8 +314,16 @@ if ($edition_active && !$est_complet) {
               <span class="caracteristique-valeur"><?= esc_html($txt_top); ?></span>
             </div>
           <?php endif; ?>
-        <?php endif; ?>
-      </div>
+          <?php endif; ?>
+          </div>
+
+          <?php if (($cta_data['type'] ?? '') !== 'engage') : ?>
+            <div class="cta-chasse-row">
+              <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
+              <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
+            </div>
+          <?php endif; ?>
+        </div>
 
         <?php if (!empty($titre_recompense) || (float) $valeur_recompense > 0 || !empty($lot)) : ?>
             <div class="chasse-lot-complet" style="margin-top: 30px;">
@@ -329,16 +341,6 @@ if ($edition_active && !$est_complet) {
                     <p><strong><?= esc_html__('Description complète :', 'chassesautresor-com'); ?></strong><br><?= wp_kses_post($lot); ?></p>
                 <?php endif; ?>
             </div>
-        <?php endif; ?>
-
-        <?php
-        $cta_data = $infos_chasse['cta_data'] ?? [];
-        if (($cta_data['type'] ?? '') !== 'engage') :
-        ?>
-          <div class="cta-chasse-row">
-            <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
-            <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
-          </div>
         <?php endif; ?>
 
       </div>


### PR DESCRIPTION
## Résumé
- regroupe les caractéristiques et l'appel à l'action dans une section dédiée
- applique un style CTA existant avec largeur adaptable
- réduit l'espacement entre libellé et valeur des caractéristiques

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68afe121d2ec833294dbfcd5247beed4