### PR TITLE
Ajoute le partage AddToAny sous l'image de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -90,6 +90,11 @@
   box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
 }
 
+.champ-chasse.champ-liens .chasse-share-right {
+  text-align: right;
+  margin-top: var(--space-xs);
+}
+
 @media (--bp-mobile) {
   .chasse-fiche-container {
     --hunt-img-max-height: 500px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -342,6 +342,11 @@
   box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
 }
 
+.champ-chasse.champ-liens .chasse-share-right {
+  text-align: right;
+  margin-top: var(--space-xs);
+}
+
 @media (min-width: 600px) {
   .chasse-fiche-container {
     --hunt-img-max-height: 500px;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -204,6 +204,11 @@ if ($edition_active && !$est_complet) {
                 'wrap'           => false,
                 'placeholder'    => false,
             ]); ?>
+            <?php if (function_exists('ADDTOANY_SHARE_SAVE_KIT')) : ?>
+                <div class="chasse-share-right">
+                    <?php ADDTOANY_SHARE_SAVE_KIT(); ?>
+                </div>
+            <?php endif; ?>
           </div>
         </div>
         <div class="champ-feedback"></div>


### PR DESCRIPTION
### Résumé
Ajout des boutons de partage AddToAny sous l'image principale des chasses.

### Changements
- Intégration du kit AddToAny dans le template.
- Alignement à droite via une nouvelle règle SCSS.
- Recompilation du CSS du thème.

### Testing
- `npm install`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aeec8b6eac8332ae9bb41b53bedf49