### PR TITLE
Corrige le formatage de date pour les éditions

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -589,9 +589,9 @@ function formater_date($date): string
     if ($date instanceof DateTimeInterface) {
         $timestamp = $date->getTimestamp();
     } elseif (is_array($date) && isset($date['date'])) {
-        $timestamp = strtotime($date['date']);
+        $timestamp = convertir_en_timestamp($date['date']);
     } else {
-        $timestamp = strtotime((string) $date);
+        $timestamp = convertir_en_timestamp((string) $date);
     }
 
     if ($timestamp === false) {


### PR DESCRIPTION
## Résumé
- corrige l'interprétation des dates en passant par `convertir_en_timestamp`

## Changements notables
- utilisation de `convertir_en_timestamp` pour parser les dates

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b0416291a08332a6f75d654aac9385