### PR TITLE
Ajoute la classe .message-erreur et nettoie les templates

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -935,7 +935,7 @@ a[aria-disabled="true"] {
 }
 
 /* ========== ❌ MESSAGE ERREUR ========== */
-.message-error {
+.message-erreur {
     text-align: center;
     font-weight: bold;
     color: var(--color-error);

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -1404,7 +1404,7 @@ a[aria-disabled=true] {
 }
 
 /* ========== ❌ MESSAGE ERREUR ========== */
-.message-error {
+.message-erreur {
   text-align: center;
   font-weight: bold;
   color: var(--color-error);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1404,7 +1404,7 @@ a[aria-disabled=true] {
 }
 
 /* ========== ❌ MESSAGE ERREUR ========== */
-.message-error {
+.message-erreur {
   text-align: center;
   font-weight: bold;
   color: var(--color-error);

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -163,12 +163,12 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     <?php if (!empty($_GET['erreur'])) : ?>
         <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
         <?php if ($error_message === 'points_insuffisants') : ?>
-            <div class="message-erreur" role="alert" aria-live="assertive" style="color:red; margin-bottom:1em;">
+            <div class="message-erreur" role="alert" aria-live="assertive">
                 ❌ <?= esc_html__('Vous n’avez pas assez de points pour engager cette énigme.', 'chassesautresor-com'); ?>
                 <a href="<?= esc_url(home_url('/boutique')); ?>"><?= esc_html__('Accéder à la boutique', 'chassesautresor-com'); ?></a>
             </div>
         <?php else : ?>
-            <div class="message-erreur" role="alert" aria-live="assertive" style="color:red; margin-bottom:1em;">
+            <div class="message-erreur" role="alert" aria-live="assertive">
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>

--- a/wp-content/themes/chassesautresor/single-enigme.php
+++ b/wp-content/themes/chassesautresor/single-enigme.php
@@ -38,7 +38,7 @@ if (is_singular('enigme')) {
 
         <?php if (!empty($_GET['erreur'])) : ?>
             <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
-            <div class="message-erreur" role="alert" aria-live="assertive" style="color:red; margin-bottom:1em;">
+            <div class="message-erreur" role="alert" aria-live="assertive">
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -466,7 +466,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         class="champ-inline-nb champ-nb-edit champ-input champ-number"
                                         <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
 
-                                    <div id="erreur-nb-gagnants" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-nb-gagnants" class="message-erreur" role="alert" aria-live="assertive" style="display:none;"></div>
                                 </div>
                             </div>
                             <?php
@@ -522,7 +522,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         name="chasse-date-debut"
                                         value="<?= esc_attr($date_debut_iso); ?>"
                                         class="champ-inline-date champ-date-edit" <?= ($peut_editer && $debut_differe) ? '' : 'disabled'; ?> required />
-                                    <div id="erreur-date-debut" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-date-debut" class="message-erreur" role="alert" aria-live="assertive" style="display:none;"></div>
                                 </div>
                             </div>
                             <?php
@@ -568,7 +568,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                         name="chasse-date-fin"
                                         value="<?= esc_attr($date_fin_iso); ?>"
                                         class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
-                                    <div id="erreur-date-fin" class="message-erreur" role="alert" aria-live="assertive" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
+                                    <div id="erreur-date-fin" class="message-erreur" role="alert" aria-live="assertive" style="display:none;"></div>
                                 </div>
                             </div>
                             <?php


### PR DESCRIPTION
## Résumé
- uniformise la gestion des messages d'erreur

## Changements notables
- ajoute la classe `.message-erreur` aux styles globaux
- supprime les styles inline des templates pour utiliser la nouvelle classe

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aff74fae708332aa0b3594f2bb8eb9