### PR TITLE
feat: guard date message update

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -312,3 +312,38 @@ describe('chasse-edit UI', () => {
     expect(icone.getAttribute('title')).toBe('mode de fin de chasse : automatique');
   });
 });
+
+describe('date message utils', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="message-date">Initial</span>';
+    global.ajaxurl = '/ajax';
+    global.initZonesClicEdition = jest.fn();
+    global.initChampImage = jest.fn();
+    global.initLiensChasse = jest.fn();
+    global.initChampTexte = jest.fn();
+    global.initChampDeclencheur = jest.fn();
+    global.mettreAJourResumeInfos = jest.fn();
+    global.mettreAJourCarteAjoutEnigme = jest.fn();
+    global.mettreAJourEtatIntroChasse = jest.fn();
+    global.initChampNbGagnants = jest.fn();
+    global.initChampDate = jest.fn();
+    global.mettreAJourAffichageDateFin = jest.fn();
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
+    global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
+    global.wp = { i18n: { __: (s) => s } };
+    global.confirm = jest.fn(() => true);
+    jest.resetModules();
+    require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');
+  });
+
+  test('mettreAJourMessageDate leaves content when fields missing', () => {
+    const span = document.getElementById('message-date');
+    global.mettreAJourMessageDate();
+    expect(span.textContent).toBe('Initial');
+  });
+
+  test('calculerMessageDate parses d/m/Y format', () => {
+    const msg = global.calculerMessageDate('02/01/2024');
+    expect(msg).toContain('02/01/2024');
+  });
+});

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -18,6 +18,47 @@ function parseDateDMY(value) {
 
 window.parseDateDMY = parseDateDMY;
 
+function calculerMessageDate(debutStr = '', finStr = '') {
+  const pad = (n) => String(n).padStart(2, '0');
+  const format = (date, withTime) => {
+    const base = `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()}`;
+    return withTime
+      ? `${base} ${pad(date.getHours())}:${pad(date.getMinutes())}`
+      : base;
+  };
+
+  const debut = parseDateDMY(debutStr);
+  const fin = parseDateDMY(finStr);
+  const hasDebut = !isNaN(debut.getTime());
+  const hasFin = !isNaN(fin.getTime());
+
+  if (hasDebut && hasFin) {
+    return `${format(debut, debutStr.includes(':'))} – ${format(fin, finStr.includes(':'))}`;
+  }
+  if (hasDebut) {
+    return format(debut, debutStr.includes(':'));
+  }
+  if (hasFin) {
+    return format(fin, finStr.includes(':'));
+  }
+  return '';
+}
+
+function mettreAJourMessageDate() {
+  if (!inputDateDebut && !inputDateFin) return;
+  const span = document.getElementById('message-date');
+  if (!span) return;
+  const debutVal = inputDateDebut?.value.trim() || '';
+  const finVal = inputDateFin?.value.trim() || '';
+  const message = calculerMessageDate(debutVal, finVal);
+  if (message) {
+    span.textContent = message;
+  }
+}
+
+window.calculerMessageDate = calculerMessageDate;
+window.mettreAJourMessageDate = mettreAJourMessageDate;
+
 function rafraichirCarteIndices() {
   const card = document.querySelector('.dashboard-card.champ-indices');
   if (!card || !window.ChasseIndices) return;
@@ -1277,6 +1318,9 @@ function enregistrerDatesChasse() {
       console.error('❌ Erreur réseau sauvegarde dates:', err);
       return false;
     });
+}
+if (document.getElementById('chasse-date-debut') || document.getElementById('chasse-date-fin')) {
+  mettreAJourMessageDate();
 }
 window.enregistrerDatesChasse = enregistrerDatesChasse;
 


### PR DESCRIPTION
## Résumé
- gère l'absence de champs de dates avant de mettre à jour le message associé
- parse les dates au format d/m/Y pour l'affichage du message
- teste la mise à jour inerte sans champs et la compatibilité du parseur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a47c9da083329121bf5073e728db