### PR TITLE
Affiche la durée dynamique d'une chasse

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -119,7 +119,7 @@ describe('chasse-edit UI', () => {
     global.mettreAJourAffichageDateFin = jest.fn();
     global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
-    global.wp = { i18n: { __: (s) => s } };
+    global.wp = { i18n: { __: (s) => s, _n: (s, p, n) => (n > 1 ? p : s) } };
     global.confirm = jest.fn(() => true);
     jest.resetModules();
     require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');
@@ -330,7 +330,7 @@ describe('date message utils', () => {
     global.mettreAJourAffichageDateFin = jest.fn();
     global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
     global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
-    global.wp = { i18n: { __: (s) => s } };
+    global.wp = { i18n: { __: (s) => s, _n: (s, p, n) => (n > 1 ? p : s) } };
     global.confirm = jest.fn(() => true);
     jest.resetModules();
     require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -158,6 +158,9 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
   erreurFin = document.getElementById('erreur-date-fin');
   toggleDateFin = document.getElementById('date-fin-limitee');
   mettreAJourCaracteristiqueDate();
+  inputDateDebut?.addEventListener('change', mettreAJourCaracteristiqueDate);
+  inputDateFin?.addEventListener('change', mettreAJourCaracteristiqueDate);
+  toggleDateFin?.addEventListener('change', mettreAJourCaracteristiqueDate);
 
   // ==============================
   // 🟢 Initialisation des champs
@@ -780,14 +783,41 @@ function afficherErreurGlobale(message) {
 
 function mettreAJourCaracteristiqueDate() {
   const span = document.querySelector('.caracteristique-date .caracteristique-valeur');
-  if (!span || !inputDateDebut || !inputDateFin) return;
+  if (!span || !inputDateDebut) return;
   const debut = parseDateDMY(inputDateDebut.value);
-  const fin = parseDateDMY(inputDateFin.value);
-  if (isNaN(debut.getTime()) || isNaN(fin.getTime())) return;
-  const diff = Math.round((fin.getTime() - debut.getTime()) / (1000 * 60 * 60 * 24));
-  const label = diff > 1 ? wp.i18n.__('jours', 'chassesautresor-com') : wp.i18n.__('jour', 'chassesautresor-com');
-  span.textContent = `${diff} ${label}`;
+  const fin = parseDateDMY(inputDateFin?.value || '');
+  const illimite = toggleDateFin ? !toggleDateFin.checked : false;
+
+  if (illimite) {
+    span.textContent = wp.i18n.__('illimitée', 'chassesautresor-com');
+    return;
+  }
+  if (isNaN(debut.getTime())) return;
+
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  if (!isNaN(fin.getTime())) {
+    if (today > fin) {
+      const tpl = wp.i18n.__('terminée depuis %s', 'chassesautresor-com');
+      span.textContent = tpl.replace('%s', fin.toISOString().slice(0, 10));
+    } else if (today < debut) {
+      const diff = Math.ceil((debut - today) / (1000 * 60 * 60 * 24));
+      const tpl = wp.i18n._n('%d jour à attendre', '%d jours à attendre', diff, 'chassesautresor-com');
+      span.textContent = tpl.replace('%d', diff);
+    } else {
+      const diff = Math.ceil((fin - today) / (1000 * 60 * 60 * 24));
+      const tpl = wp.i18n._n('%d jour restant', '%d jours restants', diff, 'chassesautresor-com');
+      span.textContent = tpl.replace('%d', diff);
+    }
+  } else if (today < debut) {
+    const diff = Math.ceil((debut - today) / (1000 * 60 * 60 * 24));
+    const tpl = wp.i18n._n('%d jour à attendre', '%d jours à attendre', diff, 'chassesautresor-com');
+    span.textContent = tpl.replace('%d', diff);
+  }
 }
+
+window.mettreAJourCaracteristiqueDate = mettreAJourCaracteristiqueDate;
 
 function mettreAJourBadgeCoutChasse(postId, cout) {
   const container = document.querySelector('.header-chasse__image');

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2790,3 +2790,27 @@ msgstr "Unauthorized"
 #: inc/user-functions.php:706
 msgid "Section not found"
 msgstr "Section not found"
+
+#: template-parts/chasse/chasse-affichage-complet.php:58
+#: assets/js/chasse-edit.js:792
+msgid "illimitée"
+msgstr "unlimited"
+
+#: template-parts/chasse/chasse-affichage-complet.php:65
+#: assets/js/chasse-edit.js:806 assets/js/chasse-edit.js:815
+msgid "%d jour à attendre"
+msgid_plural "%d jours à attendre"
+msgstr[0] "%d day to wait"
+msgstr[1] "%d days to wait"
+
+#: template-parts/chasse/chasse-affichage-complet.php:70
+#: assets/js/chasse-edit.js:802
+msgid "terminée depuis %s"
+msgstr "ended on %s"
+
+#: template-parts/chasse/chasse-affichage-complet.php:76
+#: assets/js/chasse-edit.js:810
+msgid "%d jour restant"
+msgid_plural "%d jours restants"
+msgstr[0] "%d day remaining"
+msgstr[1] "%d days remaining"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2649,3 +2649,27 @@ msgstr "Non autorisé"
 #: inc/user-functions.php:706
 msgid "Section not found"
 msgstr "Section introuvable"
+
+#: template-parts/chasse/chasse-affichage-complet.php:58
+#: assets/js/chasse-edit.js:792
+msgid "illimitée"
+msgstr "illimitée"
+
+#: template-parts/chasse/chasse-affichage-complet.php:65
+#: assets/js/chasse-edit.js:806 assets/js/chasse-edit.js:815
+msgid "%d jour à attendre"
+msgid_plural "%d jours à attendre"
+msgstr[0] "%d jour à attendre"
+msgstr[1] "%d jours à attendre"
+
+#: template-parts/chasse/chasse-affichage-complet.php:70
+#: assets/js/chasse-edit.js:802
+msgid "terminée depuis %s"
+msgstr "terminée depuis %s"
+
+#: template-parts/chasse/chasse-affichage-complet.php:76
+#: assets/js/chasse-edit.js:810
+msgid "%d jour restant"
+msgid_plural "%d jours restants"
+msgstr[0] "%d jour restant"
+msgstr[1] "%d jours restants"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -52,6 +52,33 @@ $date_fin_formatee   = $illimitee
     ? __('Illimitée', 'chassesautresor-com')
     : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
 
+$now          = current_time('timestamp');
+$message_date = '';
+if ($illimitee) {
+    $message_date = __('illimitée', 'chassesautresor-com');
+} else {
+    $debut_ts = $date_debut ? strtotime($date_debut) : null;
+    $fin_ts   = $date_fin ? strtotime($date_fin) : null;
+    if ($debut_ts && $now < $debut_ts) {
+        $diff = (int) ceil(($debut_ts - $now) / DAY_IN_SECONDS);
+        $message_date = sprintf(
+            _n('%d jour à attendre', '%d jours à attendre', $diff, 'chassesautresor-com'),
+            $diff
+        );
+    } elseif ($fin_ts && $now > $fin_ts) {
+        $message_date = sprintf(
+            __('terminée depuis %s', 'chassesautresor-com'),
+            wp_date('Y-m-d', $fin_ts)
+        );
+    } elseif ($fin_ts) {
+        $diff = (int) ceil(($fin_ts - $now) / DAY_IN_SECONDS);
+        $message_date = sprintf(
+            _n('%d jour restant', '%d jours restants', $diff, 'chassesautresor-com'),
+            $diff
+        );
+    }
+}
+
 // Edition
 $edition_active = utilisateur_peut_modifier_post($chasse_id);
 
@@ -271,6 +298,10 @@ if ($edition_active && !$est_complet) {
         ?>
         <div class="chasse-cta-section cta-chasse">
           <div class="chasse-caracteristiques">
+          <div class="caracteristique caracteristique-date">
+            <span class="caracteristique-label"><?= esc_html__('Date', 'chassesautresor-com'); ?></span>
+            <span class="caracteristique-valeur"><?= esc_html($message_date); ?></span>
+          </div>
           <?php if ($mode_fin === 'automatique') : ?>
             <div class="caracteristique">
               <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>


### PR DESCRIPTION
## Résumé
- Ajout d'une ligne « Date » calculant l'état de la chasse (terminée, en cours, à venir ou illimitée)
- Rafraîchissement dynamique du message lors des modifications de dates
- Ajout des traductions FR/EN pour les nouveaux messages

## Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b11351f7d4833299b83a1dc1c57cc0