### PR TITLE
feat: add typed account messages

### DIFF
--- a/tests/js/myaccount-admin-ajax.test.js
+++ b/tests/js/myaccount-admin-ajax.test.js
@@ -85,7 +85,7 @@ describe('myaccount ajax navigation', () => {
         success: true,
         data: {
           html: '<p>outils</p>',
-          messages: '<p class="flash">Temp</p><p>Persistent</p>'
+          messages: '<p class="flash flash--info">Temp</p><p class="alerte-discret alerte-discret--info">Persistent</p>'
         }
       })
     }));
@@ -94,10 +94,10 @@ describe('myaccount ajax navigation', () => {
     await Promise.resolve();
     await Promise.resolve();
     const container = document.querySelector('.msg-important');
-    expect(container.innerHTML).toBe('<p class="flash">Temp</p><p class="alerte-discret">Persistent</p>');
+    expect(container.innerHTML).toBe('<p class="flash flash--info">Temp</p><p class="alerte-discret alerte-discret--info">Persistent</p>');
     jest.advanceTimersByTime(3000);
     await Promise.resolve();
-    expect(container.innerHTML).toBe('<p class="alerte-discret">Persistent</p>');
+    expect(container.innerHTML).toBe('<p class="alerte-discret alerte-discret--info">Persistent</p>');
     jest.useRealTimers();
   });
 

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -934,6 +934,41 @@ a[aria-disabled="true"] {
     margin-top: 15px;
 }
 
+/* ========== ❌ MESSAGE ERREUR ========== */
+.message-error {
+    text-align: center;
+    font-weight: bold;
+    color: var(--color-error);
+    font-size: 16px;
+    margin-top: 15px;
+}
+
+/* ========== ⚠️ MESSAGE WARNING ========== */
+.message-warning {
+    text-align: center;
+    font-weight: bold;
+    color: var(--color-accent);
+    font-size: 16px;
+    margin-top: 15px;
+}
+
+/* ========== 📨 ALERTES DISCRÈTES (TYPES) ========== */
+.alerte-discret--success {
+    border-left-color: var(--color-success);
+}
+
+.alerte-discret--info {
+    border-left-color: var(--color-accent);
+}
+
+.alerte-discret--error {
+    border-left-color: var(--color-error);
+}
+
+.alerte-discret--warning {
+    border-left-color: var(--color-secondary);
+}
+
 /* ========== 🖼️ ICONES SVG ========== */
 .icone-aces-casino, .icone-compass-rose {
   color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -429,6 +429,7 @@
   line-height: 1.3;
   color: var(--color-editor-text-muted);
   text-align: left;
+  width: -moz-fit-content;
   width: fit-content;
 }
 
@@ -1400,6 +1401,41 @@ a[aria-disabled=true] {
   color: var(--color-text-primary);
   font-size: 16px;
   margin-top: 15px;
+}
+
+/* ========== ❌ MESSAGE ERREUR ========== */
+.message-error {
+  text-align: center;
+  font-weight: bold;
+  color: var(--color-error);
+  font-size: 16px;
+  margin-top: 15px;
+}
+
+/* ========== ⚠️ MESSAGE WARNING ========== */
+.message-warning {
+  text-align: center;
+  font-weight: bold;
+  color: var(--color-accent);
+  font-size: 16px;
+  margin-top: 15px;
+}
+
+/* ========== 📨 ALERTES DISCRÈTES (TYPES) ========== */
+.alerte-discret--success {
+  border-left-color: var(--color-success);
+}
+
+.alerte-discret--info {
+  border-left-color: var(--color-accent);
+}
+
+.alerte-discret--error {
+  border-left-color: var(--color-error);
+}
+
+.alerte-discret--warning {
+  border-left-color: var(--color-secondary);
 }
 
 /* ========== 🖼️ ICONES SVG ========== */

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1851,7 +1851,7 @@ function traiter_validation_chasse_admin() {
             esc_html($titre_chasse)
         );
         foreach ($user_ids as $uid) {
-            myaccount_add_flash_message($uid, $flash);
+            myaccount_add_flash_message($uid, $flash, 'success');
         }
 
         envoyer_mail_chasse_validee($organisateur_id, $chasse_id);
@@ -1895,7 +1895,7 @@ function traiter_validation_chasse_admin() {
         }
         $flash .= '<br>' . __('Une copie de ce message vous a été envoyée par email.', 'chassesautresor-com');
         foreach ($user_ids as $uid) {
-            myaccount_add_flash_message($uid, $flash);
+            myaccount_add_flash_message($uid, $flash, 'warning');
         }
 
     } elseif ($action === 'bannir') {
@@ -1920,7 +1920,7 @@ function traiter_validation_chasse_admin() {
             esc_html($titre_chasse)
         );
         foreach ($user_ids as $uid) {
-            myaccount_add_flash_message($uid, $flash);
+            myaccount_add_flash_message($uid, $flash, 'error');
         }
 
     } elseif ($action === 'supprimer') {
@@ -1942,7 +1942,7 @@ function traiter_validation_chasse_admin() {
             esc_html($titre_chasse)
         );
         foreach ($user_ids as $uid) {
-            myaccount_add_flash_message($uid, $flash);
+            myaccount_add_flash_message($uid, $flash, 'error');
         }
     }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -212,8 +212,8 @@ function soumettre_reponse_manuelle()
     enigme_mettre_a_jour_statut_utilisateur($enigme_id, $user_id, 'soumis', true);
 
     $titre_enigme = get_the_title($enigme_id);
