### PR TITLE
feat: afficher le statut de date d'une chasse

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -119,7 +119,13 @@ describe('chasse-edit UI', () => {
     global.mettreAJourAffichageDateFin = jest.fn();
     global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
-    global.wp = { i18n: { __: (s) => s } };
+    global.wp = {
+      i18n: {
+        __: (s) => s,
+        _n: (sing, plur, n) => (n > 1 ? plur : sing),
+        sprintf: (fmt, ...args) => fmt.replace(/%d|%s/g, () => args.shift())
+      }
+    };
     global.confirm = jest.fn(() => true);
     jest.resetModules();
     require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2776,3 +2776,27 @@ msgid "%d gagnant"
 msgid_plural "%d gagnants"
 msgstr[0] "%d winner"
 msgstr[1] "%d winners"
+
+#: template-parts/chasse/chasse-affichage-complet.php:59
+#: assets/js/chasse-edit.js:1165
+msgid "illimitée"
+msgstr "unlimited"
+
+#: template-parts/chasse/chasse-affichage-complet.php:63
+#: assets/js/chasse-edit.js:1174
+msgid "%d jour à attendre"
+msgid_plural "%d jours à attendre"
+msgstr[0] "%d day to wait"
+msgstr[1] "%d days to wait"
+
+#: template-parts/chasse/chasse-affichage-complet.php:68
+#: assets/js/chasse-edit.js:1182
+msgid "terminée depuis %s"
+msgstr "ended on %s"
+
+#: template-parts/chasse/chasse-affichage-complet.php:74
+#: assets/js/chasse-edit.js:1190
+msgid "%d jour restant"
+msgid_plural "%d jours restants"
+msgstr[0] "%d day remaining"
+msgstr[1] "%d days remaining"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2635,3 +2635,27 @@ msgid "%d gagnant"
 msgid_plural "%d gagnants"
 msgstr[0] "%d gagnant"
 msgstr[1] "%d gagnants"
+
+#: template-parts/chasse/chasse-affichage-complet.php:59
+#: assets/js/chasse-edit.js:1165
+msgid "illimitée"
+msgstr "illimitée"
+
+#: template-parts/chasse/chasse-affichage-complet.php:63
+#: assets/js/chasse-edit.js:1174
+msgid "%d jour à attendre"
+msgid_plural "%d jours à attendre"
+msgstr[0] "%d jour à attendre"
+msgstr[1] "%d jours à attendre"
+
+#: template-parts/chasse/chasse-affichage-complet.php:68
+#: assets/js/chasse-edit.js:1182
+msgid "terminée depuis %s"
+msgstr "terminée depuis %s"
+
+#: template-parts/chasse/chasse-affichage-complet.php:74
+#: assets/js/chasse-edit.js:1190
+msgid "%d jour restant"
+msgid_plural "%d jours restants"
+msgstr[0] "%d jour restant"
+msgstr[1] "%d jours restants"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -52,6 +52,32 @@ $date_fin_formatee   = $illimitee
     ? __('Illimitée', 'chassesautresor-com')
     : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
 
+$now = current_time('timestamp');
+$date_debut_ts = convertir_en_timestamp($date_debut);
+$date_fin_ts   = convertir_en_timestamp($date_fin);
+if ($illimitee) {
+    $date_message = __('illimitée', 'chassesautresor-com');
+} elseif ($date_debut_ts && $date_debut_ts > $now) {
+    $days_wait = (int) ceil(($date_debut_ts - $now) / DAY_IN_SECONDS);
+    $date_message = sprintf(
+        _n('%d jour à attendre', '%d jours à attendre', $days_wait, 'chassesautresor-com'),
+        $days_wait
+    );
+} elseif ($date_fin_ts && $date_fin_ts < $now) {
+    $date_message = sprintf(
+        __('terminée depuis %s', 'chassesautresor-com'),
+        wp_date('Y-m-d', $date_fin_ts)
+    );
+} elseif ($date_fin_ts) {
+    $days_left = (int) ceil(($date_fin_ts - $now) / DAY_IN_SECONDS);
+    $date_message = sprintf(
+        _n('%d jour restant', '%d jours restants', $days_left, 'chassesautresor-com'),
+        $days_left
+    );
+} else {
+    $date_message = __('Non spécifiée', 'chassesautresor-com');
+}
+
 // Edition
 $edition_active = utilisateur_peut_modifier_post($chasse_id);
 
@@ -271,6 +297,10 @@ if ($edition_active && !$est_complet) {
         ?>
         <div class="chasse-cta-section cta-chasse">
           <div class="chasse-caracteristiques">
+          <div class="caracteristique caracteristique-date">
+            <span class="caracteristique-label"><?= esc_html__('Date', 'chassesautresor-com'); ?></span>
+            <span class="caracteristique-valeur" data-post-id="<?= esc_attr($chasse_id); ?>"><?= esc_html($date_message); ?></span>
+          </div>
           <?php if ($mode_fin === 'automatique') : ?>
             <div class="caracteristique">
               <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>


### PR DESCRIPTION
## Résumé
- affiche un message de date dynamique pour chaque chasse
- rafraîchit le message côté édition JS
- ajoute les chaînes de traduction associées

## Changements notables
- calcul du message en PHP selon les dates de début/fin
- actualisation en direct via `chasse-edit.js`
- compléments des fichiers `po`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test` *(échoue: myaccount-admin-ajax.test.js)*
- `npx jest tests/js/chasse-edit.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b098ca75bc8332b7259565984c0f5c