### PR TITLE
Améliore la détection de la zone compte utilisateur

### DIFF
--- a/tests/LayoutFunctionsTest.php
+++ b/tests/LayoutFunctionsTest.php
@@ -98,6 +98,13 @@ if (!function_exists('peut_valider_chasse')) {
     }
 }
 
+if (!function_exists('is_account_page')) {
+    function is_account_page(): bool
+    {
+        return $GLOBALS['is_account_page_return'] ?? false;
+    }
+}
+
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/layout-functions.php';
 
 class LayoutFunctionsTest extends TestCase
@@ -144,5 +151,42 @@ class LayoutFunctionsTest extends TestCase
         $current_post_id = 456;
 
         $this->assertSame('', $this->getBannerOutput());
+    }
+
+    /**
+     * @dataProvider accountUriProvider
+     */
+    public function test_is_user_account_area_with_slugs(string $uri): void
+    {
+        $GLOBALS['is_account_page_return'] = false;
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        $this->assertTrue(is_user_account_area());
+    }
+
+    public function accountUriProvider(): array
+    {
+        return [
+            ['/mon-compte'],
+            ['/mon-compte/?lang=fr'],
+            ['/my-account'],
+            ['/my-account?lang=en'],
+        ];
+    }
+
+    public function test_is_user_account_area_false_on_other_pages(): void
+    {
+        $GLOBALS['is_account_page_return'] = false;
+        $_SERVER['REQUEST_URI'] = '/autre-page';
+
+        $this->assertFalse(is_user_account_area());
+    }
+
+    public function test_is_user_account_area_respects_is_account_page(): void
+    {
+        $GLOBALS['is_account_page_return'] = true;
+        $_SERVER['REQUEST_URI'] = '/autre-page';
+
+        $this->assertTrue(is_user_account_area());
     }
 }

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -262,10 +262,22 @@ function get_svg_icon($icone) {
  *
  * @return bool
  */
-function is_user_account_area(): bool {
-    $request = trim($_SERVER['REQUEST_URI'], '/');
+function is_user_account_area(): bool
+{
+    if (function_exists('is_account_page') && is_account_page()) {
+        return true;
+    }
 
-    return strpos($request, 'mon-compte') === 0;
+    $slugs  = ['mon-compte', 'my-account'];
+    $request = trim((string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH), '/');
+
+    foreach ($slugs as $slug) {
+        if (strpos($request, $slug) === 0) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 


### PR DESCRIPTION
## Résumé
Mise à jour de la détection de la zone "Mon Compte" pour tenir compte de WooCommerce et des slugs multilingues.

## Changements notables
- Utilisation de `is_account_page()` ou des slugs `mon-compte`/`my-account` pour identifier l’espace utilisateur.
- Ajout de tests couvrant les URL avec ou sans paramètre `?lang`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b0050d71508332b2cd8d6d2b31c3b0