### PR TITLE
Ajout de messages effaçables sur Mon Compte

### DIFF
--- a/tests/js/myaccount-admin-ajax.test.js
+++ b/tests/js/myaccount-admin-ajax.test.js
@@ -1,4 +1,5 @@
 const html = `
+<section class="msg-important"></section>
 <div class="myaccount-layout">
   <aside class="myaccount-sidebar">
     <nav class="dashboard-nav">
@@ -50,7 +51,6 @@ describe('myaccount ajax navigation', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(fetch).toHaveBeenCalledWith(`/admin-ajax.php?action=cta_load_admin_section&section=${section}`, expect.any(Object));
-    expect(document.querySelector('.myaccount-content').innerHTML).toContain('<section class="msg-important"></section>');
     expect(window.history.pushState).toHaveBeenCalled();
     const expectedTitle = link.dataset.title || link.textContent;
     expect(document.querySelector('.myaccount-title').textContent).toBe(expectedTitle);

--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -1,0 +1,42 @@
+const html = `
+<section class="msg-important">
+  <p class="message-info">Message <button type="button" class="message-close" data-key="correction_chasse_123">×</button></p>
+</section>
+<form class="form-validation-chasse">
+  <input type="hidden" name="chasse_id" value="123">
+  <button type="submit" class="bouton-cta bouton-validation-chasse">VALIDATION</button>
+</form>
+`;
+
+describe('validation chasse', () => {
+  beforeEach(() => {
+    document.body.innerHTML = html;
+    global.ctaMyAccount = { ajaxUrl: '/admin-ajax.php' };
+    global.fetch = jest.fn(() => Promise.resolve());
+  });
+
+  test('dismisses correction message on confirmation', () => {
+    const form = document.querySelector('.form-validation-chasse');
+    form.submit = jest.fn();
+
+    require('../../wp-content/themes/chassesautresor/assets/js/validation-chasse.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const trigger = document.querySelector('.bouton-validation-chasse');
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    const checkbox = document.querySelector('#confirm-validation');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const confirmBtn = document.querySelector('.confirmer-envoi');
+    confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(fetch).toHaveBeenCalledWith('/admin-ajax.php', expect.objectContaining({
+      method: 'POST',
+      body: 'action=cta_dismiss_message&key=correction_chasse_123'
+    }));
+    expect(document.querySelector('.msg-important').innerHTML.trim()).toBe('');
+    expect(form.submit).toHaveBeenCalled();
+  });
+});

--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -34,10 +34,14 @@ describe('validation chasse', () => {
     const confirmBtn = document.querySelector('.confirmer-envoi');
     confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-    expect(fetch).toHaveBeenCalledWith('/admin-ajax.php', expect.objectContaining({
-      method: 'POST',
-      body: 'action=cta_dismiss_message&key=correction_chasse_123'
-    }));
+    expect(fetch).toHaveBeenCalledWith(
+      '/admin-ajax.php',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: 'action=cta_dismiss_message&key=correction_chasse_123'
+      })
+    );
     expect(document.querySelector('.msg-important').innerHTML.trim()).toBe('');
     expect(form.submit).toHaveBeenCalled();
   });
@@ -59,10 +63,14 @@ describe('validation chasse', () => {
     const confirmBtn = document.querySelector('.confirmer-envoi');
     confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-    expect(fetch).toHaveBeenCalledWith('/wp-admin/admin-ajax.php', expect.objectContaining({
-      method: 'POST',
-      body: 'action=cta_dismiss_message&key=correction_chasse_123'
-    }));
+    expect(fetch).toHaveBeenCalledWith(
+      '/wp-admin/admin-ajax.php',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: 'action=cta_dismiss_message&key=correction_chasse_123'
+      })
+    );
     expect(document.querySelector('.msg-important').innerHTML.trim()).toBe('');
     expect(form.submit).toHaveBeenCalled();
   });
@@ -78,6 +86,7 @@ describe('validation chasse', () => {
       '/wp-admin/admin-ajax.php',
       expect.objectContaining({
         method: 'POST',
+        credentials: 'include',
         body: 'action=cta_dismiss_message&key=correction_chasse_123'
       })
     );

--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -66,4 +66,21 @@ describe('validation chasse', () => {
     expect(document.querySelector('.msg-important').innerHTML.trim()).toBe('');
     expect(form.submit).toHaveBeenCalled();
   });
+
+  test('dismisses message when close button is clicked', () => {
+    require('../../wp-content/themes/chassesautresor/assets/js/validation-chasse.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const btn = document.querySelector('.message-close');
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/wp-admin/admin-ajax.php',
+      expect.objectContaining({
+        method: 'POST',
+        body: 'action=cta_dismiss_message&key=correction_chasse_123'
+      })
+    );
+    expect(document.querySelector('.msg-important').innerHTML.trim()).toBe('');
+  });
 });

--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -10,12 +10,14 @@ const html = `
 
 describe('validation chasse', () => {
   beforeEach(() => {
+    jest.resetModules();
     document.body.innerHTML = html;
-    global.ctaMyAccount = { ajaxUrl: '/admin-ajax.php' };
     global.fetch = jest.fn(() => Promise.resolve());
+    delete global.ctaMyAccount;
   });
 
   test('dismisses correction message on confirmation', () => {
+    global.ctaMyAccount = { ajaxUrl: '/admin-ajax.php' };
     const form = document.querySelector('.form-validation-chasse');
     form.submit = jest.fn();
 
@@ -33,6 +35,31 @@ describe('validation chasse', () => {
     confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(fetch).toHaveBeenCalledWith('/admin-ajax.php', expect.objectContaining({
+      method: 'POST',
+      body: 'action=cta_dismiss_message&key=correction_chasse_123'
+    }));
+    expect(document.querySelector('.msg-important').innerHTML.trim()).toBe('');
+    expect(form.submit).toHaveBeenCalled();
+  });
+
+  test('uses fallback ajax url when global config is missing', () => {
+    const form = document.querySelector('.form-validation-chasse');
+    form.submit = jest.fn();
+
+    require('../../wp-content/themes/chassesautresor/assets/js/validation-chasse.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const trigger = document.querySelector('.bouton-validation-chasse');
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    const checkbox = document.querySelector('#confirm-validation');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const confirmBtn = document.querySelector('.confirmer-envoi');
+    confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(fetch).toHaveBeenCalledWith('/wp-admin/admin-ajax.php', expect.objectContaining({
       method: 'POST',
       body: 'action=cta_dismiss_message&key=correction_chasse_123'
     }));

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -38,32 +38,6 @@ document.addEventListener('DOMContentLoaded', () => {
         p.setAttribute('aria-live', 'polite');
       }
     });
-
-    siteMessages.querySelectorAll('.message-close').forEach((btn) => {
-      btn.addEventListener('click', async () => {
-        const key = btn.dataset.key;
-        if (!key) {
-          return;
-        }
-        const params = new URLSearchParams();
-        params.set('action', 'cta_dismiss_message');
-        params.set('key', key);
-        try {
-          await fetch(ctaMyAccount.ajaxUrl, {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: params.toString(),
-          });
-        } catch (e) {
-          // ignore network errors
-        }
-        const parent = btn.closest('p');
-        if (parent) {
-          parent.remove();
-        }
-      });
-    });
   };
 
   const loadSection = async (link, push = true) => {

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -38,6 +38,32 @@ document.addEventListener('DOMContentLoaded', () => {
         p.setAttribute('aria-live', 'polite');
       }
     });
+
+    siteMessages.querySelectorAll('.message-close').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const key = btn.dataset.key;
+        if (!key) {
+          return;
+        }
+        const params = new URLSearchParams();
+        params.set('action', 'cta_dismiss_message');
+        params.set('key', key);
+        try {
+          await fetch(ctaMyAccount.ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+          });
+        } catch (e) {
+          // ignore network errors
+        }
+        const parent = btn.closest('p');
+        if (parent) {
+          parent.remove();
+        }
+      });
+    });
   };
 
   const loadSection = async (link, push = true) => {

--- a/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
+++ b/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
@@ -56,6 +56,30 @@ function ouvrirModalConfirmation(form) {
 
   confirmBtn.addEventListener('click', () => {
     confirmBtn.disabled = true;
+
+    const idInput = form.querySelector('input[name="chasse_id"]');
+    const key = idInput ? `correction_chasse_${idInput.value}` : null;
+
+    if (key) {
+      const params = new URLSearchParams();
+      params.set('action', 'cta_dismiss_message');
+      params.set('key', key);
+      if (typeof ctaMyAccount !== 'undefined') {
+        fetch(ctaMyAccount.ajaxUrl, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        }).catch(() => {});
+      }
+
+      const btn = document.querySelector(`.msg-important .message-close[data-key="${key}"]`);
+      const parent = btn ? btn.closest('p') : null;
+      if (parent) {
+        parent.remove();
+      }
+    }
+
     fermer();
     form.submit();
   });

--- a/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
+++ b/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
@@ -64,14 +64,18 @@ function ouvrirModalConfirmation(form) {
       const params = new URLSearchParams();
       params.set('action', 'cta_dismiss_message');
       params.set('key', key);
-      if (typeof ctaMyAccount !== 'undefined') {
-        fetch(ctaMyAccount.ajaxUrl, {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: params.toString(),
-        }).catch(() => {});
-      }
+
+      const ajaxUrl =
+        typeof ctaMyAccount !== 'undefined'
+          ? ctaMyAccount.ajaxUrl
+          : '/wp-admin/admin-ajax.php';
+
+      fetch(ajaxUrl, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      }).catch(() => {});
 
       const btn = document.querySelector(`.msg-important .message-close[data-key="${key}"]`);
       const parent = btn ? btn.closest('p') : null;

--- a/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
+++ b/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
@@ -5,6 +5,28 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('click', (e) => {
+    const close = e.target.closest('.msg-important .message-close');
+    if (close) {
+      const key = close.dataset.key;
+      if (key) {
+        const params = new URLSearchParams();
+        params.set('action', 'cta_dismiss_message');
+        params.set('key', key);
+        const ajaxUrl =
+          typeof ctaMyAccount !== 'undefined'
+            ? ctaMyAccount.ajaxUrl
+            : '/wp-admin/admin-ajax.php';
+        fetch(ajaxUrl, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        }).catch(() => {});
+      }
+      close.closest('p')?.remove();
+      return;
+    }
+
     const btn = e.target.closest('.bouton-validation-chasse');
     if (!btn) return;
 

--- a/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
+++ b/wp-content/themes/chassesautresor/assets/js/validation-chasse.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
             : '/wp-admin/admin-ajax.php';
         fetch(ajaxUrl, {
           method: 'POST',
-          credentials: 'same-origin',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: params.toString(),
         }).catch(() => {});
@@ -94,7 +94,7 @@ function ouvrirModalConfirmation(form) {
 
       fetch(ajaxUrl, {
         method: 'POST',
-        credentials: 'same-origin',
+        credentials: 'include',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: params.toString(),
       }).catch(() => {});

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -952,6 +952,14 @@ a[aria-disabled="true"] {
     margin-top: 15px;
 }
 
+.message-close {
+    margin-left: 0.5rem;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    font-size: 1em;
+}
+
 /* ========== 🖼️ ICONES SVG ========== */
 .icone-aces-casino, .icone-compass-rose {
   color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -954,10 +954,16 @@ a[aria-disabled="true"] {
 
 .message-close {
     margin-left: 0.5rem;
-    background: transparent;
+    background: var(--color-grey-light);
     border: 0;
     cursor: pointer;
     font-size: 1em;
+    color: var(--color-grey-light);
+}
+
+.message-close:hover,
+.message-close:focus {
+    color: var(--color-error);
 }
 
 /* ========== 🖼️ ICONES SVG ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -961,8 +961,8 @@ a[aria-disabled="true"] {
     color: var(--color-grey-light);
 }
 
-.message-close:hover,
-.message-close:focus {
+.message-info:hover .message-close,
+.message-info:focus-within .message-close {
     color: var(--color-error);
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -958,11 +958,6 @@ a[aria-disabled="true"] {
     border: 0;
     cursor: pointer;
     font-size: 1em;
-    color: var(--color-grey-light);
-}
-
-.message-info:hover .message-close,
-.message-info:focus-within .message-close {
     color: var(--color-error);
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1486,6 +1486,14 @@ a[aria-disabled=true] {
   margin-top: 15px;
 }
 
+.message-close {
+  margin-left: 0.5rem;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: 1em;
+}
+
 /* ========== 🖼️ ICONES SVG ========== */
 .icone-aces-casino, .icone-compass-rose {
   color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1495,8 +1495,8 @@ a[aria-disabled=true] {
   color: var(--color-grey-light);
 }
 
-.message-close:hover,
-.message-close:focus {
+.message-info:hover .message-close,
+.message-info:focus-within .message-close {
   color: var(--color-error);
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1488,10 +1488,16 @@ a[aria-disabled=true] {
 
 .message-close {
   margin-left: 0.5rem;
-  background: transparent;
+  background: var(--color-grey-light);
   border: 0;
   cursor: pointer;
   font-size: 1em;
+  color: var(--color-grey-light);
+}
+
+.message-close:hover,
+.message-close:focus {
+  color: var(--color-error);
 }
 
 /* ========== 🖼️ ICONES SVG ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1492,11 +1492,6 @@ a[aria-disabled=true] {
   border: 0;
   cursor: pointer;
   font-size: 1em;
-  color: var(--color-grey-light);
-}
-
-.message-info:hover .message-close,
-.message-info:focus-within .message-close {
   color: var(--color-error);
 }
 

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1895,7 +1895,13 @@ function traiter_validation_chasse_admin() {
         }
         $flash .= '<br>' . __('Une copie de ce message vous a été envoyée par email.', 'chassesautresor-com');
         foreach ($user_ids as $uid) {
-            myaccount_add_flash_message($uid, $flash, 'warning');
+            myaccount_add_persistent_message(
+                $uid,
+                uniqid('correction_', true),
+                $flash,
+                'warning',
+                true
+            );
         }
 
     } elseif ($action === 'bannir') {

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1897,7 +1897,7 @@ function traiter_validation_chasse_admin() {
         foreach ($user_ids as $uid) {
             myaccount_add_persistent_message(
                 $uid,
-                uniqid('correction_', true),
+                'correction_chasse_' . $chasse_id,
                 $flash,
                 'warning',
                 true

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -690,7 +690,7 @@ function myaccount_get_important_messages(): string
 function ca_load_admin_section()
 {
     if (!is_user_logged_in()) {
-        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor')], 403);
+        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor-com')], 403);
     }
 
     $section = sanitize_key($_GET['section'] ?? '');
@@ -703,12 +703,12 @@ function ca_load_admin_section()
     ];
 
     if (!isset($allowed[$section])) {
-        wp_send_json_error(['message' => __('Section not found', 'chassesautresor')], 404);
+        wp_send_json_error(['message' => __('Section not found', 'chassesautresor-com')], 404);
     }
 
     $cap = $allowed[$section]['cap'];
     if ($cap !== 'read' && !current_user_can($cap)) {
-        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor')], 403);
+        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor-com')], 403);
     }
 
     ob_start();
@@ -733,7 +733,7 @@ add_action('wp_ajax_cta_load_admin_section', 'ca_load_admin_section');
 function ca_dismiss_message(): void
 {
     if (!is_user_logged_in()) {
-        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor')], 403);
+        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor-com')], 403);
     }
 
     $key = sanitize_key($_POST['key'] ?? '');

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -305,6 +305,33 @@ function myaccount_remove_persistent_message(int $user_id, string $key): void
 }
 
 /**
+ * Remove correction messages for a given hunt for all related users.
+ *
+ * @param int $chasse_id Hunt identifier.
+ *
+ * @return void
+ */
+function myaccount_clear_correction_message(int $chasse_id): void
+{
+    $current = get_current_user_id();
+    $organisateur_id = get_organisateur_from_chasse($chasse_id);
+    $users = $organisateur_id ? (array) get_field('utilisateurs_associes', $organisateur_id) : [];
+
+    $user_ids = array_unique(array_merge([
+        $current,
+    ], array_map(
+        static function ($uid) {
+            return is_object($uid) ? (int) $uid->ID : (int) $uid;
+        },
+        $users
+    )));
+
+    foreach ($user_ids as $uid) {
+        myaccount_remove_persistent_message($uid, 'correction_chasse_' . $chasse_id);
+    }
+}
+
+/**
  * Retrieve persistent important messages for the given user.
  *
  * @param int $user_id User identifier.

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -250,33 +250,32 @@ add_filter('woocommerce_endpoint_edit-account_title', 'ca_profile_endpoint_title
 // 📣 IMPORTANT MESSAGES
 // ==================================================
 /**
- * Store a flash message for the given user.
- *
- * @param int    $user_id User identifier.
- * @param string $message Message to store.
- *
- * @return void
- */
-/**
  * Store a persistent important message for the given user.
  *
- * @param int    $user_id User identifier.
- * @param string $key     Unique message key.
- * @param string $message Message to store.
- * @param string $type    Message type (success, info, error, warning).
+ * @param int    $user_id     User identifier.
+ * @param string $key         Unique message key.
+ * @param string $message     Message to store.
+ * @param string $type        Message type (success, info, error, warning).
+ * @param bool   $dismissible Whether the user can dismiss the message.
  *
  * @return void
  */
-function myaccount_add_persistent_message(int $user_id, string $key, string $message, string $type = 'info'): void
-{
+function myaccount_add_persistent_message(
+    int $user_id,
+    string $key,
+    string $message,
+    string $type = 'info',
+    bool $dismissible = false
+): void {
     $messages = get_user_meta($user_id, '_myaccount_messages', true);
     if (!is_array($messages)) {
         $messages = [];
     }
 
     $messages[$key] = [
-        'text' => $message,
-        'type' => $type,
+        'text'        => $message,
+        'type'        => $type,
+        'dismissible' => $dismissible,
     ];
     update_user_meta($user_id, '_myaccount_messages', $messages);
 }
@@ -310,7 +309,7 @@ function myaccount_remove_persistent_message(int $user_id, string $key): void
  *
  * @param int $user_id User identifier.
  *
- * @return array<int, array{text:string,type:string}>
+ * @return array<int, array{key:string,text:string,type:string,dismissible:bool}>
  */
 function myaccount_get_persistent_messages(int $user_id): array
 {
@@ -321,7 +320,9 @@ function myaccount_get_persistent_messages(int $user_id): array
 
     $tentatives = [];
     foreach ($messages as $key => $msg) {
-        $item = is_array($msg) ? $msg : ['text' => $msg, 'type' => 'info'];
+        $item = is_array($msg)
+            ? $msg
+            : ['text' => $msg, 'type' => 'info', 'dismissible' => false];
         if (strpos($key, 'tentative_') === 0) {
             $text = $item['text'] ?? '';
             if (preg_match('/<a[^>]*>.*?<\/a>/', $text, $matches)) {
@@ -336,11 +337,13 @@ function myaccount_get_persistent_messages(int $user_id): array
     }
 
     $output = [];
-    foreach ($messages as $msg) {
+    foreach ($messages as $key => $msg) {
         if (is_array($msg) && isset($msg['text'])) {
             $output[] = [
-                'text' => (string) $msg['text'],
-                'type' => isset($msg['type']) ? (string) $msg['type'] : 'info',
+                'key'         => (string) $key,
+                'text'        => (string) $msg['text'],
+                'type'        => isset($msg['type']) ? (string) $msg['type'] : 'info',
+                'dismissible' => !empty($msg['dismissible']),
             ];
         }
     }
@@ -386,22 +389,28 @@ function myaccount_get_persistent_messages(int $user_id): array
 /**
  * Store a flash message for the given user.
  *
- * @param int    $user_id User identifier.
- * @param string $message Message to store.
- * @param string $type    Message type (success, info, error, warning).
+ * @param int    $user_id     User identifier.
+ * @param string $message     Message to store.
+ * @param string $type        Message type (success, info, error, warning).
+ * @param bool   $dismissible Whether the user can dismiss the message.
  *
  * @return void
  */
-function myaccount_add_flash_message(int $user_id, string $message, string $type = 'info'): void
-{
+function myaccount_add_flash_message(
+    int $user_id,
+    string $message,
+    string $type = 'info',
+    bool $dismissible = false
+): void {
     $messages = get_user_meta($user_id, '_myaccount_flash_messages', true);
     if (!is_array($messages)) {
         $messages = [];
     }
 
     $messages[] = [
-        'text' => $message,
-        'type' => $type,
+        'text'        => $message,
+        'type'        => $type,
+        'dismissible' => $dismissible,
     ];
     update_user_meta($user_id, '_myaccount_flash_messages', $messages);
 }
@@ -411,7 +420,7 @@ function myaccount_add_flash_message(int $user_id, string $message, string $type
  *
  * @param int $user_id User identifier.
  *
- * @return array<int, array{text:string,type:string}>
+ * @return array<int, array{text:string,type:string,dismissible:bool}>
  */
 function myaccount_get_flash_messages(int $user_id): array
 {
@@ -424,14 +433,16 @@ function myaccount_get_flash_messages(int $user_id): array
         function ($msg) {
             if (is_array($msg) && isset($msg['text'])) {
                 return [
-                    'text' => (string) $msg['text'],
-                    'type' => isset($msg['type']) ? (string) $msg['type'] : 'info',
+                    'text'        => (string) $msg['text'],
+                    'type'        => isset($msg['type']) ? (string) $msg['type'] : 'info',
+                    'dismissible' => !empty($msg['dismissible']),
                 ];
             }
             if (is_string($msg)) {
                 return [
-                    'text' => $msg,
-                    'type' => 'info',
+                    'text'        => $msg,
+                    'type'        => 'info',
+                    'dismissible' => false,
                 ];
             }
             return null;
@@ -601,8 +612,10 @@ function myaccount_get_important_messages(): string
 
     $output = array_map(
         function ($msg) {
-            $type = $msg['type'] ?? 'info';
-            $text = $msg['text'] ?? '';
+            $type        = $msg['type'] ?? 'info';
+            $text        = $msg['text'] ?? '';
+            $dismissible = !empty($msg['dismissible']) && !empty($msg['key']);
+
             switch ($type) {
                 case 'success':
                     $class = 'message-succes';
@@ -621,7 +634,17 @@ function myaccount_get_important_messages(): string
                     $aria  = 'role="status" aria-live="polite"';
                     break;
             }
-            return '<p class="' . esc_attr($class) . '" ' . $aria . '>' . $text . '</p>';
+
+            $button = '';
+            if ($dismissible) {
+                $button = ' <button type="button" class="message-close" data-key="'
+                    . esc_attr($msg['key'])
+                    . '" aria-label="'
+                    . esc_attr__('Supprimer ce message', 'chassesautresor-com')
+                    . '">×</button>';
+            }
+
+            return '<p class="' . esc_attr($class) . '" ' . $aria . '>' . $text . $button . '</p>';
         },
         $messages
     );
@@ -674,6 +697,28 @@ function ca_load_admin_section()
     ]);
 }
 add_action('wp_ajax_cta_load_admin_section', 'ca_load_admin_section');
+
+/**
+ * Dismiss a persistent message via AJAX.
+ *
+ * @return void
+ */
+function ca_dismiss_message(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor')], 403);
+    }
+
+    $key = sanitize_key($_POST['key'] ?? '');
+    if ($key === '') {
+        wp_send_json_error(['message' => __('Clé de message invalide.', 'chassesautresor-com')], 400);
+    }
+
+    myaccount_remove_persistent_message(get_current_user_id(), $key);
+
+    wp_send_json_success();
+}
+add_action('wp_ajax_cta_dismiss_message', 'ca_dismiss_message');
 
 // ==================================================
 // 📦 MODIFICATION AVATAR EN FRONT

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -257,6 +257,14 @@ msgstr ""
 msgid "Votre chasse « %s » a été bannie."
 msgstr ""
 
+#: inc/user-functions.php:643
+msgid "Supprimer ce message"
+msgstr ""
+
+#: inc/user-functions.php:714
+msgid "Clé de message invalide."
+msgstr ""
+
 #: inc/admin-functions.php:1941
 #, php-format
 msgid "Votre chasse « %s » a été supprimée."

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2660,3 +2660,11 @@ msgstr ""
 #: assets/js/reponse-automatique.js:187
 msgid "Tentatives quotidiennes"
 msgstr ""
+
+#: inc/user-functions.php:693 inc/user-functions.php:711 inc/user-functions.php:736
+msgid "Unauthorized"
+msgstr ""
+
+#: inc/user-functions.php:706
+msgid "Section not found"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -312,6 +312,12 @@ msgstr "Your hunt “%s” was banned."
 msgid "Votre chasse « %s » a été supprimée."
 msgstr "Your hunt “%s” was banned."
 
+msgid "Supprimer ce message"
+msgstr "Dismiss this message"
+
+msgid "Clé de message invalide."
+msgstr "Invalid message key."
+
 #: inc/chasse-functions.php:245
 msgid ""
 "⚠️ Erreur : La date de fin ne peut pas être antérieure à la date de début."

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2782,3 +2782,11 @@ msgid "%d gagnant"
 msgid_plural "%d gagnants"
 msgstr[0] "%d winner"
 msgstr[1] "%d winners"
+
+#: inc/user-functions.php:693 inc/user-functions.php:711 inc/user-functions.php:736
+msgid "Unauthorized"
+msgstr "Unauthorized"
+
+#: inc/user-functions.php:706
+msgid "Section not found"
+msgstr "Section not found"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -258,6 +258,12 @@ msgstr ""
 msgid "Votre chasse « %s » a été bannie."
 msgstr ""
 
+msgid "Supprimer ce message"
+msgstr ""
+
+msgid "Clé de message invalide."
+msgstr ""
+
 #: inc/admin-functions.php:1940
 #, php-format
 msgid "Votre chasse « %s » a été supprimée."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2641,3 +2641,11 @@ msgid "%d gagnant"
 msgid_plural "%d gagnants"
 msgstr[0] "%d gagnant"
 msgstr[1] "%d gagnants"
+
+#: inc/user-functions.php:693 inc/user-functions.php:711 inc/user-functions.php:736
+msgid "Unauthorized"
+msgstr "Non autorisé"
+
+#: inc/user-functions.php:706
+msgid "Section not found"
+msgstr "Section introuvable"

--- a/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
@@ -39,22 +39,7 @@ forcer_statut_apres_acf($chasse_id, 'en_attente');
 // Met à jour le statut métier pour refléter l'attente de validation
 update_field('chasse_cache_statut', 'en_attente', $chasse_id);
 
-$organisateur_id = get_organisateur_from_chasse($chasse_id);
-$users           = $organisateur_id ? (array) get_field('utilisateurs_associes', $organisateur_id) : [];
-$user_ids        = array_values(
-    array_filter(
-        array_map(
-            static function ($uid) {
-                return is_object($uid) ? (int) $uid->ID : (int) $uid;
-            },
-            $users
-        )
-    )
-);
-
-foreach ($user_ids as $uid) {
-    myaccount_remove_persistent_message($uid, 'correction_chasse_' . $chasse_id);
-}
+myaccount_clear_correction_message($chasse_id);
 
 wp_redirect(add_query_arg('validation_demandee', '1', get_permalink($chasse_id)));
 exit;

--- a/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
@@ -7,6 +7,8 @@ defined('ABSPATH') || exit;
 
 require_once get_theme_file_path('inc/chasse-functions.php');
 require_once get_theme_file_path('inc/statut-functions.php');
+require_once get_theme_file_path('inc/relations-functions.php');
+require_once get_theme_file_path('inc/user-functions.php');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     wp_redirect(home_url());
@@ -36,6 +38,23 @@ forcer_statut_apres_acf($chasse_id, 'en_attente');
 
 // Met à jour le statut métier pour refléter l'attente de validation
 update_field('chasse_cache_statut', 'en_attente', $chasse_id);
+
+$organisateur_id = get_organisateur_from_chasse($chasse_id);
+$users           = $organisateur_id ? (array) get_field('utilisateurs_associes', $organisateur_id) : [];
+$user_ids        = array_values(
+    array_filter(
+        array_map(
+            static function ($uid) {
+                return is_object($uid) ? (int) $uid->ID : (int) $uid;
+            },
+            $users
+        )
+    )
+);
+
+foreach ($user_ids as $uid) {
+    myaccount_remove_persistent_message($uid, 'correction_chasse_' . $chasse_id);
+}
 
 wp_redirect(add_query_arg('validation_demandee', '1', get_permalink($chasse_id)));
 exit;

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -355,6 +355,26 @@ class MyAccountMessagesTest extends TestCase
         $this->assertStringContainsString('<p class="message-info" role="status" aria-live="polite">Stylé</p>', $output);
     }
 
+    public function test_dismissible_message_has_button(): void
+    {
+        update_user_meta(
+            1,
+            '_myaccount_messages',
+            [
+                'foo' => [
+                    'text'        => 'Salut',
+                    'type'        => 'info',
+                    'dismissible' => true,
+                ],
+            ]
+        );
+
+        $output = myaccount_get_important_messages();
+        $this->assertStringContainsString('class="message-close" data-key="foo"', $output);
+
+        delete_user_meta(1, '_myaccount_messages');
+    }
+
     public function test_ajax_section_returns_flash_message(): void
     {
         update_user_meta(


### PR DESCRIPTION
## Résumé
- ajout d’un paramètre permettant la suppression manuelle des messages dans l’espace Mon Compte
- message de correction de chasse enregistré comme notification effaçable
- styles, scripts et traductions mis à jour

## Changements notables
- ajout du flag `dismissible` pour les messages et rendu avec un bouton de fermeture
- nouvelle action AJAX `cta_dismiss_message` pour retirer un message
- utilisation de messages persistants pour la demande de correction d’une chasse
- support de l’icône de suppression via JS et SCSS
- mise à jour des fichiers de traduction

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`
- `node build-css.js`


------
https://chatgpt.com/codex/tasks/task_e_68b098c2bd748332aaef7a4f1cbf2e0f