### PR TITLE
Affiche titre et montant de la récompense sur la fiche chasse

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1270,23 +1270,15 @@ msgid_plural "%1$d joueurs ont trouvé %2$d énigmes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:332
+#: template-parts/chasse/chasse-affichage-complet.php:345
 msgid "Les + avancés"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:349
-msgid "Récompense de la chasse"
+#: template-parts/chasse/chasse-affichage-complet.php:363
+msgid "Récompense :"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:352
-msgid "Titre :"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:356
-msgid "Valeur :"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:360
+#: template-parts/chasse/chasse-affichage-complet.php:375
 msgid "Description complète :"
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2699,9 +2699,17 @@ msgstr "Riddle access"
 msgid "gratuit"
 msgstr "free"
 
-#: template-parts/chasse/chasse-affichage-complet.php:332
+#: template-parts/chasse/chasse-affichage-complet.php:345
 msgid "Les + avancés"
 msgstr "Most advanced"
+
+#: template-parts/chasse/chasse-affichage-complet.php:363
+msgid "Récompense :"
+msgstr "Reward:"
+
+#: template-parts/chasse/chasse-affichage-complet.php:375
+msgid "Description complète :"
+msgstr "Full description:"
 
 #: inc/chasse-functions.php:606
 msgid "S'identifier"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -359,15 +359,18 @@ if ($edition_active && !$est_complet) {
 
         <?php if (!empty($titre_recompense) || (float) $valeur_recompense > 0 || !empty($lot)) : ?>
             <div class="chasse-lot-complet" style="margin-top: 30px;">
-                <h3><?= '🏆 ' . esc_html__('Récompense de la chasse', 'chassesautresor-com'); ?></h3>
-
-                <?php if (!empty($titre_recompense)) : ?>
-                    <p><strong><?= esc_html__('Titre :', 'chassesautresor-com'); ?></strong> <?= esc_html($titre_recompense); ?></p>
-                <?php endif; ?>
-
-                <?php if ((float) $valeur_recompense > 0) : ?>
-                    <p><strong><?= esc_html__('Valeur :', 'chassesautresor-com'); ?></strong> <?= esc_html($valeur_recompense); ?> €</p>
-                <?php endif; ?>
+                <h3>
+                    <?= '🏆 ' . esc_html__('Récompense :', 'chassesautresor-com'); ?>
+                    <?php if (!empty($titre_recompense)) : ?>
+                        <?= esc_html($titre_recompense); ?>
+                    <?php endif; ?>
+                    <?php if (!empty($titre_recompense) && (float) $valeur_recompense > 0) : ?>
+                        -
+                    <?php endif; ?>
+                    <?php if ((float) $valeur_recompense > 0) : ?>
+                        <span class="badge-recompense avec-recompense"><?= esc_html($valeur_recompense); ?> €</span>
+                    <?php endif; ?>
+                </h3>
 
                 <?php if (!empty($lot)) : ?>
                     <p><strong><?= esc_html__('Description complète :', 'chassesautresor-com'); ?></strong><br><?= wp_kses_post($lot); ?></p>


### PR DESCRIPTION
Affiche le titre et le montant de la récompense sur la fiche chasse.

- Ajout du nom et de la valeur de la récompense dans l'en-tête de la chasse avec une étiquette dédiée.
- Mise à jour des fichiers de traduction pour la nouvelle formulation.

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test` *(échoue : 7 tests en erreur)*

------
https://chatgpt.com/codex/tasks/task_e_68b0546401bc83328ddec18e82cb0b87