### PR TITLE
Fix missing French translations for hunt durations

### DIFF
--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1164,18 +1164,17 @@ msgid "Début"
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:390
-#, fuzzy
 #: template-parts/chasse/chasse-edition-main.php:554
 msgid "Date de fin"
-msgstr ""
+msgstr "Date de fin"
 
 #: template-parts/chasse/chasse-edition-main.php:560
 msgid "Illimitée"
-msgstr ""
+msgstr "Illimitée"
 
 #: template-parts/chasse/chasse-edition-main.php:569
 msgid "Limitée"
-msgstr ""
+msgstr "Limitée"
 
 #: template-parts/chasse/chasse-edition-main.php:607
 msgid "En savoir plus sur les points"
@@ -1183,7 +1182,7 @@ msgstr "En savoir plus sur les points"
 
 #: template-parts/chasse/chasse-edition-main.php:610
 msgid "Coût d’accès à une chasse"
-msgstr ""
+msgstr "Coût d’accès à une chasse"
 
 #: template-parts/chasse/chasse-edition-main.php:601 template-parts/enigme/enigme-edition-main.php:434
 msgid "Accès"
@@ -2616,3 +2615,6 @@ msgstr "Non spécifiée"
 msgctxt "formatting for dates"
 msgid "j F Y"
 msgstr "j F Y"
+
+msgid "Unlimited"
+msgstr "Illimitée"


### PR DESCRIPTION
## Résumé
- corrige les traductions manquantes des libellés de durée de chasse

## Changements notables
- ajoute les traductions françaises pour les options "Illimitée" et "Limitée"
- complète les libellés "Date de fin" et "Coût d’accès à une chasse"
- fournit une traduction de "Unlimited" en "Illimitée"

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b03ce637b08332b5ff9a1b15dd53a9