-    $link = '<a href="' . esc_url(get_permalink($enigme_id)) . '">' . esc_html($titre_enigme) . '</a>';
-    myaccount_add_persistent_message($user_id, 'tentative_' . $uid, $link);
+    $link         = '<a href="' . esc_url(get_permalink($enigme_id)) . '">' . esc_html($titre_enigme) . '</a>';
+    myaccount_add_persistent_message($user_id, 'tentative_' . $uid, $link, 'info');
 
     envoyer_mail_reponse_manuelle($user_id, $enigme_id, $reponse, $uid);
 

--- a/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/tentatives.php
@@ -139,7 +139,11 @@ defined('ABSPATH') || exit;
             '</a>'
         );
         myaccount_remove_persistent_message($user_id, 'tentative_' . $uid);
-        myaccount_add_flash_message($user_id, $message);
+        myaccount_add_flash_message(
+            $user_id,
+            $message,
+            $resultat === 'bon' ? 'success' : 'error'
+        );
 
         cat_debug("✅ Tentative UID=$uid traitée comme $resultat");
         return true;

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -210,7 +210,10 @@ class MyAccountMessagesTest extends TestCase
             1,
             '_myaccount_messages',
             [
-                'tentative_123' => '<a href="https://example.com/enigme">Énigme</a>',
+                'tentative_123' => [
+                    'text' => '<a href="https://example.com/enigme">Énigme</a>',
+                    'type' => 'info',
+                ],
             ]
         );
 
@@ -228,8 +231,14 @@ class MyAccountMessagesTest extends TestCase
             1,
             '_myaccount_messages',
             [
-                'tentative_1' => '<a href="https://example.com/e1">E1</a>',
-                'tentative_2' => '<a href="https://example.com/e2">E2</a>',
+                'tentative_1' => [
+                    'text' => '<a href="https://example.com/e1">E1</a>',
+                    'type' => 'info',
+                ],
+                'tentative_2' => [
+                    'text' => '<a href="https://example.com/e2">E2</a>',
+                    'type' => 'info',
+                ],
             ]
         );
 
@@ -249,7 +258,10 @@ class MyAccountMessagesTest extends TestCase
             1,
             '_myaccount_messages',
             [
-                'tentative_456' => $stored,
+                'tentative_456' => [
+                    'text' => $stored,
+                    'type' => 'info',
+                ],
             ]
         );
 
@@ -263,7 +275,13 @@ class MyAccountMessagesTest extends TestCase
 
     public function test_flash_message_is_displayed_once(): void
     {
-        update_user_meta(1, '_myaccount_flash_messages', ['Message unique']);
+        update_user_meta(
+            1,
+            '_myaccount_flash_messages',
+            [
+                ['text' => 'Message unique', 'type' => 'info'],
+            ]
+        );
 
         $first = myaccount_get_important_messages();
         $this->assertStringContainsString('Message unique', $first);
@@ -274,7 +292,13 @@ class MyAccountMessagesTest extends TestCase
 
     public function test_persistent_message_persists_until_removed(): void
     {
-        update_user_meta(1, '_myaccount_messages', ['foo' => 'Persiste']);
+        update_user_meta(
+            1,
+            '_myaccount_messages',
+            [
+                'foo' => ['text' => 'Persiste', 'type' => 'info'],
+            ]
+        );
 
         $first = myaccount_get_important_messages();
         $this->assertStringContainsString('Persiste', $first);
@@ -289,14 +313,26 @@ class MyAccountMessagesTest extends TestCase
 
     public function test_messages_are_styled(): void
     {
-        update_user_meta(1, '_myaccount_flash_messages', ['Stylé']);
+        update_user_meta(
+            1,
+            '_myaccount_flash_messages',
+            [
+                ['text' => 'Stylé', 'type' => 'info'],
+            ]
+        );
         $output = myaccount_get_important_messages();
-        $this->assertStringContainsString('<p class="alerte-discret">Stylé</p>', $output);
+        $this->assertStringContainsString('<p class="alerte-discret alerte-discret--info">Stylé</p>', $output);
     }
 
     public function test_ajax_section_returns_flash_message(): void
     {
-        update_user_meta(1, '_myaccount_flash_messages', ['Via AJAX']);
+        update_user_meta(
+            1,
+            '_myaccount_flash_messages',
+            [
+                ['text' => 'Via AJAX', 'type' => 'info'],
+            ]
+        );
         $_GET['section'] = 'organisateurs';
 
         ob_start();


### PR DESCRIPTION
### Résumé
- gestion de types pour les messages de l'espace Mon Compte
- styles SCSS pour les alertes selon le type
- mise à jour des appels aux fonctions de messages

### Détails
- étend les API de messages pour accepter `success`, `info`, `error`, `warning`
- applique les classes de type lors de l'affichage des alertes
- ajoute les classes SCSS correspondantes

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68aff302c960833291a0dbd4375863b2