### PR TITLE
Fix missing hunt and organizer translations

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -603,8 +603,12 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     // 🧑‍💻 Utilisateur non connecté
     if (!$user_id) {
         return [
-            'cta_html'    => '<a href="' . esc_url(site_url('/mon-compte')) . '" class="bouton-cta">S\'identifier</a>',
-            'cta_message' => 'Vous devez être identifié pour participer à cette chasse',
+            'cta_html'    => sprintf(
+                '<a href="%s" class="bouton-cta">%s</a>',
+                esc_url(site_url('/mon-compte')),
+                esc_html__('S\'identifier', 'chassesautresor-com')
+            ),
+            'cta_message' => __('Vous devez être identifié pour participer à cette chasse', 'chassesautresor-com'),
             'type'        => 'connexion',
         ];
     }
@@ -636,11 +640,17 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     $type    = '';
 
     if ($statut === 'a_venir') {
-        $html = '<button class="bouton-cta" disabled>Indisponible</button>';
+        $html = sprintf(
+            '<button class="bouton-cta" disabled>%s</button>',
+            esc_html__('Indisponible', 'chassesautresor-com')
+        );
         $type = 'indisponible';
         $message = $date_debut
-            ? 'Chasse disponible à partir du ' . date_i18n('d/m/Y \à H:i', strtotime($date_debut))
-            : 'Chasse disponible prochainement';
+            ? sprintf(
+                __('Chasse disponible à partir du %s', 'chassesautresor-com'),
+                date_i18n('d/m/Y \à H:i', strtotime($date_debut))
+            )
+            : __('Chasse disponible prochainement', 'chassesautresor-com');
     } elseif ($statut === 'en_cours' || $statut === 'payante') {
         $cout_points        = (int) get_field('chasse_infos_cout_points', $chasse_id);
         $points_disponibles = get_user_points($user_id);
@@ -667,9 +677,12 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             $html  = '<form method="post" action="' . esc_url(site_url('/traitement-engagement')) . '" class="cta-chasse-form">';
             $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
             $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
-            $html .= '<button type="submit" class="bouton-cta">Participer</button>';
+            $html .= sprintf(
+                '<button type="submit" class="bouton-cta">%s</button>',
+                esc_html__('Participer', 'chassesautresor-com')
+            );
             $html .= '</form>';
-            $message = 'Accès libre à cette chasse. Les tentatives seront tarifées individuellement.';
+            $message = __('Accès libre à cette chasse. Les tentatives seront tarifées individuellement.', 'chassesautresor-com');
             $type    = 'engager';
         }
     } elseif ($statut === 'termine') {
@@ -677,12 +690,18 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         $html  = '<form method="post" action="' . esc_url(site_url('/traitement-engagement')) . '" class="cta-chasse-form">';
         $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
         $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
-        $html .= '<button type="submit" class="bouton-cta">Voir</button>';
+        $html .= sprintf(
+            '<button type="submit" class="bouton-cta">%s</button>',
+            esc_html__('Voir', 'chassesautresor-com')
+        );
         $html .= '</form>';
         $type = 'voir';
         $message = $date_fin
-            ? 'Cette chasse est terminée depuis le ' . date_i18n('d/m/Y', strtotime($date_fin))
-            : 'Cette chasse est terminée';
+            ? sprintf(
+                __('Cette chasse est terminée depuis le %s', 'chassesautresor-com'),
+                date_i18n('d/m/Y', strtotime($date_fin))
+            )
+            : __('Cette chasse est terminée', 'chassesautresor-com');
     }
 
     return [

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -217,8 +217,8 @@ function render_conversion_modal_content($access_message = null): string
         <span class="close-modal">&times;</span>
         <div class="points-modal-message">
             <i class="fa-solid fa-building-columns modal-icon" aria-hidden="true"></i>
-            <h2>Coordonnées bancaires manquantes</h2>
-            <p>nous avons besoin d'enregistrer vos coordonnées bancaires pour vous envoyer un versement</p>
+            <h2><?php esc_html_e('Coordonnées bancaires manquantes', 'chassesautresor-com'); ?></h2>
+            <p><?php esc_html_e("Nous avons besoin d'enregistrer vos coordonnées bancaires pour vous envoyer un versement", 'chassesautresor-com'); ?></p>
             <p>
                 <a
                     id="ouvrir-coordonnees-modal"
@@ -232,7 +232,7 @@ function render_conversion_modal_content($access_message = null): string
                     data-label-edit="<?php esc_attr_e('Éditer', 'chassesautresor-com'); ?>"
                     data-aria-add="<?php esc_attr_e('Ajouter des coordonnées bancaires', 'chassesautresor-com'); ?>"
                     data-aria-edit="<?php esc_attr_e('Modifier les coordonnées bancaires', 'chassesautresor-com'); ?>"
-                >renseigner coordonnées bancaires</a>
+                ><?php esc_html_e('renseigner coordonnées bancaires', 'chassesautresor-com'); ?></a>
             </p>
             <button type="button" class="close-modal">Fermer</button>
         </div>

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-23T01:54:31+00:00\n"
+"POT-Creation-Date: 2025-08-28T06:27:25+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: chassesautresor-com\n"
@@ -34,24 +34,15 @@ msgstr ""
 msgid "Accueil Plein Ecran"
 msgstr ""
 
-#: functions.php:102
+#: functions.php:114
 msgid "Français"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:112
-#: assets/js/core/resume.js:322
-msgid "renseigner le titre de la chasse"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:120
-msgid "renseigner le titre de l’organisateur"
-msgstr ""
-
-#: functions.php:107
+#: functions.php:119
 msgid "English"
 msgstr ""
 
-#: functions.php:116
+#: functions.php:128
 msgid "Change language"
 msgstr ""
 
@@ -115,7 +106,7 @@ msgid "Régler"
 msgstr ""
 
 #: inc/admin-functions.php:467
-#: template-parts/chasse/chasse-edition-main.php:309
+#: template-parts/chasse/chasse-edition-main.php:347
 msgid "Annuler"
 msgstr ""
 
@@ -146,120 +137,127 @@ msgid "⛔ Erreur de sécurité. Veuillez réessayer."
 msgstr ""
 
 #: inc/admin-functions.php:1343
-#: inc/admin-functions.php:1368
+#: inc/admin-functions.php:1369
 msgid "Non autorisé"
 msgstr ""
 
-#: inc/admin-functions.php:1425
+#: inc/admin-functions.php:1426
 msgid "Confirmez-vous la réinitialisation des statistiques ?"
 msgstr ""
 
-#: inc/admin-functions.php:1426
+#: inc/admin-functions.php:1427
 msgid "Statistiques effacées."
 msgstr ""
 
-#: inc/admin-functions.php:1647
+#: inc/admin-functions.php:1648
 #: templates/myaccount/content-organisateurs.php:21
 msgid "Aucun organisateur."
 msgstr ""
 
-#: inc/admin-functions.php:1676
+#: inc/admin-functions.php:1677
 msgid "Organisateur"
 msgstr ""
 
-#: inc/admin-functions.php:1677
-#: template-parts/indice/indice-edition-main.php:153
+#: inc/admin-functions.php:1678
+#: template-parts/common/indices-table.php:128
+#: template-parts/common/solutions-table.php:53
 msgid "Chasse"
 msgstr ""
 
-#: inc/admin-functions.php:1678
+#: inc/admin-functions.php:1679
 msgid "Nb énigmes"
 msgstr ""
 
-#: inc/admin-functions.php:1679
+#: inc/admin-functions.php:1680
 msgid "État"
 msgstr ""
 
-#: inc/admin-functions.php:1680
+#: inc/admin-functions.php:1681
 #: inc/organisateur-functions.php:437
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:26
 msgid "Utilisateur"
 msgstr ""
 
-#: inc/admin-functions.php:1681
+#: inc/admin-functions.php:1682
 msgid "Créé le"
 msgstr ""
 
-#: inc/admin-functions.php:1701
+#: inc/admin-functions.php:1702
 msgid "valide"
 msgstr ""
 
-#: inc/admin-functions.php:1704
+#: inc/admin-functions.php:1705
+#: inc/chasse-functions.php:1122
+#: template-parts/chasse/chasse-affichage-complet.php:96
 msgid "correction"
 msgstr ""
 
-#: inc/admin-functions.php:1707
+#: inc/admin-functions.php:1708
+#: inc/chasse-functions.php:1124
+#: template-parts/chasse/chasse-affichage-complet.php:98
 msgid "en attente"
 msgstr ""
 
-#: inc/admin-functions.php:1710
+#: inc/admin-functions.php:1711
+#: inc/chasse-functions.php:1120
+#: template-parts/chasse/chasse-affichage-complet.php:94
 msgid "création"
 msgstr ""
 
-#: inc/admin-functions.php:1714
+#: inc/admin-functions.php:1715
 msgid "banni"
 msgstr ""
 
-#: inc/admin-functions.php:1730
+#: inc/admin-functions.php:1731
 msgid "Demande de validation et tentatives manuelles en attente"
 msgstr ""
 
-#: inc/admin-functions.php:1732
+#: inc/admin-functions.php:1733
 msgid "Demande de validation en attente"
 msgstr ""
 
-#: inc/admin-functions.php:1734
+#: inc/admin-functions.php:1735
 msgid "Tentatives manuelles en attente de réponse"
 msgstr ""
 
-#: inc/admin-functions.php:1785
-#: template-parts/chasse/chasse-edition-main.php:469
+#: inc/admin-functions.php:1786
+#: template-parts/chasse/chasse-edition-main.php:659
 msgid "Accès refusé."
 msgstr ""
 
-#: inc/admin-functions.php:1792
+#: inc/admin-functions.php:1793
 msgid "ID de chasse invalide."
 msgstr ""
 
-#: inc/admin-functions.php:1796
+#: inc/admin-functions.php:1797
 msgid "Nonce invalide."
 msgstr ""
 
-#: inc/admin-functions.php:1849
+#: inc/admin-functions.php:1850
 #, php-format
 msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
 msgstr ""
 
-#: inc/admin-functions.php:1886
+#: inc/admin-functions.php:1887
 #, php-format
 msgid "Votre demande de validation pour la chasse « %s » nécessite des corrections."
 msgstr ""
 
-#: inc/admin-functions.php:1891
+#: inc/admin-functions.php:1892
 #, php-format
 msgid "Message de l’administrateur : %s"
 msgstr ""
 
-#: inc/admin-functions.php:1895
+#: inc/admin-functions.php:1896
 msgid "Une copie de ce message vous a été envoyée par email."
 msgstr ""
 
-#: inc/admin-functions.php:1918
+#: inc/admin-functions.php:1919
 #, php-format
 msgid "Votre chasse « %s » a été bannie."
 msgstr ""
 
-#: inc/admin-functions.php:1940
+#: inc/admin-functions.php:1941
 #, php-format
 msgid "Votre chasse « %s » a été supprimée."
 msgstr ""
@@ -272,87 +270,327 @@ msgstr ""
 msgid "⚠️ Erreur : La date de fin ne peut pas être antérieure à la date du jour si la chasse commence maintenant."
 msgstr ""
 
-#: inc/chasse-functions.php:644
+#: inc/chasse-functions.php:617
+msgid "Participer"
+msgstr ""
+
+#: inc/chasse-functions.php:651
 msgid "Points insuffisants"
 msgstr ""
 
-#: inc/chasse-functions.php:650
+#: inc/chasse-functions.php:657
 #: inc/organisateur-functions.php:273
-#: template-parts/chasse/chasse-edition-main.php:417
-#: template-parts/enigme/enigme-edition-main.php:387
+#: template-parts/enigme/enigme-edition-main.php:572
 msgid "points"
 msgstr ""
 
-#: inc/chasse-functions.php:653
+#: inc/chasse-functions.php:660
 #, php-format
 msgid "Il vous manque %1$d %2$s pour participer à cette chasse."
 msgstr ""
 
-#: inc/chasse-functions.php:903
+#: inc/chasse-functions.php:780
+#: template-parts/chasse/chasse-affichage-complet.php:229
+#, php-format
+msgid "%d joueur"
+msgid_plural "%d joueurs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: inc/chasse-functions.php:910
 #: single-chasse.php:115
 msgid "Certaines énigmes doivent être complétées :"
 msgstr ""
 
-#: inc/edition/edition-chasse.php:48
+#: inc/chasse-functions.php:1126
+#: template-parts/chasse/chasse-affichage-complet.php:100
+msgid "révision"
+msgstr ""
+
+#: inc/chasse-functions.php:1129
+#: template-parts/chasse/chasse-affichage-complet.php:103
+msgid "en cours"
+msgstr ""
+
+#: inc/chasse-functions.php:1132
+#: template-parts/chasse/chasse-affichage-complet.php:106
+msgid "à venir"
+msgstr ""
+
+#: inc/chasse-functions.php:1134
+#: template-parts/chasse/chasse-affichage-complet.php:108
+msgid "terminée"
+msgstr ""
+
+#: inc/edition/edition-chasse.php:58
 msgid "Erreur lors du chargement des indices."
 msgstr ""
 
-#: inc/edition/edition-chasse.php:115
+#: inc/edition/edition-chasse.php:67
+#: inc/edition/edition-enigme.php:62
+#: template-parts/chasse/partials/chasse-partial-solutions.php:76
+#: template-parts/chasse/partials/chasse-partial-solutions.php:90
+msgid "Il existe déjà une solution pour cette chasse"
+msgstr ""
+
+#: inc/edition/edition-chasse.php:68
+#: template-parts/chasse/partials/chasse-partial-solutions.php:105
+msgid "Toutes les énigmes de la chasse ont déjà une solution"
+msgstr ""
+
+#: inc/edition/edition-chasse.php:135
 msgid "Aucun organisateur associé."
 msgstr ""
 
-#: inc/edition/edition-chasse.php:123
+#: inc/edition/edition-chasse.php:143
 msgid "Limite atteinte"
 msgstr ""
 
-#: inc/edition/edition-chasse.php:126
+#: inc/edition/edition-chasse.php:146
 msgid "Accès refusé"
 msgstr ""
 
-#: inc/edition/edition-chasse.php:136
+#: inc/edition/edition-chasse.php:156
 msgid "Une chasse est déjà en attente de validation."
 msgstr ""
 
-#: inc/edition/edition-chasse.php:149
+#: inc/edition/edition-chasse.php:169
 msgid "Erreur lors de la création de la chasse."
 msgstr ""
 
-#: inc/edition/edition-enigme.php:166
-msgid "Chasse non spécifiée ou invalide."
+#: inc/edition/edition-core.php:147
+#: inc/edition/edition-core.php:179
+#: assets/js/help-modal.js:19
+msgid "Fermer"
 msgstr ""
 
-#: inc/edition/edition-indice.php:45
-msgid "Type de cible invalide."
+#: inc/edition/edition-core.php:148
+msgid "Choisir une image"
 msgstr ""
 
-#: inc/edition/edition-indice.php:49
-msgid "ID cible invalide."
+#: inc/edition/edition-core.php:149
+#: inc/edition/edition-core.php:188
+#: templates/myaccount/content-outils.php:33
+msgid "Modifier"
 msgstr ""
 
-#: inc/edition/edition-indice.php:53
-msgid "Utilisateur non connecté."
+#: inc/edition/edition-core.php:150
+#: template-parts/common/indices-table.php:185
+#: template-parts/common/solutions-table.php:163
+#: assets/js/enigme-edit.js:886
+msgid "Supprimer"
 msgstr ""
 
-#: inc/edition/edition-indice.php:57
-#: inc/edition/edition-indice.php:65
-msgid "Droits insuffisants."
+#: inc/edition/edition-core.php:151
+msgid "Texte de l’indice"
 msgstr ""
 
-#: inc/edition/edition-indice.php:83
+#: inc/edition/edition-core.php:152
+msgid "Immédiate"
+msgstr ""
+
+#: inc/edition/edition-core.php:153
+#: inc/edition/edition-core.php:184
+msgid "Différée"
+msgstr ""
+
+#: inc/edition/edition-core.php:154
+#: inc/edition/edition-core.php:186
+#: inc/enigme/reponses.php:137
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
+msgid "Valider"
+msgstr ""
+
+#: inc/edition/edition-core.php:155
+msgid "Sélectionner une image"
+msgstr ""
+
+#: inc/edition/edition-core.php:156
+#: inc/edition/edition-indice.php:164
+#: inc/edition/edition-indice.php:262
 #, php-format
 msgid "Indice #%d"
 msgstr ""
 
-#: inc/edition/edition-core.php:155
-msgid "lié à"
+#: inc/edition/edition-core.php:157
+#: inc/edition/edition-core.php:196
+msgid "liée à"
 msgstr ""
 
-#: inc/edition/edition-indice.php:151
+#: inc/edition/edition-core.php:158
+#: inc/edition/edition-core.php:197
+msgid "la chasse"
+msgstr ""
+
+#: inc/edition/edition-core.php:159
+#: inc/edition/edition-core.php:198
+msgid "l’énigme"
+msgstr ""
+
+#: inc/edition/edition-core.php:160
+#: inc/edition/edition-core.php:191
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+#: template-parts/common/indices-table.php:127
+#: template-parts/common/solutions-table.php:52
+#: templates/myaccount/content-chasses.php:125
+msgid "Énigme"
+msgstr ""
+
+#: inc/edition/edition-core.php:161
+#: inc/edition/edition-core.php:192
+msgid "Sélectionner une énigme"
+msgstr ""
+
+#: inc/edition/edition-core.php:162
+#: inc/edition/edition-core.php:193
+msgid "Sélectionnez une énigme"
+msgstr ""
+
+#: inc/edition/edition-core.php:163
+#: inc/edition/edition-core.php:194
+msgid "Chargement…"
+msgstr ""
+
+#: inc/edition/edition-core.php:164
+msgid "Au moins une image ou un texte nécessaire"
+msgstr ""
+
+#: inc/edition/edition-core.php:165
+#: inc/edition/edition-core.php:202
+msgid "Date et heure requises"
+msgstr ""
+
+#: inc/edition/edition-core.php:166
+msgid "Date invalide"
+msgstr ""
+
+#: inc/edition/edition-core.php:167
+#: inc/edition/edition-core.php:190
+#: assets/js/indices-pager.js:34
+#: assets/js/indices-pager.js:83
+#: assets/js/solutions-pager.js:28
+#: assets/js/solutions-pager.js:77
+msgid "Erreur réseau"
+msgstr ""
+
+#: inc/edition/edition-core.php:180
+msgid "Texte de la solution"
+msgstr ""
+
+#: inc/edition/edition-core.php:181
+msgid "Fichier"
+msgstr ""
+
+#: inc/edition/edition-core.php:182
+msgid "Disponibilité"
+msgstr ""
+
+#: inc/edition/edition-core.php:183
+msgid "Fin de la chasse"
+msgstr ""
+
+#: inc/edition/edition-core.php:185
+msgid "jours"
+msgstr ""
+
+#: inc/edition/edition-core.php:187
+#: template-parts/chasse/partials/chasse-partial-solutions.php:43
+msgid "Ajouter une solution"
+msgstr ""
+
+#: inc/edition/edition-core.php:189
+msgid "Solution enregistrée."
+msgstr ""
+
+#: inc/edition/edition-core.php:195
+msgid "Ajoutez un fichier ou un texte"
+msgstr ""
+
+#: inc/edition/edition-core.php:199
+msgid "Choisir un fichier"
+msgstr ""
+
+#: inc/edition/edition-core.php:200
+msgid "Aucun fichier choisi"
+msgstr ""
+
+#: inc/edition/edition-core.php:201
+msgid "Supprimer le fichier"
+msgstr ""
+
+#: inc/edition/edition-enigme.php:63
+#: template-parts/chasse/partials/chasse-partial-solutions.php:63
+msgid "Il existe déjà une solution pour cette énigme"
+msgstr ""
+
+#: inc/edition/edition-enigme.php:64
+#: template-parts/common/edition-animation.php:521
+#: assets/js/enigme-edit.js:85
+#: assets/js/enigme-edit.js:259
+msgid "Voir toutes les solutions de la chasse"
+msgstr ""
+
+#: inc/edition/edition-enigme.php:65
+#: assets/js/enigme-edit.js:96
+#: assets/js/enigme-edit.js:257
+msgid "Voir la solution de cette énigme"
+msgstr ""
+
+#: inc/edition/edition-enigme.php:189
+msgid "Chasse non spécifiée ou invalide."
+msgstr ""
+
+#: inc/edition/edition-indice.php:225
+#: inc/edition/edition-solution.php:269
+msgid "Type de cible invalide."
+msgstr ""
+
+#: inc/edition/edition-indice.php:229
+#: inc/edition/edition-solution.php:273
+msgid "ID cible invalide."
+msgstr ""
+
+#: inc/edition/edition-indice.php:233
+#: inc/edition/edition-solution.php:277
+msgid "Utilisateur non connecté."
+msgstr ""
+
+#: inc/edition/edition-indice.php:237
+#: inc/edition/edition-indice.php:245
+#: inc/edition/edition-solution.php:281
+#: inc/edition/edition-solution.php:289
+msgid "Droits insuffisants."
+msgstr ""
+
+#: inc/edition/edition-indice.php:335
+#: inc/edition/edition-solution.php:386
 msgid "Action non autorisée."
 msgstr ""
 
-#: inc/edition/edition-indice.php:167
+#: inc/edition/edition-indice.php:351
+#: inc/edition/edition-solution.php:402
 msgid "ID cible manquant."
+msgstr ""
+
+#: inc/edition/edition-indice.php:587
+#: template-parts/common/edition-animation.php:481
+#: assets/js/enigme-edit.js:221
+msgid "Voir tous les indices de la chasse"
+msgstr ""
+
+#: inc/edition/edition-indice.php:588
+#: assets/js/enigme-edit.js:220
+msgid "Voir les indices de cette énigme"
+msgstr ""
+
+#: inc/edition/edition-solution.php:307
+msgid "Une solution existe déjà pour cet objet."
+msgstr ""
+
+#: inc/edition/edition-solution.php:322
+#, php-format
+msgid "Solution | %s"
 msgstr ""
 
 #: inc/enigme/affichage.php:159
@@ -398,136 +636,101 @@ msgid "Définition du taux de résolution"
 msgstr ""
 
 #: inc/enigme/affichage.php:518
-#: inc/enigme/affichage.php:1037
+#: inc/enigme/affichage.php:1039
+#: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
-#: template-parts/indice/indice-edition-main.php:154
 msgid "Énigmes"
 msgstr ""
 
-#: inc/enigme/affichage.php:546
+#: inc/enigme/affichage.php:536
+#: inc/enigme/affichage.php:1008
+msgid "Retour"
+msgstr ""
+
+#: inc/enigme/affichage.php:548
 msgid "Afficher les statistiques"
 msgstr ""
 
-#: inc/enigme/affichage.php:649
-#: template-parts/chasse/chasse-edition-main.php:708
+#: inc/enigme/affichage.php:651
 msgid "Indices"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:708
-#: template-parts/enigme/enigme-edition-main.php:774
-#: template-parts/common/edition-animation.php:366
-#: template-parts/common/edition-animation.php:370
-#, php-format
-msgid "Indices pour %s"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:35
-msgid "Ajouter un indice"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:42
-msgid "Pour…"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:56
-msgid "Cette énigme"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:66
-#: template-parts/chasse/partials/chasse-partial-indices.php:77
-msgid "La chasse entière"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:89
-msgid "Une énigme de la chasse"
-msgstr ""
-
-#: inc/enigme/affichage.php:677
+#: inc/enigme/affichage.php:679
+#: template-parts/chasse/chasse-affichage-complet.php:273
 msgid "automatique"
 msgstr ""
 
-#: inc/enigme/affichage.php:678
+#: inc/enigme/affichage.php:680
+#: template-parts/chasse/chasse-affichage-complet.php:274
 msgid "manuelle"
 msgstr ""
 
-#: inc/enigme/affichage.php:680
+#: inc/enigme/affichage.php:682
 #, php-format
 msgid "Mode de validation de l'énigme : %s"
 msgstr ""
 
-#: inc/enigme/affichage.php:712
+#: inc/enigme/affichage.php:714
 #, php-format
 msgid "Solde : %d pts"
 msgstr ""
 
-#: inc/enigme/affichage.php:721
+#: inc/enigme/affichage.php:723
 #, php-format
 msgid "Tentatives quotidiennes : %1$d/%2$s"
 msgstr ""
 
-#: inc/enigme/affichage.php:737
+#: inc/enigme/affichage.php:739
 #, php-format
 msgid "Coût par tentative : %d points."
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:120
-#: template-parts/chasse/chasse-affichage-complet.php:130
-#, php-format
-msgid "Coût de participation : %d points."
-msgstr ""
-
-#: inc/enigme/affichage.php:741
+#: inc/enigme/affichage.php:743
+#: template-parts/chasse/chasse-affichage-complet.php:131
+#: template-parts/chasse/chasse-affichage-complet.php:152
 #: assets/js/reponse-automatique.js:76
 #: assets/js/reponse-automatique.js:98
 msgid "pts"
 msgstr ""
 
-#: inc/enigme/affichage.php:780
+#: inc/enigme/affichage.php:782
 msgid "Voir la solution"
 msgstr ""
 
-#: inc/enigme/affichage.php:945
-#: inc/enigme/affichage.php:956
-#: inc/enigme/affichage.php:1012
-#: inc/enigme/affichage.php:1013
-#: inc/enigme/affichage.php:1026
-#: inc/enigme/affichage.php:1027
-#: single-indice.php:27
-#: template-parts/chasse/chasse-edition-main.php:67
-#: template-parts/chasse/chasse-edition-main.php:76
-#: template-parts/enigme/enigme-edition-main.php:94
-#: template-parts/enigme/enigme-edition-main.php:104
-#: template-parts/indice/indice-edition-main.php:59
-#: template-parts/indice/indice-edition-main.php:67
-#: template-parts/organisateur/organisateur-edition-main.php:75
-#: template-parts/organisateur/organisateur-edition-main.php:85
+#: inc/enigme/affichage.php:947
+#: inc/enigme/affichage.php:958
+#: inc/enigme/affichage.php:1014
+#: inc/enigme/affichage.php:1015
+#: inc/enigme/affichage.php:1028
+#: inc/enigme/affichage.php:1029
+#: template-parts/chasse/chasse-edition-main.php:69
+#: template-parts/chasse/chasse-edition-main.php:78
+#: template-parts/enigme/enigme-edition-main.php:93
+#: template-parts/enigme/enigme-edition-main.php:103
+#: template-parts/organisateur/organisateur-edition-main.php:76
+#: template-parts/organisateur/organisateur-edition-main.php:86
 msgid "Paramètres"
 msgstr ""
 
-#: inc/enigme/affichage.php:1006
-msgid "Retour"
-msgstr ""
-
-#: inc/enigme/affichage.php:1017
-#: inc/enigme/affichage.php:1018
+#: inc/enigme/affichage.php:1019
+#: inc/enigme/affichage.php:1020
 msgid "Menu énigme"
 msgstr ""
 
-#: inc/enigme/affichage.php:1035
+#: inc/enigme/affichage.php:1037
 msgid "Panneau d'énigme"
 msgstr ""
 
-#: inc/enigme/affichage.php:1038
-#: inc/enigme/affichage.php:1135
-#: template-parts/chasse/chasse-edition-main.php:68
-#: template-parts/enigme/enigme-edition-main.php:95
-#: template-parts/enigme/enigme-edition-main.php:499
+#: inc/enigme/affichage.php:1040
+#: inc/enigme/affichage.php:1137
+#: template-parts/chasse/chasse-edition-main.php:70
+#: template-parts/chasse/chasse-edition-main.php:656
+#: template-parts/enigme/enigme-edition-main.php:94
+#: template-parts/enigme/enigme-edition-main.php:645
 #: template-parts/enigme/partials/enigme-sidebar-section.php:52
-#: template-parts/indice/indice-edition-main.php:60
-#: template-parts/indice/indice-edition-main.php:218
-#: template-parts/organisateur/organisateur-edition-main.php:76
-#: template-parts/organisateur/organisateur-edition-main.php:252
+#: template-parts/organisateur/organisateur-edition-main.php:77
+#: template-parts/organisateur/organisateur-edition-main.php:328
 #: templates/myaccount/layout.php:111
 msgid "Statistiques"
 msgstr ""
@@ -541,7 +744,6 @@ msgid "Chasse verrouillée"
 msgstr ""
 
 #: inc/enigme/cta.php:195
-#: template-parts/enigme/enigme-edition-main.php:451
 msgid "Pré-requis"
 msgstr ""
 
@@ -631,12 +833,6 @@ msgstr ""
 msgid "Solde : %1$d → %2$d pts"
 msgstr ""
 
-#: inc/enigme/reponses.php:137
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
-msgid "Valider"
-msgstr ""
-
 #: inc/enigme/reponses.php:140
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:147
 #, php-format
@@ -719,7 +915,9 @@ msgid "ID"
 msgstr ""
 
 #: inc/gamify-functions.php:525
-#: template-parts/enigme/enigme-edition-main.php:577
+#: template-parts/common/indices-table.php:63
+#: template-parts/common/solutions-table.php:30
+#: template-parts/enigme/enigme-edition-main.php:723
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:35
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:25
 #: templates/myaccount/content-chasses.php:124
@@ -744,33 +942,52 @@ msgstr ""
 msgid "Solde"
 msgstr ""
 
+#: inc/handlers/voir-fichier.php:25
+msgid "Fichier introuvable (ID)."
+msgstr ""
+
+#: inc/handlers/voir-fichier.php:33
+msgid "Solution introuvable."
+msgstr ""
+
+#: inc/handlers/voir-fichier.php:44
+msgid "Accès non autorisé à cette solution."
+msgstr ""
+
+#: inc/handlers/voir-fichier.php:54
+msgid "Aucun fichier PDF lié à cette solution."
+msgstr ""
+
 #: inc/organisateur-functions.php:227
 #: inc/organisateur-functions.php:233
-#: template-parts/organisateur/organisateur-edition-main.php:308
-#: template-parts/organisateur/organisateur-edition-main.php:321
+#: template-parts/organisateur/organisateur-edition-main.php:384
+#: template-parts/organisateur/organisateur-edition-main.php:397
 msgid "Ajouter des coordonnées bancaires"
 msgstr ""
 
 #: inc/organisateur-functions.php:231
-#: template-parts/chasse/chasse-edition-main.php:673
 #: template-parts/chasse/partials/chasse-partial-indices.php:97
-#: template-parts/organisateur/organisateur-edition-main.php:305
-#: template-parts/organisateur/organisateur-edition-main.php:319
-#: template-parts/organisateur/organisateur-edition-main.php:360
+#: template-parts/chasse/partials/chasse-partial-solutions.php:115
+#: template-parts/common/edition-animation.php:82
+#: template-parts/common/edition-animation.php:108
+#: template-parts/organisateur/organisateur-edition-main.php:381
+#: template-parts/organisateur/organisateur-edition-main.php:395
 msgid "Ajouter"
 msgstr ""
 
 #: inc/organisateur-functions.php:232
-#: template-parts/chasse/chasse-edition-main.php:674
-#: template-parts/organisateur/organisateur-edition-main.php:306
-#: template-parts/organisateur/organisateur-edition-main.php:320
-#: template-parts/organisateur/organisateur-edition-main.php:361
+#: template-parts/common/edition-animation.php:83
+#: template-parts/common/edition-animation.php:109
+#: template-parts/common/indices-table.php:176
+#: template-parts/common/solutions-table.php:156
+#: template-parts/organisateur/organisateur-edition-main.php:382
+#: template-parts/organisateur/organisateur-edition-main.php:396
 msgid "Éditer"
 msgstr ""
 
 #: inc/organisateur-functions.php:234
-#: template-parts/organisateur/organisateur-edition-main.php:309
-#: template-parts/organisateur/organisateur-edition-main.php:322
+#: template-parts/organisateur/organisateur-edition-main.php:385
+#: template-parts/organisateur/organisateur-edition-main.php:398
 msgid "Modifier les coordonnées bancaires"
 msgstr ""
 
@@ -790,7 +1007,7 @@ msgstr ""
 
 #: inc/organisateur-functions.php:262
 #: inc/organisateur-functions.php:282
-#: template-parts/organisateur/organisateur-edition-main.php:281
+#: template-parts/organisateur/organisateur-edition-main.php:357
 msgid "Convertir"
 msgstr ""
 
@@ -918,23 +1135,23 @@ msgstr ""
 msgid "Vos commandes"
 msgstr ""
 
-#: inc/user-functions.php:335
+#: inc/user-functions.php:352
 #, php-format
 msgid "Votre demande de résolution de l'énigme %s est en cours de traitement. Vous recevrez une notification dès que votre demande sera traitée."
 msgstr ""
 
-#: inc/user-functions.php:351
+#: inc/user-functions.php:371
 #, php-format
 msgid "Vos demandes de résolution d'énigmes sont en cours de traitement : %s. Vous recevrez une notification dès que vos demandes seront traitées."
 msgstr ""
 
 #. translators: 1: opening anchor tag, 2: closing anchor tag
-#: inc/user-functions.php:456
+#: inc/user-functions.php:504
 #, php-format
 msgid "Vous avez des %1$sdemandes de conversion%2$s en attente."
 msgstr ""
 
-#: inc/user-functions.php:478
+#: inc/user-functions.php:529
 msgid "Important ! Des tentatives attendent votre action :"
 msgstr ""
 
@@ -958,258 +1175,382 @@ msgstr ""
 msgid "C'est parti !"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:61
+#: template-parts/chasse/chasse-affichage-complet.php:46
+#: template-parts/chasse/chasse-affichage-complet.php:132
+msgid "mode de fin de chasse : automatique"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:47
+#: template-parts/chasse/chasse-affichage-complet.php:133
+msgid "mode de fin de chasse : manuelle"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:130
+#: template-parts/chasse/chasse-affichage-complet.php:147
+#, php-format
+msgid "Coût de participation : %d points."
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:176
+#: template-parts/chasse/chasse-edition-main.php:157
+#: template-parts/chasse/chasse-edition-main.php:167
+msgid "Image de la chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:220
+msgid "Par"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:227
+#: template-parts/chasse/chasse-card.php:33
+#, php-format
+msgid "%d énigme"
+msgid_plural "%d énigmes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:263
+msgid "Limite"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:264
+#, php-format
+msgid "%d gagnants"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:269
+msgid "Fin de chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:280
+msgid "Accès chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:283
+#, php-format
+msgid "%d points"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:284
+msgid "libre"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:289
+msgid "Accès énigme"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:294
+#, php-format
+msgid "%d énigme nécessite des points pour soumettre une tentative"
+msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:305
+msgid "gratuit"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:312
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+#: template-parts/chasse/partials/chasse-partial-participants.php:40
+msgid "Joueurs"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:314
+#, php-format
+msgid "%d participant"
+msgid_plural "%d participants"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:321
+#, php-format
+msgid "%1$d joueur a trouvé %2$d énigme"
+msgid_plural "%1$d joueurs ont trouvé %2$d énigmes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:332
+msgid "Les + avancés"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:349
+msgid "Récompense de la chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:352
+msgid "Titre :"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:356
+msgid "Valeur :"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:360
+msgid "Description complète :"
+msgstr ""
+
+#: template-parts/chasse/chasse-card.php:48
+msgid "En savoir plus"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:63
 msgid "Panneau d'édition chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:69
-#: template-parts/chasse/chasse-edition-main.php:647
-#: template-parts/enigme/enigme-edition-main.php:96
-#: template-parts/organisateur/organisateur-edition-main.php:77
-#: template-parts/organisateur/organisateur-edition-main.php:335
+#: template-parts/chasse/chasse-edition-main.php:71
+#: template-parts/common/edition-animation.php:55
+#: template-parts/enigme/enigme-edition-main.php:95
+#: template-parts/organisateur/organisateur-edition-main.php:78
 msgid "Animation"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:104
-#: template-parts/enigme/enigme-edition-main.php:128
-#: template-parts/indice/indice-edition-main.php:90
+#: template-parts/chasse/chasse-edition-main.php:106
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:29
+#: template-parts/enigme/enigme-edition-main.php:127
 #: template-parts/organisateur/organisateur-edition-main.php:110
 msgid "Titre"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:126
+#: template-parts/chasse/chasse-edition-main.php:114
+#: assets/js/core/resume.js:297
+msgid "renseigner le titre de la chasse"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:139
 msgid "Image chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:133
-#: template-parts/indice/indice-edition-main.php:107
+#: template-parts/chasse/chasse-edition-main.php:154
 msgid "Modifier l’image"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:135
-#: template-parts/chasse/chasse-edition-main.php:141
-#: template-parts/indice/indice-edition-main.php:109
-#: template-parts/indice/indice-edition-main.php:115
+#: template-parts/chasse/chasse-edition-main.php:160
+#: template-parts/chasse/chasse-edition-main.php:171
+#: template-parts/organisateur/organisateur-edition-main.php:165
+#: template-parts/organisateur/organisateur-edition-main.php:176
 msgid "ajouter une image"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:201
 msgid "Description chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:162
-#: template-parts/enigme/enigme-edition-main.php:172
-#: template-parts/enigme/enigme-edition-main.php:185
-#: template-parts/enigme/enigme-edition-main.php:202
-#: template-parts/indice/indice-edition-main.php:129
-#: template-parts/organisateur/organisateur-edition-main.php:161
-#: assets/js/enigme-edit.js:645
+#: template-parts/chasse/chasse-edition-main.php:215
+#: template-parts/enigme/enigme-edition-main.php:182
+#: template-parts/enigme/enigme-edition-main.php:195
+#: template-parts/enigme/enigme-edition-main.php:231
+#: template-parts/organisateur/organisateur-edition-main.php:218
+#: assets/js/enigme-edit.js:902
 msgid "ajouter"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:174
+#: template-parts/chasse/chasse-edition-main.php:227
 msgid "Modifier la description"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:175
-#: template-parts/indice/indice-edition-main.php:137
-#: template-parts/organisateur/organisateur-edition-main.php:173
-#: template-parts/organisateur/organisateur-edition-main.php:220
+#: template-parts/chasse/chasse-edition-main.php:232
+#: template-parts/organisateur/organisateur-edition-main.php:231
+#: template-parts/organisateur/organisateur-edition-main.php:292
 #: assets/js/core/helpers.js:234
 #: assets/js/core/helpers.js:256
-#: assets/js/core/helpers.js:278
-#: assets/js/core/resume.js:384
-#: assets/js/enigme-edit.js:743
-#: assets/js/enigme-edit.js:988
+#: assets/js/core/helpers.js:283
+#: assets/js/core/resume.js:378
+#: assets/js/enigme-edit.js:1001
+#: assets/js/enigme-edit.js:1247
 msgid "modifier"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:191
+#: template-parts/chasse/chasse-edition-main.php:262
 msgid "Récompense"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:227
-#: template-parts/enigme/enigme-edition-main.php:238
-#: template-parts/indice/indice-edition-main.php:148
+#: template-parts/chasse/chasse-edition-main.php:321
+#: template-parts/enigme/enigme-edition-main.php:288
 msgid "Réglages"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:239
-msgid "Mode de fin"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:250
-#: template-parts/enigme/enigme-edition-main.php:247
-msgid "Automatique"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:256
-#: template-parts/enigme/enigme-edition-main.php:253
-msgid "Explication du mode automatique"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:258
-msgid "Fin de chasse automatique"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:259
-msgid "Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode automatique, la chasse se termine dès que le nombre de gagnants prévu est atteint."
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:272
-#: template-parts/enigme/enigme-edition-main.php:264
-msgid "Manuelle"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:278
-#: template-parts/enigme/enigme-edition-main.php:270
-msgid "Explication du mode manuel"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:280
-msgid "Fin de chasse manuelle"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:281
-msgid "Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans le panneau d’édition de la chasse, onglet Animation."
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:295
+#: template-parts/chasse/chasse-edition-main.php:333
 msgid "Terminer la chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:297
+#: template-parts/chasse/chasse-edition-main.php:335
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:21
 msgid "Gagnants"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:305
+#: template-parts/chasse/chasse-edition-main.php:343
 msgid "Valider la fin de chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:319
+#: template-parts/chasse/chasse-edition-main.php:367
+msgid "Mode de fin"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:374
+#: template-parts/enigme/enigme-edition-main.php:315
+msgid "Automatique"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:380
+#: template-parts/enigme/enigme-edition-main.php:321
+msgid "Explication du mode automatique"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:382
+msgid "Fin de chasse automatique"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:383
+msgid "Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode automatique, la chasse se termine dès que le nombre de gagnants prévu est atteint."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:400
+#: template-parts/enigme/enigme-edition-main.php:333
+msgid "Manuelle"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:406
+#: template-parts/enigme/enigme-edition-main.php:339
+msgid "Explication du mode manuel"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:408
+msgid "Fin de chasse manuelle"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:409
+msgid "Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans le panneau d’édition de la chasse, onglet Animation."
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/common/edition-animation.php:139
 #, php-format
 msgid "Chasse gagnée le %s par %s"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:337
-#: template-parts/chasse/chasse-edition-main.php:448
+#: template-parts/chasse/chasse-edition-main.php:443
 msgid "Nb gagnants"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:454
+#: template-parts/chasse/chasse-edition-main.php:449
 msgid "Illimité"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:464
+#: template-parts/chasse/chasse-edition-main.php:459
 msgid "Limité"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:514
-msgid "Now"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:524
-msgid "Later"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:374
+#: template-parts/chasse/chasse-edition-main.php:502
 msgid "Début"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:554
+#: template-parts/chasse/chasse-edition-main.php:508
+msgid "Now"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:518
+msgid "Later"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:549
 msgid "Date de fin"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:560
+#: template-parts/chasse/chasse-edition-main.php:555
 msgid "Illimitée"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:569
+#: template-parts/chasse/chasse-edition-main.php:564
 msgid "Limitée"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:601
+#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/enigme/enigme-edition-main.php:601
 msgid "Accès"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:423
+#: template-parts/chasse/chasse-edition-main.php:603
 msgid "En savoir plus sur les points"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:426
+#: template-parts/chasse/chasse-edition-main.php:606
 msgid "Coût d’accès à une chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:427
+#: template-parts/chasse/chasse-edition-main.php:607
 msgid "Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou payant. Cet accès est indispensable pour consulter les énigmes, qui restent invisibles tant qu’il n’a pas été débloqué."
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:621
-#: template-parts/enigme/enigme-edition-main.php:394
-#: template-parts/indice/indice-edition-main.php:202
+#: template-parts/chasse/chasse-edition-main.php:617
 msgid "Gratuit"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:552
-#: template-parts/enigme/enigme-edition-main.php:517
+#: template-parts/chasse/chasse-edition-main.php:625
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:32
+#: template-parts/enigme/enigme-edition-main.php:568
+#: template-parts/organisateur/organisateur-edition-main.php:79
+#: template-parts/organisateur/organisateur-edition-main.php:340
+#: template-parts/organisateur/organisateur-edition-main.php:346
+#: templates/myaccount/content-points.php:75
+#: templates/myaccount/content-points.php:96
+#: templates/myaccount/layout.php:57
+#: templates/myaccount/layout.php:58
+#: templates/myaccount/layout.php:160
+msgid "Points"
+msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:742
+#: template-parts/enigme/enigme-edition-main.php:663
 msgid "Actualiser"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:554
-#: template-parts/enigme/enigme-edition-main.php:519
+#: template-parts/chasse/chasse-edition-main.php:744
+#: template-parts/enigme/enigme-edition-main.php:665
 msgid "Période :"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:568
-#: template-parts/enigme/enigme-edition-main.php:533
+#: template-parts/chasse/chasse-edition-main.php:758
+#: template-parts/enigme/enigme-edition-main.php:679
 msgid "Participants"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:575
-#: template-parts/enigme/enigme-edition-main.php:97
-#: template-parts/enigme/enigme-edition-main.php:540
-#: template-parts/enigme/enigme-edition-main.php:578
-#: template-parts/enigme/enigme-edition-main.php:627
+#: template-parts/chasse/chasse-edition-main.php:765
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
+#: template-parts/enigme/enigme-edition-main.php:96
+#: template-parts/enigme/enigme-edition-main.php:686
+#: template-parts/enigme/enigme-edition-main.php:724
+#: template-parts/enigme/enigme-edition-main.php:773
 #: template-parts/enigme/partials/enigme-partial-participants.php:69
 #: templates/myaccount/content-chasses.php:108
 msgid "Tentatives"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:582
-#: template-parts/enigme/enigme-edition-main.php:548
+#: template-parts/chasse/chasse-edition-main.php:772
+#: template-parts/enigme/enigme-edition-main.php:694
 msgid "Points collectés"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:589
-#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/chasse/chasse-edition-main.php:779
+#: template-parts/chasse/chasse-edition-main.php:787
 msgid "Taux d'engagement"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:592
+#: template-parts/chasse/chasse-edition-main.php:782
 msgid "Pourcentage moyen d’énigmes auxquelles chaque joueur a participé, par rapport à l’ensemble des énigmes proposées."
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:596
+#: template-parts/chasse/chasse-edition-main.php:786
 msgid "Explication du taux d’engagement"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:605
+#: template-parts/chasse/chasse-edition-main.php:795
 #: template-parts/enigme/partials/enigme-partial-participants.php:39
 msgid "Les statistiques seront disponibles une fois la chasse activée."
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:616
+#: template-parts/chasse/chasse-edition-main.php:806
 msgid "Énigmes sans validation"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:655
-#: template-parts/organisateur/organisateur-edition-main.php:342
-msgid "Communiquez"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:662
-msgid "Sites et réseaux de la chasse"
 msgstr ""
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:28
@@ -1220,14 +1561,12 @@ msgstr ""
 #: template-parts/chasse/panneaux/chasse-edition-recompense.php:16
 #: template-parts/enigme/panneaux/enigme-edition-description.php:19
 #: template-parts/enigme/panneaux/enigme-edition-images.php:12
-#: template-parts/indice/panneaux/indice-edition-description.php:19
 msgid "Fermer le panneau"
 msgstr ""
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:37
 #: template-parts/enigme/panneaux/enigme-edition-description.php:27
 #: template-parts/enigme/panneaux/enigme-edition-images.php:31
-#: template-parts/indice/panneaux/indice-edition-description.php:26
 msgid "💾 Enregistrer"
 msgstr ""
 
@@ -1271,13 +1610,34 @@ msgstr ""
 msgid "Supprimer la récompense"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:40
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
-msgid "Joueurs"
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:33
+#: template-parts/chasse/partials/chasse-partial-participants.php:70
+msgid "Trouvées"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:35
+msgid "Ajouter un indice"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:42
+#: template-parts/chasse/partials/chasse-partial-solutions.php:50
+msgid "Pour…"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:66
+#: template-parts/chasse/partials/chasse-partial-indices.php:77
+#: template-parts/chasse/partials/chasse-partial-solutions.php:79
+#: template-parts/chasse/partials/chasse-partial-solutions.php:93
+msgid "La chasse entière"
+msgstr ""
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:89
+#: template-parts/chasse/partials/chasse-partial-solutions.php:108
+msgid "Une énigme de la chasse"
 msgstr ""
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:51
-#: template-parts/enigme/enigme-edition-main.php:576
+#: template-parts/enigme/enigme-edition-main.php:722
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:34
 msgid "Joueur"
 msgstr ""
@@ -1298,25 +1658,240 @@ msgstr ""
 msgid "Trier par énigmes trouvées"
 msgstr ""
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:70
-msgid "Trouvées"
+#: template-parts/chasse/partials/chasse-partial-solutions.php:66
+msgid "Cette énigme"
 msgstr ""
 
-#: template-parts/common/edition-animation.php:512
-msgid "Solutions pour toute la chasse %s"
+#: template-parts/common/edition-animation.php:53
+msgid "Animation de cette énigme"
 msgstr ""
 
+#: template-parts/common/edition-animation.php:74
+msgid "Sites et réseaux de la chasse"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:100
+msgid "Sites et réseaux de l'organisation"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:135
+msgid "Arrêt chasse"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:154
+msgid "Adresse de votre organisation :"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:156
+msgid "Adresse de votre chasse&nbsp;:"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:161
+#: template-parts/common/edition-animation.php:165
+msgid "QR code de votre organisation"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:161
+#: template-parts/common/edition-animation.php:172
+msgid "QR code de votre chasse"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:166
+msgid "Partagez votre organisation en un scan"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:167
+msgid "Facilitez l'accès à votre organisation avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
+msgstr ""
+
+#: template-parts/common/edition-animation.php:169
+#: template-parts/common/edition-animation.php:176
+msgid "Télécharger"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:173
+msgid "Partagez votre chasse en un scan"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:174
+msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
+msgstr ""
+
+#: template-parts/common/edition-animation.php:335
+#: template-parts/common/indices-table.php:30
+msgid "en création"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:339
+#: template-parts/common/indices-table.php:32
+msgid "Nouvelle chasse"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:455
+#: template-parts/common/edition-animation.php:464
+#, php-format
+msgid "Indices pour %s"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:456
+#: template-parts/common/edition-animation.php:462
+#, php-format
+msgid "Indices pour toute la chasse %s"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:493
+msgid "Sécurité des PDF de solution"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:494
+msgid "Vos PDF sont conservés dans un coffre-fort numérique"
+msgstr ""
+
+#: template-parts/common/edition-animation.php:496
+msgid "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
+msgstr ""
+
+#: template-parts/common/edition-animation.php:497
+msgid "Ils ne seront partagés qu'à la date que vous aurez choisie : "
+msgstr ""
+
+#: template-parts/common/edition-animation.php:498
+msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
+msgstr ""
+
+#: template-parts/common/edition-animation.php:506
 #: template-parts/common/edition-animation.php:514
+#, php-format
 msgid "Solutions pour %s"
 msgstr ""
 
-#: template-parts/common/edition-animation.php:521
-#: inc/edition/edition-enigme.php:64
-msgid "Voir toutes les solutions de la chasse"
+#: template-parts/common/edition-animation.php:507
+#: template-parts/common/edition-animation.php:512
+#, php-format
+msgid "Solutions pour toute la chasse %s"
 msgstr ""
 
-#: inc/edition/edition-enigme.php:65
-msgid "Voir la solution de cette énigme"
+#: template-parts/common/indices-table.php:34
+#, php-format
+msgid "Vous n'avez publié aucun indice attaché à %s"
+msgstr ""
+
+#: template-parts/common/indices-table.php:42
+#, php-format
+msgid "%d indice au total"
+msgid_plural "%d indices au total"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/indices-table.php:45
+#, php-format
+msgid "%d indice chasse"
+msgid_plural "%d indices chasse"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/indices-table.php:48
+#, php-format
+msgid "%d indice énigme"
+msgid_plural "%d indices énigme"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/indices-table.php:64
+msgid "Indice"
+msgstr ""
+
+#: template-parts/common/indices-table.php:65
+#: template-parts/common/solutions-table.php:123
+msgid "Texte"
+msgstr ""
+
+#: template-parts/common/indices-table.php:66
+msgid "Indice pour"
+msgstr ""
+
+#: template-parts/common/indices-table.php:67
+#: template-parts/common/solutions-table.php:34
+msgid "Action"
+msgstr ""
+
+#. translators: %s: scheduled date
+#: template-parts/common/indices-table.php:117
+#, php-format
+msgid "programmé le %s"
+msgstr ""
+
+#: template-parts/common/indices-table.php:121
+msgid "programmé"
+msgstr ""
+
+#: template-parts/common/indices-table.php:150
+#: template-parts/common/solutions-table.php:114
+#, php-format
+msgid "à %s"
+msgstr ""
+
+#: template-parts/common/indices-table.php:184
+msgid "Supprimer cet indice ?"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:23
+msgid "Aucune solution publiée"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:31
+msgid "Solution"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:32
+msgid "Availability"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:33
+msgid "Solution pour"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:78
+msgid "Invalid solution"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:79
+msgid "Hunt finished"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:80
+msgid "Hunt end delayed"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:81
+msgid "Coming soon"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:82
+msgid "In progress"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:83
+msgid "Disabled"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:120
+msgid "PDF"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:132
+#, php-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/solutions-table.php:132
+msgid "at"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:162
+msgid "Supprimer cette solution ?"
 msgstr ""
 
 #: template-parts/common/stat-histogram-card.php:38
@@ -1324,164 +1899,145 @@ msgid "Aucune donnée."
 msgstr ""
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
-#: assets/js/enigme-edit.js:1616
+#: assets/js/enigme-edit.js:1533
 msgid "Ajouter une énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:87
+#: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:91
-#: template-parts/indice/indice-edition-main.php:56
+#: template-parts/enigme/enigme-edition-main.php:90
 msgid "Fermer les paramètres"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:112
-#: template-parts/indice/indice-edition-main.php:74
+#: template-parts/enigme/enigme-edition-main.php:111
 msgid "Informations"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:138
+#: template-parts/enigme/enigme-edition-main.php:137
 msgid "renseigner le titre de l’énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:156
+#: template-parts/enigme/enigme-edition-main.php:161
 msgid "Illustrations"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:194
+#: template-parts/enigme/enigme-edition-main.php:219
 msgid "Texte énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:213
+#: template-parts/enigme/enigme-edition-main.php:242
 msgid "Éditer le texte"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:214
-#: template-parts/enigme/enigme-edition-main.php:350
-#: template-parts/enigme/enigme-edition-main.php:673
+#: template-parts/enigme/enigme-edition-main.php:243
+#: template-parts/enigme/enigme-edition-main.php:461
 msgid "éditer"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:228
+#: template-parts/enigme/enigme-edition-main.php:270
 msgid "Sous-titre"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:230
+#: template-parts/enigme/enigme-edition-main.php:276
 msgid "Ajouter un sous-titre (max 100 caractères)"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:243
+#: template-parts/enigme/enigme-edition-main.php:307
 msgid "Validation"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:256
+#: template-parts/enigme/enigme-edition-main.php:324
 msgid "Validation automatique"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:257
+#: template-parts/enigme/enigme-edition-main.php:325
 msgid "Le joueur soumet une tentative de réponse. Celle-ci est automatiquement vérifiée selon les critères définis (réponse attendue, respect de la casse, variantes), et le résultat est immédiatement communiqué au joueur."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:273
+#: template-parts/enigme/enigme-edition-main.php:342
 msgid "Validation manuelle"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:274
+#: template-parts/enigme/enigme-edition-main.php:343
 msgid "Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa tentative depuis votre espace personnel. À chaque nouvelle soumission, vous recevez une notification par email ainsi qu’un message d’alerte."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:281
+#: template-parts/enigme/enigme-edition-main.php:351
 msgid "Aucune"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:288
+#: template-parts/enigme/enigme-edition-main.php:377
 msgid "Bonne(s) réponse(s)"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:294
+#: template-parts/enigme/enigme-edition-main.php:383
 msgid "La ou les bonnes réponses"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:295
+#: template-parts/enigme/enigme-edition-main.php:384
 msgid "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — selon votre réglage de respect de la casse — résout l’énigme."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:307
+#: template-parts/enigme/enigme-edition-main.php:397
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
 msgid "Respecter la casse"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:315
+#: template-parts/enigme/enigme-edition-main.php:423
 msgid "Variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:321
+#: template-parts/enigme/enigme-edition-main.php:429
 msgid "Explication des variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:324
+#: template-parts/enigme/enigme-edition-main.php:432
 msgid "Système de variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:325
+#: template-parts/enigme/enigme-edition-main.php:433
 msgid "Les variantes sont des réponses alternatives qui ne sont pas validées comme correctes, mais qui déclenchent un message personnalisé en retour (par exemple une aide, un indice, un lien ou tout autre contenu de votre choix)."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:335
-#: assets/js/enigme-edit.js:915
+#: template-parts/enigme/enigme-edition-main.php:446
+#: assets/js/enigme-edit.js:1174
 msgid "Variante"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:336
-#: assets/js/enigme-edit.js:918
+#: template-parts/enigme/enigme-edition-main.php:447
+#: assets/js/enigme-edit.js:1177
 msgid "Message"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:349
+#: template-parts/enigme/enigme-edition-main.php:460
 msgid "Éditer les variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:354
-#: assets/js/enigme-edit.js:966
+#: template-parts/enigme/enigme-edition-main.php:465
+#: assets/js/enigme-edit.js:1225
 msgid "Ajouter des variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:355
-#: assets/js/enigme-edit.js:967
+#: template-parts/enigme/enigme-edition-main.php:466
+#: assets/js/enigme-edit.js:1226
 msgid "ajouter des variantes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:371
-msgid "Coût tentative"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:377
-msgid "Informations sur le coût des tentatives"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:380
-msgid "Tentative gratuite ou payante ?"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:381
-msgid "Vous êtes libre de définir le coût d’une tentative pour votre énigme : gratuite ou payante en points. Lorsqu’un joueur dépense des points pour soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:402
+#: template-parts/enigme/enigme-edition-main.php:491
 msgid "Nb tentatives"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:408
+#: template-parts/enigme/enigme-edition-main.php:497
 msgid "Explication du nombre de tentatives"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:411
+#: template-parts/enigme/enigme-edition-main.php:500
 msgid "Plafond nb de tentatives quotidiennes"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:412
+#: template-parts/enigme/enigme-edition-main.php:501
 msgid ""
 "Nombre maximal de tentatives quotidiennes par joueur:\n"
 "\n"
@@ -1490,154 +2046,69 @@ msgid ""
 "Mode gratuit : 24 tentatives par jour"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:418
+#: template-parts/enigme/enigme-edition-main.php:513
 msgid "max par jour"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:434
-msgid "Accès"
+#: template-parts/enigme/enigme-edition-main.php:543
+msgid "Coût tentative"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:438
+#: template-parts/enigme/enigme-edition-main.php:549
+msgid "Informations sur le coût des tentatives"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:552
+msgid "Tentative gratuite ou payante ?"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:553
+msgid "Vous êtes libre de définir le coût d’une tentative pour votre énigme : gratuite ou payante en points. Lorsqu’un joueur dépense des points pour soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:563
+msgid "Free"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:607
 msgid "Libre"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:442
+#: template-parts/enigme/enigme-edition-main.php:612
 msgid "Date programmée"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:455
-msgid "Aucune autre énigme disponible comme prérequis."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:491
+#: template-parts/enigme/enigme-edition-main.php:637
 msgid "❌ Suppression énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:521
+#: template-parts/enigme/enigme-edition-main.php:667
 msgid "Total"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:522
+#: template-parts/enigme/enigme-edition-main.php:668
 msgid "Aujourd’hui"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:523
+#: template-parts/enigme/enigme-edition-main.php:669
 msgid "Semaine"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:524
+#: template-parts/enigme/enigme-edition-main.php:670
 msgid "Mois"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:556
+#: template-parts/enigme/enigme-edition-main.php:702
 msgid "Bonnes réponses"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:570
+#: template-parts/enigme/enigme-edition-main.php:716
 #, php-format
 msgid "Résolue par (%s) joueurs"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:575
+#: template-parts/enigme/enigme-edition-main.php:721
 msgid "Rang"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:655
-msgid "Animation de cette énigme"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:667
-msgid "Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée terminée. Une fois celle-ci achevée, elles restent conservées dans un coffre-fort numérique pendant le délai que vous définissez ici."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:670
-msgid "Document PDF"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:671
-#: templates/myaccount/content-outils.php:33
-msgid "Modifier"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:671
-msgid "Choisir un fichier"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:673
-msgid "Rédiger"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:675
-msgid "aucune solution ne"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:680
-#, php-format
-msgid "votre fichier %s"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:681
-#, php-format
-msgid " %d jours après la fin de la chasse, à %s"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:683
-msgid " (pdf sélectionné mais pas de fichier chargé)"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:687
-msgid "votre texte d'explication"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:688
-#, php-format
-msgid ", %d jours après la fin de la chasse, à %s"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:690
-msgid " (rédaction libre sélectionnée mais non remplie)"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:702
-#: template-parts/enigme/enigme-edition-main.php:710
-msgid "Vider"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:712
-msgid "Rédaction libre"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:720
-msgid "Délai après fin de chasse"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:726
-msgid "Informations sur la publication de la solution"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:729
-msgid "Délai de parution des solutions"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:745
-msgid "jours, publié à"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:760
-msgid "Vos solutions sont protégées"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:761
-msgid "Stockées dans un espace privé, hors de portée des joueurs."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:762
-msgid "Aucun lien ne peut être trouvé ni ouvert."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:763
-msgid "Débloquées uniquement au moment choisi."
 msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-description.php:18
@@ -1661,12 +2132,12 @@ msgid "Configurer les variantes de réponse"
 msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:50
-#: assets/js/enigme-edit.js:826
+#: assets/js/enigme-edit.js:1084
 msgid "réponse déclenchant l'affichage du message"
 msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:51
-#: assets/js/enigme-edit.js:829
+#: assets/js/enigme-edit.js:1087
 msgid "Message affiché au joueur"
 msgstr ""
 
@@ -1818,59 +2289,6 @@ msgstr ""
 msgid "🏴‍☠️ Titre (pirate)"
 msgstr ""
 
-#: template-parts/indice/indice-edition-main.php:53
-msgid "Panneau d'édition indice"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:95
-msgid "renseigner le titre de l’indice"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:105
-msgid "Image"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:124
-msgid "Texte"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:136
-#: template-parts/indice/panneaux/indice-edition-description.php:18
-msgid "Modifier le texte de l’indice"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:151
-msgid "Aide pour"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:158
-msgid "Aucune énigme disponible."
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:184
-msgid "Publication"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:186
-msgid "Immédiate"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:187
-msgid "Différée"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:198
-msgid "(points)"
-msgstr ""
-
-#: template-parts/indice/indice-edition-main.php:221
-msgid "Statistiques à venir"
-msgstr ""
-
-#: template-parts/indice/panneaux/indice-edition-description.php:31
-msgid "Texte de l’indice mis à jour."
-msgstr ""
-
 #: template-parts/modals/modal-points.php:9
 msgid "À quoi servent les points ?"
 msgstr ""
@@ -1895,77 +2313,78 @@ msgstr ""
 msgid "La gratuité ou l'accès par points est choisi librement par chaque organisateur."
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:69
+#: template-parts/organisateur/organisateur-edition-main.php:70
 msgid "Panneau d'édition organisateur"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:629
-#: template-parts/organisateur/organisateur-edition-main.php:78
-#: template-parts/organisateur/organisateur-edition-main.php:264
-#: template-parts/organisateur/organisateur-edition-main.php:270
-#: templates/myaccount/content-points.php:75
-#: templates/myaccount/content-points.php:96
-#: templates/myaccount/layout.php:57
-#: templates/myaccount/layout.php:58
-#: templates/myaccount/layout.php:160
-msgid "Points"
+#: template-parts/organisateur/organisateur-edition-main.php:120
+msgid "renseigner le titre de l’organisateur"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:153
+#: template-parts/organisateur/organisateur-edition-main.php:144
+msgid "Logo organisateur"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:159
+msgid "Modifier le logo"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:162
+#: template-parts/organisateur/organisateur-edition-main.php:172
+msgid "Logo de l’organisateur"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:204
 msgid "Présentation"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:173
+#: template-parts/organisateur/organisateur-edition-main.php:230
 msgid "Modifier la présentation"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:207
+#: template-parts/organisateur/organisateur-edition-main.php:265
+msgid "Email de contact"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:279
 msgid "Informations sur l’adresse email de contact"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:209
+#: template-parts/organisateur/organisateur-edition-main.php:281
 msgid "Email de contact organisateur"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:210
+#: template-parts/organisateur/organisateur-edition-main.php:282
 msgid "Si aucune adresse n’est renseignée, votre adresse email utilisateur est utilisée par défaut."
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:293
-msgid "Informations sur les coordonnées bancaires"
+#: template-parts/organisateur/organisateur-edition-main.php:290
+msgid "Modifier l’adresse email de contact"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:296
+#: template-parts/organisateur/organisateur-edition-main.php:305
+msgid "exemple@domaine.com"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:363
+#: template-parts/organisateur/organisateur-edition-main.php:372
 msgid "Coordonnées bancaires"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:297
+#: template-parts/organisateur/organisateur-edition-main.php:369
+msgid "Informations sur les coordonnées bancaires"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:373
 msgid "Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d'argent."
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:352
-msgid "Sites et réseaux de l'organisation"
+#: template-parts/organisateur/organisateur-header.php:59
+msgid "Voir la page de l\\u2019organisateur"
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:380
-msgid "QR code de l'organisation"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:381
-msgid "QR code de votre organisation"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:863
-msgid "QR code de la chasse"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:864
-msgid "QR code de votre chasse"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:866
-#: template-parts/organisateur/organisateur-edition-main.php:383
-msgid "Télécharger"
+#: template-parts/organisateur/organisateur-header.php:61
+msgid "Logo de l\\u2019organisateur"
 msgstr ""
 
 #: templates/myaccount/content-chasses.php:111
@@ -1988,10 +2407,6 @@ msgid "%d bonne réponse"
 msgid_plural "%d bonnes réponses"
 msgstr[0] ""
 msgstr[1] ""
-
-#: templates/myaccount/content-chasses.php:125
-msgid "Énigme"
-msgstr ""
 
 #: templates/myaccount/content-dashboard-organisateur.php:25
 msgid "Votre demande de conversion a bien été envoyée."
@@ -2169,54 +2584,42 @@ msgstr ""
 msgid "✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande."
 msgstr ""
 
+#: assets/js/chasse-edit.js:328
+msgid "Voulez-vous vraiment supprimer la récompense ?"
+msgstr ""
+
+#: assets/js/chasse-edit.js:527
+msgid "Voulez-vous vraiment arrêter la chasse ?"
+msgstr ""
+
 #: assets/js/enigme-aside.js:15
 msgid "Afficher le panneau"
 msgstr ""
 
-#: assets/js/enigme-edit.js:600
+#: assets/js/enigme-edit.js:857
 msgid "Ex : soleil"
 msgstr ""
 
-#: assets/js/enigme-edit.js:605
-#: assets/js/enigme-edit.js:657
+#: assets/js/enigme-edit.js:862
+#: assets/js/enigme-edit.js:914
 msgid "valider"
 msgstr ""
 
-#: assets/js/enigme-edit.js:629
-msgid "Supprimer"
-msgstr ""
-
-#: assets/js/enigme-edit.js:703
+#: assets/js/enigme-edit.js:960
 msgid "Ajouter une illustration"
 msgstr ""
 
-#: assets/js/enigme-edit.js:742
-#: assets/js/enigme-edit.js:987
+#: assets/js/enigme-edit.js:1000
+#: assets/js/enigme-edit.js:1246
 msgid "Modifier les variantes"
 msgstr ""
 
-#: assets/js/enigme-edit.js:878
-msgid "Enregistrement..."
-msgstr ""
-
-#: assets/js/enigme-edit.js:898
-msgid "✔️ Variantes enregistrées"
-msgstr ""
-
-#: assets/js/enigme-edit.js:1005
+#: assets/js/enigme-edit.js:1264
 msgid "❌ Erreur réseau"
 msgstr ""
 
-#: assets/js/enigme-edit.js:1663
+#: assets/js/enigme-edit.js:1580
 msgid "Erreur lors de l'enregistrement de l'ordre"
-msgstr ""
-
-#: assets/js/help-modal.js:19
-msgid "Fermer"
-msgstr ""
-
-#: inc/edition/edition-core.php:149
-msgid "Texte de l’indice"
 msgstr ""
 
 #: assets/js/reponse-automatique.js:35
@@ -2248,226 +2651,3 @@ msgstr ""
 #: assets/js/reponse-automatique.js:187
 msgid "Tentatives quotidiennes"
 msgstr ""
-
-#: assets/js/chasse-edit.js:376
-msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
-msgstr ""
-
-#: assets/js/chasse-edit.js:318
-msgid "Voulez-vous vraiment supprimer la récompense ?"
-msgstr ""
-
-#: assets/js/chasse-edit.js
-msgid "Voulez-vous vraiment arrêter la chasse ?"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php
-msgid "Arrêt chasse"
-msgstr ""
-
-#: template-parts/common/indices-table.php:69
-msgid "accessible"
-msgstr ""
-
-#: template-parts/common/indices-table.php:69
-msgid "programme"
-msgstr ""
-
-#: template-parts/common/indices-table.php:83
-msgid "programmé"
-msgstr ""
-
-#: template-parts/common/indices-table.php:75
-#, php-format
-msgid "programmé le %s"
-msgstr ""
-
-#: template-parts/common/indices-table.php:41
-#, php-format
-msgid "%d indice au total"
-msgid_plural "%d indices au total"
-msgstr[0] ""
-msgstr[1] ""
-
-#: template-parts/common/indices-table.php:44
-#, php-format
-msgid "%d indice chasse"
-msgid_plural "%d indices chasse"
-msgstr[0] ""
-msgstr[1] ""
-
-#: template-parts/common/indices-table.php:47
-#, php-format
-msgid "%d indice énigme"
-msgid_plural "%d indices énigme"
-msgstr[0] ""
-msgstr[1] ""
-
-#: template-parts/common/indices-table.php:55
-msgid "Indice"
-msgstr ""
-
-#: template-parts/common/indices-table.php:136
-#, php-format
-msgid "à %s"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:867 template-parts/chasse/chasse-edition-main.php:986
-msgid "Solution"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:974
-msgid "Partagez votre chasse en un scan"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:975
-msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:987
-msgid "Contenu de la solution à venir."
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:973
-msgid "Vos liens"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:976
-msgid "Adresse de votre chasse&nbsp;:"
-msgstr ""
-
-#: template-parts/common/solutions-table.php:33
-msgid "Solution pour"
-msgstr ""
-
-#: template-parts/common/solutions-table.php:105
-msgid "PDF"
-msgstr ""
-
-#: inc/edition/edition-core.php:180
-msgid "Texte de la solution"
-msgstr ""
-
-#: inc/edition/edition-core.php:181
-msgid "Fichier"
-msgstr ""
-
-#: inc/edition/edition-core.php:182
-msgid "Disponibilité"
-msgstr ""
-
-#: inc/edition/edition-core.php:187 template-parts/chasse/partials/chasse-partial-solutions.php:24
-msgid "Ajouter une solution"
-msgstr ""
-
-#: inc/edition/edition-core.php:195
-msgid "Ajoutez un fichier ou un texte"
-msgstr ""
-
-#: inc/edition/edition-core.php:200
-msgid "Aucun fichier choisi"
-
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:47
-#: inc/edition/edition-enigme.php:62
-msgid "Il existe déjà une solution pour cette chasse"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:33
-#: inc/edition/edition-enigme.php:63
-msgid "Il existe déjà une solution pour cette énigme"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:62
-msgid "Toutes les énigmes de la chasse ont déjà une solution"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:987
-msgid "Sécurité des PDF de solution"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:988
-msgid "Vos PDF sont conservés dans un coffre-fort numérique"
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:991
-msgid "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:995
-msgid "Ils ne seront partagés qu'à la date que vous aurez choisie : "
-msgstr ""
-
-#: template-parts/chasse/chasse-edition-main.php:999
-msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:144
-msgid "Logo organisateur"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:159
-msgid "Modifier le logo"
-msgstr ""
-
-#: template-parts/organisateur/organisateur-edition-main.php:162
-#: template-parts/organisateur/organisateur-edition-main.php:172
-msgid "Logo de l’organisateur"
-msgstr ""
-
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvées"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:48
-msgid "mode de fin de chasse : automatique"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:49
-msgid "mode de fin de chasse : manuelle"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:178
-msgid "Par"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:206
-#: template-parts/chasse/chasse-card.php:24
-msgid "%d énigme"
-msgid_plural "%d énigmes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: inc/chasse-functions.php:772
-#: template-parts/chasse/chasse-affichage-complet.php:207
-#: template-parts/chasse/chasse-card.php:25
-msgid "%d joueur"
-msgid_plural "%d joueurs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: template-parts/chasse/chasse-card.php:32
-msgid "En savoir plus"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "en cours"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "révision"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "à venir"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "terminée"
-msgstr ""
-

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #: inc/enigme/cta.php:206
 msgid "Indisponible"
-msgstr ""
+msgstr "Unavailable"
 
 #: inc/enigme/cta.php:232
 msgid "Commencer"
@@ -2669,4 +2669,77 @@ msgstr "See all hunt solutions"
 #: inc/edition/edition-enigme.php:65
 msgid "Voir la solution de cette énigme"
 msgstr "See this riddle's solution"
+
+#: template-parts/chasse/chasse-affichage-complet.php:263
+msgid "Limite"
+msgstr "Limit"
+
+#: template-parts/chasse/chasse-affichage-complet.php:264
+#, php-format
+msgid "%d gagnants"
+msgstr "%d winners"
+
+#: template-parts/chasse/chasse-affichage-complet.php:269
+msgid "Fin de chasse"
+msgstr "Hunt end"
+
+#: template-parts/chasse/chasse-affichage-complet.php:280
+msgid "Accès chasse"
+msgstr "Hunt access"
+
+#: template-parts/chasse/chasse-affichage-complet.php:284
+msgid "libre"
+msgstr "free"
+
+#: template-parts/chasse/chasse-affichage-complet.php:289
+msgid "Accès énigme"
+msgstr "Riddle access"
+
+#: template-parts/chasse/chasse-affichage-complet.php:305
+msgid "gratuit"
+msgstr "free"
+
+#: template-parts/chasse/chasse-affichage-complet.php:332
+msgid "Les + avancés"
+msgstr "Most advanced"
+
+#: inc/chasse-functions.php:606
+msgid "S'identifier"
+msgstr "Sign in"
+
+#: inc/chasse-functions.php:607
+msgid "Vous devez être identifié pour participer à cette chasse"
+msgstr "You must be logged in to participate in this hunt"
+
+#: inc/chasse-functions.php:639
+msgid "Chasse disponible à partir du %s"
+msgstr "Hunt available from %s"
+
+#: inc/chasse-functions.php:641
+msgid "Chasse disponible prochainement"
+msgstr "Hunt available soon"
+
+#: inc/chasse-functions.php:672
+msgid "Accès libre à cette chasse. Les tentatives seront tarifées individuellement."
+msgstr "Free access to this hunt. Attempts will be charged individually."
+
+#: inc/chasse-functions.php:683
+msgid "Cette chasse est terminée depuis le %s"
+msgstr "This hunt has ended since %s"
+
+#: inc/chasse-functions.php:685
+msgid "Cette chasse est terminée"
+msgstr "This hunt is over"
+
+#: inc/organisateur-functions.php:220
+msgid "Coordonnées bancaires manquantes"
+msgstr "Missing bank details"
+
+#: inc/organisateur-functions.php:221
+msgid "Nous avons besoin d'enregistrer vos coordonnées bancaires pour vous envoyer un versement"
+msgstr "We need to record your bank details to send you a payout"
+
+#: inc/organisateur-functions.php:235
+msgid "renseigner coordonnées bancaires"
+msgstr "enter bank details"
 


### PR DESCRIPTION
## Résumé
- internationalisation des CTA d'engagement de chasse
- traduction anglaise des caractéristiques de chasse et du panneau coordonnées bancaires
- mise à jour des fichiers de traduction

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aff62654f4833287d19685279265cc