### PR TITLE
Affichage global des messages sous la topbar

### DIFF
--- a/tests/js/myaccount-admin-ajax.test.js
+++ b/tests/js/myaccount-admin-ajax.test.js
@@ -1,4 +1,5 @@
 const html = `
+<section class="msg-important"></section>
 <div class="myaccount-layout">
   <aside class="myaccount-sidebar">
     <nav class="dashboard-nav">
@@ -50,7 +51,7 @@ describe('myaccount ajax navigation', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(fetch).toHaveBeenCalledWith(`/admin-ajax.php?action=cta_load_admin_section&section=${section}`, expect.any(Object));
-    expect(document.querySelector('.myaccount-content').innerHTML).toContain('<section class="msg-important"></section>');
+    expect(document.querySelector('.myaccount-content').innerHTML).toContain(section);
     expect(window.history.pushState).toHaveBeenCalled();
     const expectedTitle = link.dataset.title || link.textContent;
     expect(document.querySelector('.myaccount-title').textContent).toBe(expectedTitle);

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -7,13 +7,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const navs = document.querySelectorAll('.dashboard-nav');
   const content = document.querySelector('.myaccount-content');
   const header = document.querySelector('.myaccount-title');
+  const messages = document.querySelector('.msg-important');
 
-  if (!navs.length || !content || typeof ctaMyAccount === 'undefined') {
+  if (!navs.length || !content || !messages || typeof ctaMyAccount === 'undefined') {
     return;
   }
 
   const fadeFlash = () => {
-    const flash = content.querySelector('.msg-important .flash');
+    const flash = messages.querySelector('.flash');
     if (flash) {
       setTimeout(() => {
         flash.remove();
@@ -22,11 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const decorateMessages = () => {
-    const container = content.querySelector('.msg-important');
-    if (!container) {
-      return;
-    }
-    container.querySelectorAll('p').forEach((p) => {
+    messages.querySelectorAll('p').forEach((p) => {
       if (p.classList.contains('message-erreur')) {
         p.setAttribute('role', 'alert');
         p.setAttribute('aria-live', 'assertive');
@@ -61,10 +58,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!data.success) {
         throw new Error('Request failed');
       }
-      const messages = data.data.messages || '';
-      content.innerHTML = `<section class="msg-important">${messages}</section>` + data.data.html;
+      const messageHtml = data.data.messages || '';
+      messages.innerHTML = messageHtml;
       decorateMessages();
       fadeFlash();
+      content.innerHTML = data.data.html;
       document
         .querySelectorAll('.dashboard-nav-link[data-section]')
         .forEach((a) => a.classList.remove('active'));
@@ -84,18 +82,18 @@ document.addEventListener('DOMContentLoaded', () => {
         window.history.replaceState(null, '', '/mon-compte/');
       }
     } catch (err) {
-      content.innerHTML = `
-        <section class="msg-important">
+      messages.innerHTML = `
           <p class="message-erreur" role="alert" aria-live="assertive">Impossible de charger la section.</p>
           <p class="message-info" role="status" aria-live="polite"><a href="#" class="reload-section">Recharger</a> ou <a href="${link.href}">ouvrir la page complète</a>.</p>
-        </section>`;
-      const reload = content.querySelector('.reload-section');
+        `;
+      const reload = messages.querySelector('.reload-section');
       if (reload) {
         reload.addEventListener('click', (e) => {
           e.preventDefault();
           loadSection(link);
         });
       }
+      content.innerHTML = '';
     }
   };
 

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -97,6 +97,6 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
 
 	
         <div id="content" class="site-content">
+                <section class="msg-important"><?php echo get_site_messages(); ?></section>
                 <div class="ast-container<?php echo ( is_singular('enigme') || is_singular('chasse') ) ? '' : ' ast-container--boxed'; ?>">
                 <?php astra_content_top(); ?>
-                <section class="msg-important"><?php echo get_site_messages(); ?></section>

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -171,13 +171,6 @@ get_header();
         </header>
         <main class="myaccount-content">
             <?php
-            $messages = '';
-            if (empty($_GET['section'])) {
-                $messages = trim(myaccount_get_important_messages());
-            }
-            ?>
-            <section class="msg-important"><?php echo $messages; ?></section>
-            <?php
             if ($content_template && file_exists($content_template)) {
                 include $content_template;
             } else {


### PR DESCRIPTION
## Summary
- affiche les messages du site sous la topbar sur toutes les pages
- nettoie le template "Mon compte" et met à jour le JS associé

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff039367483329204e09e04f582a6