### PR TITLE
Améliorer l'icône d'avertissement pour les énigmes incomplètes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -261,9 +261,15 @@
   position: absolute;
   top: var(--space-xs);
   right: var(--space-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 24px;
   height: 24px;
-  background: url('../assets/svg/warning.svg') no-repeat center/contain;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
   animation: clignoteTitre 1s infinite alternate;
   z-index: 2;
 }
@@ -272,6 +278,7 @@
   .warning-icon {
     width: 28px;
     height: 28px;
+    font-size: 1rem;
   }
 }
 
@@ -279,5 +286,6 @@
   .warning-icon {
     width: 32px;
     height: 32px;
+    font-size: 1.125rem;
   }
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -257,9 +257,15 @@
   position: absolute;
   top: var(--space-xs);
   right: var(--space-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 24px;
   height: 24px;
-  background: url("../assets/svg/warning.svg") no-repeat center/contain;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
   animation: clignoteTitre 1s infinite alternate;
   z-index: 2;
 }
@@ -268,12 +274,14 @@
   .warning-icon {
     width: 28px;
     height: 28px;
+    font-size: 1rem;
   }
 }
 @media (min-width: 1024px) {
   .warning-icon {
     width: 32px;
     height: 32px;
+    font-size: 1.125rem;
   }
 }
 /* ==================================================

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -121,7 +121,9 @@ foreach ($posts as $p) {
           <?php endif; ?>
         </div>
         <?php if ($classe_completion === 'carte-incomplete') : ?>
-          <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>"></span>
+          <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
+            <i class="fa-solid fa-exclamation" aria-hidden="true"></i>
+          </span>
         <?php endif; ?>
       </article>
     <?php endforeach; ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -121,7 +121,7 @@ foreach ($posts as $p) {
           <?php endif; ?>
         </div>
         <?php if ($classe_completion === 'carte-incomplete') : ?>
-          <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
+          <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
             <i class="fa-solid fa-exclamation" aria-hidden="true"></i>
           </span>
         <?php endif; ?>


### PR DESCRIPTION
## Résumé
- Harmonisation de l’icône d’avertissement avec le style "warning" du site.
- Icône Font Awesome en forme de pastille en haut à droite des cartes d’énigmes incomplètes.
- Regénération des styles compilés.

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b0729dcbf08332aac5548b7933c6cb