### PR TITLE
Déplacement du CTA de validation de chasse

### DIFF
--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -4,7 +4,7 @@ const html = `
 </section>
 <form class="form-validation-chasse">
   <input type="hidden" name="chasse_id" value="123">
-  <button type="submit" class="bouton-cta bouton-validation-chasse">VALIDATION</button>
+  <button type="submit" class="bouton-cta bouton-cta--color bouton-validation-chasse">Demander la validation</button>
 </form>
 `;
 

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -100,9 +100,7 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
                 <div class="ast-container<?php echo ( is_singular('enigme') || is_singular('chasse') ) ? '' : ' ast-container--boxed'; ?>">
                 <?php astra_content_top(); ?>
                 <?php
-                $messages = get_site_messages();
-                if ( ! is_singular( 'enigme' ) ) {
-                    $messages .= myaccount_get_important_messages();
-                }
+                $messages  = get_site_messages();
+                $messages .= myaccount_get_important_messages();
                 ?>
                 <section class="msg-important"><?php echo $messages; ?></section>

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1900,6 +1900,17 @@ function traiter_validation_chasse_admin() {
                 'correction_chasse_' . $chasse_id,
                 $flash,
                 'warning',
+                true,
+                $chasse_id,
+                true
+            );
+            myaccount_add_persistent_message(
+                $uid,
+                'correction_info_chasse_' . $chasse_id,
+                __('Lorsque vous aurez terminé vos corrections, demandez sa validation.', 'chassesautresor-com'),
+                'info',
+                false,
+                $chasse_id,
                 true
             );
         }

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1904,10 +1904,16 @@ function traiter_validation_chasse_admin() {
                 $chasse_id,
                 true
             );
+            $info_msg = sprintf(
+                /* translators: %1$s and %2$s are anchor tags */
+                __('Votre chasse est éligible à une %1$sdemande de validation%2$s.', 'chassesautresor-com'),
+                '<a href="' . esc_url(get_permalink($chasse_id) . '#cta-validation-chasse') . '">',
+                '</a>'
+            );
             myaccount_add_persistent_message(
                 $uid,
                 'correction_info_chasse_' . $chasse_id,
-                __('Lorsque vous aurez terminé vos corrections, demandez sa validation.', 'chassesautresor-com'),
+                $info_msg,
                 'info',
                 false,
                 $chasse_id,

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -850,7 +850,9 @@ function render_form_validation_chasse(int $chasse_id): string
         <input type="hidden" name="chasse_id" value="<?= esc_attr($chasse_id); ?>">
         <input type="hidden" name="validation_chasse_nonce" value="<?= esc_attr($nonce); ?>">
         <input type="hidden" name="demande_validation_chasse" value="1">
-        <button type="submit" class="bouton-cta bouton-validation-chasse">VALIDATION</button>
+        <button type="submit" class="bouton-cta bouton-cta--color bouton-validation-chasse">
+            <?= esc_html__( 'Demander la validation', 'chassesautresor-com' ); ?>
+        </button>
     </form>
 <?php
     return ob_get_clean();
@@ -902,7 +904,7 @@ function actualiser_cta_validation_chasse(): void
 
     ob_start();
     if (peut_valider_chasse($chasse_id, get_current_user_id())) {
-        echo '<div class="cta-chasse-row">';
+        echo '<div id="cta-validation-chasse" class="cta-chasse-row">';
         echo '<div class="cta-action">' . render_form_validation_chasse($chasse_id) . '</div>';
         echo '<div class="cta-message" aria-live="polite"></div>';
         echo '</div>';

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -613,6 +613,14 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         ];
     }
 
