### PR TITLE
Supprime l’en-tête des énigmes et recentre les liens

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -24,6 +24,15 @@
   gap: var(--grid-gap);
 }
 
+.chasse-visuel-wrapper {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 auto;
+  gap: var(--space-xs);
+}
+
 
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
@@ -92,12 +101,14 @@
     flex-direction: row;
     --hunt-img-max-height: 800px;
   }
-  .champ-chasse.champ-img {
-    margin: 0;
+  .chasse-visuel-wrapper {
     position: sticky;
     top: 0;
-    flex: 0 0 auto;
     max-width: 40%;
+    margin: 0;
+  }
+  .champ-chasse.champ-img {
+    margin: 0;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -502,6 +502,7 @@ body .header-img-modifiable .icone-modif {
 .champ-liens .champ-affichage-liens {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .dashboard-card.champ-liens .icone-defaut {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2310,6 +2310,7 @@ body .header-img-modifiable .icone-modif {
 .champ-liens .champ-affichage-liens {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .dashboard-card.champ-liens .icone-defaut, .champ-liens.carte-orgy .icone-defaut {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -275,6 +275,15 @@
   gap: var(--grid-gap);
 }
 
+.chasse-visuel-wrapper {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 auto;
+  gap: var(--space-xs);
+}
+
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
   flex: 0 0 auto;
@@ -343,12 +352,14 @@
     flex-direction: row;
     --hunt-img-max-height: 800px;
   }
-  .champ-chasse.champ-img {
-    margin: 0;
+  .chasse-visuel-wrapper {
     position: sticky;
     top: 0;
-    flex: 0 0 auto;
     max-width: 40%;
+    margin: 0;
+  }
+  .champ-chasse.champ-img {
+    margin: 0;
   }
 }
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -182,59 +182,31 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     ]);
     ?>
 
-    <div class="separateur-avec-icone"></div>
-
-      <!-- 🧩 Liste des énigmes -->
-      <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">
-      <header class="chasse-enigmes-header">
-        <div class="barre-progression">
-          <div class="remplissage" style="width: <?= ($total_enigmes ? round(100 * $enigmes_resolues / $total_enigmes) : 0); ?>%;"></div>
+    <!-- 🧩 Liste des énigmes -->
+    <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">
+        <div class="titre-enigmes-wrapper">
+            <h2>Énigmes</h2>
+            <?php if ($peut_ajouter_enigme && $total_enigmes > 0 && !$has_incomplete_enigme) :
+                get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
+                    'has_enigmes' => true,
+                    'chasse_id'   => $chasse_id,
+                    'use_button'  => true,
+                ]);
+            endif; ?>
+        </div>
+        <div id="liste-enigmes" class="chasse-enigmes-liste">
+            <?php
+            get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [
+                'chasse_id'       => $chasse_id,
+                'est_orga_associe'=> $est_orga_associe,
+                'infos_chasse'    => $infos_chasse,
+            ]);
+            ?>
         </div>
 
-        <?php if (!empty($date_decouverte_formatee)) : ?>
-          <div class="meta-etiquette">🕵️‍♂️ Trouvée le <?= esc_html($date_decouverte_formatee); ?></div>
-        <?php endif; ?>
+        <footer class="chasse-enigmes-footer">
 
-        <?php
-        $liens = $infos_chasse['liens'];
-        $vide  = empty($liens);
-        ?>
-        <div class="champ-chasse champ-liens champ-fiche-publication <?= $vide ? 'champ-vide' : 'champ-rempli'; ?>"
-          data-champ="chasse_principale_liens"
-          data-cpt="chasse"
-          data-post-id="<?= esc_attr($chasse_id); ?>">
-          <div class="champ-donnees"
-            data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
-          <div class="champ-affichage">
-            <?= render_liens_publics($liens, 'chasse', ['afficher_titre' => false, 'wrap' => false]); ?>
-          </div>
-          <div class="champ-feedback"></div>
-        </div>
-      </header>
-
-      <div class="titre-enigmes-wrapper">
-        <h2>Énigmes</h2>
-        <?php if ($peut_ajouter_enigme && $total_enigmes > 0 && !$has_incomplete_enigme) :
-          get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
-            'has_enigmes' => true,
-            'chasse_id'   => $chasse_id,
-            'use_button'  => true,
-          ]);
-        endif; ?>
-      </div>
-      <div id="liste-enigmes" class="chasse-enigmes-liste">
-        <?php
-        get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [
-          'chasse_id'       => $chasse_id,
-          'est_orga_associe'=> $est_orga_associe,
-          'infos_chasse'    => $infos_chasse,
-        ]);
-        ?>
-      </div>
-
-      <footer class="chasse-enigmes-footer">
-
-      </footer>
+        </footer>
     </section>
 
   </main>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -118,90 +118,90 @@ if ($edition_active && !$est_complet) {
       </button>
     <?php endif; ?>
 
-    <!-- 📷 Image principale -->
-    <div class="champ-chasse champ-img <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
-      data-champ="chasse_principale_image"
-      data-cpt="chasse"
-      data-post-id="<?= esc_attr($chasse_id); ?>">
-
-      <div class="champ-affichage">
-        <div
-            class="header-chasse__image"
-            data-cout-label="<?= esc_attr__('Coût de participation : %d points.', 'chassesautresor-com'); ?>"
-            data-pts-label="<?= esc_attr__('pts', 'chassesautresor-com'); ?>"
-            data-mode-auto-label="<?= esc_attr__('mode de fin de chasse : automatique', 'chassesautresor-com'); ?>"
-            data-mode-manuel-label="<?= esc_attr__('mode de fin de chasse : manuelle', 'chassesautresor-com'); ?>"
-            data-mode-auto-icon="<?= esc_attr('<i class="fa-solid fa-bolt"></i>'); ?>"
-            data-mode-manuel-icon="<?= esc_attr(get_svg_icon('hand')); ?>"
-        >
-            <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>"
-              data-post-id="<?= esc_attr($chasse_id); ?>">
-              <?= esc_html($statut_label); ?>
-            </span>
-            <?php if ($cout_points > 0) : ?>
-              <span
-                  class="badge-cout"
-                  data-post-id="<?= esc_attr($chasse_id); ?>"
-                  aria-label="<?= esc_attr(
-                      sprintf(
-                          __('Coût de participation : %d points.', 'chassesautresor-com'),
-                          $cout_points
-                      )
-                  ); ?>"
-              >
-                <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
+    <div class="chasse-visuel-wrapper">
+      <!-- 📷 Image principale -->
+      <div class="champ-chasse champ-img <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
+        data-champ="chasse_principale_image"
+        data-cpt="chasse"
+        data-post-id="<?= esc_attr($chasse_id); ?>">
+        <div class="champ-affichage">
+          <div
+              class="header-chasse__image"
+              data-cout-label="<?= esc_attr__('Coût de participation : %d points.', 'chassesautresor-com'); ?>"
+              data-pts-label="<?= esc_attr__('pts', 'chassesautresor-com'); ?>"
+              data-mode-auto-label="<?= esc_attr__('mode de fin de chasse : automatique', 'chassesautresor-com'); ?>"
+              data-mode-manuel-label="<?= esc_attr__('mode de fin de chasse : manuelle', 'chassesautresor-com'); ?>"
+              data-mode-auto-icon="<?= esc_attr('<i class="fa-solid fa-bolt"></i>'); ?>"
+              data-mode-manuel-icon="<?= esc_attr(get_svg_icon('hand')); ?>"
+          >
+              <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>"
+                data-post-id="<?= esc_attr($chasse_id); ?>">
+                <?= esc_html($statut_label); ?>
               </span>
