### PR TITLE
Add site-wide messaging system

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -265,6 +265,7 @@ $inc_path = get_stylesheet_directory() . '/inc/';
 require_once $inc_path . 'constants.php';
 require_once $inc_path . 'utils.php';
 require_once $inc_path . 'PointsRepository.php';
+require_once $inc_path . 'messages.php';
 
 require_once $inc_path . 'shortcodes-init.php';
 require_once $inc_path . 'enigme-functions.php';

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -99,3 +99,4 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
         <div id="content" class="site-content">
                 <div class="ast-container<?php echo ( is_singular('enigme') || is_singular('chasse') ) ? '' : ' ast-container--boxed'; ?>">
                 <?php astra_content_top(); ?>
+                <section class="msg-important"><?php echo get_site_messages(); ?></section>

--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -1,0 +1,77 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Store a site-wide message.
+ *
+ * @param string $type       Message type used as CSS class.
+ * @param string $content    Message content.
+ * @param bool   $persistent Whether the message should persist across sessions.
+ *
+ * @return void
+ */
+function add_site_message(string $type, string $content, bool $persistent = false): void
+{
+    $message = [
+        'type'    => $type,
+        'content' => $content,
+    ];
+
+    if ($persistent) {
+        $messages = get_transient('cat_site_messages');
+        if (!is_array($messages)) {
+            $messages = [];
+        }
+        $messages[] = $message;
+        set_transient('cat_site_messages', $messages, 0);
+        return;
+    }
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+
+    $messages   = $_SESSION['cat_site_messages'] ?? [];
+    $messages[] = $message;
+
+    $_SESSION['cat_site_messages'] = $messages;
+}
+
+/**
+ * Retrieve site-wide messages.
+ *
+ * @return string HTML content for the messages.
+ */
+function get_site_messages(): string
+{
+    $messages = [];
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+
+    if (!empty($_SESSION['cat_site_messages'])) {
+        $messages = array_merge($messages, $_SESSION['cat_site_messages']);
+        unset($_SESSION['cat_site_messages']);
+    }
+
+    $transient = get_transient('cat_site_messages');
+    if (is_array($transient) && !empty($transient)) {
+        $messages = array_merge($messages, $transient);
+    }
+
+    if (empty($messages)) {
+        return '';
+    }
+
+    $output = array_map(
+        function (array $msg): string {
+            return '<p class="' . esc_attr($msg['type']) . '">' . esc_html($msg['content']) . '</p>';
+        },
+        $messages
+    );
+
+    return implode('', $output);
+}
+


### PR DESCRIPTION
## Résumé
- gestion centralisée des messages de site

## Changements notables
- ajout des helpers `add_site_message` et `get_site_messages`
- affichage des messages importants dans le header
- chargement du nouveau module dans `functions.php`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aff19324788332bb4d675e1e09dad8