### PR TITLE
feat: remplacer les alertes par des messages accessibles

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -26,7 +26,7 @@ const html = `
             <span class="toggle-option">Later</span>
             <div class="date-debut-actions" style="display:none;">
               <input type="datetime-local" id="chasse-date-debut" value="" class="champ-inline-date champ-date-edit">
-              <div id="erreur-date-debut" class="message-erreur"></div>
+              <div id="erreur-date-debut" class="message-erreur" role="alert" aria-live="assertive"></div>
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@ const html = `
             <span class="toggle-option">Limitée</span>
             <div class="date-fin-actions" style="display:none;">
               <input type="date" id="chasse-date-fin" value="" class="champ-inline-date champ-date-edit">
-              <div id="erreur-date-fin" class="message-erreur"></div>
+              <div id="erreur-date-fin" class="message-erreur" role="alert" aria-live="assertive"></div>
             </div>
           </div>
         </div>

--- a/tests/js/myaccount-admin-ajax.test.js
+++ b/tests/js/myaccount-admin-ajax.test.js
@@ -85,7 +85,7 @@ describe('myaccount ajax navigation', () => {
         success: true,
         data: {
           html: '<p>outils</p>',
-          messages: '<p class="flash flash--info">Temp</p><p class="alerte-discret alerte-discret--info">Persistent</p>'
+          messages: '<p class="flash flash--info">Temp</p><p class="message-info" role="status" aria-live="polite">Persistent</p>'
         }
       })
     }));