-            <?php endif; ?>
-            <span class="mode-fin-icone" title="<?= esc_attr($title_mode); ?>" aria-label="<?= esc_attr($title_mode); ?>">
-              <?php if ($mode_fin === 'automatique') : ?>
-                <i class="fa-solid fa-bolt"></i>
-              <?php else : ?>
-                <?= get_svg_icon('hand'); ?>
+              <?php if ($cout_points > 0) : ?>
+                <span
+                    class="badge-cout"
+                    data-post-id="<?= esc_attr($chasse_id); ?>"
+                    aria-label="<?= esc_attr(
+                        sprintf(
+                            __('Coût de participation : %d points.', 'chassesautresor-com'),
+                            $cout_points
+                        )
+                    ); ?>"
+                >
+                  <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
+                </span>
               <?php endif; ?>
-            </span>
-            <?php if ($image_id) : ?>
-              <a
-                href="<?= esc_url(wp_get_attachment_image_url($image_id, 'full')); ?>"
-                class="fancybox image"
-              >
-                <?php
-                echo wp_get_attachment_image(
-                    $image_id,
-                    'chasse-fiche',
-                    false,
-                    [
-                        'class'       => 'chasse-image visuel-cpt img-h-max',
-                        'data-cpt'    => 'chasse',
-                        'data-post-id' => $chasse_id,
-                        'alt'         => __('Image de la chasse', 'chassesautresor-com'),
-                        'sizes'       => '(max-width: 800px) 100vw, 800px',
-                    ]
-                );
-                ?>
-              </a>
-            <?php endif; ?>
+              <span class="mode-fin-icone" title="<?= esc_attr($title_mode); ?>" aria-label="<?= esc_attr($title_mode); ?>">
+                <?php if ($mode_fin === 'automatique') : ?>
+                  <i class="fa-solid fa-bolt"></i>
+                <?php else : ?>
+                  <?= get_svg_icon('hand'); ?>
+                <?php endif; ?>
+              </span>
+              <?php if ($image_id) : ?>
+                <a
+                  href="<?= esc_url(wp_get_attachment_image_url($image_id, 'full')); ?>"
+                  class="fancybox image"
+                >
+                  <?php
+                  echo wp_get_attachment_image(
+                      $image_id,
+                      'chasse-fiche',
+                      false,
+                      [
+                          'class'       => 'chasse-image visuel-cpt img-h-max',
+                          'data-cpt'    => 'chasse',
+                          'data-post-id' => $chasse_id,
+                          'alt'         => __('Image de la chasse', 'chassesautresor-com'),
+                          'sizes'       => '(max-width: 800px) 100vw, 800px',
+                      ]
+                  );
+                  ?>
+                </a>
+              <?php endif; ?>
+            </div>
+          </div>
+
+        <input type="hidden" class="champ-input" value="<?= esc_attr($image_id); ?>">
+        <div class="champ-feedback"></div>
+      </div>
+      <?php
+      $vide = empty($liens);
+      ?>
+      <div class="champ-chasse champ-liens champ-fiche-publication <?= $vide ? 'champ-vide' : 'champ-rempli'; ?>"
+        data-champ="chasse_principale_liens"
+        data-cpt="chasse"
+        data-post-id="<?= esc_attr($chasse_id); ?>">
+        <div class="champ-donnees"
+          data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
+        <div class="champ-affichage">
+          <div class="champ-affichage-liens">
+            <?= render_liens_publics($liens, 'chasse', ['afficher_titre' => false, 'wrap' => false]); ?>
           </div>
         </div>
