### PR TITLE
docs: retirer le champ commentaire chasse

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -1,7 +1,7 @@
 🔹 Groupe : paramètre de la chasse
 🆔 ID : 27
 🔑 Key : group_67b58c51b9a49
-📦 Champs trouvés : 20
+📦 Champs trouvés : 19
 
 — chasse_principale_image —
 Type : image
@@ -113,12 +113,6 @@ Requis : non
 Type : relationship
 Label : Énigmes associées
 Instructions : Sélectionnez les énigmes associées à cette chasse
-Requis : non
-----------------------------------------
-— chasse_cache_commentaire —
-Type : textarea
-Label : commentaire validation
-Instructions : (vide)
 Requis : non
 ----------------------------------------
 — chasse_cache_organisateur —

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -368,7 +368,6 @@ Groupe : paramètre de la chasse
 * chasse_cache_gagnants (text)
 * chasse_cache_date_decouverte (date_picker)
 * chasse_cache_enigmes (relationship)
-* chasse_cache_commentaire (textarea)
 * chasse_cache_organisateur (relationship)
 * chasse_cache_statut_validation (select)
 * chasse_cache_statut (select)


### PR DESCRIPTION
## Résumé
- retirer le champ `chasse_cache_commentaire` de la documentation

## Changements notables
- mise à jour de la liste des champs ACF
- suppression de la référence dans la documentation globale

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68afe298097c8332b64d1723b9bfe0d4