### PR TITLE
Améliore le CTA et les messages de validation de chasse

### DIFF
--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -4,7 +4,7 @@ const html = `
 </section>
 <form class="form-validation-chasse">
   <input type="hidden" name="chasse_id" value="123">
-  <button type="submit" class="bouton-cta bouton-validation-chasse">VALIDATION</button>
+  <button type="submit" class="bouton-cta bouton-cta--color bouton-validation-chasse">Demander la validation</button>
 </form>
 `;
 

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -100,9 +100,7 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
                 <div class="ast-container<?php echo ( is_singular('enigme') || is_singular('chasse') ) ? '' : ' ast-container--boxed'; ?>">
                 <?php astra_content_top(); ?>
                 <?php
-                $messages = get_site_messages();
-                if ( ! is_singular( 'enigme' ) ) {
-                    $messages .= myaccount_get_important_messages();
-                }
+                $messages  = get_site_messages();
+                $messages .= myaccount_get_important_messages();
                 ?>
                 <section class="msg-important"><?php echo $messages; ?></section>

--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1900,6 +1900,23 @@ function traiter_validation_chasse_admin() {
                 'correction_chasse_' . $chasse_id,
                 $flash,
                 'warning',
+                true,
+                $chasse_id,
+                true
+            );
+            $info_msg = sprintf(
+                /* translators: %1$s and %2$s are anchor tags */
+                __('Votre chasse est éligible à une %1$sdemande de validation%2$s.', 'chassesautresor-com'),
+                '<a href="' . esc_url(get_permalink($chasse_id) . '#cta-validation-chasse') . '">',
+                '</a>'
+            );
+            myaccount_add_persistent_message(
+                $uid,
+                'correction_info_chasse_' . $chasse_id,
+                $info_msg,
+                'info',
+                false,
+                $chasse_id,
                 true
             );
         }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -613,6 +613,14 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         ];
     }
 
+    if (peut_valider_chasse($chasse_id, $user_id)) {
+        return [
+            'cta_html'    => render_form_validation_chasse($chasse_id),
+            'cta_message' => '',
+            'type'        => 'validation',
+        ];
+    }
+
     // 🔐 Admin or organiser: disabled participation button
     if (current_user_can('administrator') || utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
         return [
@@ -842,7 +850,9 @@ function render_form_validation_chasse(int $chasse_id): string
         <input type="hidden" name="chasse_id" value="<?= esc_attr($chasse_id); ?>">
         <input type="hidden" name="validation_chasse_nonce" value="<?= esc_attr($nonce); ?>">
         <input type="hidden" name="demande_validation_chasse" value="1">
-        <button type="submit" class="bouton-cta bouton-validation-chasse">VALIDATION</button>
+        <button type="submit" class="bouton-cta bouton-cta--color bouton-validation-chasse">
+            <?= esc_html__( 'Demander la validation', 'chassesautresor-com' ); ?>
+        </button>
     </form>
 <?php
     return ob_get_clean();
@@ -894,13 +904,9 @@ function actualiser_cta_validation_chasse(): void
 
     ob_start();
     if (peut_valider_chasse($chasse_id, get_current_user_id())) {
-        echo '<div class="cta-chasse">';
-        $statut = get_field('chasse_cache_statut_validation', $chasse_id);
-        $msg = ($statut === 'correction')
-            ? 'Lorsque vous aurez terminé vos corrections, demandez sa validation :'
-            : 'Lorsque vous avez finalisé votre chasse, demandez sa validation :';
-        echo '<p>' . $msg . '</p>';
-        echo render_form_validation_chasse($chasse_id);
+        echo '<div id="cta-validation-chasse" class="cta-chasse-row">';
+        echo '<div class="cta-action">' . render_form_validation_chasse($chasse_id) . '</div>';
+        echo '<div class="cta-message" aria-live="polite"></div>';
         echo '</div>';
     }
     $html = ob_get_clean();

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2668,3 +2668,11 @@ msgstr ""
 #: inc/user-functions.php:706
 msgid "Section not found"
 msgstr ""
+
+#: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+msgstr ""
+
+#: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
+msgid "Demander la validation"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2791,6 +2791,14 @@ msgstr "Unauthorized"
 msgid "Section not found"
 msgstr "Section not found"
 
+#: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+msgstr "Your hunt is eligible for a %1$svalidation request%2$s."
+
+#: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
+msgid "Demander la validation"
+msgstr "Request validation"
+
 #: template-parts/chasse/chasse-affichage-complet.php:58
 #: assets/js/chasse-edit.js:792
 msgid "illimitée"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2650,6 +2650,14 @@ msgstr "Non autorisé"
 msgid "Section not found"
 msgstr "Section introuvable"
 
+#: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+msgstr "Votre chasse est éligible à une %1$sdemande de validation%2$s."
+
+#: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
+msgid "Demander la validation"
+msgstr "Demander la validation"
+
 #: template-parts/chasse/chasse-affichage-complet.php:58
 #: assets/js/chasse-edit.js:792
 msgid "illimitée"

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -119,14 +119,6 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         );
         echo '<p>⚠️ ' . esc_html($msg) . '</p>';
         echo '</div>';
-    } elseif ($can_validate) {
-        echo '<div class="cta-chasse">';
-        $msg = ($statut_validation === 'correction')
-            ? 'Lorsque vous aurez terminé vos corrections, demandez sa validation :'
-            : 'Lorsque vous avez finalisé votre chasse, demandez sa validation :';
-        echo '<p>' . $msg . '</p>';
-        echo render_form_validation_chasse($chasse_id);
-        echo '</div>';
     }
     ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -387,7 +387,8 @@ if ($edition_active && !$est_complet) {
           </div>
 
           <?php if (($cta_data['type'] ?? '') !== 'engage') : ?>
-            <div class="cta-chasse-row">
+            <?php $cta_id = ($cta_data['type'] ?? '') === 'validation' ? 'cta-validation-chasse' : ''; ?>
+            <div class="cta-chasse-row"<?php echo $cta_id ? ' id="' . esc_attr($cta_id) . '"' : ''; ?>>
               <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
               <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
             </div>


### PR DESCRIPTION
## Résumé
- ajoute un bouton de validation dédié pour les organisateurs
- enregistre des messages persistants avec périmètre chasse/énigme
- retire la restriction d'affichage des messages importants

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b117ccae3c8332a82743f48804d0e0