-
-      <input type="hidden" class="champ-input" value="<?= esc_attr($image_id); ?>">
-      <div class="champ-feedback"></div>
-    </div>
-
-    <?php
-    $vide = empty($liens);
-    ?>
-    <div class="champ-chasse champ-liens champ-fiche-publication <?= $vide ? 'champ-vide' : 'champ-rempli'; ?>"
-      data-champ="chasse_principale_liens"
-      data-cpt="chasse"
-      data-post-id="<?= esc_attr($chasse_id); ?>">
-      <div class="champ-donnees"
-        data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
-      <div class="champ-affichage">
-        <div class="champ-affichage-liens">
-          <?= render_liens_publics($liens, 'chasse', ['afficher_titre' => false, 'wrap' => false]); ?>
-        </div>
+        <div class="champ-feedback"></div>
       </div>
-      <div class="champ-feedback"></div>
     </div>
 
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -33,6 +33,7 @@ $current_stored_statut = $champs['current_stored_statut'];
 $image_raw = $infos_chasse['image_raw'];
 $image_id  = $infos_chasse['image_id'];
 $image_url = $infos_chasse['image_url'];
+$liens     = $infos_chasse['liens'] ?? [];
 
 // Enigmes
 $enigmes_associees = $infos_chasse['enigmes_associees'];
@@ -183,6 +184,23 @@ if ($edition_active && !$est_complet) {
         </div>
 
       <input type="hidden" class="champ-input" value="<?= esc_attr($image_id); ?>">
+      <div class="champ-feedback"></div>
+    </div>
+
+    <?php
+    $vide = empty($liens);
+    ?>
+    <div class="champ-chasse champ-liens champ-fiche-publication <?= $vide ? 'champ-vide' : 'champ-rempli'; ?>"
+      data-champ="chasse_principale_liens"
+      data-cpt="chasse"
+      data-post-id="<?= esc_attr($chasse_id); ?>">
+      <div class="champ-donnees"
+        data-valeurs='<?= json_encode($liens, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT); ?>'></div>
+      <div class="champ-affichage">
+        <div class="champ-affichage-liens">
+          <?= render_liens_publics($liens, 'chasse', ['afficher_titre' => false, 'wrap' => false]); ?>
+        </div>
+      </div>
       <div class="champ-feedback"></div>
     </div>
 


### PR DESCRIPTION
### Résumé
- Retire le séparateur décoratif et l’en-tête de progression des énigmes
- Place le bloc de liens sous l’image de la chasse et centre son affichage
- Centre horizontalement les liens via les styles SCSS/CSS

### Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68afe19bfa5c8332b9a7643c2f6dafbb