### PR TITLE
Uniformiser le style des boutons de partage AddToAny

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -129,33 +129,6 @@
 }
 
 
-.chasse-details-actions .chasse-share-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.4rem;
-  height: 2.4rem;
-  padding: 0;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  color: #fff;
-  background: none;
-  transition: background-color 0.2s ease;
-}
-
-.chasse-details-actions .chasse-share-button:hover,
-.chasse-details-actions .chasse-share-button:focus {
-  background-color: rgba(255, 255, 255, 0.15);
-}
-
-.chasse-details-actions .chasse-share-button:active {
-  background-color: rgba(255, 255, 255, 0.3);
-}
-
-.chasse-share-button svg {
-  width: 1rem;
-  height: 1rem;
-}
 .header-chasse {
   font-size: 30px;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -973,6 +973,28 @@ a[aria-disabled="true"] {
   display: inline-block;
 }
 
+/* 🔗 Boutons de partage AddToAny */
+.addtoany_share {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.addtoany_share img,
+.addtoany_share svg,
+.addtoany_share span {
+  width: 30px;
+  height: 30px;
+  border-radius: 0;
+}
+
 /* 🌐 Language switcher */
 
 .lang-switcher {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -378,34 +378,6 @@
   align-items: center;
 }
 
-.chasse-details-actions .chasse-share-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.4rem;
-  height: 2.4rem;
-  padding: 0;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  color: #fff;
-  background: none;
-  transition: background-color 0.2s ease;
-}
-
-.chasse-details-actions .chasse-share-button:hover,
-.chasse-details-actions .chasse-share-button:focus {
-  background-color: rgba(255, 255, 255, 0.15);
-}
-
-.chasse-details-actions .chasse-share-button:active {
-  background-color: rgba(255, 255, 255, 0.3);
-}
-
-.chasse-share-button svg {
-  width: 1rem;
-  height: 1rem;
-}
-
 .header-chasse {
   font-size: 30px;
 }
@@ -1489,6 +1461,28 @@ a[aria-disabled=true] {
   width: 60px;
   height: 60px;
   display: inline-block;
+}
+
+/* 🔗 Boutons de partage AddToAny */
+.addtoany_share {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.addtoany_share img,
+.addtoany_share svg,
+.addtoany_share span {
+  width: 30px;
+  height: 30px;
+  border-radius: 0;
 }
 
 /* 🌐 Language switcher */


### PR DESCRIPTION
### Résumé
- Uniformise le style des boutons de partage AddToAny pour qu'ils aient une icône 30x30 sans cercle et avec une légère ombre.

### Changements
- Ajout d'un style global pour AddToAny (icône 30x30, suppression du cercle, ombre)
- Nettoyage de l'ancien style spécifique aux chasses
- Recompilation du CSS du thème

### Testing
- `npm run build:css`
- `npm test` *(échoué : 7 tests échoués)*
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b049d4359c83329ba773f8cbec26ec