### PR TITLE
Affiche le lien vers la chasse pour les validations en attente

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -579,10 +579,18 @@ function myaccount_get_important_messages(): string
             ]);
 
             if (!empty($pendingChasses)) {
-                $messages[] = [
-                    'text' => __('Demande de validation en cours de traitement.', 'chassesautresor'),
-                    'type' => 'info',
-                ];
+                foreach ($pendingChasses as $chasse_id) {
+                    $url   = esc_url(get_permalink($chasse_id));
+                    $title = esc_html(get_the_title($chasse_id));
+                    $messages[] = [
+                        'text' => sprintf(
+                            /* translators: %s: hunt title with link */
+                            __('Demande pour %s en cours de traitement', 'chassesautresor-com'),
+                            '<a href="' . $url . '">' . $title . '</a>'
+                        ),
+                        'type' => 'info',
+                    ];
+                }
             }
         }
     }

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2751,3 +2751,8 @@ msgstr "Not specified"
 msgctxt "formatting for dates"
 msgid "j F Y"
 msgstr "F j, Y"
+
+#: inc/user-functions.php:588
+#. translators: %s: hunt title with link
+msgid "Demande pour %s en cours de traitement"
+msgstr "Request for %s is being processed"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2618,3 +2618,8 @@ msgstr "j F Y"
 
 msgid "Unlimited"
 msgstr "Illimitée"
+
+#: inc/user-functions.php:588
+#. translators: %s: hunt title with link
+msgid "Demande pour %s en cours de traitement"
+msgstr "Demande pour %s en cours de traitement"

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -110,7 +110,33 @@ if (!function_exists('wp_send_json_success')) {
 if (!function_exists('get_permalink')) {
     function get_permalink($post_id)
     {
-        return 'https://example.com/organisateur';
+        if ($post_id === 99) {
+            return 'https://example.com/organisateur';
+        }
+
+        if ($post_id === 101) {
+            return 'https://example.com/chasse-101';
+        }
+
+        return 'https://example.com/post-' . $post_id;
+    }
+}
+
+if (!function_exists('get_the_title')) {
+    function get_the_title($post_id)
+    {
+        if ($post_id === 101) {
+            return 'Chasse Example';
+        }
+
+        return 'Post ' . $post_id;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return $text;
     }
 }
 
@@ -201,7 +227,12 @@ class MyAccountMessagesTest extends TestCase
     {
         $output = myaccount_get_important_messages();
 
-        $this->assertStringContainsString('Demande de validation en cours de traitement', $output);
+        $this->assertStringContainsString('Demande pour', $output);
+        $this->assertStringContainsString('en cours de traitement', $output);
+        $this->assertStringContainsString(
+            '<a href="https://example.com/chasse-101">Chasse Example</a>',
+            $output
+        );
     }
 
     public function test_pending_request_message_contains_riddle_link(): void


### PR DESCRIPTION
## Résumé
- affiche un message avec le titre et le lien de la chasse lorsqu'une validation est en attente
- ajoute les traductions en_US et fr_FR pour ce message
- met à jour les tests liés aux messages du compte

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b04583381c8332bcdbe122cb6826ce