@@ -94,10 +94,10 @@ describe('myaccount ajax navigation', () => {
     await Promise.resolve();
     await Promise.resolve();
     const container = document.querySelector('.msg-important');
-    expect(container.innerHTML).toBe('<p class="flash flash--info">Temp</p><p class="alerte-discret alerte-discret--info">Persistent</p>');
+    expect(container.innerHTML).toBe('<p class="flash flash--info" role="status" aria-live="polite">Temp</p><p class="message-info" role="status" aria-live="polite">Persistent</p>');
     jest.advanceTimersByTime(3000);
     await Promise.resolve();
-    expect(container.innerHTML).toBe('<p class="alerte-discret alerte-discret--info">Persistent</p>');
+    expect(container.innerHTML).toBe('<p class="message-info" role="status" aria-live="polite">Persistent</p>');
     jest.useRealTimers();
   });
 

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -23,11 +23,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const decorateMessages = () => {
     const container = content.querySelector('.msg-important');
-    if (container) {
-      container
-        .querySelectorAll('p:not(.flash)')
-        .forEach((p) => p.classList.add('alerte-discret'));
+    if (!container) {
+      return;
     }
+    container.querySelectorAll('p').forEach((p) => {
+      if (p.classList.contains('message-erreur')) {
+        p.setAttribute('role', 'alert');
+        p.setAttribute('aria-live', 'assertive');
+      } else {
+        if (!p.className.match(/message-(info|succes)/) && !p.classList.contains('flash')) {
+          p.classList.add('message-info');
+        }
+        p.setAttribute('role', 'status');
+        p.setAttribute('aria-live', 'polite');
+      }
+    });
   };
 
   const loadSection = async (link, push = true) => {
@@ -76,8 +86,8 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       content.innerHTML = `
         <section class="msg-important">
-          <p>Impossible de charger la section.</p>
-          <p><a href="#" class="reload-section">Recharger</a> ou <a href="${link.href}">ouvrir la page complète</a>.</p>
+          <p class="message-erreur" role="alert" aria-live="assertive">Impossible de charger la section.</p>
+          <p class="message-info" role="status" aria-live="polite"><a href="#" class="reload-section">Recharger</a> ou <a href="${link.href}">ouvrir la page complète</a>.</p>
         </section>`;
       const reload = content.querySelector('.reload-section');
       if (reload) {

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -952,21 +952,17 @@ a[aria-disabled="true"] {
     margin-top: 15px;
 }
 
-/* ========== 📨 ALERTES DISCRÈTES (TYPES) ========== */
-.alerte-discret--success {
+/* ========== 📨 MESSAGES (TYPES) ========== */
+.message-succes {
     border-left-color: var(--color-success);
 }
 
-.alerte-discret--info {
+.message-info {
     border-left-color: var(--color-accent);
 }
 
-.alerte-discret--error {
+.message-erreur {
     border-left-color: var(--color-error);
-}
-
-.alerte-discret--warning {
-    border-left-color: var(--color-secondary);
 }
 
 /* ========== 🖼️ ICONES SVG ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -355,7 +355,9 @@ body #primary {
 }
 
 /* ========== 🌒 ALERTE DISCRET ========== */
-.alerte-discret {
+.message-info,
+.message-erreur,
+.message-succes {
   background: var(--color-text-primary, #fff4d4);
   color: var(--color-text, var(--color-grey-dark));
   border-left: 4px solid var(--color-accent);
@@ -364,6 +366,14 @@ body #primary {
   max-width: 700px;
   border-radius: 4px;
   font-size: 0.95rem;
+}
+
+.message-erreur {
+  border-left-color: var(--color-error);
+}
+
+.message-succes {
+  border-left-color: var(--color-success);
 }
 
 

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -32,12 +32,12 @@
   gap: var(--space-xl);
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .grille-3 {
     grid-template-columns: repeat(2, 1fr);
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .grille-3 {
     grid-template-columns: 1fr;
   }
@@ -136,8 +136,10 @@
 .carte-ligne__image img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  object-position: center;
+  -o-object-fit: cover;
+     object-fit: cover;
+  -o-object-position: center;
+     object-position: center;
   display: block;
   max-height: 350px;
 }
@@ -258,7 +260,8 @@
   max-height: var(--hunt-img-max-height);
   width: auto;
   height: auto;
-  object-fit: contain;
+  -o-object-fit: contain;
+     object-fit: contain;
 }
 
 .chasse-fiche-container {
@@ -272,10 +275,20 @@
   gap: var(--grid-gap);
 }
 
+.chasse-visuel-wrapper {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 auto;
+  gap: var(--space-xs);
+}
+
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
   flex: 0 0 auto;
   padding: var(--space-xs);
+  width: -moz-fit-content;
   width: fit-content;
   max-width: 100%;
   margin: 0 auto;
@@ -329,22 +342,24 @@
   box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
 }
 
-@media (--bp-mobile) {
+@media (min-width: 600px) {
   .chasse-fiche-container {
     --hunt-img-max-height: 500px;
   }
 }
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .chasse-fiche-container {
     flex-direction: row;
     --hunt-img-max-height: 800px;
   }
-  .champ-chasse.champ-img {
-    margin: 0;
+  .chasse-visuel-wrapper {
     position: sticky;
     top: 0;
-    flex: 0 0 auto;
     max-width: 40%;
+    margin: 0;
+  }
+  .champ-chasse.champ-img {
+    margin: 0;
   }
 }
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
@@ -414,6 +429,7 @@
   line-height: 1.3;
   color: var(--color-editor-text-muted);
   text-align: left;
+  width: -moz-fit-content;
   width: fit-content;
 }
 
@@ -468,7 +484,7 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
 }
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .header-chasse {
     font-size: 22px;
   }
@@ -611,6 +627,7 @@ button,
   margin-top: 10px;
   transition: var(--transition-medium);
   text-align: center;
+  width: -moz-fit-content;
   width: fit-content;
 }
 
@@ -673,7 +690,7 @@ button,
   opacity: 0.7;
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   .bloc-reponse .reponse-cta-row {
     flex-direction: row;
   }
@@ -687,7 +704,7 @@ button,
     padding: 8px 13px;
   }
 }
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .bouton-cta {
     padding: 10px 15px;
   }
@@ -752,6 +769,7 @@ button,
   cursor: not-allowed;
   pointer-events: none;
   text-align: center;
+  width: -moz-fit-content;
   width: fit-content;
   display: flex;
   align-items: center;
@@ -913,7 +931,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .btn-lire-plus {
     width: auto;
   }
@@ -950,7 +968,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   .bouton-retour {
     font-size: 1.5rem;
   }
@@ -1017,7 +1035,7 @@ a.ajout-link:focus-visible {
   font-size: 100%;
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   .bloc-metas-inline {
     gap: 0.7rem;
   }
@@ -1176,7 +1194,7 @@ a.ajout-link:focus-visible {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media (--bp-small) {
+@media (min-width: 480px) {
   .separateur-2 {
     margin: var(--space-xs) 0 var(--space-xl);
   }
@@ -1200,7 +1218,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   color: var(--color-text-primary);
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   .formulaire-contact-wrapper {
     padding-left: 0;
     padding-right: 0;
@@ -1287,7 +1305,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   text-align: center;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .countdown-container {
     font-size: 1.2rem;
   }
@@ -1385,6 +1403,37 @@ a[aria-disabled=true] {
   margin-top: 15px;
 }
 
+/* ========== ❌ MESSAGE ERREUR ========== */
+.message-error {
+  text-align: center;
+  font-weight: bold;
+  color: var(--color-error);
+  font-size: 16px;
+  margin-top: 15px;
+}
+
+/* ========== ⚠️ MESSAGE WARNING ========== */
+.message-warning {
+  text-align: center;
+  font-weight: bold;
+  color: var(--color-accent);
+  font-size: 16px;
+  margin-top: 15px;
+}
+
+/* ========== 📨 MESSAGES (TYPES) ========== */
+.message-succes {
+  border-left-color: var(--color-success);
+}
+
+.message-info {
+  border-left-color: var(--color-accent);
+}
+
+.message-erreur {
+  border-left-color: var(--color-error);
+}
+
 /* ========== 🖼️ ICONES SVG ========== */
 .icone-aces-casino, .icone-compass-rose {
   color: var(--color-text-primary);
@@ -1433,6 +1482,7 @@ a[aria-disabled=true] {
   display: none;
   z-index: 10;
   min-width: 6rem;
+  width: -moz-max-content;
   width: max-content;
 }
 
@@ -1756,7 +1806,7 @@ a[aria-disabled=true] {
   padding-bottom: var(--space-sm);
 }
 
-@media (--bp-wide) {
+@media (min-width: 1280px) {
   .menu-lateral {
     position: fixed;
     top: 50%;
@@ -1959,7 +2009,7 @@ li.edition-row {
   gap: var(--space-xs);
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-row-label {
     min-width: unset;
     width: var(--editor-label-width);
@@ -1986,7 +2036,7 @@ li.edition-row {
   color: var(--color-editor-error);
 }
 
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   li.edition-row {
     flex-direction: column;
     align-items: flex-start;
@@ -2020,7 +2070,8 @@ li.edition-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  column-gap: var(--space-xl);
+  -moz-column-gap: var(--space-xl);
+       column-gap: var(--space-xl);
   row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
@@ -2061,7 +2112,7 @@ li.edition-row {
   margin-top: 0;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image,
   .champ-qr-code.carte-orgy .qr-code-image {
@@ -2078,7 +2129,7 @@ li.edition-row {
     font-size: 150px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image,
   .champ-qr-code.carte-orgy .qr-code-image {
@@ -2088,7 +2139,7 @@ li.edition-row {
     font-size: 100px;
   }
 }
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .dashboard-card.champ-protection-solutions .qr-code-block, .champ-protection-solutions.carte-orgy .qr-code-block,
   .dashboard-card.champ-qr-code .qr-code-block,
   .champ-qr-code.carte-orgy .qr-code-block {
@@ -2331,6 +2382,7 @@ body .header-img-modifiable .icone-modif {
 .champ-liens .champ-affichage-liens {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .dashboard-card.champ-liens .icone-defaut, .champ-liens.carte-orgy .icone-defaut {
@@ -2411,7 +2463,7 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-panel-body input.champ-input,
   .edition-panel-body input[type=date],
   .edition-panel-body input[type=datetime-local] {
@@ -2476,6 +2528,10 @@ body .header-img-modifiable .icone-modif {
 .bonne-reponse-ajouter {
   font-size: 0.85rem;
   padding: 0.1rem var(--space-xs);
+}
+
+.champ-edition input.champ-input::-moz-placeholder {
+  color: var(--color-editor-placeholder);
 }
 
 .champ-edition input.champ-input::placeholder {
@@ -2649,7 +2705,7 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 /* ========== 📱 RESPONSIVE GLOBAL ========== */
 /* Empilage à partir de tablette */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -2697,7 +2753,7 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 /* ========== 📱 RESPONSIVE HEADER ========== */
 /* Empilage à partir de tablette */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -2891,12 +2947,12 @@ body.edition-active .edition-panel {
   font-size: 1rem;
 }
 
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .edition-panel label {
     font-size: 0.9rem;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .edition-panel label {
     font-size: 0.8rem;
   }
@@ -3055,7 +3111,7 @@ li.ligne-email .champ-affichage {
 }
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .edition-tab-content {
     padding-left: 0;
     padding-right: 0;
@@ -3071,7 +3127,7 @@ li.ligne-email .champ-affichage {
     padding-right: 0;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -3356,12 +3412,12 @@ body.panneau-ouvert::before {
   border-bottom: 3px solid var(--color-primary);
 }
 
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .edition-tab {
     font-size: 16px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .edition-tab {
     font-size: 16px;
   }
@@ -3374,7 +3430,7 @@ body.panneau-ouvert::before {
   position: relative;
 }
 
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .edition-tab-content {
     padding-left: 0;
     padding-right: 0;
@@ -3576,7 +3632,7 @@ body.panneau-ouvert::before {
   margin: var(--space-4xl) auto;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy,
   .dashboard-card.champ-protection-solutions,
   .champ-protection-solutions.carte-orgy {
@@ -3885,7 +3941,9 @@ body.panneau-ouvert::before {
   align-items: center;
   justify-content: center;
   gap: var(--space-xxs);
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
 }
 
 .champ-mode-options.segmented-control label:last-of-type {
@@ -4147,7 +4205,8 @@ body.panneau-ouvert::before {
 .champ-pre-requis .prerequis-mini img {
   width: 80px;
   height: 80px;
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
   border-radius: 4px;
 }
 
@@ -4449,7 +4508,7 @@ body.panneau-ouvert::before {
   grid-column: 1;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .enigme-layout .menu-lateral {
     position: sticky;
     top: var(--space-md);
@@ -4462,7 +4521,7 @@ body.panneau-ouvert::before {
   grid-template-columns: 1fr;
 }
 
-@media (--bp-wide) {
+@media (min-width: 1280px) {
   .enigme-layout {
     display: block;
     gap: 0;
@@ -4728,7 +4787,7 @@ li.active .enigme-menu__edit {
   margin-top: var(--space-md);
 }
 
-@media (--bp-desktop) and (hover: hover) {
+@media (min-width: 1024px) and (hover: hover) {
   body.single-enigme .page-enigme {
     margin-top: calc(var(--space-4xl) + var(--space-md));
   }
@@ -4756,7 +4815,7 @@ li.active .enigme-menu__edit {
   font-size: 32px;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .page-enigme {
     gap: var(--space-xl);
   }
@@ -4768,7 +4827,7 @@ li.active .enigme-menu__edit {
     font-size: 1rem;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .page-enigme {
     gap: var(--space-lg);
   }
@@ -4781,7 +4840,8 @@ li.active .enigme-menu__edit {
 }
 .hero-visuel img {
   /*width: 100%;*/
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
   /*max-height: 300px;*/
 }
 
@@ -4808,7 +4868,7 @@ li.active .enigme-menu__edit {
   margin-top: 0;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .participation {
     width: 70%;
   }
@@ -4882,7 +4942,7 @@ li.active .enigme-menu__edit {
   margin-inline: auto;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .enigme-layout {
     grid-template-columns: 1fr;
   }
@@ -4914,7 +4974,7 @@ body.topbar-visible .enigme-edit-toggle--desktop {
   top: calc(var(--space-md) + var(--space-4xl));
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .enigme-layout .menu-lateral {
     display: none;
   }
@@ -5073,7 +5133,7 @@ body.single-enigme.topbar-visible header.site-header {
   transform: translateY(0);
 }
 
-@media not all and (--bp-desktop), (hover: none) {
+@media not all and (min-width: 1024px), (hover: none) {
   body.single-enigme header.site-header {
     display: none;
   }
@@ -5129,7 +5189,8 @@ body.single-enigme.topbar-visible header.site-header {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
   box-shadow: inset 0 0 10px rgba(255, 215, 0, 0.8), 0 0 20px rgba(255, 215, 0, 0.5);
 }
 
@@ -5421,22 +5482,22 @@ header .points-link:hover {
 }
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .points-value {
     font-size: 16px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .points-value {
     font-size: 14px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .points-unite {
     display: none;
   }
 }
-@media not all and (--bp-xs) {
+@media not all and (min-width: 374px) {
   .points-unite {
     display: none;
   }
@@ -5712,7 +5773,7 @@ h1.h1-diff { /* variation couleur bronze, plus petite, centrée */
   color: var(--color-accent);
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   h1, .entry-content h1 {
     font-size: 36px;
   }
@@ -5720,7 +5781,7 @@ h1.h1-diff { /* variation couleur bronze, plus petite, centrée */
     font-size: 30px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   h1, .entry-content h1 {
     font-size: 30px;
   }
@@ -5739,12 +5800,12 @@ h2, .entry-content h2 {
   font-size: 32px;
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   h2, .entry-content h2 {
     font-size: 28px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   h2, .entry-content h2 {
     font-size: 24px;
   }
@@ -5760,7 +5821,7 @@ h3, .entry-content h3 {
   margin-bottom: var(--space-sm);
 }
 
-@media not all and (--bp-desktop) {
+@media not all and (min-width: 1024px) {
   .page header.entry-header .entry-title {
     font-size: 36px;
   }
@@ -5768,7 +5829,7 @@ h3, .entry-content h3 {
     font-size: 22px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .page header.entry-header .entry-title {
     font-size: 30px;
   }
@@ -5997,7 +6058,8 @@ tbody tr:nth-child(even) {
 .indices-table td img {
   width: 80px;
   height: 80px;
-  object-fit: cover;
+  -o-object-fit: cover;
+     object-fit: cover;
 }
 
 .indices-table .badge-action {
@@ -6026,7 +6088,7 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .indices-table th.indice-text,
   .indices-table td.proposition-cell {
     display: none;
@@ -6142,7 +6204,7 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .indices-table,
   .solutions-table,
   .stats-table {
@@ -6154,7 +6216,7 @@ tbody tr:nth-child(even) {
     font-weight: 400;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .solutions-table th:nth-child(3),
   .solutions-table td:nth-child(3) {
     display: none;
@@ -6239,12 +6301,12 @@ span.champ-obligatoire {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
     font-size: 96%;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
     font-size: 93%;
   }
@@ -6271,17 +6333,17 @@ span.champ-obligatoire {
   --editor-icon-width: 1rem; /* 📏 Largeur des icônes dans les panneaux */
 }
 
-@media (--bp-tablet) and (max-width: 1023px) {
+@media (min-width: 768px) and (max-width: 1023px) {
   .mode-edition {
     --editor-label-width: 220px;
   }
 }
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .mode-edition {
     --editor-label-width: 165px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .mode-edition {
     --editor-label-width: 135px;
   }
@@ -6392,7 +6454,7 @@ span.champ-obligatoire {
   padding-right: 13px;
 }
 
-@media (--bp-desktop) {
+@media (min-width: 1024px) {
   .container,
   .ast-container,
   .ast-container-fluid {
@@ -6400,7 +6462,7 @@ span.champ-obligatoire {
     padding-right: var(--space-md);
   }
 }
-@media (--bp-xxl) {
+@media (min-width: 1440px) {
   .container,
   .ast-container,
   .ast-container-fluid {
@@ -6481,17 +6543,17 @@ span.champ-obligatoire {
   --col-span: 12;
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   .row {
     --grid-columns: 6;
   }
 }
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .row {
     --grid-columns: 8;
   }
 }
-@media (--bp-desktop) {
+@media (min-width: 1024px) {
   .row {
     --grid-columns: 12;
   }
@@ -6574,7 +6636,7 @@ header.site-header {
   padding: 0 7px;
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   header.site-header {
     padding: 0 10px;
   }
@@ -6583,7 +6645,7 @@ header.site-header {
     padding-right: 10px;
   }
 }
-@media (--bp-desktop) {
+@media (min-width: 1024px) {
   header.site-header {
     padding: 0;
   }
@@ -6686,7 +6748,7 @@ header.site-header {
   padding-top: 235px;
 }
 
-@media (--bp-small) {
+@media (min-width: 480px) {
   .hero-title {
     font-size: 1.8rem;
   }
@@ -6701,7 +6763,7 @@ header.site-header {
     padding-top: 300px;
   }
 }
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .hero-title {
     font-size: 2.6rem;
   }
@@ -6812,7 +6874,7 @@ body #primary {
   line-height: 1.5;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .bloc-temoignages .temoignage-colonnes {
     flex-direction: row;
     align-items: stretch;
@@ -6857,7 +6919,9 @@ body #primary {
 }
 
 /* ========== 🌒 ALERTE DISCRET ========== */
-.alerte-discret {
+.message-info,
+.message-erreur,
+.message-succes {
   background: var(--color-text-primary, #fff4d4);
   color: var(--color-text, var(--color-grey-dark));
   border-left: 4px solid var(--color-accent);
@@ -6866,6 +6930,14 @@ body #primary {
   max-width: 700px;
   border-radius: 4px;
   font-size: 0.95rem;
+}
+
+.message-erreur {
+  border-left-color: var(--color-error);
+}
+
+.message-succes {
+  border-left-color: var(--color-success);
 }
 
 /* ==================================================
@@ -6907,6 +6979,10 @@ body #primary {
   height: 42px;
   min-width: 0;
   box-sizing: border-box;
+}
+
+.newsletter-group input[type=email]::-moz-placeholder {
+  color: var(--color-gris-3);
 }
 
 .newsletter-group input[type=email]::placeholder {
@@ -7003,11 +7079,12 @@ footer .site-footer-primary-section-3 {
 }
 
 .ast-builder-footer-grid-columns {
-  column-gap: 20px;
+  -moz-column-gap: 20px;
+       column-gap: 20px;
   padding-inline: 10px;
 }
 
-@media (--bp-mobile) {
+@media (min-width: 600px) {
   .site-footer-primary-section-1 {
     order: 1;
     margin: 0;
@@ -7023,7 +7100,8 @@ footer .site-footer-primary-section-3 {
     display: flex;
   }
   .ast-builder-footer-grid-columns {
-    column-gap: 20px;
+    -moz-column-gap: 20px;
+         column-gap: 20px;
     padding-inline: 0;
   }
 }
@@ -7475,7 +7553,7 @@ footer .site-footer-primary-section-3 {
 }
 
 /* ✅ Mobile : Les éléments s'empilent */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .dashboard-profile-wrapper {
     flex-direction: column; /* ✅ Empile les éléments */
     justify-content: center; /* ✅ Centre les éléments verticalement */
@@ -7535,7 +7613,7 @@ footer .site-footer-primary-section-3 {
   vertical-align: middle;
 }
 
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .menu-deroulant .submenu {
     left: -50px;
   }
@@ -7642,7 +7720,8 @@ footer .site-footer-primary-section-3 {
 .dashboard-logo {
   width: 100%;
   height: 100%;
-  object-fit: cover; /* Ajuste l’image pour occuper tout l’espace sans déformation */
+  -o-object-fit: cover;
+     object-fit: cover; /* Ajuste l’image pour occuper tout l’espace sans déformation */
 }
 
 /* 🔥 Overlay du nombre de chasses */
@@ -7869,7 +7948,7 @@ footer .site-footer-primary-section-3 {
 }
 
 /* Tablette : 2 colonnes */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .image-container {
     height: 260px;
   }
@@ -8072,7 +8151,8 @@ a.bouton-edition-attention {
 .header-organisateur__logo img {
   width: 50px;
   height: 50px;
-  object-fit: contain;
+  -o-object-fit: contain;
+     object-fit: contain;
   border-radius: 50%;
 }
 
@@ -8178,7 +8258,7 @@ a.bouton-edition-attention {
   margin: 0 auto;
 }
 
-@media (--bp-tablet) {
+@media (min-width: 768px) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
@@ -8205,7 +8285,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 RESPONSIVE – TABLETTES (600PX À 768PX) ========== */
-@media (min-width: 600px) and (--bp-tablet) {
+@media (min-width: 600px) and (min-width: 768px) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
@@ -8230,7 +8310,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 BASCULE EN COLONNE (≤ 600PX) ========== */
-@media not all and (--bp-mobile) {
+@media not all and (min-width: 600px) {
   .conteneur-organisateur {
     gap: var(--space-md);
   }
@@ -8241,7 +8321,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 RESPONSIVE – MOBILE (≤ 480PX) ========== */
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .conteneur-organisateur {
     gap: 0.2rem;
   }
@@ -8409,7 +8489,7 @@ section#presentation .presentation-fermer {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .lien-public .texte-lien {
     display: none;
   }
@@ -8512,7 +8592,7 @@ section#presentation .presentation-fermer {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (--bp-tablet) {
+@media not all and (min-width: 768px) {
   .separateur-avec-icone {
     margin: 2.1rem 0;
   }
@@ -8528,7 +8608,7 @@ section#presentation .presentation-fermer {
     height: 50px;
   }
 }
-@media not all and (--bp-small) {
+@media not all and (min-width: 480px) {
   .separateur-avec-icone {
     margin: var(--space-xl) 0;
   }
@@ -8565,20 +8645,7 @@ section#presentation .presentation-fermer {
 }
 
 /* 🎨 Variables globales */
-@custom-media --bp-xs (min-width: 374px);
-@custom-media --bp-small (min-width: 480px);
-@custom-media --bp-mobile (min-width: 600px);
-@custom-media --bp-tablet (min-width: 768px);
-@custom-media --bp-desktop (min-width: 1024px);
-@custom-media --bp-wide (min-width: 1280px);
-@custom-media --bp-xxl (min-width: 1440px);
-@custom-media --bp-xxxl (min-width: 1920px);
 /* Legacy aliases */
-@custom-media --bp-sm (--bp-small);
-@custom-media --bp-600 (--bp-mobile);
-@custom-media --bp-md (--bp-tablet);
-@custom-media --bp-lg (--bp-desktop);
-@custom-media --bp-xl (--bp-wide);
 :root {
   /* Typographie et breakpoints */
   --font-main: "Poppins", sans-serif; /* Police principale */
@@ -8665,7 +8732,7 @@ section#presentation .presentation-fermer {
   --breakpoint-wide: 1280px;
 }
 
-@media (--bp-xxl) {
+@media (min-width: 1440px) {
   :root {
     --container-max-width: none;
   }
@@ -8684,5 +8751,3 @@ section#presentation .presentation-fermer {
   --editor-button-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-button) */
   --editor-button-hover-hsl: 214 79% 39%; /* = #1558B0 → var(--color-editor-button-hover) */
 }
-
-/*# sourceMappingURL=main.css.map */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1421,21 +1421,17 @@ a[aria-disabled=true] {
   margin-top: 15px;
 }
 
-/* ========== 📨 ALERTES DISCRÈTES (TYPES) ========== */
-.alerte-discret--success {
+/* ========== 📨 MESSAGES (TYPES) ========== */
+.message-succes {
   border-left-color: var(--color-success);
 }
 
-.alerte-discret--info {
+.message-info {
   border-left-color: var(--color-accent);
 }
 
-.alerte-discret--error {
+.message-erreur {
   border-left-color: var(--color-error);
-}
-
-.alerte-discret--warning {
-  border-left-color: var(--color-secondary);
 }
 
 /* ========== 🖼️ ICONES SVG ========== */
@@ -6923,7 +6919,9 @@ body #primary {
 }
 
 /* ========== 🌒 ALERTE DISCRET ========== */
-.alerte-discret {
+.message-info,
+.message-erreur,
+.message-succes {
   background: var(--color-text-primary, #fff4d4);
   color: var(--color-text, var(--color-grey-dark));
   border-left: 4px solid var(--color-accent);
@@ -6932,6 +6930,14 @@ body #primary {
   max-width: 700px;
   border-radius: 4px;
   font-size: 0.95rem;
+}
+
+.message-erreur {
+  border-left-color: var(--color-error);
+}
+
+.message-succes {
+  border-left-color: var(--color-success);
 }
 
 /* ==================================================

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -846,10 +846,10 @@ function afficher_message_validation_chasse(int $chasse_id): void
     $statut_validation  = get_field('chasse_cache_statut_validation', $chasse_id);
 
     if ($validation_envoyee) {
-        echo '<p class="message-succes">✅ Votre demande de validation est en cours de traitement par l’équipe.</p>';
+        echo '<p class="message-succes" role="status" aria-live="polite">✅ Votre demande de validation est en cours de traitement par l’équipe.</p>';
         echo '<script>if(window.history.replaceState){const u=new URL(window.location);u.searchParams.delete("validation_demandee");history.replaceState(null,"",u);}</script>';
     } elseif ($statut_validation === 'en_attente' && !current_user_can('administrator')) {
-        echo '<p class="message-info">⏳ Votre demande est en cours de traitement</p>';
+        echo '<p class="message-info" role="status" aria-live="polite">⏳ Votre demande est en cours de traitement</p>';
     }
 }
 

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -595,7 +595,25 @@ function myaccount_get_important_messages(): string
         function ($msg) {
             $type = $msg['type'] ?? 'info';
             $text = $msg['text'] ?? '';
-            return '<p class="alerte-discret alerte-discret--' . esc_attr($type) . '">' . $text . '</p>';
+            switch ($type) {
+                case 'success':
+                    $class = 'message-succes';
+                    $aria  = 'role="status" aria-live="polite"';
+                    break;
+                case 'error':
+                    $class = 'message-erreur';
+                    $aria  = 'role="alert" aria-live="assertive"';
+                    break;
+                case 'warning':
+                    $class = 'message-info';
+                    $aria  = 'role="status" aria-live="polite"';
+                    break;
+                default:
+                    $class = 'message-info';
+                    $aria  = 'role="status" aria-live="polite"';
+                    break;
+            }
+            return '<p class="' . esc_attr($class) . '" ' . $aria . '>' . $text . '</p>';
         },
         $messages
     );

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -615,7 +615,7 @@ En revanche, les champs obligatoires ou facultatifs sont masqués derrière un r
             min="1"
             class="champ-inline-nb champ-nb-edit champ-input champ-number"
             <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
-      <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+      <div id="erreur-nb-gagnants" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
     </div>
   </div>
 </li>
@@ -645,7 +645,7 @@ En revanche, les champs obligatoires ou facultatifs sont masqués derrière un r
             name="chasse-date-debut"
             value="<?= esc_attr($date_debut_iso); ?>"
             class="champ-inline-date champ-date-edit" <?= ($peut_editer && $debut_differe) ? '' : 'disabled'; ?> />
-      <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+      <div id="erreur-date-debut" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
     </div>
   </div>
 </li>

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -163,12 +163,12 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     <?php if (!empty($_GET['erreur'])) : ?>
         <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
         <?php if ($error_message === 'points_insuffisants') : ?>
-            <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+            <div class="message-erreur" role="alert" aria-live="assertive" style="color:red; margin-bottom:1em;">
                 ❌ <?= esc_html__('Vous n’avez pas assez de points pour engager cette énigme.', 'chassesautresor-com'); ?>
                 <a href="<?= esc_url(home_url('/boutique')); ?>"><?= esc_html__('Accéder à la boutique', 'chassesautresor-com'); ?></a>
             </div>
         <?php else : ?>
-            <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+            <div class="message-erreur" role="alert" aria-live="assertive" style="color:red; margin-bottom:1em;">
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -38,7 +38,7 @@ if (is_singular('enigme')) {
 
         <?php if (!empty($_GET['erreur'])) : ?>
             <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
-            <div class="message-erreur" role="alert" style="color:red; margin-bottom:1em;">
+            <div class="message-erreur" role="alert" aria-live="assertive" style="color:red; margin-bottom:1em;">
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -466,7 +466,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         class="champ-inline-nb champ-nb-edit champ-input champ-number"
                                         <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
 
-                                    <div id="erreur-nb-gagnants" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-nb-gagnants" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
                                 </div>
                             </div>
                             <?php
@@ -522,7 +522,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         name="chasse-date-debut"
                                         value="<?= esc_attr($date_debut_iso); ?>"
                                         class="champ-inline-date champ-date-edit" <?= ($peut_editer && $debut_differe) ? '' : 'disabled'; ?> required />
-                                    <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-date-debut" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
                                 </div>
                             </div>
                             <?php
@@ -568,7 +568,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         name="chasse-date-fin"
                                         value="<?= esc_attr($date_fin_iso); ?>"
                                         class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
-                                    <div id="erreur-date-fin" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-date-fin" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
                                 </div>
                             </div>
                             <?php

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -321,7 +321,7 @@ class MyAccountMessagesTest extends TestCase
             ]
         );
         $output = myaccount_get_important_messages();
-        $this->assertStringContainsString('<p class="alerte-discret alerte-discret--info">Stylé</p>', $output);
+        $this->assertStringContainsString('<p class="message-info" role="status" aria-live="polite">Stylé</p>', $output);
     }
 
     public function test_ajax_section_returns_flash_message(): void


### PR DESCRIPTION
## Résumé
- remplace `alerte-discret` par `message-info`, `message-erreur` et `message-succes`
- ajoute les attributs ARIA pour une meilleure accessibilité
- met à jour les styles et les tests associés

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff5417ee083329ff211126764d33f