### PR TITLE
Limit hunt description with expandable toggle

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-description-toggle.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-description-toggle.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var container = document.querySelector('.chasse-description');
+    if (!container) {
+        return;
+    }
+
+    var toggle = container.querySelector('.description-toggle');
+    var shortDesc = container.querySelector('.description-short');
+    var fullDesc = container.querySelector('.description-full');
+
+    if (!toggle || !shortDesc || !fullDesc) {
+        return;
+    }
+
+    var moreLabel = toggle.getAttribute('data-label-more');
+    var lessLabel = toggle.getAttribute('data-label-less');
+
+    toggle.addEventListener('click', function () {
+        var expanded = toggle.getAttribute('aria-expanded') === 'true';
+
+        if (expanded) {
+            fullDesc.hidden = true;
+            shortDesc.hidden = false;
+            toggle.textContent = moreLabel;
+            toggle.setAttribute('aria-expanded', 'false');
+        } else {
+            fullDesc.hidden = false;
+            shortDesc.hidden = true;
+            toggle.textContent = lessLabel;
+            toggle.setAttribute('aria-expanded', 'true');
+        }
+    });
+});

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -175,6 +175,9 @@
 .chasse-description {
   margin-top: var(--space-xl);
   line-height: 1.6;
+  font-size: 1.05rem;
+  padding-left: var(--space-md);
+  padding-right: var(--space-md);
 
   p {
     margin-bottom: var(--space-md);
@@ -182,6 +185,16 @@
 
   p:last-child {
     margin-bottom: 0;
+  }
+
+  .description-toggle {
+    background: none;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-decoration: underline;
   }
 }
 .chasse-section-intro.champ-vide-obligatoire {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -428,12 +428,24 @@
 .chasse-description {
   margin-top: var(--space-xl);
   line-height: 1.6;
+  font-size: 1.05rem;
+  padding-left: var(--space-md);
+  padding-right: var(--space-md);
 }
 .chasse-description p {
   margin-bottom: var(--space-md);
 }
 .chasse-description p:last-child {
   margin-bottom: 0;
+}
+.chasse-description .description-toggle {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
 }
 
 .chasse-section-intro.champ-vide-obligatoire {
@@ -1451,9 +1463,7 @@ a[aria-disabled=true] {
 }
 
 /* 🔗 Boutons de partage AddToAny */
-
 a.addtoany_share {
-
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1472,7 +1482,6 @@ a.addtoany_share span {
   width: 30px;
   height: 30px;
   border: none;
-
   border-radius: 0;
 }
 

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -367,7 +367,7 @@ function filtrer_content_sans_titre($content) {
  * @param string $more  Optional string appended after trimming.
  * @return string Trimmed HTML content.
  */
-function cst_trim_html_words($html, $limit = 50, $more = '…') {
+function cst_trim_html_words($html, $limit = 200, $more = '…') {
     $wordCount = 0;
     $output = '';
     $openTags = [];

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -131,6 +131,13 @@ function charger_scripts_personnalises() {
     // 📌 Chargement des scripts JS personnalisés
     wp_enqueue_script('toggle-text', $theme_dir . 'toggle-text.js', ['jquery'], null, true);
     wp_enqueue_script('toggle-tooltip', $theme_dir . 'toggle-tooltip.js', [], null, true);
+    wp_enqueue_script(
+        'chasse-description-toggle',
+        $theme_dir . 'chasse-description-toggle.js',
+        [],
+        filemtime(get_stylesheet_directory() . '/assets/js/chasse-description-toggle.js'),
+        true
+    );
     
     wp_enqueue_script(
       'encodage-morse',

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -358,6 +358,51 @@ function filtrer_content_sans_titre($content) {
 // ==================================================
 // 🎯 AFFICHAGES SPÉCIFIQUES
 // ==================================================
+
+/**
+ * Trim HTML content to a given number of words while preserving tags.
+ *
+ * @param string $html  HTML to trim.
+ * @param int    $limit Number of words to retain.
+ * @param string $more  Optional string appended after trimming.
+ * @return string Trimmed HTML content.
+ */
+function cst_trim_html_words($html, $limit = 50, $more = '…') {
+    $wordCount = 0;
+    $output = '';
+    $openTags = [];
+
+    preg_match_all('/(<[^>]+>|\s+|[^<\s]+)/u', $html, $tokens);
+
+    foreach ($tokens[0] as $token) {
+        if ($token[0] === '<') {
+            if ($token[1] === '/') {
+                array_pop($openTags);
+            } elseif (substr($token, -2) !== '/>') {
+                $tagName = strtolower(preg_replace('/[\s>].*/', '', substr($token, 1)));
+                $openTags[] = $tagName;
+            }
+            $output .= $token;
+        } elseif (trim($token) === '') {
+            $output .= $token;
+        } else {
+            $wordCount++;
+            $output .= $token;
+
+            if ($wordCount >= $limit) {
+                $output = rtrim($output);
+                $output .= $more;
+                break;
+            }
+        }
+    }
+
+    while (!empty($openTags)) {
+        $output .= '</' . array_pop($openTags) . '>';
+    }
+
+    return $output;
+}
 /**
  * Limite l'affichage d'un texte à un certain nombre de caractères, avec un bouton "Lire la suite" pour afficher la totalité.
  *

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -3,10 +3,31 @@ defined('ABSPATH') || exit;
 
 $description = $args['description'] ?? '';
 
-if (!empty($description)) :
-    ?>
-    <div class="chasse-description" id="chasse-description">
-        <?= wp_kses_post($description); ?>
-    </div>
-    <?php
-endif;
+if (!empty($description)) {
+    $word_count = str_word_count(wp_strip_all_tags($description));
+
+    if ($word_count > 50) {
+        $short_description = wp_trim_words(wp_strip_all_tags($description), 50, '…');
+        ?>
+        <div class="chasse-description" id="chasse-description">
+            <div class="description-short"><?= esc_html($short_description); ?></div>
+            <div class="description-full" hidden><?= wp_kses_post($description); ?></div>
+            <button
+                type="button"
+                class="description-toggle"
+                aria-expanded="false"
+                data-label-more="<?= esc_attr__('Voir plus', 'chassesautresor-com'); ?>"
+                data-label-less="<?= esc_attr__('Voir moins', 'chassesautresor-com'); ?>"
+            >
+                <?= esc_html__('Voir plus', 'chassesautresor-com'); ?>
+            </button>
+        </div>
+        <?php
+    } else {
+        ?>
+        <div class="chasse-description" id="chasse-description">
+            <?= wp_kses_post($description); ?>
+        </div>
+        <?php
+    }
+}

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -6,8 +6,8 @@ $description = $args['description'] ?? '';
 if (!empty($description)) {
     $word_count = str_word_count(wp_strip_all_tags($description));
 
-    if ($word_count > 50) {
-        $short_description = cst_trim_html_words($description, 50);
+    if ($word_count > 200) {
+        $short_description = cst_trim_html_words($description, 200);
         ?>
         <div class="chasse-description" id="chasse-description">
             <div class="description-short"><?= wp_kses_post($short_description); ?></div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -6,11 +6,11 @@ $description = $args['description'] ?? '';
 if (!empty($description)) {
     $word_count = str_word_count(wp_strip_all_tags($description));
 
-    if ($word_count > 200) {
-        $short_description = wp_trim_words(wp_strip_all_tags($description), 200, '…');
+    if ($word_count > 50) {
+        $short_description = cst_trim_html_words($description, 50);
         ?>
         <div class="chasse-description" id="chasse-description">
-            <div class="description-short"><?= esc_html($short_description); ?></div>
+            <div class="description-short"><?= wp_kses_post($short_description); ?></div>
             <div class="description-full" hidden><?= wp_kses_post($description); ?></div>
             <button
                 type="button"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -6,8 +6,8 @@ $description = $args['description'] ?? '';
 if (!empty($description)) {
     $word_count = str_word_count(wp_strip_all_tags($description));
 
-    if ($word_count > 50) {
-        $short_description = wp_trim_words(wp_strip_all_tags($description), 50, '…');
+    if ($word_count > 200) {
+        $short_description = wp_trim_words(wp_strip_all_tags($description), 200, '…');
         ?>
         <div class="chasse-description" id="chasse-description">
             <div class="description-short"><?= esc_html($short_description); ?></div>


### PR DESCRIPTION
## Résumé
- Limite la description de chasse à 50 mots avec un bouton « Voir plus » pour afficher la suite
- Ajoute le script et les styles associés

## Changements notables
- Tronquage de `chasse_principale_description` et ajout d'un toggle "Voir plus/moins"
- Chargement du script `chasse-description-toggle.js` dans le thème
- Style renforcé pour le bloc de description de chasse

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b05379d15483328c95a8ada9355c7d