### PR TITLE
Handle unlimited hunt limit with pluralization

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1139,10 +1139,14 @@ function mettreAJourAffichageNbGagnants(postId, nb) {
   const nbGagnantsAffichage = document.querySelector(`.nb-gagnants-affichage[data-post-id="${postId}"]`);
   if (!nbGagnantsAffichage) return;
 
-  if (parseInt(nb, 10) === 0) {
-    nbGagnantsAffichage.textContent = 'Nombre illimité de gagnants';
+  const valeur = parseInt(nb, 10);
+  if (valeur === 0) {
+    nbGagnantsAffichage.textContent = wp.i18n.__('illimité', 'chassesautresor-com');
   } else {
-    nbGagnantsAffichage.textContent = `${nb} gagnant${nb > 1 ? 's' : ''}`;
+    nbGagnantsAffichage.textContent = wp.i18n.sprintf(
+      wp.i18n._n('%d gagnant', '%d gagnants', valeur, 'chassesautresor-com'),
+      valeur
+    );
   }
 }
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2764,3 +2764,15 @@ msgstr "F j, Y"
 #. translators: %s: hunt title with link
 msgid "Demande pour %s en cours de traitement"
 msgstr "Request for %s is being processed"
+
+#: template-parts/chasse/chasse-affichage-complet.php:279
+#: assets/js/chasse-edit.js:1144
+msgid "illimité"
+msgstr "unlimited"
+
+#: template-parts/chasse/chasse-affichage-complet.php:281
+#: assets/js/chasse-edit.js:1147
+msgid "%d gagnant"
+msgid_plural "%d gagnants"
+msgstr[0] "%d winner"
+msgstr[1] "%d winners"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2623,3 +2623,15 @@ msgstr "Illimitée"
 #. translators: %s: hunt title with link
 msgid "Demande pour %s en cours de traitement"
 msgstr "Demande pour %s en cours de traitement"
+
+#: template-parts/chasse/chasse-affichage-complet.php:279
+#: assets/js/chasse-edit.js:1144
+msgid "illimité"
+msgstr "illimité"
+
+#: template-parts/chasse/chasse-affichage-complet.php:281
+#: assets/js/chasse-edit.js:1147
+msgid "%d gagnant"
+msgid_plural "%d gagnants"
+msgstr[0] "%d gagnant"
+msgstr[1] "%d gagnants"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -271,10 +271,16 @@ if ($edition_active && !$est_complet) {
         ?>
         <div class="chasse-cta-section cta-chasse">
           <div class="chasse-caracteristiques">
-          <?php if ($mode_fin === 'automatique' && (int) $nb_max > 0) : ?>
+          <?php if ($mode_fin === 'automatique') : ?>
             <div class="caracteristique">
               <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
-              <span class="caracteristique-valeur"><?= sprintf(esc_html__('%d gagnants', 'chassesautresor-com'), $nb_max); ?></span>
+              <span class="caracteristique-valeur nb-gagnants-affichage" data-post-id="<?= esc_attr($chasse_id); ?>">
+                <?php if ((int) $nb_max === 0) : ?>
+                  <?= esc_html__('illimité', 'chassesautresor-com'); ?>
+                <?php else : ?>
+                  <?= esc_html(sprintf(_n('%d gagnant', '%d gagnants', $nb_max, 'chassesautresor-com'), $nb_max)); ?>
+                <?php endif; ?>
+              </span>
             </div>
           <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- Gère le pluriel de la limite de gagnants et affiche "illimité" le cas échéant
- Met à jour dynamiquement la limite de gagnants dans l'interface d'édition
- Ajoute les chaînes de traduction correspondantes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b07145fb5883329125c56edb54f3d0