### PR TITLE
feat: add AddToAny share button to chasse page

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -127,6 +127,33 @@
   gap: var(--space-xs);
   align-items: center;
 }
+
+.chasse-details-actions .bouton-edition-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: #fff;
+  background: none;
+}
+
+.chasse-details-actions .bouton-edition-toggle:hover,
+.chasse-details-actions .bouton-edition-toggle:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.chasse-details-actions .bouton-edition-toggle:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.chasse-share-button svg {
+  width: 1rem;
+  height: 1rem;
+}
 .header-chasse {
   font-size: 30px;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -116,6 +116,16 @@
 .chasse-details-wrapper {
   min-width: 240px;
   flex: 1;
+  position: relative;
+}
+
+.chasse-details-actions {
+  position: absolute;
+  top: 1.2rem;
+  right: var(--space-xs);
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
 }
 .header-chasse {
   font-size: 30px;

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -853,12 +853,6 @@ body[class*="edition-active"] .champ-desactive .champ-modifier,
    🧭 HEADER
    ================================================== */
 
-/* Bouton d'ouverture du panneau sur la page chasse */
-.chasse-fiche-container .bouton-edition-toggle {
-  position: absolute;
-  top: 1.2rem;
-  right: var(--space-xs);
-}
 
 .header-coordonnees.champ-vide {
   border: 1px dashed var(--color-border-header-organisateur);

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -374,6 +374,33 @@
   align-items: center;
 }
 
+.chasse-details-actions .bouton-edition-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: #fff;
+  background: none;
+}
+
+.chasse-details-actions .bouton-edition-toggle:hover,
+.chasse-details-actions .bouton-edition-toggle:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.chasse-details-actions .bouton-edition-toggle:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.chasse-share-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 .header-chasse {
   font-size: 30px;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/main.css
+++ b/wp-content/themes/chassesautresor/assets/scss/main.css
@@ -32,12 +32,12 @@
   gap: var(--space-xl);
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .grille-3 {
     grid-template-columns: repeat(2, 1fr);
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .grille-3 {
     grid-template-columns: 1fr;
   }
@@ -136,10 +136,8 @@
 .carte-ligne__image img {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
-  -o-object-position: center;
-     object-position: center;
+  object-fit: cover;
+  object-position: center;
   display: block;
   max-height: 350px;
 }
@@ -260,8 +258,7 @@
   max-height: var(--hunt-img-max-height);
   width: auto;
   height: auto;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 
 .chasse-fiche-container {
@@ -288,7 +285,6 @@
 .champ-chasse.champ-img {
   flex: 0 0 auto;
   padding: var(--space-xs);
-  width: -moz-fit-content;
   width: fit-content;
   max-width: 100%;
   margin: 0 auto;
@@ -342,12 +338,12 @@
   box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
 }
 
-@media (min-width: 600px) {
+@media (--bp-mobile) {
   .chasse-fiche-container {
     --hunt-img-max-height: 500px;
   }
 }
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .chasse-fiche-container {
     flex-direction: row;
     --hunt-img-max-height: 800px;
@@ -366,6 +362,16 @@
 .chasse-details-wrapper {
   min-width: 240px;
   flex: 1;
+  position: relative;
+}
+
+.chasse-details-actions {
+  position: absolute;
+  top: 1.2rem;
+  right: var(--space-xs);
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
 }
 
 .header-chasse {
@@ -415,6 +421,17 @@
   margin-top: 0.3rem;
 }
 
+.chasse-description {
+  margin-top: var(--space-xl);
+  line-height: 1.6;
+}
+.chasse-description p {
+  margin-bottom: var(--space-md);
+}
+.chasse-description p:last-child {
+  margin-bottom: 0;
+}
+
 .chasse-section-intro.champ-vide-obligatoire {
   border: 2px dashed var(--color-editor-error);
   animation: clignoteTitre 1s infinite alternate;
@@ -429,7 +446,6 @@
   line-height: 1.3;
   color: var(--color-editor-text-muted);
   text-align: left;
-  width: -moz-fit-content;
   width: fit-content;
 }
 
@@ -460,7 +476,7 @@
   justify-content: center;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .chasse-cta-section {
     max-width: 650px;
   }
@@ -484,7 +500,7 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
 }
 
 /* ========== 📱 RESPONSIVE PAGE DE CHASSE ========== */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .header-chasse {
     font-size: 22px;
   }
@@ -627,7 +643,6 @@ button,
   margin-top: 10px;
   transition: var(--transition-medium);
   text-align: center;
-  width: -moz-fit-content;
   width: fit-content;
 }
 
@@ -690,7 +705,7 @@ button,
   opacity: 0.7;
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   .bloc-reponse .reponse-cta-row {
     flex-direction: row;
   }
@@ -704,7 +719,7 @@ button,
     padding: 8px 13px;
   }
 }
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .bouton-cta {
     padding: 10px 15px;
   }
@@ -769,7 +784,6 @@ button,
   cursor: not-allowed;
   pointer-events: none;
   text-align: center;
-  width: -moz-fit-content;
   width: fit-content;
   display: flex;
   align-items: center;
@@ -931,7 +945,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .btn-lire-plus {
     width: auto;
   }
@@ -968,7 +982,7 @@ a.ajout-link:focus-visible {
   outline-offset: 2px;
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   .bouton-retour {
     font-size: 1.5rem;
   }
@@ -1035,7 +1049,7 @@ a.ajout-link:focus-visible {
   font-size: 100%;
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   .bloc-metas-inline {
     gap: 0.7rem;
   }
@@ -1194,7 +1208,7 @@ a.ajout-link:focus-visible {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media (min-width: 480px) {
+@media (--bp-small) {
   .separateur-2 {
     margin: var(--space-xs) 0 var(--space-xl);
   }
@@ -1218,7 +1232,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   color: var(--color-text-primary);
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   .formulaire-contact-wrapper {
     padding-left: 0;
     padding-right: 0;
@@ -1305,7 +1319,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   text-align: center;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .countdown-container {
     font-size: 1.2rem;
   }
@@ -1482,7 +1496,6 @@ a[aria-disabled=true] {
   display: none;
   z-index: 10;
   min-width: 6rem;
-  width: -moz-max-content;
   width: max-content;
 }
 
@@ -1806,7 +1819,7 @@ a[aria-disabled=true] {
   padding-bottom: var(--space-sm);
 }
 
-@media (min-width: 1280px) {
+@media (--bp-wide) {
   .menu-lateral {
     position: fixed;
     top: 50%;
@@ -2009,7 +2022,7 @@ li.edition-row {
   gap: var(--space-xs);
 }
 
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .edition-row-label {
     min-width: unset;
     width: var(--editor-label-width);
@@ -2036,7 +2049,7 @@ li.edition-row {
   color: var(--color-editor-error);
 }
 
-@media not all and (min-width: 600px) {
+@media not all and (--bp-mobile) {
   li.edition-row {
     flex-direction: column;
     align-items: flex-start;
@@ -2070,8 +2083,7 @@ li.edition-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  -moz-column-gap: var(--space-xl);
-       column-gap: var(--space-xl);
+  column-gap: var(--space-xl);
   row-gap: var(--space-md);
   margin-top: var(--space-lg);
 }
@@ -2112,7 +2124,7 @@ li.edition-row {
   margin-top: 0;
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image,
   .champ-qr-code.carte-orgy .qr-code-image {
@@ -2129,7 +2141,7 @@ li.edition-row {
     font-size: 150px;
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .dashboard-card.champ-protection-solutions .qr-code-image, .champ-protection-solutions.carte-orgy .qr-code-image,
   .dashboard-card.champ-qr-code .qr-code-image,
   .champ-qr-code.carte-orgy .qr-code-image {
@@ -2139,7 +2151,7 @@ li.edition-row {
     font-size: 100px;
   }
 }
-@media not all and (min-width: 600px) {
+@media not all and (--bp-mobile) {
   .dashboard-card.champ-protection-solutions .qr-code-block, .champ-protection-solutions.carte-orgy .qr-code-block,
   .dashboard-card.champ-qr-code .qr-code-block,
   .champ-qr-code.carte-orgy .qr-code-block {
@@ -2463,7 +2475,7 @@ body .header-img-modifiable .icone-modif {
   transition: border-color 0.2s, background-color 0.2s;
 }
 
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .edition-panel-body input.champ-input,
   .edition-panel-body input[type=date],
   .edition-panel-body input[type=datetime-local] {
@@ -2528,10 +2540,6 @@ body .header-img-modifiable .icone-modif {
 .bonne-reponse-ajouter {
   font-size: 0.85rem;
   padding: 0.1rem var(--space-xs);
-}
-
-.champ-edition input.champ-input::-moz-placeholder {
-  color: var(--color-editor-placeholder);
 }
 
 .champ-edition input.champ-input::placeholder {
@@ -2705,7 +2713,7 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 /* ========== 📱 RESPONSIVE GLOBAL ========== */
 /* Empilage à partir de tablette */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -2713,13 +2721,6 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 /* ==================================================
    🧭 HEADER
    ================================================== */
-/* Bouton d'ouverture du panneau sur la page chasse */
-.chasse-fiche-container .bouton-edition-toggle {
-  position: absolute;
-  top: 1.2rem;
-  right: var(--space-xs);
-}
-
 .header-coordonnees.champ-vide {
   border: 1px dashed var(--color-border-header-organisateur);
   padding: 0.2rem var(--space-xs);
@@ -2753,7 +2754,7 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 
 /* ========== 📱 RESPONSIVE HEADER ========== */
 /* Empilage à partir de tablette */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -2947,12 +2948,12 @@ body.edition-active .edition-panel {
   font-size: 1rem;
 }
 
-@media not all and (min-width: 600px) {
+@media not all and (--bp-mobile) {
   .edition-panel label {
     font-size: 0.9rem;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .edition-panel label {
     font-size: 0.8rem;
   }
@@ -3111,7 +3112,7 @@ li.ligne-email .champ-affichage {
 }
 
 /* ========== 📱 RESPONSIVE PANNEAU EDITION ========== */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .edition-tab-content {
     padding-left: 0;
     padding-right: 0;
@@ -3127,7 +3128,7 @@ li.ligne-email .champ-affichage {
     padding-right: 0;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .edition-panel-body {
     flex-direction: column;
   }
@@ -3412,12 +3413,12 @@ body.panneau-ouvert::before {
   border-bottom: 3px solid var(--color-primary);
 }
 
-@media not all and (min-width: 600px) {
+@media not all and (--bp-mobile) {
   .edition-tab {
     font-size: 16px;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .edition-tab {
     font-size: 16px;
   }
@@ -3430,7 +3431,7 @@ body.panneau-ouvert::before {
   position: relative;
 }
 
-@media not all and (min-width: 600px) {
+@media not all and (--bp-mobile) {
   .edition-tab-content {
     padding-left: 0;
     padding-right: 0;
@@ -3632,7 +3633,7 @@ body.panneau-ouvert::before {
   margin: var(--space-4xl) auto;
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .dashboard-card.champ-qr-code, .champ-qr-code.carte-orgy,
   .dashboard-card.champ-protection-solutions,
   .champ-protection-solutions.carte-orgy {
@@ -3941,9 +3942,7 @@ body.panneau-ouvert::before {
   align-items: center;
   justify-content: center;
   gap: var(--space-xxs);
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .champ-mode-options.segmented-control label:last-of-type {
@@ -4205,8 +4204,7 @@ body.panneau-ouvert::before {
 .champ-pre-requis .prerequis-mini img {
   width: 80px;
   height: 80px;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   border-radius: 4px;
 }
 
@@ -4508,7 +4506,7 @@ body.panneau-ouvert::before {
   grid-column: 1;
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .enigme-layout .menu-lateral {
     position: sticky;
     top: var(--space-md);
@@ -4521,7 +4519,7 @@ body.panneau-ouvert::before {
   grid-template-columns: 1fr;
 }
 
-@media (min-width: 1280px) {
+@media (--bp-wide) {
   .enigme-layout {
     display: block;
     gap: 0;
@@ -4787,7 +4785,7 @@ li.active .enigme-menu__edit {
   margin-top: var(--space-md);
 }
 
-@media (min-width: 1024px) and (hover: hover) {
+@media (--bp-desktop) and (hover: hover) {
   body.single-enigme .page-enigme {
     margin-top: calc(var(--space-4xl) + var(--space-md));
   }
@@ -4815,7 +4813,7 @@ li.active .enigme-menu__edit {
   font-size: 32px;
 }
 
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .page-enigme {
     gap: var(--space-xl);
   }
@@ -4827,7 +4825,7 @@ li.active .enigme-menu__edit {
     font-size: 1rem;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .page-enigme {
     gap: var(--space-lg);
   }
@@ -4840,8 +4838,7 @@ li.active .enigme-menu__edit {
 }
 .hero-visuel img {
   /*width: 100%;*/
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   /*max-height: 300px;*/
 }
 
@@ -4868,7 +4865,7 @@ li.active .enigme-menu__edit {
   margin-top: 0;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .participation {
     width: 70%;
   }
@@ -4942,7 +4939,7 @@ li.active .enigme-menu__edit {
   margin-inline: auto;
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .enigme-layout {
     grid-template-columns: 1fr;
   }
@@ -4974,7 +4971,7 @@ body.topbar-visible .enigme-edit-toggle--desktop {
   top: calc(var(--space-md) + var(--space-4xl));
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .enigme-layout .menu-lateral {
     display: none;
   }
@@ -5133,7 +5130,7 @@ body.single-enigme.topbar-visible header.site-header {
   transform: translateY(0);
 }
 
-@media not all and (min-width: 1024px), (hover: none) {
+@media not all and (--bp-desktop), (hover: none) {
   body.single-enigme header.site-header {
     display: none;
   }
@@ -5189,8 +5186,7 @@ body.single-enigme.topbar-visible header.site-header {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   box-shadow: inset 0 0 10px rgba(255, 215, 0, 0.8), 0 0 20px rgba(255, 215, 0, 0.5);
 }
 
@@ -5482,22 +5478,22 @@ header .points-link:hover {
 }
 
 /* 📱 Responsive : ajuste la taille du texte sur mobile/tablette */
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .points-value {
     font-size: 16px;
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .points-value {
     font-size: 14px;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .points-unite {
     display: none;
   }
 }
-@media not all and (min-width: 374px) {
+@media not all and (--bp-xs) {
   .points-unite {
     display: none;
   }
@@ -5773,7 +5769,7 @@ h1.h1-diff { /* variation couleur bronze, plus petite, centrée */
   color: var(--color-accent);
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   h1, .entry-content h1 {
     font-size: 36px;
   }
@@ -5781,7 +5777,7 @@ h1.h1-diff { /* variation couleur bronze, plus petite, centrée */
     font-size: 30px;
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   h1, .entry-content h1 {
     font-size: 30px;
   }
@@ -5800,12 +5796,12 @@ h2, .entry-content h2 {
   font-size: 32px;
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   h2, .entry-content h2 {
     font-size: 28px;
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   h2, .entry-content h2 {
     font-size: 24px;
   }
@@ -5821,7 +5817,7 @@ h3, .entry-content h3 {
   margin-bottom: var(--space-sm);
 }
 
-@media not all and (min-width: 1024px) {
+@media not all and (--bp-desktop) {
   .page header.entry-header .entry-title {
     font-size: 36px;
   }
@@ -5829,7 +5825,7 @@ h3, .entry-content h3 {
     font-size: 22px;
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .page header.entry-header .entry-title {
     font-size: 30px;
   }
@@ -6058,8 +6054,7 @@ tbody tr:nth-child(even) {
 .indices-table td img {
   width: 80px;
   height: 80px;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 .indices-table .badge-action {
@@ -6088,7 +6083,7 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .indices-table th.indice-text,
   .indices-table td.proposition-cell {
     display: none;
@@ -6204,7 +6199,7 @@ tbody tr:nth-child(even) {
   margin-left: 0.25rem;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .indices-table,
   .solutions-table,
   .stats-table {
@@ -6216,7 +6211,7 @@ tbody tr:nth-child(even) {
     font-weight: 400;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .solutions-table th:nth-child(3),
   .solutions-table td:nth-child(3) {
     display: none;
@@ -6301,12 +6296,12 @@ span.champ-obligatoire {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
     font-size: 96%;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   address, blockquote, body, dd, dl, dt, fieldset, figure, html, iframe, legend, li, ol, p, pre, textarea, ul {
     font-size: 93%;
   }
@@ -6333,17 +6328,17 @@ span.champ-obligatoire {
   --editor-icon-width: 1rem; /* 📏 Largeur des icônes dans les panneaux */
 }
 
-@media (min-width: 768px) and (max-width: 1023px) {
+@media (--bp-tablet) and (max-width: 1023px) {
   .mode-edition {
     --editor-label-width: 220px;
   }
 }
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .mode-edition {
     --editor-label-width: 165px;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .mode-edition {
     --editor-label-width: 135px;
   }
@@ -6454,7 +6449,7 @@ span.champ-obligatoire {
   padding-right: 13px;
 }
 
-@media (min-width: 1024px) {
+@media (--bp-desktop) {
   .container,
   .ast-container,
   .ast-container-fluid {
@@ -6462,7 +6457,7 @@ span.champ-obligatoire {
     padding-right: var(--space-md);
   }
 }
-@media (min-width: 1440px) {
+@media (--bp-xxl) {
   .container,
   .ast-container,
   .ast-container-fluid {
@@ -6543,17 +6538,17 @@ span.champ-obligatoire {
   --col-span: 12;
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   .row {
     --grid-columns: 6;
   }
 }
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .row {
     --grid-columns: 8;
   }
 }
-@media (min-width: 1024px) {
+@media (--bp-desktop) {
   .row {
     --grid-columns: 12;
   }
@@ -6636,7 +6631,7 @@ header.site-header {
   padding: 0 7px;
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   header.site-header {
     padding: 0 10px;
   }
@@ -6645,7 +6640,7 @@ header.site-header {
     padding-right: 10px;
   }
 }
-@media (min-width: 1024px) {
+@media (--bp-desktop) {
   header.site-header {
     padding: 0;
   }
@@ -6748,7 +6743,7 @@ header.site-header {
   padding-top: 235px;
 }
 
-@media (min-width: 480px) {
+@media (--bp-small) {
   .hero-title {
     font-size: 1.8rem;
   }
@@ -6763,7 +6758,7 @@ header.site-header {
     padding-top: 300px;
   }
 }
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .hero-title {
     font-size: 2.6rem;
   }
@@ -6874,7 +6869,7 @@ body #primary {
   line-height: 1.5;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .bloc-temoignages .temoignage-colonnes {
     flex-direction: row;
     align-items: stretch;
@@ -6981,10 +6976,6 @@ body #primary {
   box-sizing: border-box;
 }
 
-.newsletter-group input[type=email]::-moz-placeholder {
-  color: var(--color-gris-3);
-}
-
 .newsletter-group input[type=email]::placeholder {
   color: var(--color-gris-3);
 }
@@ -7079,12 +7070,11 @@ footer .site-footer-primary-section-3 {
 }
 
 .ast-builder-footer-grid-columns {
-  -moz-column-gap: 20px;
-       column-gap: 20px;
+  column-gap: 20px;
   padding-inline: 10px;
 }
 
-@media (min-width: 600px) {
+@media (--bp-mobile) {
   .site-footer-primary-section-1 {
     order: 1;
     margin: 0;
@@ -7100,8 +7090,7 @@ footer .site-footer-primary-section-3 {
     display: flex;
   }
   .ast-builder-footer-grid-columns {
-    -moz-column-gap: 20px;
-         column-gap: 20px;
+    column-gap: 20px;
     padding-inline: 0;
   }
 }
@@ -7553,7 +7542,7 @@ footer .site-footer-primary-section-3 {
 }
 
 /* ✅ Mobile : Les éléments s'empilent */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .dashboard-profile-wrapper {
     flex-direction: column; /* ✅ Empile les éléments */
     justify-content: center; /* ✅ Centre les éléments verticalement */
@@ -7613,7 +7602,7 @@ footer .site-footer-primary-section-3 {
   vertical-align: middle;
 }
 
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .menu-deroulant .submenu {
     left: -50px;
   }
@@ -7720,8 +7709,7 @@ footer .site-footer-primary-section-3 {
 .dashboard-logo {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover; /* Ajuste l’image pour occuper tout l’espace sans déformation */
+  object-fit: cover; /* Ajuste l’image pour occuper tout l’espace sans déformation */
 }
 
 /* 🔥 Overlay du nombre de chasses */
@@ -7948,7 +7936,7 @@ footer .site-footer-primary-section-3 {
 }
 
 /* Tablette : 2 colonnes */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .image-container {
     height: 260px;
   }
@@ -8151,8 +8139,7 @@ a.bouton-edition-attention {
 .header-organisateur__logo img {
   width: 50px;
   height: 50px;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
   border-radius: 50%;
 }
 
@@ -8258,7 +8245,7 @@ a.bouton-edition-attention {
   margin: 0 auto;
 }
 
-@media (min-width: 768px) {
+@media (--bp-tablet) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
@@ -8285,7 +8272,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 RESPONSIVE – TABLETTES (600PX À 768PX) ========== */
-@media (min-width: 600px) and (min-width: 768px) {
+@media (min-width: 600px) and (--bp-tablet) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
@@ -8310,7 +8297,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 BASCULE EN COLONNE (≤ 600PX) ========== */
-@media not all and (min-width: 600px) {
+@media not all and (--bp-mobile) {
   .conteneur-organisateur {
     gap: var(--space-md);
   }
@@ -8321,7 +8308,7 @@ a.bouton-edition-attention {
   }
 }
 /* ========== 📱 RESPONSIVE – MOBILE (≤ 480PX) ========== */
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .conteneur-organisateur {
     gap: 0.2rem;
   }
@@ -8454,6 +8441,26 @@ body:not(.edition-active) #presentation .champ-liens.champ-vide {
   white-space: nowrap;
 }
 
+.lien-public.lien-facebook i {
+  color: #1877f2;
+}
+
+.lien-public.lien-twitter i {
+  color: #1da1f2;
+}
+
+.lien-public.lien-instagram i {
+  color: #e4405f;
+}
+
+.lien-public.lien-discord i {
+  color: #5865f2;
+}
+
+.lien-public.lien-site_web i {
+  color: var(--color-secondary);
+}
+
 /* ========== 🧾 DESCRIPTION ORGANISATEUR ========== */
 section#presentation {
   margin-top: var(--space-md);
@@ -8489,7 +8496,7 @@ section#presentation .presentation-fermer {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .lien-public .texte-lien {
     display: none;
   }
@@ -8592,7 +8599,7 @@ section#presentation .presentation-fermer {
 }
 
 /* ========== 📱 RESPONSIVE ========== */
-@media not all and (min-width: 768px) {
+@media not all and (--bp-tablet) {
   .separateur-avec-icone {
     margin: 2.1rem 0;
   }
@@ -8608,7 +8615,7 @@ section#presentation .presentation-fermer {
     height: 50px;
   }
 }
-@media not all and (min-width: 480px) {
+@media not all and (--bp-small) {
   .separateur-avec-icone {
     margin: var(--space-xl) 0;
   }
@@ -8645,7 +8652,20 @@ section#presentation .presentation-fermer {
 }
 
 /* 🎨 Variables globales */
+@custom-media --bp-xs (min-width: 374px);
+@custom-media --bp-small (min-width: 480px);
+@custom-media --bp-mobile (min-width: 600px);
+@custom-media --bp-tablet (min-width: 768px);
+@custom-media --bp-desktop (min-width: 1024px);
+@custom-media --bp-wide (min-width: 1280px);
+@custom-media --bp-xxl (min-width: 1440px);
+@custom-media --bp-xxxl (min-width: 1920px);
 /* Legacy aliases */
+@custom-media --bp-sm (--bp-small);
+@custom-media --bp-600 (--bp-mobile);
+@custom-media --bp-md (--bp-tablet);
+@custom-media --bp-lg (--bp-desktop);
+@custom-media --bp-xl (--bp-wide);
 :root {
   /* Typographie et breakpoints */
   --font-main: "Poppins", sans-serif; /* Police principale */
@@ -8732,7 +8752,7 @@ section#presentation .presentation-fermer {
   --breakpoint-wide: 1280px;
 }
 
-@media (min-width: 1440px) {
+@media (--bp-xxl) {
   :root {
     --container-max-width: none;
   }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -378,6 +378,33 @@
   align-items: center;
 }
 
+.chasse-details-actions .bouton-edition-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: #fff;
+  background: none;
+}
+
+.chasse-details-actions .bouton-edition-toggle:hover,
+.chasse-details-actions .bouton-edition-toggle:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.chasse-details-actions .bouton-edition-toggle:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.chasse-share-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 .header-chasse {
   font-size: 30px;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -366,6 +366,16 @@
 .chasse-details-wrapper {
   min-width: 240px;
   flex: 1;
+  position: relative;
+}
+
+.chasse-details-actions {
+  position: absolute;
+  top: 1.2rem;
+  right: var(--space-xs);
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
 }
 
 .header-chasse {
@@ -2724,13 +2734,6 @@ body[class*=edition-active] .champ-desactive .champ-modifier,
 /* ==================================================
    🧭 HEADER
    ================================================== */
-/* Bouton d'ouverture du panneau sur la page chasse */
-.chasse-fiche-container .bouton-edition-toggle {
-  position: absolute;
-  top: 1.2rem;
-  right: var(--space-xs);
-}
-
 .header-coordonnees.champ-vide {
   border: 1px dashed var(--color-border-header-organisateur);
   padding: 0.2rem var(--space-xs);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -113,13 +113,6 @@ if ($edition_active && !$est_complet) {
     }
     ?>
 
-    <!-- 🔧 Bouton panneau édition -->
-    <?php if ($edition_active) : ?>
-      <button id="toggle-mode-edition-chasse" class="bouton-edition-toggle" aria-label="Activer Orgy">
-        <i class="fa-solid fa-gear"></i>
-      </button>
-    <?php endif; ?>
-
     <div class="chasse-visuel-wrapper">
       <!-- 📷 Image principale -->
       <div class="champ-chasse champ-img <?= empty($image_url) ? 'champ-vide' : 'champ-rempli'; ?>"
@@ -213,6 +206,17 @@ if ($edition_active && !$est_complet) {
 
     <!-- 📟 Informations -->
     <div class="chasse-details-wrapper">
+
+      <div class="chasse-details-actions">
+        <?php if (function_exists('ADDTOANY_SHARE_SAVE_BUTTON')) : ?>
+          <?php ADDTOANY_SHARE_SAVE_BUTTON(); ?>
+        <?php endif; ?>
+        <?php if ($edition_active) : ?>
+          <button id="toggle-mode-edition-chasse" class="bouton-edition-toggle" aria-label="<?php esc_attr_e('Paramètres de chasse', 'chassesautresor-com'); ?>">
+            <i class="fa-solid fa-gear"></i>
+          </button>
+        <?php endif; ?>
+      </div>
 
       <!-- Titre dynamique -->
       <h1 class="titre-objet header-chasse"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -209,7 +209,10 @@ if ($edition_active && !$est_complet) {
 
       <div class="chasse-details-actions">
         <?php if (function_exists('ADDTOANY_SHARE_SAVE_BUTTON')) : ?>
-          <?php ADDTOANY_SHARE_SAVE_BUTTON(); ?>
+          <?= ADDTOANY_SHARE_SAVE_BUTTON([
+            'html_content' => get_svg_icon('share-icon'),
+            'button_additional_classes' => 'bouton-edition-toggle chasse-share-button',
+          ]); ?>
         <?php endif; ?>
         <?php if ($edition_active) : ?>
           <button id="toggle-mode-edition-chasse" class="bouton-edition-toggle" aria-label="<?php esc_attr_e('Paramètres de chasse', 'chassesautresor-com'); ?>">


### PR DESCRIPTION
### Résumé
- ajoute un bouton de partage AddToAny sur la fiche de chasse
- aligne le bouton de partage avec le bouton d’édition

### Changements notables
- Ajout d’un conteneur d’actions dans la fiche de chasse
- Positionnement absolu du conteneur en haut à droite

### Testing
- `npm run build:css`
- `npx sass --no-source-map wp-content/themes/chassesautresor/assets/scss/main.scss wp-content/themes/chassesautresor/assets/scss/main.css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b039a86df8833286bc7c42d2654728