+    if (peut_valider_chasse($chasse_id, $user_id)) {
+        return [
+            'cta_html'    => render_form_validation_chasse($chasse_id),
+            'cta_message' => '',
+            'type'        => 'validation',
+        ];
+    }
+
     // 🔐 Admin or organiser: disabled participation button
     if (current_user_can('administrator') || utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
         return [
@@ -894,13 +902,9 @@ function actualiser_cta_validation_chasse(): void
 
     ob_start();
     if (peut_valider_chasse($chasse_id, get_current_user_id())) {
-        echo '<div class="cta-chasse">';
-        $statut = get_field('chasse_cache_statut_validation', $chasse_id);
-        $msg = ($statut === 'correction')
-            ? 'Lorsque vous aurez terminé vos corrections, demandez sa validation :'
-            : 'Lorsque vous avez finalisé votre chasse, demandez sa validation :';
-        echo '<p>' . $msg . '</p>';
-        echo render_form_validation_chasse($chasse_id);
+        echo '<div class="cta-chasse-row">';
+        echo '<div class="cta-action">' . render_form_validation_chasse($chasse_id) . '</div>';
+        echo '<div class="cta-message" aria-live="polite"></div>';
         echo '</div>';
     }
     $html = ob_get_clean();

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2670,5 +2670,9 @@ msgid "Section not found"
 msgstr ""
 
 #: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
-msgid "Lorsque vous aurez terminé vos corrections, demandez sa validation."
+msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+msgstr ""
+
+#: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
+msgid "Demander la validation"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2668,3 +2668,7 @@ msgstr ""
 #: inc/user-functions.php:706
 msgid "Section not found"
 msgstr ""
+
+#: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+msgid "Lorsque vous aurez terminé vos corrections, demandez sa validation."
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2792,5 +2792,9 @@ msgid "Section not found"
 msgstr "Section not found"
 
 #: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
-msgid "Lorsque vous aurez terminé vos corrections, demandez sa validation."
-msgstr "Once you have finished your corrections, request validation."
+msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+msgstr "Your hunt is eligible for a %1$svalidation request%2$s."
+
+#: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
+msgid "Demander la validation"
+msgstr "Request validation"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2790,3 +2790,7 @@ msgstr "Unauthorized"
 #: inc/user-functions.php:706
 msgid "Section not found"
 msgstr "Section not found"
+
+#: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+msgid "Lorsque vous aurez terminé vos corrections, demandez sa validation."
+msgstr "Once you have finished your corrections, request validation."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2649,3 +2649,7 @@ msgstr "Non autorisé"
 #: inc/user-functions.php:706
 msgid "Section not found"
 msgstr "Section introuvable"
+
+#: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+msgid "Lorsque vous aurez terminé vos corrections, demandez sa validation."
+msgstr "Lorsque vous aurez terminé vos corrections, demandez sa validation."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2651,5 +2651,9 @@ msgid "Section not found"
 msgstr "Section introuvable"
 
 #: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
-msgid "Lorsque vous aurez terminé vos corrections, demandez sa validation."
-msgstr "Lorsque vous aurez terminé vos corrections, demandez sa validation."
+msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+msgstr "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+
+#: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
+msgid "Demander la validation"
+msgstr "Demander la validation"

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -119,14 +119,6 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         );
         echo '<p>⚠️ ' . esc_html($msg) . '</p>';
         echo '</div>';
-    } elseif ($can_validate) {
-        echo '<div class="cta-chasse">';
-        $msg = ($statut_validation === 'correction')
-            ? 'Lorsque vous aurez terminé vos corrections, demandez sa validation :'
-            : 'Lorsque vous avez finalisé votre chasse, demandez sa validation :';
-        echo '<p>' . $msg . '</p>';
-        echo render_form_validation_chasse($chasse_id);
-        echo '</div>';
     }
     ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -356,7 +356,8 @@ if ($edition_active && !$est_complet) {
           </div>
 
           <?php if (($cta_data['type'] ?? '') !== 'engage') : ?>
-            <div class="cta-chasse-row">
+            <?php $cta_id = ($cta_data['type'] ?? '') === 'validation' ? 'cta-validation-chasse' : ''; ?>
+            <div class="cta-chasse-row"<?php echo $cta_id ? ' id="' . esc_attr($cta_id) . '"' : ''; ?>>
               <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
               <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
             </div>

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -23,6 +23,21 @@ if (!function_exists('is_user_logged_in')) {
     }
 }
 
+if (!function_exists('is_singular')) {
+    function is_singular($types = [])
+    {
+        $post_id = $GLOBALS['test_current_post_id'] ?? 0;
+        $post_type = $GLOBALS['test_post_types'][$post_id] ?? 'post';
+        if (empty($types)) {
+            return true;
+        }
+        if (is_array($types)) {
+            return in_array($post_type, $types, true);
+        }
+        return $post_type === $types;
+    }
+}
+
 if (!function_exists('get_current_user_id')) {
     function get_current_user_id()
     {
@@ -200,6 +215,13 @@ if (!function_exists('recuperer_id_chasse_associee')) {
     {
         $post_id = $post_id ?? 0;
         return $GLOBALS['test_enigme_to_chasse'][$post_id] ?? 0;
+    }
+}
+
+if (!function_exists('peut_valider_chasse')) {
+    function peut_valider_chasse($chasse_id, $user_id)
+    {
+        return true;
     }
 }
 
@@ -443,6 +465,19 @@ class MyAccountMessagesTest extends TestCase
         $GLOBALS['test_enigme_to_chasse'] = [101 => 43];
         $output = myaccount_get_important_messages();
         $this->assertStringNotContainsString('Info', $output);
+
+        delete_user_meta(1, '_myaccount_messages');
+    }
+
+    public function test_maybe_add_validation_message_populates_meta(): void
+    {
+        delete_user_meta(1, '_myaccount_messages');
+        $GLOBALS['test_current_post_id'] = 42;
+        $GLOBALS['test_post_types']      = [42 => 'chasse'];
+
+        myaccount_maybe_add_validation_message();
+        $messages = get_user_meta(1, '_myaccount_messages', true);
+        $this->assertArrayHasKey('correction_info_chasse_42', $messages);
 
         delete_user_meta(1, '_myaccount_messages');
     }


### PR DESCRIPTION
## Résumé
- déplace le bouton de validation dans la fiche chasse
- ajoute un message d’information persistant sur les pages de la chasse et de ses énigmes
- enrichit le système de messages utilisateur pour cibler une chasse spécifique

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b0b89b03b0833286147265bcfb3a62