### PR TITLE
chore: update translations for hunt date messages

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2676,3 +2676,27 @@ msgstr ""
 #: wp-content/themes/chassesautresor/inc/chasse-functions.php:853
 msgid "Demander la validation"
 msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:58
+#: assets/js/chasse-edit.js:792
+msgid "illimitée"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:65
+#: assets/js/chasse-edit.js:806 assets/js/chasse-edit.js:815
+msgid "%d jour à attendre"
+msgid_plural "%d jours à attendre"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:70
+#: assets/js/chasse-edit.js:802
+msgid "terminée depuis %s"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:76
+#: assets/js/chasse-edit.js:810
+msgid "%d jour restant"
+msgid_plural "%d jours restants"
+msgstr[0] ""
+msgstr[1] ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: chassesautresor.com 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/chassesautresor\n"
-"POT-Creation-Date: 2025-08-23T01:54:31+00:00\n"
+"POT-Creation-Date: 2025-08-28T06:27:25+00:00\n"
 "PO-Revision-Date: 2025-08-23 08:28+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,15 +35,15 @@ msgstr "https://chassesautresor.com/"
 msgid "Accueil Plein Ecran"
 msgstr "Full Screen Home"
 
-#: functions.php:102
+#: functions.php:114
 msgid "Français"
 msgstr "French"
 
-#: functions.php:107
+#: functions.php:119
 msgid "English"
 msgstr "English"
 
-#: functions.php:116
+#: functions.php:128
 msgid "Change language"
 msgstr "Change language"
 
@@ -105,7 +105,7 @@ msgid "Régler"
 msgstr "Set"
 
 #: inc/admin-functions.php:467
-#: template-parts/chasse/chasse-edition-main.php:309
+#: template-parts/chasse/chasse-edition-main.php:347
 msgid "Annuler"
 msgstr "Cancel"
 
@@ -136,187 +136,141 @@ msgstr "⛔ Access denied. You do not have permission to perform this action."
 msgid "⛔ Erreur de sécurité. Veuillez réessayer."
 msgstr "Security ⛔ error. Please try again."
 
-#: inc/admin-functions.php:1343 inc/admin-functions.php:1368
+#: inc/admin-functions.php:1343 inc/admin-functions.php:1369
 msgid "Non autorisé"
 msgstr "Not allowed"
 
-#: inc/admin-functions.php:1425
+#: inc/admin-functions.php:1426
 msgid "Confirmez-vous la réinitialisation des statistiques ?"
 msgstr ""
 
-#: inc/admin-functions.php:1426
+#: inc/admin-functions.php:1427
 #, fuzzy
 msgid "Statistiques effacées."
 msgstr "Statistics"
 
-#: inc/admin-functions.php:1647
+#: inc/admin-functions.php:1648
 #: templates/myaccount/content-organisateurs.php:21
 #, fuzzy
 msgid "Aucun organisateur."
 msgstr "No associated organizers."
 
-#: inc/admin-functions.php:1676
+#: inc/admin-functions.php:1677
 #, fuzzy
 msgid "Organisateur"
 msgstr "Organizers"
 
-#: inc/admin-functions.php:1677
-#: template-parts/indice/indice-edition-main.php:153
+#: inc/admin-functions.php:1678 template-parts/common/indices-table.php:128
+#: template-parts/common/solutions-table.php:53
 msgid "Chasse"
 msgstr "Hunt"
 
-#: inc/admin-functions.php:1678
+#: inc/admin-functions.php:1679
 #, fuzzy
 msgid "Nb énigmes"
 msgstr "Riddles"
 
-#: inc/admin-functions.php:1679
+#: inc/admin-functions.php:1680
 msgid "État"
 msgstr ""
 
-#: inc/admin-functions.php:1680 inc/organisateur-functions.php:437
+#: inc/admin-functions.php:1681 inc/organisateur-functions.php:437
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:26
 msgid "Utilisateur"
 msgstr "User"
 
-#: inc/admin-functions.php:1681
+#: inc/admin-functions.php:1682
 msgid "Créé le"
 msgstr ""
 
-#: inc/admin-functions.php:1701
+#: inc/admin-functions.php:1702
 #, fuzzy
 msgid "valide"
 msgstr "Validate"
 
-#: inc/admin-functions.php:1704
+#: inc/admin-functions.php:1705 inc/chasse-functions.php:1122
+#: template-parts/chasse/chasse-affichage-complet.php:96
 msgid "correction"
 msgstr "correction"
 
-#: inc/admin-functions.php:1707
+#: inc/admin-functions.php:1708 inc/chasse-functions.php:1124
+#: template-parts/chasse/chasse-affichage-complet.php:98
 msgid "en attente"
 msgstr "pending"
 
-#: inc/admin-functions.php:1710
+#: inc/admin-functions.php:1711 inc/chasse-functions.php:1120
+#: template-parts/chasse/chasse-affichage-complet.php:94
 msgid "création"
 msgstr "creation"
 
-#: inc/admin-functions.php:1714
+#: inc/admin-functions.php:1715
 msgid "banni"
 msgstr ""
 
-#: inc/admin-functions.php:1730
+#: inc/admin-functions.php:1731
 msgid "Demande de validation et tentatives manuelles en attente"
 msgstr ""
 
-#: inc/admin-functions.php:1732
+#: inc/admin-functions.php:1733
 #, fuzzy
 msgid "Demande de validation en attente"
 msgstr "%d pending attempt"
 
-#: inc/admin-functions.php:1734
+#: inc/admin-functions.php:1735
 #, fuzzy
 msgid "Tentatives manuelles en attente de réponse"
 msgstr "Configure answer variants"
 
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "en cours"
-msgstr "in progress"
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "révision"
-msgstr "review"
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "à venir"
-msgstr "upcoming"
-
-#: template-parts/chasse/chasse-affichage-complet.php:46
-#: inc/chasse-functions.php:1096
-msgid "terminée"
-msgstr "finished"
-
-#: template-parts/chasse/chasse-affichage-complet.php:178
-msgid "Par"
-msgstr "By"
-
-#: template-parts/chasse/chasse-affichage-complet.php:48
-msgid "mode de fin de chasse : automatique"
-msgstr "hunt end mode: automatic"
-
-#: template-parts/chasse/chasse-affichage-complet.php:49
-msgid "mode de fin de chasse : manuelle"
-msgstr "hunt end mode: manual"
-
-#: template-parts/chasse/chasse-affichage-complet.php:206
-#: template-parts/chasse/chasse-card.php:24
-msgid "%d énigme"
-msgid_plural "%d énigmes"
-msgstr[0] "%d puzzle"
-msgstr[1] "%d puzzles"
-
-#: inc/chasse-functions.php:772
-#: template-parts/chasse/chasse-affichage-complet.php:207
-#: template-parts/chasse/chasse-card.php:25
-msgid "%d joueur"
-msgid_plural "%d joueurs"
-msgstr[0] "%d player"
-msgstr[1] "%d players"
-
-#: template-parts/chasse/chasse-card.php:32
-msgid "En savoir plus"
-msgstr "Learn more"
-
-#: inc/admin-functions.php:1785
-#: template-parts/chasse/chasse-edition-main.php:469
+#: inc/admin-functions.php:1786
+#: template-parts/chasse/chasse-edition-main.php:659
 msgid "Accès refusé."
 msgstr "Access denied."
 
-#: inc/admin-functions.php:1792
+#: inc/admin-functions.php:1793
 msgid "ID de chasse invalide."
 msgstr "Invalid hunt ID."
 
-#: inc/admin-functions.php:1796
+#: inc/admin-functions.php:1797
 msgid "Nonce invalide."
 msgstr "Invalid nonce."
 
-#: inc/admin-functions.php:1849
+#: inc/admin-functions.php:1850
 #, php-format
 msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
 msgstr "Your validation request for the hunt “%s” was accepted."
 
-#: inc/admin-functions.php:1886
+#: inc/admin-functions.php:1887
 #, php-format
 msgid ""
 "Votre demande de validation pour la chasse « %s » nécessite des corrections."
 msgstr "Your validation request for the hunt “%s” requires corrections."
 
-#: inc/admin-functions.php:1891
+#: inc/admin-functions.php:1892
 #, php-format
 msgid "Message de l’administrateur : %s"
 msgstr "Administrator's message: %s"
 
-#: inc/admin-functions.php:1895
+#: inc/admin-functions.php:1896
 msgid "Une copie de ce message vous a été envoyée par email."
 msgstr "A copy of this message has been sent to you by email."
 
-#: inc/admin-functions.php:1918
+#: inc/admin-functions.php:1919
 #, php-format
 msgid "Votre chasse « %s » a été bannie."
 msgstr "Your hunt “%s” was banned."
 
-#: inc/admin-functions.php:1940
-#, fuzzy, php-format
-msgid "Votre chasse « %s » a été supprimée."
-msgstr "Your hunt “%s” was banned."
-
+#: inc/user-functions.php:643
 msgid "Supprimer ce message"
 msgstr "Dismiss this message"
 
+#: inc/user-functions.php:714
 msgid "Clé de message invalide."
 msgstr "Invalid message key."
+
+#: inc/admin-functions.php:1941
+#, fuzzy, php-format
+msgid "Votre chasse « %s » a été supprimée."
+msgstr "Your hunt “%s” was banned."
 
 #: inc/chasse-functions.php:245
 msgid ""
@@ -331,102 +285,310 @@ msgstr ""
 "⚠️ Error: The end date cannot be earlier than today's date if the hunt starts "
 "now."
 
-#: inc/chasse-functions.php:644
+#: inc/chasse-functions.php:617
+#, fuzzy
+msgid "Participer"
+msgstr "Players"
+
+#: inc/chasse-functions.php:651
 msgid "Points insuffisants"
 msgstr "Insufficient Points"
 
-#: inc/chasse-functions.php:650 inc/organisateur-functions.php:273
-#: template-parts/chasse/chasse-edition-main.php:417
-#: template-parts/enigme/enigme-edition-main.php:387
+#: inc/chasse-functions.php:657 inc/organisateur-functions.php:273
+#: template-parts/enigme/enigme-edition-main.php:572
 msgid "points"
 msgstr "points"
 
-#: inc/chasse-functions.php:653
+#: inc/chasse-functions.php:660
 #, php-format
 msgid "Il vous manque %1$d %2$s pour participer à cette chasse."
 msgstr "You are %1$d %2$s short to participate in this hunt."
 
-#: inc/chasse-functions.php:903 single-chasse.php:115
+#: inc/chasse-functions.php:780
+#: template-parts/chasse/chasse-affichage-complet.php:229
+#, php-format
+msgid "%d joueur"
+msgid_plural "%d joueurs"
+msgstr[0] "%d player"
+msgstr[1] "%d players"
+
+#: inc/chasse-functions.php:910 single-chasse.php:115
 msgid "Certaines énigmes doivent être complétées :"
 msgstr "Some puzzles need to be completed:"
 
-#: inc/edition/edition-chasse.php:48
+#: inc/chasse-functions.php:1126
+#: template-parts/chasse/chasse-affichage-complet.php:100
+msgid "révision"
+msgstr "review"
+
+#: inc/chasse-functions.php:1129
+#: template-parts/chasse/chasse-affichage-complet.php:103
+msgid "en cours"
+msgstr "in progress"
+
+#: inc/chasse-functions.php:1132
+#: template-parts/chasse/chasse-affichage-complet.php:106
+msgid "à venir"
+msgstr "upcoming"
+
+#: inc/chasse-functions.php:1134
+#: template-parts/chasse/chasse-affichage-complet.php:108
+msgid "terminée"
+msgstr "finished"
+
+#: inc/edition/edition-chasse.php:58
 #, fuzzy
 msgid "Erreur lors du chargement des indices."
 msgstr "Error creating hunt."
 
-#: inc/edition/edition-chasse.php:115
+#: inc/edition/edition-chasse.php:67 inc/edition/edition-enigme.php:62
+#: template-parts/chasse/partials/chasse-partial-solutions.php:76
+#: template-parts/chasse/partials/chasse-partial-solutions.php:90
+msgid "Il existe déjà une solution pour cette chasse"
+msgstr "A solution already exists for this hunt"
+
+#: inc/edition/edition-chasse.php:68
+#: template-parts/chasse/partials/chasse-partial-solutions.php:105
+msgid "Toutes les énigmes de la chasse ont déjà une solution"
+msgstr "All riddles in this hunt already have a solution"
+
+#: inc/edition/edition-chasse.php:135
 msgid "Aucun organisateur associé."
 msgstr "No associated organizers."
 
-#: inc/edition/edition-chasse.php:123
+#: inc/edition/edition-chasse.php:143
 msgid "Limite atteinte"
 msgstr "Limit reached"
 
-#: inc/edition/edition-chasse.php:126
+#: inc/edition/edition-chasse.php:146
 msgid "Accès refusé"
 msgstr "Access denied"
 
-#: inc/edition/edition-chasse.php:136
+#: inc/edition/edition-chasse.php:156
 msgid "Une chasse est déjà en attente de validation."
 msgstr "A hunt is already awaiting validation."
 
-#: inc/edition/edition-chasse.php:149
+#: inc/edition/edition-chasse.php:169
 msgid "Erreur lors de la création de la chasse."
 msgstr "Error creating hunt."
 
-#: inc/edition/edition-enigme.php:166
-msgid "Chasse non spécifiée ou invalide."
-msgstr "Hunting unspecified or invalid."
-
-#: inc/edition/edition-indice.php:45
+#: inc/edition/edition-core.php:147 inc/edition/edition-core.php:179
+#: assets/js/help-modal.js:19
 #, fuzzy
-msgid "Type de cible invalide."
-msgstr "Invalid hunt ID."
+msgid "Fermer"
+msgstr "<g x=1 id=\"40\">Close Chart</g>"
 
-#: inc/edition/edition-indice.php:49
+#: inc/edition/edition-core.php:148
+msgid "Choisir une image"
+msgstr "Choose an image"
+
+#: inc/edition/edition-core.php:149 inc/edition/edition-core.php:188
+#: templates/myaccount/content-outils.php:33
+msgid "Modifier"
+msgstr "Edit"
+
+#: inc/edition/edition-core.php:150 template-parts/common/indices-table.php:185
+#: template-parts/common/solutions-table.php:163 assets/js/enigme-edit.js:886
+msgid "Supprimer"
+msgstr "Remove"
+
+#: inc/edition/edition-core.php:151
+msgid "Texte de l’indice"
+msgstr "Clue text"
+
+#: inc/edition/edition-core.php:152
+msgid "Immédiate"
+msgstr "Immediate"
+
+#: inc/edition/edition-core.php:153 inc/edition/edition-core.php:184
+msgid "Différée"
+msgstr "Delayed"
+
+#: inc/edition/edition-core.php:154 inc/edition/edition-core.php:186
+#: inc/enigme/reponses.php:137
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
+msgid "Valider"
+msgstr "Validate"
+
+#: inc/edition/edition-core.php:155
 #, fuzzy
-msgid "ID cible invalide."
-msgstr "Invalid hunt ID."
+msgid "Sélectionner une image"
+msgstr "Select a riddle"
 
-#: inc/edition/edition-indice.php:53
-msgid "Utilisateur non connecté."
-msgstr ""
-
-#: inc/edition/edition-indice.php:57 inc/edition/edition-indice.php:65
-#, fuzzy
-msgid "Droits insuffisants."
-msgstr "Insufficient Points"
-
-#: inc/edition/edition-indice.php:83
+#: inc/edition/edition-core.php:156 inc/edition/edition-indice.php:164
+#: inc/edition/edition-indice.php:262
 #, php-format
 msgid "Indice #%d"
 msgstr "Clue #%d"
 
-#: inc/edition/edition-core.php:155
-msgid "lié à"
-msgstr "linked to"
-
-#: inc/edition/edition-core.php:155
+#: inc/edition/edition-core.php:157 inc/edition/edition-core.php:196
 msgid "liée à"
 msgstr "linked to"
 
-#: inc/edition/edition-core.php:155
+#: inc/edition/edition-core.php:158 inc/edition/edition-core.php:197
 msgid "la chasse"
 msgstr "the hunt"
 
-#: inc/edition/edition-core.php:155
+#: inc/edition/edition-core.php:159 inc/edition/edition-core.php:198
 msgid "l’énigme"
 msgstr "the riddle"
 
-#: inc/edition/edition-indice.php:151
+#: inc/edition/edition-core.php:160 inc/edition/edition-core.php:191
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+#: template-parts/common/indices-table.php:127
+#: template-parts/common/solutions-table.php:52
+#: templates/myaccount/content-chasses.php:125
+msgid "Énigme"
+msgstr "Riddle"
+
+#: inc/edition/edition-core.php:161 inc/edition/edition-core.php:192
+msgid "Sélectionner une énigme"
+msgstr "Select a riddle"
+
+#: inc/edition/edition-core.php:162 inc/edition/edition-core.php:193
+msgid "Sélectionnez une énigme"
+msgstr "Please select a riddle"
+
+#: inc/edition/edition-core.php:163 inc/edition/edition-core.php:194
+msgid "Chargement…"
+msgstr "Loading…"
+
+#: inc/edition/edition-core.php:164
+msgid "Au moins une image ou un texte nécessaire"
+msgstr "At least one image or text required"
+
+#: inc/edition/edition-core.php:165 inc/edition/edition-core.php:202
+msgid "Date et heure requises"
+msgstr "Date and time required"
+
+#: inc/edition/edition-core.php:166
+msgid "Date invalide"
+msgstr "Invalid date"
+
+#: inc/edition/edition-core.php:167 inc/edition/edition-core.php:190
+#: assets/js/indices-pager.js:34 assets/js/indices-pager.js:83
+#: assets/js/solutions-pager.js:28 assets/js/solutions-pager.js:77
+#, fuzzy
+msgid "Erreur réseau"
+msgstr "Network error"
+
+#: inc/edition/edition-core.php:180
+msgid "Texte de la solution"
+msgstr "Solution text"
+
+#: inc/edition/edition-core.php:181
+msgid "Fichier"
+msgstr "File"
+
+#: inc/edition/edition-core.php:182
+msgid "Disponibilité"
+msgstr "Availability"
+
+#: inc/edition/edition-core.php:183
+#, fuzzy
+msgid "Fin de la chasse"
+msgstr "Hunt end"
+
+#: inc/edition/edition-core.php:185
+#, fuzzy
+msgid "jours"
+msgstr "in progress"
+
+#: inc/edition/edition-core.php:187
+#: template-parts/chasse/partials/chasse-partial-solutions.php:43
+msgid "Ajouter une solution"
+msgstr "Add a solution"
+
+#: inc/edition/edition-core.php:189
+msgid "Solution enregistrée."
+msgstr ""
+
+#: inc/edition/edition-core.php:195
+msgid "Ajoutez un fichier ou un texte"
+msgstr "Add a file or text"
+
+#: inc/edition/edition-core.php:199
+msgid "Choisir un fichier"
+msgstr "Choose a file"
+
+#: inc/edition/edition-core.php:200
+msgid "Aucun fichier choisi"
+msgstr "No file selected"
+
+#: inc/edition/edition-core.php:201
+#, fuzzy
+msgid "Supprimer le fichier"
+msgstr "Dismiss this message"
+
+#: inc/edition/edition-enigme.php:63
+#: template-parts/chasse/partials/chasse-partial-solutions.php:63
+msgid "Il existe déjà une solution pour cette énigme"
+msgstr "A solution already exists for this riddle"
+
+#: inc/edition/edition-enigme.php:64
+#: template-parts/common/edition-animation.php:521 assets/js/enigme-edit.js:85
+#: assets/js/enigme-edit.js:259
+msgid "Voir toutes les solutions de la chasse"
+msgstr "See all hunt solutions"
+
+#: inc/edition/edition-enigme.php:65 assets/js/enigme-edit.js:96
+#: assets/js/enigme-edit.js:257
+msgid "Voir la solution de cette énigme"
+msgstr "See this riddle's solution"
+
+#: inc/edition/edition-enigme.php:189
+msgid "Chasse non spécifiée ou invalide."
+msgstr "Hunting unspecified or invalid."
+
+#: inc/edition/edition-indice.php:225 inc/edition/edition-solution.php:269
+#, fuzzy
+msgid "Type de cible invalide."
+msgstr "Invalid hunt ID."
+
+#: inc/edition/edition-indice.php:229 inc/edition/edition-solution.php:273
+#, fuzzy
+msgid "ID cible invalide."
+msgstr "Invalid hunt ID."
+
+#: inc/edition/edition-indice.php:233 inc/edition/edition-solution.php:277
+msgid "Utilisateur non connecté."
+msgstr ""
+
+#: inc/edition/edition-indice.php:237 inc/edition/edition-indice.php:245
+#: inc/edition/edition-solution.php:281 inc/edition/edition-solution.php:289
+#, fuzzy
+msgid "Droits insuffisants."
+msgstr "Insufficient Points"
+
+#: inc/edition/edition-indice.php:335 inc/edition/edition-solution.php:386
 #, fuzzy
 msgid "Action non autorisée."
 msgstr "Not allowed"
 
-#: inc/edition/edition-indice.php:167
+#: inc/edition/edition-indice.php:351 inc/edition/edition-solution.php:402
 msgid "ID cible manquant."
 msgstr ""
+
+#: inc/edition/edition-indice.php:587
+#: template-parts/common/edition-animation.php:481 assets/js/enigme-edit.js:221
+#, fuzzy
+msgid "Voir tous les indices de la chasse"
+msgstr "See all hunt solutions"
+
+#: inc/edition/edition-indice.php:588 assets/js/enigme-edit.js:220
+#, fuzzy
+msgid "Voir les indices de cette énigme"
+msgstr "See this riddle's solution"
+
+#: inc/edition/edition-solution.php:307
+msgid "Une solution existe déjà pour cet objet."
+msgstr ""
+
+#: inc/edition/edition-solution.php:322
+#, fuzzy, php-format
+msgid "Solution | %s"
+msgstr "Solutions for %s"
 
 #: inc/enigme/affichage.php:159 inc/enigme/affichage.php:204
 msgid "Vous"
@@ -478,134 +640,96 @@ msgstr ""
 msgid "Définition du taux de résolution"
 msgstr "Definition of the resolution rate"
 
-#: inc/enigme/affichage.php:518 inc/enigme/affichage.php:1037
+#: inc/enigme/affichage.php:518 inc/enigme/affichage.php:1039
+#: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
-#: template-parts/indice/indice-edition-main.php:154
-#: template-parts/chasse/chasse-edition-main.php:625
 msgid "Énigmes"
 msgstr "Riddles"
 
-#: inc/enigme/affichage.php:546
+#: inc/enigme/affichage.php:536 inc/enigme/affichage.php:1008
+msgid "Retour"
+msgstr ""
+
+#: inc/enigme/affichage.php:548
 msgid "Afficher les statistiques"
 msgstr "View Stats"
 
-#: inc/enigme/affichage.php:649
-#: template-parts/chasse/chasse-edition-main.php:708
-#: inc/enigme/affichage.php:649
-#: template-parts/chasse/chasse-edition-main.php:708
+#: inc/enigme/affichage.php:651
 msgid "Indices"
 msgstr "Hints"
 
-#: template-parts/chasse/chasse-edition-main.php:708
-#: template-parts/enigme/enigme-edition-main.php:774
-#: template-parts/common/edition-animation.php:366
-#: template-parts/common/edition-animation.php:370
-#, php-format
-msgid "Indices pour %s"
-msgstr "Hints for %s"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:35
-msgid "Ajouter un indice"
-msgstr "Add a hint"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:42
-msgid "Pour…"
-msgstr "For…"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:56
-msgid "Cette énigme"
-msgstr "This riddle"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:66
-#: template-parts/chasse/partials/chasse-partial-indices.php:77
-msgid "La chasse entière"
-msgstr "The entire hunt"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:89
-msgid "Une énigme de la chasse"
-msgstr "A riddle from the hunt"
-
-#: inc/enigme/affichage.php:677
+#: inc/enigme/affichage.php:679
+#: template-parts/chasse/chasse-affichage-complet.php:273
 msgid "automatique"
 msgstr "automatic"
 
-#: inc/enigme/affichage.php:678
+#: inc/enigme/affichage.php:680
+#: template-parts/chasse/chasse-affichage-complet.php:274
 msgid "manuelle"
 msgstr "manual"
 
-#: inc/enigme/affichage.php:680
+#: inc/enigme/affichage.php:682
 #, php-format
 msgid "Mode de validation de l'énigme : %s"
 msgstr "Riddle validation mode: %s"
 
-#: inc/enigme/affichage.php:712
+#: inc/enigme/affichage.php:714
 #, php-format
 msgid "Solde : %d pts"
 msgstr "Balance: %d pts"
 
-#: inc/enigme/affichage.php:721
+#: inc/enigme/affichage.php:723
 #, php-format
 msgid "Tentatives quotidiennes : %1$d/%2$s"
 msgstr "Daily Attempts: %1$d/%2$s"
 
-#: inc/enigme/affichage.php:737
+#: inc/enigme/affichage.php:739
 #, fuzzy, php-format
 msgid "Coût par tentative : %d points."
 msgstr "Attempt cost"
 
-#: template-parts/chasse/chasse-affichage-complet.php:120
-#: template-parts/chasse/chasse-affichage-complet.php:130
-#, php-format
-msgid "Coût de participation : %d points."
-msgstr "Participation cost: %d points."
-
-#: inc/enigme/affichage.php:741 assets/js/reponse-automatique.js:76
-#: assets/js/reponse-automatique.js:98
+#: inc/enigme/affichage.php:743
+#: template-parts/chasse/chasse-affichage-complet.php:131
+#: template-parts/chasse/chasse-affichage-complet.php:152
+#: assets/js/reponse-automatique.js:76 assets/js/reponse-automatique.js:98
 msgid "pts"
 msgstr "pts"
 
-#: inc/enigme/affichage.php:780
+#: inc/enigme/affichage.php:782
 msgid "Voir la solution"
 msgstr "View solution"
 
-#: inc/enigme/affichage.php:945 inc/enigme/affichage.php:956
-#: inc/enigme/affichage.php:1012 inc/enigme/affichage.php:1013
-#: inc/enigme/affichage.php:1026 inc/enigme/affichage.php:1027
-#: single-indice.php:27 template-parts/chasse/chasse-edition-main.php:67
-#: template-parts/chasse/chasse-edition-main.php:76
-#: template-parts/enigme/enigme-edition-main.php:94
-#: template-parts/enigme/enigme-edition-main.php:104
-#: template-parts/indice/indice-edition-main.php:59
-#: template-parts/indice/indice-edition-main.php:67
-#: template-parts/organisateur/organisateur-edition-main.php:75
-#: template-parts/organisateur/organisateur-edition-main.php:85
+#: inc/enigme/affichage.php:947 inc/enigme/affichage.php:958
+#: inc/enigme/affichage.php:1014 inc/enigme/affichage.php:1015
+#: inc/enigme/affichage.php:1028 inc/enigme/affichage.php:1029
+#: template-parts/chasse/chasse-edition-main.php:69
+#: template-parts/chasse/chasse-edition-main.php:78
+#: template-parts/enigme/enigme-edition-main.php:93
+#: template-parts/enigme/enigme-edition-main.php:103
+#: template-parts/organisateur/organisateur-edition-main.php:76
+#: template-parts/organisateur/organisateur-edition-main.php:86
 msgid "Paramètres"
 msgstr "Settings"
 
-#: inc/enigme/affichage.php:1006
-msgid "Retour"
-msgstr ""
-
-#: inc/enigme/affichage.php:1017 inc/enigme/affichage.php:1018
+#: inc/enigme/affichage.php:1019 inc/enigme/affichage.php:1020
 #, fuzzy
 msgid "Menu énigme"
 msgstr "Riddle text"
 
-#: inc/enigme/affichage.php:1035
+#: inc/enigme/affichage.php:1037
 #, fuzzy
 msgid "Panneau d'énigme"
 msgstr "Riddle Editing Panel"
 
-#: inc/enigme/affichage.php:1038 inc/enigme/affichage.php:1135
-#: template-parts/chasse/chasse-edition-main.php:68
-#: template-parts/enigme/enigme-edition-main.php:95
-#: template-parts/enigme/enigme-edition-main.php:499
+#: inc/enigme/affichage.php:1040 inc/enigme/affichage.php:1137
+#: template-parts/chasse/chasse-edition-main.php:70
+#: template-parts/chasse/chasse-edition-main.php:656
+#: template-parts/enigme/enigme-edition-main.php:94
+#: template-parts/enigme/enigme-edition-main.php:645
 #: template-parts/enigme/partials/enigme-sidebar-section.php:52
-#: template-parts/indice/indice-edition-main.php:60
-#: template-parts/indice/indice-edition-main.php:218
-#: template-parts/organisateur/organisateur-edition-main.php:76
-#: template-parts/organisateur/organisateur-edition-main.php:252
+#: template-parts/organisateur/organisateur-edition-main.php:77
+#: template-parts/organisateur/organisateur-edition-main.php:328
 #: templates/myaccount/layout.php:111
 msgid "Statistiques"
 msgstr "Statistics"
@@ -619,7 +743,7 @@ msgstr ""
 msgid "Chasse verrouillée"
 msgstr "Hunting not found."
 
-#: inc/enigme/cta.php:195 template-parts/enigme/enigme-edition-main.php:451
+#: inc/enigme/cta.php:195
 msgid "Pré-requis"
 msgstr "Requirements"
 
@@ -707,12 +831,6 @@ msgstr "Add points"
 #, php-format
 msgid "Solde : %1$d → %2$d pts"
 msgstr "Balance: %1$d → %2$d pts"
-
-#: inc/enigme/reponses.php:137
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
-msgid "Valider"
-msgstr "Validate"
 
 #: inc/enigme/reponses.php:140
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:147
@@ -808,8 +926,9 @@ msgstr "History of your points"
 msgid "ID"
 msgstr "ID"
 
-#: inc/gamify-functions.php:525
-#: template-parts/enigme/enigme-edition-main.php:577
+#: inc/gamify-functions.php:525 template-parts/common/indices-table.php:63
+#: template-parts/common/solutions-table.php:30
+#: template-parts/enigme/enigme-edition-main.php:723
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:35
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:25
 #: templates/myaccount/content-chasses.php:124
@@ -833,32 +952,53 @@ msgstr "Variation"
 msgid "Solde"
 msgstr "Balance"
 
+#: inc/handlers/voir-fichier.php:25
+#, fuzzy
+msgid "Fichier introuvable (ID)."
+msgstr "Hunting not found."
+
+#: inc/handlers/voir-fichier.php:33
+#, fuzzy
+msgid "Solution introuvable."
+msgstr "Attemp not found"
+
+#: inc/handlers/voir-fichier.php:44
+msgid "Accès non autorisé à cette solution."
+msgstr ""
+
+#: inc/handlers/voir-fichier.php:54
+msgid "Aucun fichier PDF lié à cette solution."
+msgstr ""
+
 #: inc/organisateur-functions.php:227 inc/organisateur-functions.php:233
-#: template-parts/organisateur/organisateur-edition-main.php:308
-#: template-parts/organisateur/organisateur-edition-main.php:321
+#: template-parts/organisateur/organisateur-edition-main.php:384
+#: template-parts/organisateur/organisateur-edition-main.php:397
 msgid "Ajouter des coordonnées bancaires"
 msgstr "Add bank details"
 
 #: inc/organisateur-functions.php:231
-#: template-parts/chasse/chasse-edition-main.php:673
 #: template-parts/chasse/partials/chasse-partial-indices.php:97
-#: template-parts/organisateur/organisateur-edition-main.php:305
-#: template-parts/organisateur/organisateur-edition-main.php:319
-#: template-parts/organisateur/organisateur-edition-main.php:360
+#: template-parts/chasse/partials/chasse-partial-solutions.php:115
+#: template-parts/common/edition-animation.php:82
+#: template-parts/common/edition-animation.php:108
+#: template-parts/organisateur/organisateur-edition-main.php:381
+#: template-parts/organisateur/organisateur-edition-main.php:395
 msgid "Ajouter"
 msgstr "Add"
 
 #: inc/organisateur-functions.php:232
-#: template-parts/chasse/chasse-edition-main.php:674
-#: template-parts/organisateur/organisateur-edition-main.php:306
-#: template-parts/organisateur/organisateur-edition-main.php:320
-#: template-parts/organisateur/organisateur-edition-main.php:361
+#: template-parts/common/edition-animation.php:83
+#: template-parts/common/edition-animation.php:109
+#: template-parts/common/indices-table.php:176
+#: template-parts/common/solutions-table.php:156
+#: template-parts/organisateur/organisateur-edition-main.php:382
+#: template-parts/organisateur/organisateur-edition-main.php:396
 msgid "Éditer"
 msgstr "Edit"
 
 #: inc/organisateur-functions.php:234
-#: template-parts/organisateur/organisateur-edition-main.php:309
-#: template-parts/organisateur/organisateur-edition-main.php:322
+#: template-parts/organisateur/organisateur-edition-main.php:385
+#: template-parts/organisateur/organisateur-edition-main.php:398
 msgid "Modifier les coordonnées bancaires"
 msgstr "Edit Bank Details"
 
@@ -877,7 +1017,7 @@ msgid "Transformez vos %d points en euros."
 msgstr "Turn your %d points into euros."
 
 #: inc/organisateur-functions.php:262 inc/organisateur-functions.php:282
-#: template-parts/organisateur/organisateur-edition-main.php:281
+#: template-parts/organisateur/organisateur-edition-main.php:357
 msgid "Convertir"
 msgstr "Convert"
 
@@ -999,14 +1139,14 @@ msgstr "Statistics - Scavenger Hunt"
 msgid "Vos commandes"
 msgstr "Your orders"
 
-#: inc/user-functions.php:335
+#: inc/user-functions.php:352
 #, php-format
 msgid ""
 "Votre demande de résolution de l'énigme %s est en cours de traitement. Vous "
 "recevrez une notification dès que votre demande sera traitée."
 msgstr ""
 
-#: inc/user-functions.php:351
+#: inc/user-functions.php:371
 #, php-format
 msgid ""
 "Vos demandes de résolution d'énigmes sont en cours de traitement : %s. Vous "
@@ -1014,12 +1154,12 @@ msgid ""
 msgstr ""
 
 #. translators: 1: opening anchor tag, 2: closing anchor tag
-#: inc/user-functions.php:456
+#: inc/user-functions.php:504
 #, php-format
 msgid "Vous avez des %1$sdemandes de conversion%2$s en attente."
 msgstr "You have %1$ sconversion requests %2$s pending."
 
-#: inc/user-functions.php:478
+#: inc/user-functions.php:529
 msgid "Important ! Des tentatives attendent votre action :"
 msgstr ""
 
@@ -1048,99 +1188,223 @@ msgstr "Treasure hunts"
 msgid "C'est parti !"
 msgstr "Here we go!"
 
-#: template-parts/chasse/chasse-edition-main.php:61
+#: template-parts/chasse/chasse-affichage-complet.php:46
+#: template-parts/chasse/chasse-affichage-complet.php:132
+msgid "mode de fin de chasse : automatique"
+msgstr "hunt end mode: automatic"
+
+#: template-parts/chasse/chasse-affichage-complet.php:47
+#: template-parts/chasse/chasse-affichage-complet.php:133
+msgid "mode de fin de chasse : manuelle"
+msgstr "hunt end mode: manual"
+
+#: template-parts/chasse/chasse-affichage-complet.php:130
+#: template-parts/chasse/chasse-affichage-complet.php:147
+#, php-format
+msgid "Coût de participation : %d points."
+msgstr "Participation cost: %d points."
+
+#: template-parts/chasse/chasse-affichage-complet.php:176
+#: template-parts/chasse/chasse-edition-main.php:157
+#: template-parts/chasse/chasse-edition-main.php:167
+#, fuzzy
+msgid "Image de la chasse"
+msgstr "Hunt image"
+
+#: template-parts/chasse/chasse-affichage-complet.php:220
+msgid "Par"
+msgstr "By"
+
+#: template-parts/chasse/chasse-affichage-complet.php:227
+#: template-parts/chasse/chasse-card.php:33
+#, php-format
+msgid "%d énigme"
+msgid_plural "%d énigmes"
+msgstr[0] "%d puzzle"
+msgstr[1] "%d puzzles"
+
+#: template-parts/chasse/chasse-affichage-complet.php:263
+msgid "Limite"
+msgstr "Limit"
+
+#: template-parts/chasse/chasse-affichage-complet.php:264
+#, php-format
+msgid "%d gagnants"
+msgstr "%d winners"
+
+#: template-parts/chasse/chasse-affichage-complet.php:269
+msgid "Fin de chasse"
+msgstr "Hunt end"
+
+#: template-parts/chasse/chasse-affichage-complet.php:280
+msgid "Accès chasse"
+msgstr "Hunt access"
+
+#: template-parts/chasse/chasse-affichage-complet.php:283
+#, fuzzy, php-format
+msgid "%d points"
+msgstr "points"
+
+#: template-parts/chasse/chasse-affichage-complet.php:284
+msgid "libre"
+msgstr "free"
+
+#: template-parts/chasse/chasse-affichage-complet.php:289
+msgid "Accès énigme"
+msgstr "Riddle access"
+
+#: template-parts/chasse/chasse-affichage-complet.php:294
+#, php-format
+msgid "%d énigme nécessite des points pour soumettre une tentative"
+msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:305
+msgid "gratuit"
+msgstr "free"
+
+#: template-parts/chasse/chasse-affichage-complet.php:312
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+#: template-parts/chasse/partials/chasse-partial-participants.php:40
+msgid "Joueurs"
+msgstr "Players"
+
+#: template-parts/chasse/chasse-affichage-complet.php:314
+#, fuzzy, php-format
+msgid "%d participant"
+msgid_plural "%d participants"
+msgstr[0] "Players"
+msgstr[1] "Players"
+
+#: template-parts/chasse/chasse-affichage-complet.php:321
+#, php-format
+msgid "%1$d joueur a trouvé %2$d énigme"
+msgid_plural "%1$d joueurs ont trouvé %2$d énigmes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:345
+msgid "Les + avancés"
+msgstr "Most advanced"
+
+#: template-parts/chasse/chasse-affichage-complet.php:363
+msgid "Récompense :"
+msgstr "Reward:"
+
+#: template-parts/chasse/chasse-affichage-complet.php:375
+msgid "Description complète :"
+msgstr "Full description:"
+
+#: template-parts/chasse/chasse-card.php:48
+msgid "En savoir plus"
+msgstr "Learn more"
+
+#: template-parts/chasse/chasse-edition-main.php:63
 msgid "Panneau d'édition chasse"
 msgstr "Hunt Edit Panel"
 
-#: template-parts/chasse/chasse-edition-main.php:69
-#: template-parts/chasse/chasse-edition-main.php:647
-#: template-parts/enigme/enigme-edition-main.php:96
-#: template-parts/organisateur/organisateur-edition-main.php:77
-#: template-parts/organisateur/organisateur-edition-main.php:335
+#: template-parts/chasse/chasse-edition-main.php:71
+#: template-parts/common/edition-animation.php:55
+#: template-parts/enigme/enigme-edition-main.php:95
+#: template-parts/organisateur/organisateur-edition-main.php:78
 msgid "Animation"
 msgstr "Animation"
 
-#: template-parts/chasse/chasse-edition-main.php:104
-#: template-parts/enigme/enigme-edition-main.php:128
-#: template-parts/indice/indice-edition-main.php:90
+#: template-parts/chasse/chasse-edition-main.php:106
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:29
+#: template-parts/enigme/enigme-edition-main.php:127
 #: template-parts/organisateur/organisateur-edition-main.php:110
 msgid "Titre"
 msgstr "Title"
 
-#: template-parts/chasse/chasse-edition-main.php:126
+#: template-parts/chasse/chasse-edition-main.php:114
+#: assets/js/core/resume.js:297
+msgid "renseigner le titre de la chasse"
+msgstr "enter the hunt title"
+
+#: template-parts/chasse/chasse-edition-main.php:139
 msgid "Image chasse"
 msgstr "Hunt image"
 
-#: template-parts/chasse/chasse-edition-main.php:133
-#: template-parts/indice/indice-edition-main.php:107
+#: template-parts/chasse/chasse-edition-main.php:154
 msgid "Modifier l’image"
 msgstr "Edit image"
 
-#: template-parts/chasse/chasse-edition-main.php:135
-#: template-parts/chasse/chasse-edition-main.php:141
-#: template-parts/indice/indice-edition-main.php:109
-#: template-parts/indice/indice-edition-main.php:115
+#: template-parts/chasse/chasse-edition-main.php:160
+#: template-parts/chasse/chasse-edition-main.php:171
+#: template-parts/organisateur/organisateur-edition-main.php:165
+#: template-parts/organisateur/organisateur-edition-main.php:176
 msgid "ajouter une image"
 msgstr "add an image"
 
-#: template-parts/chasse/chasse-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:201
 msgid "Description chasse"
 msgstr "Hunting description"
 
-#: template-parts/chasse/chasse-edition-main.php:162
-#: template-parts/enigme/enigme-edition-main.php:172
-#: template-parts/enigme/enigme-edition-main.php:185
-#: template-parts/enigme/enigme-edition-main.php:202
-#: template-parts/indice/indice-edition-main.php:129
-#: template-parts/organisateur/organisateur-edition-main.php:161
-#: assets/js/enigme-edit.js:645
+#: template-parts/chasse/chasse-edition-main.php:215
+#: template-parts/enigme/enigme-edition-main.php:182
+#: template-parts/enigme/enigme-edition-main.php:195
+#: template-parts/enigme/enigme-edition-main.php:231
+#: template-parts/organisateur/organisateur-edition-main.php:218
+#: assets/js/enigme-edit.js:902
 msgid "ajouter"
 msgstr "Add"
 
-#: template-parts/chasse/chasse-edition-main.php:174
+#: template-parts/chasse/chasse-edition-main.php:227
 msgid "Modifier la description"
 msgstr "Modifying the description"
 
-#: template-parts/chasse/chasse-edition-main.php:175
-#: template-parts/indice/indice-edition-main.php:137
-#: template-parts/organisateur/organisateur-edition-main.php:173
-#: template-parts/organisateur/organisateur-edition-main.php:220
+#: template-parts/chasse/chasse-edition-main.php:232
+#: template-parts/organisateur/organisateur-edition-main.php:231
+#: template-parts/organisateur/organisateur-edition-main.php:292
 #: assets/js/core/helpers.js:234 assets/js/core/helpers.js:256
-#: assets/js/core/helpers.js:278 assets/js/core/resume.js:384
-#: assets/js/enigme-edit.js:743 assets/js/enigme-edit.js:988
+#: assets/js/core/helpers.js:283 assets/js/core/resume.js:378
+#: assets/js/enigme-edit.js:1001 assets/js/enigme-edit.js:1247
 msgid "modifier"
 msgstr "Edit"
 
-#: template-parts/chasse/chasse-edition-main.php:191
+#: template-parts/chasse/chasse-edition-main.php:262
 msgid "Récompense"
 msgstr "Award"
 
-#: template-parts/chasse/chasse-edition-main.php:227
-#: template-parts/enigme/enigme-edition-main.php:238
-#: template-parts/indice/indice-edition-main.php:148
+#: template-parts/chasse/chasse-edition-main.php:321
+#: template-parts/enigme/enigme-edition-main.php:288
 msgid "Réglages"
 msgstr "Settings"
 
-#: template-parts/chasse/chasse-edition-main.php:239
+#: template-parts/chasse/chasse-edition-main.php:333
+msgid "Terminer la chasse"
+msgstr "End Hunt"
+
+#: template-parts/chasse/chasse-edition-main.php:335
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
+msgid "Gagnants"
+msgstr "Winners"
+
+#: template-parts/chasse/chasse-edition-main.php:343
+msgid "Valider la fin de chasse"
+msgstr "Validate the end of hunting"
+
+#: template-parts/chasse/chasse-edition-main.php:367
 msgid "Mode de fin"
 msgstr "End Mode"
 
-#: template-parts/chasse/chasse-edition-main.php:250
-#: template-parts/enigme/enigme-edition-main.php:247
+#: template-parts/chasse/chasse-edition-main.php:374
+#: template-parts/enigme/enigme-edition-main.php:315
 msgid "Automatique"
 msgstr "Automatic"
 
-#: template-parts/chasse/chasse-edition-main.php:256
-#: template-parts/enigme/enigme-edition-main.php:253
+#: template-parts/chasse/chasse-edition-main.php:380
+#: template-parts/enigme/enigme-edition-main.php:321
 msgid "Explication du mode automatique"
 msgstr "Explanation of automatic mode"
 
-#: template-parts/chasse/chasse-edition-main.php:258
+#: template-parts/chasse/chasse-edition-main.php:382
 msgid "Fin de chasse automatique"
 msgstr "Automatic hunt end"
 
-#: template-parts/chasse/chasse-edition-main.php:259
+#: template-parts/chasse/chasse-edition-main.php:383
 msgid ""
 "Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode "
 "automatique, la chasse se termine dès que le nombre de gagnants prévu est "
@@ -1150,91 +1414,93 @@ msgstr ""
 "automatic mode, the hunt ends as soon as the planned number of winners is "
 "reached."
 
-#: template-parts/chasse/chasse-edition-main.php:272
-#: template-parts/enigme/enigme-edition-main.php:264
+#: template-parts/chasse/chasse-edition-main.php:400
+#: template-parts/enigme/enigme-edition-main.php:333
 msgid "Manuelle"
 msgstr "Manual"
 
-#: template-parts/chasse/chasse-edition-main.php:278
-#: template-parts/enigme/enigme-edition-main.php:270
+#: template-parts/chasse/chasse-edition-main.php:406
+#: template-parts/enigme/enigme-edition-main.php:339
 msgid "Explication du mode manuel"
 msgstr "Explanation of manual mode"
 
-#: template-parts/chasse/chasse-edition-main.php:280
+#: template-parts/chasse/chasse-edition-main.php:408
 msgid "Fin de chasse manuelle"
 msgstr "Manual hunt end"
 
-#: template-parts/chasse/chasse-edition-main.php:281
-msgid "Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans le panneau d’édition de la chasse, onglet Animation."
-msgstr "You can stop the hunt at any time using the button available in the hunt editing panel, Animation tab."
+#: template-parts/chasse/chasse-edition-main.php:409
+msgid ""
+"Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans "
+"le panneau d’édition de la chasse, onglet Animation."
+msgstr ""
+"You can stop the hunt at any time using the button available in the hunt "
+"editing panel, Animation tab."
 
-#: template-parts/chasse/chasse-edition-main.php:295
-msgid "Terminer la chasse"
-msgstr "End Hunt"
-
-#: template-parts/chasse/chasse-edition-main.php:297
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
-msgid "Gagnants"
-msgstr "Winners"
-
-#: template-parts/chasse/chasse-edition-main.php:305
-msgid "Valider la fin de chasse"
-msgstr "Validate the end of hunting"
-
-#: template-parts/chasse/chasse-edition-main.php:319
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/common/edition-animation.php:139
 #, php-format
 msgid "Chasse gagnée le %s par %s"
 msgstr "Hunting won on %s by %s"
 
-#: template-parts/chasse/chasse-edition-main.php:448
+#: template-parts/chasse/chasse-edition-main.php:443
 msgid "Nb gagnants"
 msgstr "Number of winners"
 
-#: template-parts/chasse/chasse-edition-main.php:454
+#: template-parts/chasse/chasse-edition-main.php:449
 msgid "Illimité"
 msgstr "Unlimited"
 
-#: template-parts/chasse/chasse-edition-main.php:464
+#: template-parts/chasse/chasse-edition-main.php:459
 msgid "Limité"
 msgstr "Limited"
 
-#: template-parts/chasse/chasse-edition-main.php:514
-msgid "Now"
-msgstr "Now"
-
-#: template-parts/chasse/chasse-edition-main.php:524
-msgid "Later"
-msgstr "Later"
-
-#: template-parts/chasse/chasse-edition-main.php:374
+#: template-parts/chasse/chasse-edition-main.php:502
 msgid "Début"
 msgstr "Start"
 
-#: template-parts/chasse/chasse-edition-main.php:554
+#: template-parts/chasse/chasse-edition-main.php:508
+msgid "Now"
+msgstr "Now"
+
+#: template-parts/chasse/chasse-edition-main.php:518
+msgid "Later"
+msgstr "Later"
+
+#: template-parts/chasse/chasse-edition-main.php:549
 msgid "Date de fin"
 msgstr "End date"
 
-#: template-parts/chasse/chasse-edition-main.php:560
+#: template-parts/chasse/chasse-edition-main.php:555
 msgid "Illimitée"
 msgstr "Unlimited"
 
-#: template-parts/chasse/chasse-edition-main.php:569
+#: template-parts/chasse/chasse-edition-main.php:564
 msgid "Limitée"
 msgstr "Limited"
 
-#: template-parts/chasse/chasse-edition-main.php:607
-msgid "En savoir plus sur les points"
-msgstr "Learn more about loyalty points"
-
-#: template-parts/chasse/chasse-edition-main.php:610
-msgid "Coût d’accès à une chasse"
-msgstr "Hunt access cost"
-
-#: template-parts/chasse/chasse-edition-main.php:601 template-parts/enigme/enigme-edition-main.php:434
+#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/enigme/enigme-edition-main.php:601
 msgid "Accès"
 msgstr "Access"
 
-#: template-parts/chasse/chasse-edition-main.php:427
+#: template-parts/chasse/chasse-edition-main.php:603
+msgid "En savoir plus sur les points"
+msgstr "Learn more about loyalty points"
+
+#: inc/edition/edition-core.php:583
+msgid "Non spécifiée"
+msgstr "Not specified"
+
+#: inc/edition/edition-core.php:594
+msgctxt "formatting for dates"
+msgid "j F Y"
+msgstr "F j, Y"
+
+#: template-parts/chasse/chasse-edition-main.php:606
+msgid "Coût d’accès à une chasse"
+msgstr "Hunt access cost"
+
+#: template-parts/chasse/chasse-edition-main.php:607
 msgid ""
 "Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou "
 "payant. Cet accès est indispensable pour consulter les énigmes, qui restent "
@@ -1244,50 +1510,59 @@ msgstr ""
 "is necessary to view the riddles, which remain hidden until it has been "
 "unlocked."
 
-#: template-parts/chasse/chasse-edition-main.php:445
-#: template-parts/enigme/enigme-edition-main.php:394
-#: template-parts/indice/indice-edition-main.php:202
+#: template-parts/chasse/chasse-edition-main.php:617
 msgid "Gratuit"
 msgstr "Free"
 
-#: template-parts/chasse/chasse-edition-main.php:621
-#: template-parts/enigme/enigme-edition-main.php:517
+#: template-parts/chasse/chasse-edition-main.php:625
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:32
+#: template-parts/enigme/enigme-edition-main.php:568
+#: template-parts/organisateur/organisateur-edition-main.php:79
+#: template-parts/organisateur/organisateur-edition-main.php:340
+#: template-parts/organisateur/organisateur-edition-main.php:346
+#: templates/myaccount/content-points.php:75
+#: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
+#: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
+msgid "Points"
+msgstr "Points"
+
+#: template-parts/chasse/chasse-edition-main.php:742
+#: template-parts/enigme/enigme-edition-main.php:663
 msgid "Actualiser"
 msgstr "Refresh"
 
-#: template-parts/chasse/chasse-edition-main.php:554
-#: template-parts/enigme/enigme-edition-main.php:519
+#: template-parts/chasse/chasse-edition-main.php:744
+#: template-parts/enigme/enigme-edition-main.php:665
 msgid "Période :"
 msgstr "Period:"
 
-#: template-parts/chasse/chasse-edition-main.php:568
-#: template-parts/enigme/enigme-edition-main.php:533
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+#: template-parts/chasse/chasse-edition-main.php:758
+#: template-parts/enigme/enigme-edition-main.php:679
 msgid "Participants"
 msgstr "Players"
 
-#: template-parts/chasse/chasse-edition-main.php:575
-#: template-parts/enigme/enigme-edition-main.php:97
-#: template-parts/enigme/enigme-edition-main.php:540
-#: template-parts/enigme/enigme-edition-main.php:578
-#: template-parts/enigme/enigme-edition-main.php:627
+#: template-parts/chasse/chasse-edition-main.php:765
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
+#: template-parts/enigme/enigme-edition-main.php:96
+#: template-parts/enigme/enigme-edition-main.php:686
+#: template-parts/enigme/enigme-edition-main.php:724
+#: template-parts/enigme/enigme-edition-main.php:773
 #: template-parts/enigme/partials/enigme-partial-participants.php:69
 #: templates/myaccount/content-chasses.php:108
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
 msgid "Tentatives"
 msgstr "Attempts"
 
-#: template-parts/chasse/chasse-edition-main.php:582
-#: template-parts/enigme/enigme-edition-main.php:548
+#: template-parts/chasse/chasse-edition-main.php:772
+#: template-parts/enigme/enigme-edition-main.php:694
 msgid "Points collectés"
 msgstr "Points collected"
 
-#: template-parts/chasse/chasse-edition-main.php:589
-#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/chasse/chasse-edition-main.php:779
+#: template-parts/chasse/chasse-edition-main.php:787
 msgid "Taux d'engagement"
 msgstr "Engagement rate"
 
-#: template-parts/chasse/chasse-edition-main.php:592
+#: template-parts/chasse/chasse-edition-main.php:782
 msgid ""
 "Pourcentage moyen d’énigmes auxquelles chaque joueur a participé, par "
 "rapport à l’ensemble des énigmes proposées."
@@ -1295,27 +1570,18 @@ msgstr ""
 "Average percentage of puzzles each player has participated in compared to "
 "all the puzzles offered."
 
-#: template-parts/chasse/chasse-edition-main.php:596
+#: template-parts/chasse/chasse-edition-main.php:786
 msgid "Explication du taux d’engagement"
 msgstr "Engagement Rate Explanation"
 
-#: template-parts/chasse/chasse-edition-main.php:605
+#: template-parts/chasse/chasse-edition-main.php:795
 #: template-parts/enigme/partials/enigme-partial-participants.php:39
 msgid "Les statistiques seront disponibles une fois la chasse activée."
 msgstr "Statistics will be available once hunting is enabled."
 
-#: template-parts/chasse/chasse-edition-main.php:616
+#: template-parts/chasse/chasse-edition-main.php:806
 msgid "Énigmes sans validation"
 msgstr "Puzzles without validation"
-
-#: template-parts/chasse/chasse-edition-main.php:655
-#: template-parts/organisateur/organisateur-edition-main.php:342
-msgid "Communiquez"
-msgstr "Make contact"
-
-#: template-parts/chasse/chasse-edition-main.php:662
-msgid "Sites et réseaux de la chasse"
-msgstr "website and social networks"
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:28
 msgid "Modifier la description de la chasse"
@@ -1325,14 +1591,12 @@ msgstr "Edit Hunt Description"
 #: template-parts/chasse/panneaux/chasse-edition-recompense.php:16
 #: template-parts/enigme/panneaux/enigme-edition-description.php:19
 #: template-parts/enigme/panneaux/enigme-edition-images.php:12
-#: template-parts/indice/panneaux/indice-edition-description.php:19
 msgid "Fermer le panneau"
 msgstr "Close the panel."
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:37
 #: template-parts/enigme/panneaux/enigme-edition-description.php:27
 #: template-parts/enigme/panneaux/enigme-edition-images.php:31
-#: template-parts/indice/panneaux/indice-edition-description.php:26
 msgid "💾 Enregistrer"
 msgstr "Save"
 
@@ -1376,13 +1640,34 @@ msgstr "Save"
 msgid "Supprimer la récompense"
 msgstr "Delete the reward"
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:40
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
-msgid "Joueurs"
-msgstr "Players"
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:33
+#: template-parts/chasse/partials/chasse-partial-participants.php:70
+msgid "Trouvées"
+msgstr "Found"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:35
+msgid "Ajouter un indice"
+msgstr "Add a hint"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:42
+#: template-parts/chasse/partials/chasse-partial-solutions.php:50
+msgid "Pour…"
+msgstr "For…"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:66
+#: template-parts/chasse/partials/chasse-partial-indices.php:77
+#: template-parts/chasse/partials/chasse-partial-solutions.php:79
+#: template-parts/chasse/partials/chasse-partial-solutions.php:93
+msgid "La chasse entière"
+msgstr "The entire hunt"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:89
+#: template-parts/chasse/partials/chasse-partial-solutions.php:108
+msgid "Une énigme de la chasse"
+msgstr "A riddle from the hunt"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:51
-#: template-parts/enigme/enigme-edition-main.php:576
+#: template-parts/enigme/enigme-edition-main.php:722
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:34
 msgid "Joueur"
 msgstr "Player"
@@ -1403,84 +1688,318 @@ msgstr "Participation"
 msgid "Trier par énigmes trouvées"
 msgstr "Sort by found riddles"
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:70
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvées"
-msgstr "Found"
+#: template-parts/chasse/partials/chasse-partial-solutions.php:66
+msgid "Cette énigme"
+msgstr "This riddle"
 
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:36
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:38
-msgid "Nombre"
-msgstr "Count"
+#: template-parts/common/edition-animation.php:53
+msgid "Animation de cette énigme"
+msgstr "Animation of this riddle"
 
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:37
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:39
-msgid "Taux"
-msgstr "Rate"
+#: template-parts/common/edition-animation.php:74
+msgid "Sites et réseaux de la chasse"
+msgstr "website and social networks"
+
+#: template-parts/common/edition-animation.php:100
+#, fuzzy
+msgid "Sites et réseaux de l'organisation"
+msgstr "Organization's websites and social networks"
+
+#: template-parts/common/edition-animation.php:135
+msgid "Arrêt chasse"
+msgstr "End hunt"
+
+#: template-parts/common/edition-animation.php:154
+#, fuzzy
+msgid "Adresse de votre organisation :"
+msgstr "Your organization's QR code"
+
+#: template-parts/common/edition-animation.php:156
+msgid "Adresse de votre chasse&nbsp;:"
+msgstr "Your hunt's address:"
+
+#: template-parts/common/edition-animation.php:161
+#: template-parts/common/edition-animation.php:165
+msgid "QR code de votre organisation"
+msgstr "Your organization's QR code"
+
+#: template-parts/common/edition-animation.php:161
+#: template-parts/common/edition-animation.php:172
+msgid "QR code de votre chasse"
+msgstr "Your hunt's QR code"
+
+#: template-parts/common/edition-animation.php:166
+#, fuzzy
+msgid "Partagez votre organisation en un scan"
+msgstr "Share your hunt with a single scan"
+
+#: template-parts/common/edition-animation.php:167
+#, fuzzy
+msgid ""
+"Facilitez l'accès à votre organisation avec un simple scan. Un QR code évite "
+"de saisir une URL et se partage facilement."
+msgstr ""
+"Make access to your hunt easy with a simple scan. A QR code avoids typing a "
+"URL and is easy to share."
+
+#: template-parts/common/edition-animation.php:169
+#: template-parts/common/edition-animation.php:176
+msgid "Télécharger"
+msgstr "Download"
+
+#: template-parts/common/edition-animation.php:173
+msgid "Partagez votre chasse en un scan"
+msgstr "Share your hunt with a single scan"
+
+#: template-parts/common/edition-animation.php:174
+msgid ""
+"Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de "
+"saisir une URL et se partage facilement."
+msgstr ""
+"Make access to your hunt easy with a simple scan. A QR code avoids typing a "
+"URL and is easy to share."
+
+#: template-parts/common/edition-animation.php:335
+#: template-parts/common/indices-table.php:30
+msgid "en création"
+msgstr "in creation"
+
+#: template-parts/common/edition-animation.php:339
+#: template-parts/common/indices-table.php:32
+msgid "Nouvelle chasse"
+msgstr "New hunt"
+
+#: template-parts/common/edition-animation.php:455
+#: template-parts/common/edition-animation.php:464
+#, php-format
+msgid "Indices pour %s"
+msgstr "Hints for %s"
+
+#: template-parts/common/edition-animation.php:456
+#: template-parts/common/edition-animation.php:462
+#, fuzzy, php-format
+msgid "Indices pour toute la chasse %s"
+msgstr "Solutions for the whole hunt %s"
+
+#: template-parts/common/edition-animation.php:493
+msgid "Sécurité des PDF de solution"
+msgstr "Solution PDF security"
+
+#: template-parts/common/edition-animation.php:494
+msgid "Vos PDF sont conservés dans un coffre-fort numérique"
+msgstr "Your PDFs are stored in a digital safe"
+
+#: template-parts/common/edition-animation.php:496
+msgid "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
+msgstr "Solution PDFs are stored in a protected folder. "
+
+#: template-parts/common/edition-animation.php:497
+msgid "Ils ne seront partagés qu'à la date que vous aurez choisie : "
+msgstr "They will only be released on the date you choose: "
+
+#: template-parts/common/edition-animation.php:498
+msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
+msgstr "right after the hunt ends or after a configurable delay."
+
+#: template-parts/common/edition-animation.php:506
+#: template-parts/common/edition-animation.php:514
+#, php-format
+msgid "Solutions pour %s"
+msgstr "Solutions for %s"
+
+#: template-parts/common/edition-animation.php:507
+#: template-parts/common/edition-animation.php:512
+#, php-format
+msgid "Solutions pour toute la chasse %s"
+msgstr "Solutions for the whole hunt %s"
+
+#: template-parts/common/indices-table.php:34
+#, php-format
+msgid "Vous n'avez publié aucun indice attaché à %s"
+msgstr "You haven't published any clue attached to %s"
+
+#: template-parts/common/indices-table.php:42
+#, php-format
+msgid "%d indice au total"
+msgid_plural "%d indices au total"
+msgstr[0] "%d total hint"
+msgstr[1] "%d total hints"
+
+#: template-parts/common/indices-table.php:45
+#, php-format
+msgid "%d indice chasse"
+msgid_plural "%d indices chasse"
+msgstr[0] "%d hunt hint"
+msgstr[1] "%d hunt hints"
+
+#: template-parts/common/indices-table.php:48
+#, php-format
+msgid "%d indice énigme"
+msgid_plural "%d indices énigme"
+msgstr[0] "%d riddle hint"
+msgstr[1] "%d riddle hints"
+
+#: template-parts/common/indices-table.php:64
+msgid "Indice"
+msgstr "Hint"
+
+#: template-parts/common/indices-table.php:65
+#: template-parts/common/solutions-table.php:123
+msgid "Texte"
+msgstr "Text"
+
+#: template-parts/common/indices-table.php:66
+msgid "Indice pour"
+msgstr "Clue for"
+
+#: template-parts/common/indices-table.php:67
+#: template-parts/common/solutions-table.php:34
+msgid "Action"
+msgstr "Action"
+
+#. translators: %s: scheduled date
+#: template-parts/common/indices-table.php:117
+#, php-format
+msgid "programmé le %s"
+msgstr "scheduled for %s"
+
+#: template-parts/common/indices-table.php:121
+msgid "programmé"
+msgstr "scheduled"
+
+#: template-parts/common/indices-table.php:150
+#: template-parts/common/solutions-table.php:114
+#, php-format
+msgid "à %s"
+msgstr "at %s"
+
+#: template-parts/common/indices-table.php:184
+#, fuzzy
+msgid "Supprimer cet indice ?"
+msgstr "Dismiss this message"
+
+#: template-parts/common/solutions-table.php:23
+#, fuzzy
+msgid "Aucune solution publiée"
+msgstr "no solution"
+
+#: template-parts/common/solutions-table.php:31
+msgid "Solution"
+msgstr "Solution"
+
+#: template-parts/common/solutions-table.php:32
+msgid "Availability"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:33
+msgid "Solution pour"
+msgstr "Solution for"
+
+#: template-parts/common/solutions-table.php:78
+msgid "Invalid solution"
+msgstr "Invalid solution"
+
+#: template-parts/common/solutions-table.php:79
+msgid "Hunt finished"
+msgstr "Hunt finished"
+
+#: template-parts/common/solutions-table.php:80
+msgid "Hunt end delayed"
+msgstr "Hunt end delayed"
+
+#: template-parts/common/solutions-table.php:81
+msgid "Coming soon"
+msgstr "Coming soon"
+
+#: template-parts/common/solutions-table.php:82
+msgid "In progress"
+msgstr "In progress"
+
+#: template-parts/common/solutions-table.php:83
+msgid "Disabled"
+msgstr "Disabled"
+
+#: template-parts/common/solutions-table.php:120
+msgid "PDF"
+msgstr "PDF"
+
+#: template-parts/common/solutions-table.php:132
+#, php-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/solutions-table.php:132
+#, fuzzy
+msgid "at"
+msgstr "Date"
+
+#: template-parts/common/solutions-table.php:162
+#, fuzzy
+msgid "Supprimer cette solution ?"
+msgstr "Dismiss this message"
 
 #: template-parts/common/stat-histogram-card.php:38
 msgid "Aucune donnée."
 msgstr "No data."
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
-#: assets/js/enigme-edit.js:1616
+#: assets/js/enigme-edit.js:1533
 #, fuzzy
 msgid "Ajouter une énigme"
 msgstr "add an image"
 
-#: template-parts/enigme/enigme-edition-main.php:87
+#: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"
 msgstr "Riddle Editing Panel"
 
-#: template-parts/enigme/enigme-edition-main.php:91
-#: template-parts/indice/indice-edition-main.php:56
+#: template-parts/enigme/enigme-edition-main.php:90
 msgid "Fermer les paramètres"
 msgstr "Close settings"
 
-#: template-parts/enigme/enigme-edition-main.php:112
-#: template-parts/indice/indice-edition-main.php:74
+#: template-parts/enigme/enigme-edition-main.php:111
 msgid "Informations"
 msgstr "Information"
 
-#: template-parts/enigme/enigme-edition-main.php:138
+#: template-parts/enigme/enigme-edition-main.php:137
 msgid "renseigner le titre de l’énigme"
 msgstr "enter the riddle title"
 
-#: template-parts/enigme/enigme-edition-main.php:156
+#: template-parts/enigme/enigme-edition-main.php:161
 msgid "Illustrations"
 msgstr "Illustrations"
 
-#: template-parts/enigme/enigme-edition-main.php:194
+#: template-parts/enigme/enigme-edition-main.php:219
 msgid "Texte énigme"
 msgstr "Riddle text"
 
-#: template-parts/enigme/enigme-edition-main.php:213
+#: template-parts/enigme/enigme-edition-main.php:242
 msgid "Éditer le texte"
 msgstr "Edit simple text"
 
-#: template-parts/enigme/enigme-edition-main.php:214
-#: template-parts/enigme/enigme-edition-main.php:350
-#: template-parts/enigme/enigme-edition-main.php:673
+#: template-parts/enigme/enigme-edition-main.php:243
+#: template-parts/enigme/enigme-edition-main.php:461
 msgid "éditer"
 msgstr "edit"
 
-#: template-parts/enigme/enigme-edition-main.php:228
+#: template-parts/enigme/enigme-edition-main.php:270
 msgid "Sous-titre"
 msgstr "Subtitle"
 
-#: template-parts/enigme/enigme-edition-main.php:230
+#: template-parts/enigme/enigme-edition-main.php:276
 msgid "Ajouter un sous-titre (max 100 caractères)"
 msgstr "Add a subtitle (max 100 characters)"
 
-#: template-parts/enigme/enigme-edition-main.php:243
+#: template-parts/enigme/enigme-edition-main.php:307
 msgid "Validation"
 msgstr "Validation"
 
-#: template-parts/enigme/enigme-edition-main.php:256
+#: template-parts/enigme/enigme-edition-main.php:324
 msgid "Validation automatique"
 msgstr "Automatic validation"
 
-#: template-parts/enigme/enigme-edition-main.php:257
+#: template-parts/enigme/enigme-edition-main.php:325
 msgid ""
 "Le joueur soumet une tentative de réponse. Celle-ci est automatiquement "
 "vérifiée selon les critères définis (réponse attendue, respect de la casse, "
@@ -1490,11 +2009,11 @@ msgstr ""
 "the defined criteria (expected answer, case sensitivity, variants), and the "
 "result is immediately communicated to the player."
 
-#: template-parts/enigme/enigme-edition-main.php:273
+#: template-parts/enigme/enigme-edition-main.php:342
 msgid "Validation manuelle"
 msgstr "Manual validation"
 
-#: template-parts/enigme/enigme-edition-main.php:274
+#: template-parts/enigme/enigme-edition-main.php:343
 msgid ""
 "Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa "
 "tentative depuis votre espace personnel. À chaque nouvelle soumission, vous "
@@ -1504,19 +2023,19 @@ msgstr ""
 "attempt from your personal area. Each new submission triggers an email "
 "notification and an alert message."
 
-#: template-parts/enigme/enigme-edition-main.php:281
+#: template-parts/enigme/enigme-edition-main.php:351
 msgid "Aucune"
 msgstr "None"
 
-#: template-parts/enigme/enigme-edition-main.php:288
+#: template-parts/enigme/enigme-edition-main.php:377
 msgid "Bonne(s) réponse(s)"
 msgstr "Correct answer(s)"
 
-#: template-parts/enigme/enigme-edition-main.php:294
+#: template-parts/enigme/enigme-edition-main.php:383
 msgid "La ou les bonnes réponses"
 msgstr "The correct answer(s)"
 
-#: template-parts/enigme/enigme-edition-main.php:295
+#: template-parts/enigme/enigme-edition-main.php:384
 msgid ""
 "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — "
 "selon votre réglage de respect de la casse — résout l’énigme."
@@ -1524,24 +2043,24 @@ msgstr ""
 "You may enter between 1 and 5 correct answers. Any player submitting one—"
 "depending on your case sensitivity setting—solves the puzzle."
 
-#: template-parts/enigme/enigme-edition-main.php:307
+#: template-parts/enigme/enigme-edition-main.php:397
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
 msgid "Respecter la casse"
 msgstr "Case sensitive"
 
-#: template-parts/enigme/enigme-edition-main.php:315
+#: template-parts/enigme/enigme-edition-main.php:423
 msgid "Variantes"
 msgstr "Variants"
 
-#: template-parts/enigme/enigme-edition-main.php:321
+#: template-parts/enigme/enigme-edition-main.php:429
 msgid "Explication des variantes"
 msgstr "Explanation of variants"
 
-#: template-parts/enigme/enigme-edition-main.php:324
+#: template-parts/enigme/enigme-edition-main.php:432
 msgid "Système de variantes"
 msgstr "Variants system"
 
-#: template-parts/enigme/enigme-edition-main.php:325
+#: template-parts/enigme/enigme-edition-main.php:433
 msgid ""
 "Les variantes sont des réponses alternatives qui ne sont pas validées comme "
 "correctes, mais qui déclenchent un message personnalisé en retour (par "
@@ -1551,67 +2070,44 @@ msgstr ""
 "trigger a personalized message in return (for example a help message, a "
 "hint, a link or any other content of your choice)."
 
-#: template-parts/enigme/enigme-edition-main.php:335
-#: assets/js/enigme-edit.js:915
+#: template-parts/enigme/enigme-edition-main.php:446
+#: assets/js/enigme-edit.js:1174
 #, fuzzy
 msgid "Variante"
 msgstr "Variants"
 
-#: template-parts/enigme/enigme-edition-main.php:336
-#: assets/js/enigme-edit.js:918
+#: template-parts/enigme/enigme-edition-main.php:447
+#: assets/js/enigme-edit.js:1177
 msgid "Message"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:349
+#: template-parts/enigme/enigme-edition-main.php:460
 msgid "Éditer les variantes"
 msgstr "Edit Variants"
 
-#: template-parts/enigme/enigme-edition-main.php:354
-#: assets/js/enigme-edit.js:966
+#: template-parts/enigme/enigme-edition-main.php:465
+#: assets/js/enigme-edit.js:1225
 msgid "Ajouter des variantes"
 msgstr "Add variations"
 
-#: template-parts/enigme/enigme-edition-main.php:355
-#: assets/js/enigme-edit.js:967
+#: template-parts/enigme/enigme-edition-main.php:466
+#: assets/js/enigme-edit.js:1226
 msgid "ajouter des variantes"
 msgstr "Add variations"
 
-#: template-parts/enigme/enigme-edition-main.php:371
-msgid "Coût tentative"
-msgstr "Attempt cost"
-
-#: template-parts/enigme/enigme-edition-main.php:377
-#, fuzzy
-msgid "Informations sur le coût des tentatives"
-msgstr "Bank details information"
-
-#: template-parts/enigme/enigme-edition-main.php:380
-msgid "Tentative gratuite ou payante ?"
-msgstr "Free or paid attempt?"
-
-#: template-parts/enigme/enigme-edition-main.php:381
-msgid ""
-"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
-"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
-"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
-msgstr ""
-"You are free to set the cost of an attempt for your riddle: free or paid in "
-"points. When a player spends points to submit an answer, those points are "
-"immediately credited to your account."
-
-#: template-parts/enigme/enigme-edition-main.php:402
+#: template-parts/enigme/enigme-edition-main.php:491
 msgid "Nb tentatives"
 msgstr "Attempts"
 
-#: template-parts/enigme/enigme-edition-main.php:408
+#: template-parts/enigme/enigme-edition-main.php:497
 msgid "Explication du nombre de tentatives"
 msgstr "Explanation of the number of attempts"
 
-#: template-parts/enigme/enigme-edition-main.php:411
+#: template-parts/enigme/enigme-edition-main.php:500
 msgid "Plafond nb de tentatives quotidiennes"
 msgstr "Daily attempt limit"
 
-#: template-parts/enigme/enigme-edition-main.php:412
+#: template-parts/enigme/enigme-edition-main.php:501
 #, fuzzy
 msgid ""
 "Nombre maximal de tentatives quotidiennes par joueur:\n"
@@ -1623,156 +2119,77 @@ msgstr ""
 "Maximum number of daily attempts per player:\\n\\nPaid mode: "
 "unlimited\\n\\nFree mode: 24 attempts per day"
 
-#: template-parts/enigme/enigme-edition-main.php:418
+#: template-parts/enigme/enigme-edition-main.php:513
 msgid "max par jour"
 msgstr "max per day"
 
-#: template-parts/enigme/enigme-edition-main.php:438
+#: template-parts/enigme/enigme-edition-main.php:543
+msgid "Coût tentative"
+msgstr "Attempt cost"
+
+#: template-parts/enigme/enigme-edition-main.php:549
+#, fuzzy
+msgid "Informations sur le coût des tentatives"
+msgstr "Bank details information"
+
+#: template-parts/enigme/enigme-edition-main.php:552
+msgid "Tentative gratuite ou payante ?"
+msgstr "Free or paid attempt?"
+
+#: template-parts/enigme/enigme-edition-main.php:553
+msgid ""
+"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
+"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
+"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
+msgstr ""
+"You are free to set the cost of an attempt for your riddle: free or paid in "
+"points. When a player spends points to submit an answer, those points are "
+"immediately credited to your account."
+
+#: template-parts/enigme/enigme-edition-main.php:563
+msgid "Free"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:607
 msgid "Libre"
 msgstr "Free"
 
-#: template-parts/enigme/enigme-edition-main.php:442
+#: template-parts/enigme/enigme-edition-main.php:612
 msgid "Date programmée"
 msgstr "Schedule Date "
 
-#: template-parts/enigme/enigme-edition-main.php:455
-msgid "Aucune autre énigme disponible comme prérequis."
-msgstr "No other puzzles available as prerequisites."
-
-#: template-parts/enigme/enigme-edition-main.php:491
+#: template-parts/enigme/enigme-edition-main.php:637
 msgid "❌ Suppression énigme"
 msgstr "❌ Delete riddle"
 
-#: template-parts/enigme/enigme-edition-main.php:521
+#: template-parts/enigme/enigme-edition-main.php:667
 msgid "Total"
 msgstr "Total"
 
-#: template-parts/enigme/enigme-edition-main.php:522
+#: template-parts/enigme/enigme-edition-main.php:668
 msgid "Aujourd’hui"
 msgstr "Today"
 
-#: template-parts/enigme/enigme-edition-main.php:523
+#: template-parts/enigme/enigme-edition-main.php:669
 msgid "Semaine"
 msgstr "Week"
 
-#: template-parts/enigme/enigme-edition-main.php:524
+#: template-parts/enigme/enigme-edition-main.php:670
 msgid "Mois"
 msgstr "Month"
 
-#: template-parts/enigme/enigme-edition-main.php:556
+#: template-parts/enigme/enigme-edition-main.php:702
 msgid "Bonnes réponses"
 msgstr "Correct answers"
 
-#: template-parts/enigme/enigme-edition-main.php:570
+#: template-parts/enigme/enigme-edition-main.php:716
 #, php-format
 msgid "Résolue par (%s) joueurs"
 msgstr "Solved by (%s) players"
 
-#: template-parts/enigme/enigme-edition-main.php:575
+#: template-parts/enigme/enigme-edition-main.php:721
 msgid "Rang"
 msgstr "Rank"
-
-#: template-parts/enigme/enigme-edition-main.php:655
-msgid "Animation de cette énigme"
-msgstr "Animation of this riddle"
-
-#: template-parts/enigme/enigme-edition-main.php:667
-msgid ""
-"Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée "
-"terminée. Une fois celle-ci achevée, elles restent conservées dans un coffre-"
-"fort numérique pendant le délai que vous définissez ici."
-msgstr ""
-"Solutions can only be published once a hunt is declared over. After that, "
-"they are stored in a digital safe for the delay you set here."
-
-#: template-parts/enigme/enigme-edition-main.php:670
-msgid "Document PDF"
-msgstr "PDF document"
-
-#: template-parts/enigme/enigme-edition-main.php:671
-#: templates/myaccount/content-outils.php:33
-msgid "Modifier"
-msgstr "Edit"
-
-#: template-parts/enigme/enigme-edition-main.php:671
-msgid "Choisir un fichier"
-msgstr "Choose a file"
-
-#: template-parts/enigme/enigme-edition-main.php:673
-msgid "Rédiger"
-msgstr "Write"
-
-#: template-parts/enigme/enigme-edition-main.php:675
-msgid "aucune solution ne"
-msgstr "no solution"
-
-#: template-parts/enigme/enigme-edition-main.php:680
-#, php-format
-msgid "votre fichier %s"
-msgstr "your %s file"
-
-#: template-parts/enigme/enigme-edition-main.php:681
-#, php-format
-msgid " %d jours après la fin de la chasse, à %s"
-msgstr " %d days after the end of the hunt, at %s"
-
-#: template-parts/enigme/enigme-edition-main.php:683
-msgid " (pdf sélectionné mais pas de fichier chargé)"
-msgstr " (pdf selected but no file uploaded)"
-
-#: template-parts/enigme/enigme-edition-main.php:687
-msgid "votre texte d'explication"
-msgstr "your explanation text"
-
-#: template-parts/enigme/enigme-edition-main.php:688
-#, php-format
-msgid ", %d jours après la fin de la chasse, à %s"
-msgstr ", %d days after the end of the hunt, at %s"
-
-#: template-parts/enigme/enigme-edition-main.php:690
-msgid " (rédaction libre sélectionnée mais non remplie)"
-msgstr " (free writing selected but not filled)"
-
-#: template-parts/enigme/enigme-edition-main.php:702
-#: template-parts/enigme/enigme-edition-main.php:710
-msgid "Vider"
-msgstr "Clear"
-
-#: template-parts/enigme/enigme-edition-main.php:712
-msgid "Rédaction libre"
-msgstr "Free writing"
-
-#: template-parts/enigme/enigme-edition-main.php:720
-msgid "Délai après fin de chasse"
-msgstr "Delay after hunt end"
-
-#: template-parts/enigme/enigme-edition-main.php:726
-msgid "Informations sur la publication de la solution"
-msgstr "Solution Release Information"
-
-#: template-parts/enigme/enigme-edition-main.php:729
-msgid "Délai de parution des solutions"
-msgstr "Solutions release delay"
-
-#: template-parts/enigme/enigme-edition-main.php:745
-msgid "jours, publié à"
-msgstr "days, published at"
-
-#: template-parts/enigme/enigme-edition-main.php:760
-msgid "Vos solutions sont protégées"
-msgstr "Your solutions are protected"
-
-#: template-parts/enigme/enigme-edition-main.php:761
-msgid "Stockées dans un espace privé, hors de portée des joueurs."
-msgstr "Stored in a private area, out of players' reach."
-
-#: template-parts/enigme/enigme-edition-main.php:762
-msgid "Aucun lien ne peut être trouvé ni ouvert."
-msgstr "No link can be found or opened."
-
-#: template-parts/enigme/enigme-edition-main.php:763
-msgid "Débloquées uniquement au moment choisi."
-msgstr "Unlocked only at the chosen time."
 
 #: template-parts/enigme/panneaux/enigme-edition-description.php:18
 msgid "Modifier le texte de l’énigme"
@@ -1795,12 +2212,12 @@ msgid "Configurer les variantes de réponse"
 msgstr "Configure answer variants"
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:50
-#: assets/js/enigme-edit.js:826
+#: assets/js/enigme-edit.js:1084
 msgid "réponse déclenchant l'affichage du message"
 msgstr "response triggering the display of the message"
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:51
-#: assets/js/enigme-edit.js:829
+#: assets/js/enigme-edit.js:1087
 msgid "Message affiché au joueur"
 msgstr "Message displayed to player"
 
@@ -1954,64 +2371,6 @@ msgstr "🏴‍☠️ Text (pirate)"
 msgid "🏴‍☠️ Titre (pirate)"
 msgstr "🏴‍☠️ Title (pirate)"
 
-#: template-parts/indice/indice-edition-main.php:53
-msgid "Panneau d'édition indice"
-msgstr "Clue edit panel"
-
-#: template-parts/indice/indice-edition-main.php:95
-msgid "renseigner le titre de l’indice"
-msgstr "enter the clue title"
-
-#: template-parts/indice/indice-edition-main.php:105
-msgid "Image"
-msgstr "Image"
-
-#: template-parts/indice/indice-edition-main.php:124
-msgid "Texte"
-msgstr "Text"
-
-#: template-parts/indice/indice-edition-main.php:136
-#: template-parts/indice/panneaux/indice-edition-description.php:18
-msgid "Modifier le texte de l’indice"
-msgstr "Edit the clue text"
-
-#: template-parts/indice/indice-edition-main.php:151
-msgid "Aide pour"
-msgstr "Help for"
-
-#: template-parts/indice/indice-edition-main.php:158
-msgid "Aucune énigme disponible."
-msgstr "No puzzle available."
-
-#: template-parts/indice/indice-edition-main.php:184
-msgid "Publication"
-msgstr "Publishing"
-
-#: template-parts/indice/indice-edition-main.php:186
-msgid "Immédiate"
-msgstr "Immediate"
-
-#: template-parts/indice/indice-edition-main.php:187
-msgid "Différée"
-msgstr "Delayed"
-
-#: template-parts/indice/indice-edition-main.php:198
-msgid "(points)"
-msgstr "(points)"
-
-#: template-parts/indice/indice-edition-main.php:221
-#, fuzzy
-msgid "Statistiques à venir"
-msgstr "Statistics"
-
-#: template-parts/indice/panneaux/indice-edition-description.php:31
-msgid "Texte de l’indice mis à jour."
-msgstr "Clue text updated."
-
-#: inc/edition/edition-core.php:149
-msgid "Texte de l’indice"
-msgstr "Clue text"
-
 #: template-parts/modals/modal-points.php:9
 msgid "À quoi servent les points ?"
 msgstr "What are points used for?"
@@ -2038,52 +2397,73 @@ msgid ""
 "organisateur."
 msgstr "Free access or point access is chosen freely by each organizer."
 
-#: template-parts/organisateur/organisateur-edition-main.php:69
+#: template-parts/organisateur/organisateur-edition-main.php:70
 msgid "Panneau d'édition organisateur"
 msgstr "Organizer Edit Panel"
 
-#: template-parts/chasse/chasse-edition-main.php:629
-#: template-parts/organisateur/organisateur-edition-main.php:78
-#: template-parts/organisateur/organisateur-edition-main.php:264
-#: template-parts/organisateur/organisateur-edition-main.php:270
-#: templates/myaccount/content-points.php:75
-#: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
-#: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:32
-msgid "Points"
-msgstr "Points"
+#: template-parts/organisateur/organisateur-edition-main.php:120
+msgid "renseigner le titre de l’organisateur"
+msgstr "enter the organizer title"
 
-#: template-parts/organisateur/organisateur-edition-main.php:153
+#: template-parts/organisateur/organisateur-edition-main.php:144
+msgid "Logo organisateur"
+msgstr "Organizer logo"
+
+#: template-parts/organisateur/organisateur-edition-main.php:159
+msgid "Modifier le logo"
+msgstr "Edit logo"
+
+#: template-parts/organisateur/organisateur-edition-main.php:162
+#: template-parts/organisateur/organisateur-edition-main.php:172
+msgid "Logo de l’organisateur"
+msgstr "Organizer logo"
+
+#: template-parts/organisateur/organisateur-edition-main.php:204
 msgid "Présentation"
 msgstr "Presentation"
 
-#: template-parts/organisateur/organisateur-edition-main.php:173
+#: template-parts/organisateur/organisateur-edition-main.php:230
 msgid "Modifier la présentation"
 msgstr "Edit showcase"
 
-#: template-parts/organisateur/organisateur-edition-main.php:207
+#: template-parts/organisateur/organisateur-edition-main.php:265
+#, fuzzy
+msgid "Email de contact"
+msgstr "Organizer contact email"
+
+#: template-parts/organisateur/organisateur-edition-main.php:279
 msgid "Informations sur l’adresse email de contact"
 msgstr "Contact Email Address Information"
 
-#: template-parts/organisateur/organisateur-edition-main.php:209
+#: template-parts/organisateur/organisateur-edition-main.php:281
 msgid "Email de contact organisateur"
 msgstr "Organizer contact email"
 
-#: template-parts/organisateur/organisateur-edition-main.php:210
+#: template-parts/organisateur/organisateur-edition-main.php:282
 msgid ""
 "Si aucune adresse n’est renseignée, votre adresse email utilisateur est "
 "utilisée par défaut."
 msgstr "If no address is provided, your user email is used by default."
 
-#: template-parts/organisateur/organisateur-edition-main.php:293
-msgid "Informations sur les coordonnées bancaires"
-msgstr "Bank details information"
+#: template-parts/organisateur/organisateur-edition-main.php:290
+#, fuzzy
+msgid "Modifier l’adresse email de contact"
+msgstr "Contact Email Address Information"
 
-#: template-parts/organisateur/organisateur-edition-main.php:296
+#: template-parts/organisateur/organisateur-edition-main.php:305
+msgid "exemple@domaine.com"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:363
+#: template-parts/organisateur/organisateur-edition-main.php:372
 msgid "Coordonnées bancaires"
 msgstr "Bank details"
 
-#: template-parts/organisateur/organisateur-edition-main.php:297
+#: template-parts/organisateur/organisateur-edition-main.php:369
+msgid "Informations sur les coordonnées bancaires"
+msgstr "Bank details information"
+
+#: template-parts/organisateur/organisateur-edition-main.php:373
 msgid ""
 "Ces informations sont nécessaires uniquement pour vous verser les gains "
 "issus de la conversion de vos points en euros. Nous ne prélevons jamais "
@@ -2092,31 +2472,15 @@ msgstr ""
 "This information is only necessary to pay you the winnings from the "
 "conversion of your points into euros. We never take money."
 
-#: template-parts/organisateur/organisateur-edition-main.php:352
+#: template-parts/organisateur/organisateur-header.php:59
 #, fuzzy
-msgid "Sites et réseaux de l'organisation"
-msgstr "Organization's websites and social networks"
+msgid "Voir la page de l\\u2019organisateur"
+msgstr "Organizer logo"
 
-#: template-parts/organisateur/organisateur-edition-main.php:380
-msgid "QR code de l'organisation"
-msgstr "Organization QR code"
-
-#: template-parts/organisateur/organisateur-edition-main.php:381
-msgid "QR code de votre organisation"
-msgstr "Your organization's QR code"
-
-#: template-parts/chasse/chasse-edition-main.php:863
-msgid "QR code de la chasse"
-msgstr "Hunt QR code"
-
-#: template-parts/chasse/chasse-edition-main.php:864
-msgid "QR code de votre chasse"
-msgstr "Your hunt's QR code"
-
-#: template-parts/chasse/chasse-edition-main.php:866
-#: template-parts/organisateur/organisateur-edition-main.php:383
-msgid "Télécharger"
-msgstr "Download"
+#: template-parts/organisateur/organisateur-header.php:61
+#, fuzzy
+msgid "Logo de l\\u2019organisateur"
+msgstr "Organizer logo"
 
 #: templates/myaccount/content-chasses.php:111
 #, php-format
@@ -2138,23 +2502,6 @@ msgid "%d bonne réponse"
 msgid_plural "%d bonnes réponses"
 msgstr[0] "%d correct answer"
 msgstr[1] "%d correct answers"
-
-#: templates/myaccount/content-chasses.php:125
-#: inc/edition/edition-core.php:158
-msgid "Énigme"
-msgstr "Riddle"
-
-#: inc/edition/edition-core.php:159
-msgid "Sélectionner une énigme"
-msgstr "Select a riddle"
-
-#: inc/edition/edition-core.php:160
-msgid "Sélectionnez une énigme"
-msgstr "Please select a riddle"
-
-#: inc/edition/edition-core.php:161
-msgid "Chargement…"
-msgstr "Loading…"
 
 #: templates/myaccount/content-dashboard-organisateur.php:25
 msgid "Votre demande de conversion a bien été envoyée."
@@ -2334,53 +2681,44 @@ msgstr ""
 "✉️ A verification email has been sent to you. Please click on the link to "
 "confirm your request."
 
+#: assets/js/chasse-edit.js:328
+msgid "Voulez-vous vraiment supprimer la récompense ?"
+msgstr "Do you really want to delete the reward?"
+
+#: assets/js/chasse-edit.js:527
+msgid "Voulez-vous vraiment arrêter la chasse ?"
+msgstr "Do you really want to end the hunt?"
+
 #: assets/js/enigme-aside.js:15
 #, fuzzy
 msgid "Afficher le panneau"
 msgstr "Close the panel."
 
-#: assets/js/enigme-edit.js:600
+#: assets/js/enigme-edit.js:857
 msgid "Ex : soleil"
 msgstr "E.g. sun"
 
-#: assets/js/enigme-edit.js:605 assets/js/enigme-edit.js:657
+#: assets/js/enigme-edit.js:862 assets/js/enigme-edit.js:914
 msgid "valider"
 msgstr "Validate"
 
-#: assets/js/enigme-edit.js:629
-msgid "Supprimer"
-msgstr "Remove"
-
-#: assets/js/enigme-edit.js:703
+#: assets/js/enigme-edit.js:960
 #, fuzzy
 msgid "Ajouter une illustration"
 msgstr "Add variation"
 
-#: assets/js/enigme-edit.js:742 assets/js/enigme-edit.js:987
+#: assets/js/enigme-edit.js:1000 assets/js/enigme-edit.js:1246
 msgid "Modifier les variantes"
 msgstr "Change Variants"
 
-#: assets/js/enigme-edit.js:878
-msgid "Enregistrement..."
-msgstr "Registration"
-
-#: assets/js/enigme-edit.js:898
-msgid "✔️ Variantes enregistrées"
-msgstr "Saved ✔️ Variants"
-
-#: assets/js/enigme-edit.js:1005
+#: assets/js/enigme-edit.js:1264
 msgid "❌ Erreur réseau"
 msgstr "Network error"
 
-#: assets/js/enigme-edit.js:1663
+#: assets/js/enigme-edit.js:1580
 #, fuzzy
 msgid "Erreur lors de l'enregistrement de l'ordre"
 msgstr "Error creating hunt."
-
-#: assets/js/help-modal.js:19
-#, fuzzy
-msgid "Fermer"
-msgstr "<g x=1 id=\"40\">Close Chart</g>"
 
 #: assets/js/reponse-automatique.js:35
 msgid ""
@@ -2414,376 +2752,8 @@ msgstr "Your answer"
 msgid "Tentatives quotidiennes"
 msgstr "Daily Attempts"
 
-#: template-parts/common/indices-table.php:29
-msgid "Vous n'avez publié aucun indice attaché à %s"
-msgstr "You haven't published any clue attached to %s"
-
-#: template-parts/common/indices-table.php:25
-msgid "en création"
-msgstr "in creation"
-
-#: template-parts/common/indices-table.php:27
-msgid "Nouvelle chasse"
-msgstr "New hunt"
-
-#: template-parts/common/indices-table.php:40
-msgid "Indice pour"
-msgstr "Clue for"
-
-#: template-parts/common/indices-table.php:41
-msgid "Titre contenu"
-msgstr "Content title"
-
-#: template-parts/common/indices-table.php:44
-msgid "Action"
-msgstr "Action"
-
-msgid "Modifier la récompense"
-msgstr "Edit the reward"
-
-msgid "Ajouter la récompense"
-msgstr "Add the reward"
-
-#: template-parts/chasse/chasse-edition-main.php:112
-#: assets/js/core/resume.js:322
-msgid "renseigner le titre de la chasse"
-msgstr "enter the hunt title"
-
-#: template-parts/organisateur/organisateur-edition-main.php:120
-msgid "renseigner le titre de l’organisateur"
-msgstr "enter the organizer title"
-
-#: assets/js/chasse-edit.js:376
-msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
-msgstr "Please enter a value in euros between 0 and 5,000,000."
-
-#: assets/js/chasse-edit.js:318
-msgid "Voulez-vous vraiment supprimer la récompense ?"
-msgstr "Do you really want to delete the reward?"
-
-#: assets/js/chasse-edit.js
-msgid "Voulez-vous vraiment arrêter la chasse ?"
-msgstr "Do you really want to end the hunt?"
-
-#: template-parts/chasse/chasse-edition-main.php
-msgid "Arrêt chasse"
-msgstr "End hunt"
-
-#: inc/edition/edition-core.php
-msgid "Choisir une image"
-msgstr "Choose an image"
-
-#: inc/edition/edition-core.php
-msgid "Au moins une image ou un texte nécessaire"
-msgstr "At least one image or text required"
-
-#: inc/edition/edition-core.php
-msgid "Date et heure requises"
-msgstr "Date and time required"
-
-#: inc/edition/edition-core.php
-msgid "Date invalide"
-msgstr "Invalid date"
-
-#: template-parts/common/indices-table.php:69
-msgid "accessible"
-msgstr "accessible"
-
-#: template-parts/common/indices-table.php:69
-msgid "programme"
-msgstr "scheduled"
-
-#: template-parts/common/indices-table.php:83
-msgid "programmé"
-msgstr "scheduled"
-
-#: template-parts/common/indices-table.php:75
-#, php-format
-msgid "programmé le %s"
-msgstr "scheduled for %s"
-
-#: template-parts/common/indices-table.php:41
-#, php-format
-msgid "%d indice au total"
-msgid_plural "%d indices au total"
-msgstr[0] "%d total hint"
-msgstr[1] "%d total hints"
-
-#: template-parts/common/indices-table.php:44
-#, php-format
-msgid "%d indice chasse"
-msgid_plural "%d indices chasse"
-msgstr[0] "%d hunt hint"
-msgstr[1] "%d hunt hints"
-
-#: template-parts/common/indices-table.php:47
-#, php-format
-msgid "%d indice énigme"
-msgid_plural "%d indices énigme"
-msgstr[0] "%d riddle hint"
-msgstr[1] "%d riddle hints"
-
-#: template-parts/common/indices-table.php:55
-msgid "Indice"
-msgstr "Hint"
-
-#: template-parts/common/indices-table.php:136
-#, php-format
-msgid "à %s"
-msgstr "at %s"
-
-#: template-parts/chasse/chasse-edition-main.php:867 template-parts/chasse/chasse-edition-main.php:986
-msgid "Solution"
-msgstr "Solution"
-
-#: template-parts/chasse/chasse-edition-main.php:974
-msgid "Partagez votre chasse en un scan"
-msgstr "Share your hunt with a single scan"
-
-#: template-parts/chasse/chasse-edition-main.php:975
-msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
-msgstr "Make access to your hunt easy with a simple scan. A QR code avoids typing a URL and is easy to share."
-
-#: template-parts/chasse/chasse-edition-main.php:987
-msgid "Contenu de la solution à venir."
-msgstr "Solution content coming soon."
-
-#: template-parts/chasse/chasse-edition-main.php:976
-msgid "Adresse de votre chasse&nbsp;:"
-msgstr "Your hunt's address:"
-
-#: template-parts/common/solutions-table.php:33
-msgid "Solution pour"
-msgstr "Solution for"
-
-#: template-parts/common/solutions-table.php:105
-msgid "PDF"
-msgstr "PDF"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Invalid solution"
-msgstr "Invalid solution"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Hunt finished"
-msgstr "Hunt finished"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Hunt end delayed"
-msgstr "Hunt end delayed"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Coming soon"
-msgstr "Coming soon"
-
-#: template-parts/common/solutions-table.php:???
-msgid "In progress"
-msgstr "In progress"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Disabled"
-msgstr "Disabled"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Coming on %s"
-msgstr "Coming on %s"
-
-#: inc/edition/edition-core.php:180
-msgid "Texte de la solution"
-msgstr "Solution text"
-
-#: inc/edition/edition-core.php:181
-msgid "Fichier"
-msgstr "File"
-
-#: inc/edition/edition-core.php inc/edition/edition-core.php:182
-msgid "Disponibilité"
-msgstr "Availability"
-
-#: inc/edition/edition-core.php:187 template-parts/chasse/partials/chasse-partial-solutions.php:24
-msgid "Ajouter une solution"
-msgstr "Add a solution"
-
-#: inc/edition/edition-core.php:195
-msgid "Ajoutez un fichier ou un texte"
-msgstr "Add a file or text"
-
-#: inc/edition/edition-core.php:200
-msgid "Aucun fichier choisi"
-msgstr "No file selected"
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:47
-#: inc/edition/edition-enigme.php:62
-msgid "Il existe déjà une solution pour cette chasse"
-msgstr "A solution already exists for this hunt"
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:33
-#: inc/edition/edition-enigme.php:63
-msgid "Il existe déjà une solution pour cette énigme"
-msgstr "A solution already exists for this riddle"
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:62
-msgid "Toutes les énigmes de la chasse ont déjà une solution"
-msgstr "All riddles in this hunt already have a solution"
-
-#: template-parts/chasse/chasse-edition-main.php:987
-msgid "Sécurité des PDF de solution"
-msgstr "Solution PDF security"
-
-#: template-parts/chasse/chasse-edition-main.php:988
-msgid "Vos PDF sont conservés dans un coffre-fort numérique"
-msgstr "Your PDFs are stored in a digital safe"
-
-#: template-parts/chasse/chasse-edition-main.php:991
-msgid "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
-msgstr "Solution PDFs are stored in a protected folder. "
-
-#: template-parts/chasse/chasse-edition-main.php:995
-msgid "Ils ne seront partagés qu'à la date que vous aurez choisie : "
-msgstr "They will only be released on the date you choose: "
-
-#: template-parts/chasse/chasse-edition-main.php:999
-msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
-msgstr "right after the hunt ends or after a configurable delay."
-
-#: template-parts/organisateur/organisateur-edition-main.php:144
-msgid "Logo organisateur"
-msgstr "Organizer logo"
-
-#: template-parts/organisateur/organisateur-edition-main.php:159
-msgid "Modifier le logo"
-msgstr "Edit logo"
-
-#: template-parts/organisateur/organisateur-edition-main.php:162
-#: template-parts/organisateur/organisateur-edition-main.php:172
-msgid "Logo de l’organisateur"
-msgstr "Organizer logo"
-
-#: template-parts/common/edition-animation.php:512
-msgid "Solutions pour toute la chasse %s"
-msgstr "Solutions for the whole hunt %s"
-
-#: template-parts/common/edition-animation.php:514
-msgid "Solutions pour %s"
-msgstr "Solutions for %s"
-
-#: template-parts/common/edition-animation.php:521
-#: inc/edition/edition-enigme.php:64
-msgid "Voir toutes les solutions de la chasse"
-msgstr "See all hunt solutions"
-
-#: inc/edition/edition-enigme.php:65
-msgid "Voir la solution de cette énigme"
-msgstr "See this riddle's solution"
-
-#: template-parts/chasse/chasse-affichage-complet.php:263
-msgid "Limite"
-msgstr "Limit"
-
-#: template-parts/chasse/chasse-affichage-complet.php:264
-#, php-format
-msgid "%d gagnants"
-msgstr "%d winners"
-
-#: template-parts/chasse/chasse-affichage-complet.php:269
-msgid "Fin de chasse"
-msgstr "Hunt end"
-
-#: template-parts/chasse/chasse-affichage-complet.php:280
-msgid "Accès chasse"
-msgstr "Hunt access"
-
-#: template-parts/chasse/chasse-affichage-complet.php:284
-msgid "libre"
-msgstr "free"
-
-#: template-parts/chasse/chasse-affichage-complet.php:289
-msgid "Accès énigme"
-msgstr "Riddle access"
-
-#: template-parts/chasse/chasse-affichage-complet.php:305
-msgid "gratuit"
-msgstr "free"
-
-#: template-parts/chasse/chasse-affichage-complet.php:345
-msgid "Les + avancés"
-msgstr "Most advanced"
-
-#: template-parts/chasse/chasse-affichage-complet.php:363
-msgid "Récompense :"
-msgstr "Reward:"
-
-#: template-parts/chasse/chasse-affichage-complet.php:375
-msgid "Description complète :"
-msgstr "Full description:"
-
-#: inc/chasse-functions.php:606
-msgid "S'identifier"
-msgstr "Sign in"
-
-#: inc/chasse-functions.php:607
-msgid "Vous devez être identifié pour participer à cette chasse"
-msgstr "You must be logged in to participate in this hunt"
-
-#: inc/chasse-functions.php:639
-msgid "Chasse disponible à partir du %s"
-msgstr "Hunt available from %s"
-
-#: inc/chasse-functions.php:641
-msgid "Chasse disponible prochainement"
-msgstr "Hunt available soon"
-
-#: inc/chasse-functions.php:672
-msgid "Accès libre à cette chasse. Les tentatives seront tarifées individuellement."
-msgstr "Free access to this hunt. Attempts will be charged individually."
-
-#: inc/chasse-functions.php:683
-msgid "Cette chasse est terminée depuis le %s"
-msgstr "This hunt has ended since %s"
-
-#: inc/chasse-functions.php:685
-msgid "Cette chasse est terminée"
-msgstr "This hunt is over"
-
-#: inc/organisateur-functions.php:220
-msgid "Coordonnées bancaires manquantes"
-msgstr "Missing bank details"
-
-#: inc/organisateur-functions.php:221
-msgid "Nous avons besoin d'enregistrer vos coordonnées bancaires pour vous envoyer un versement"
-msgstr "We need to record your bank details to send you a payout"
-
-#: inc/organisateur-functions.php:235
-msgid "renseigner coordonnées bancaires"
-msgstr "enter bank details"
-
-#: inc/edition/edition-core.php:583
-msgid "Non spécifiée"
-msgstr "Not specified"
-
-#: inc/edition/edition-core.php:594
-msgctxt "formatting for dates"
-msgid "j F Y"
-msgstr "F j, Y"
-
-#: inc/user-functions.php:588
-#. translators: %s: hunt title with link
-msgid "Demande pour %s en cours de traitement"
-msgstr "Request for %s is being processed"
-
-#: template-parts/chasse/chasse-affichage-complet.php:279
-#: assets/js/chasse-edit.js:1144
-msgid "illimité"
-msgstr "unlimited"
-
-#: template-parts/chasse/chasse-affichage-complet.php:281
-#: assets/js/chasse-edit.js:1147
-msgid "%d gagnant"
-msgid_plural "%d gagnants"
-msgstr[0] "%d winner"
-msgstr[1] "%d winners"
-
-#: inc/user-functions.php:693 inc/user-functions.php:711 inc/user-functions.php:736
+#: inc/user-functions.php:693 inc/user-functions.php:711
+#: inc/user-functions.php:736
 msgid "Unauthorized"
 msgstr "Unauthorized"
 
@@ -2822,3 +2792,195 @@ msgid "%d jour restant"
 msgid_plural "%d jours restants"
 msgstr[0] "%d day remaining"
 msgstr[1] "%d days remaining"
+
+#~ msgid "lié à"
+#~ msgstr "linked to"
+
+#~ msgid "Communiquez"
+#~ msgstr "Make contact"
+
+#~ msgid "Nombre"
+#~ msgstr "Count"
+
+#~ msgid "Taux"
+#~ msgstr "Rate"
+
+#~ msgid "Aucune autre énigme disponible comme prérequis."
+#~ msgstr "No other puzzles available as prerequisites."
+
+#~ msgid ""
+#~ "Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée "
+#~ "terminée. Une fois celle-ci achevée, elles restent conservées dans un "
+#~ "coffre-fort numérique pendant le délai que vous définissez ici."
+#~ msgstr ""
+#~ "Solutions can only be published once a hunt is declared over. After that, "
+#~ "they are stored in a digital safe for the delay you set here."
+
+#~ msgid "Document PDF"
+#~ msgstr "PDF document"
+
+#~ msgid "Rédiger"
+#~ msgstr "Write"
+
+#, php-format
+#~ msgid "votre fichier %s"
+#~ msgstr "your %s file"
+
+#, php-format
+#~ msgid " %d jours après la fin de la chasse, à %s"
+#~ msgstr " %d days after the end of the hunt, at %s"
+
+#~ msgid " (pdf sélectionné mais pas de fichier chargé)"
+#~ msgstr " (pdf selected but no file uploaded)"
+
+#~ msgid "votre texte d'explication"
+#~ msgstr "your explanation text"
+
+#, php-format
+#~ msgid ", %d jours après la fin de la chasse, à %s"
+#~ msgstr ", %d days after the end of the hunt, at %s"
+
+#~ msgid " (rédaction libre sélectionnée mais non remplie)"
+#~ msgstr " (free writing selected but not filled)"
+
+#~ msgid "Vider"
+#~ msgstr "Clear"
+
+#~ msgid "Rédaction libre"
+#~ msgstr "Free writing"
+
+#~ msgid "Délai après fin de chasse"
+#~ msgstr "Delay after hunt end"
+
+#~ msgid "Informations sur la publication de la solution"
+#~ msgstr "Solution Release Information"
+
+#~ msgid "Délai de parution des solutions"
+#~ msgstr "Solutions release delay"
+
+#~ msgid "jours, publié à"
+#~ msgstr "days, published at"
+
+#~ msgid "Vos solutions sont protégées"
+#~ msgstr "Your solutions are protected"
+
+#~ msgid "Stockées dans un espace privé, hors de portée des joueurs."
+#~ msgstr "Stored in a private area, out of players' reach."
+
+#~ msgid "Aucun lien ne peut être trouvé ni ouvert."
+#~ msgstr "No link can be found or opened."
+
+#~ msgid "Débloquées uniquement au moment choisi."
+#~ msgstr "Unlocked only at the chosen time."
+
+#~ msgid "Panneau d'édition indice"
+#~ msgstr "Clue edit panel"
+
+#~ msgid "renseigner le titre de l’indice"
+#~ msgstr "enter the clue title"
+
+#~ msgid "Image"
+#~ msgstr "Image"
+
+#~ msgid "Modifier le texte de l’indice"
+#~ msgstr "Edit the clue text"
+
+#~ msgid "Aide pour"
+#~ msgstr "Help for"
+
+#~ msgid "Aucune énigme disponible."
+#~ msgstr "No puzzle available."
+
+#~ msgid "Publication"
+#~ msgstr "Publishing"
+
+#~ msgid "(points)"
+#~ msgstr "(points)"
+
+#, fuzzy
+#~ msgid "Statistiques à venir"
+#~ msgstr "Statistics"
+
+#~ msgid "Texte de l’indice mis à jour."
+#~ msgstr "Clue text updated."
+
+#~ msgid "QR code de l'organisation"
+#~ msgstr "Organization QR code"
+
+#~ msgid "QR code de la chasse"
+#~ msgstr "Hunt QR code"
+
+#~ msgid "Enregistrement..."
+#~ msgstr "Registration"
+
+#~ msgid "✔️ Variantes enregistrées"
+#~ msgstr "Saved ✔️ Variants"
+
+#~ msgid "Titre contenu"
+#~ msgstr "Content title"
+
+#~ msgid "Modifier la récompense"
+#~ msgstr "Edit the reward"
+
+#~ msgid "Ajouter la récompense"
+#~ msgstr "Add the reward"
+
+#~ msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+#~ msgstr "Please enter a value in euros between 0 and 5,000,000."
+
+#~ msgid "accessible"
+#~ msgstr "accessible"
+
+#~ msgid "programme"
+#~ msgstr "scheduled"
+
+#~ msgid "Contenu de la solution à venir."
+#~ msgstr "Solution content coming soon."
+
+#~ msgid "Coming on %s"
+#~ msgstr "Coming on %s"
+
+#~ msgid "S'identifier"
+#~ msgstr "Sign in"
+
+#~ msgid "Vous devez être identifié pour participer à cette chasse"
+#~ msgstr "You must be logged in to participate in this hunt"
+
+#~ msgid "Chasse disponible à partir du %s"
+#~ msgstr "Hunt available from %s"
+
+#~ msgid "Chasse disponible prochainement"
+#~ msgstr "Hunt available soon"
+
+#~ msgid ""
+#~ "Accès libre à cette chasse. Les tentatives seront tarifées "
+#~ "individuellement."
+#~ msgstr "Free access to this hunt. Attempts will be charged individually."
+
+#~ msgid "Cette chasse est terminée depuis le %s"
+#~ msgstr "This hunt has ended since %s"
+
+#~ msgid "Cette chasse est terminée"
+#~ msgstr "This hunt is over"
+
+#~ msgid "Coordonnées bancaires manquantes"
+#~ msgstr "Missing bank details"
+
+#~ msgid ""
+#~ "Nous avons besoin d'enregistrer vos coordonnées bancaires pour vous "
+#~ "envoyer un versement"
+#~ msgstr "We need to record your bank details to send you a payout"
+
+#~ msgid "renseigner coordonnées bancaires"
+#~ msgstr "enter bank details"
+
+#~ msgid "Demande pour %s en cours de traitement"
+#~ msgstr "Request for %s is being processed"
+
+#~ msgid "illimité"
+#~ msgstr "unlimited"
+
+#~ msgid "%d gagnant"
+#~ msgid_plural "%d gagnants"
+#~ msgstr[0] "%d winner"
+#~ msgstr[1] "%d winners"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: chassesautresor.com 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/chassesautresor\n"
-"POT-Creation-Date: 2025-08-23T01:54:31+00:00\n"
+"POT-Creation-Date: 2025-08-28T06:27:25+00:00\n"
 "PO-Revision-Date: 2025-08-23 08:28+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,15 +35,15 @@ msgstr "https://chassesautresor.com/"
 msgid "Accueil Plein Ecran"
 msgstr "Accueil Plein Ecran"
 
-#: functions.php:102
+#: functions.php:114
 msgid "Français"
 msgstr "Français"
 
-#: functions.php:107
+#: functions.php:119
 msgid "English"
 msgstr "Anglais"
 
-#: functions.php:116
+#: functions.php:128
 msgid "Change language"
 msgstr "Changer de langue"
 
@@ -105,7 +105,7 @@ msgid "Régler"
 msgstr "Régler"
 
 #: inc/admin-functions.php:467
-#: template-parts/chasse/chasse-edition-main.php:309
+#: template-parts/chasse/chasse-edition-main.php:347
 msgid "Annuler"
 msgstr "Annuler"
 
@@ -137,134 +137,139 @@ msgstr ""
 msgid "⛔ Erreur de sécurité. Veuillez réessayer."
 msgstr "⛔ Erreur de sécurité. Veuillez réessayer."
 
-#: inc/admin-functions.php:1343 inc/admin-functions.php:1368
+#: inc/admin-functions.php:1343 inc/admin-functions.php:1369
 msgid "Non autorisé"
 msgstr "Non autorisé"
 
-#: inc/admin-functions.php:1425
+#: inc/admin-functions.php:1426
 msgid "Confirmez-vous la réinitialisation des statistiques ?"
 msgstr ""
 
-#: inc/admin-functions.php:1426
+#: inc/admin-functions.php:1427
 #, fuzzy
 msgid "Statistiques effacées."
 msgstr "Statistiques"
 
-#: inc/admin-functions.php:1647
+#: inc/admin-functions.php:1648
 #: templates/myaccount/content-organisateurs.php:21
 #, fuzzy
 msgid "Aucun organisateur."
 msgstr "Aucun organisateur associé."
 
-#: inc/admin-functions.php:1676
+#: inc/admin-functions.php:1677
 #, fuzzy
 msgid "Organisateur"
 msgstr "Devenir Organisateur"
 
-#: inc/admin-functions.php:1677
-#: template-parts/indice/indice-edition-main.php:153
+#: inc/admin-functions.php:1678 template-parts/common/indices-table.php:128
+#: template-parts/common/solutions-table.php:53
 msgid "Chasse"
 msgstr "Chasse"
 
-#: inc/admin-functions.php:1678
+#: inc/admin-functions.php:1679
 #, fuzzy
 msgid "Nb énigmes"
 msgstr "Énigmes"
 
-#: inc/admin-functions.php:1679
+#: inc/admin-functions.php:1680
 msgid "État"
 msgstr ""
 
-#: inc/admin-functions.php:1680 inc/organisateur-functions.php:437
+#: inc/admin-functions.php:1681 inc/organisateur-functions.php:437
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:26
 msgid "Utilisateur"
 msgstr "Utilisateur"
 
-#: inc/admin-functions.php:1681
+#: inc/admin-functions.php:1682
 msgid "Créé le"
 msgstr ""
 
-#: inc/admin-functions.php:1701
+#: inc/admin-functions.php:1702
 #, fuzzy
 msgid "valide"
 msgstr "Invalider"
 
-#: inc/admin-functions.php:1704
+#: inc/admin-functions.php:1705 inc/chasse-functions.php:1122
+#: template-parts/chasse/chasse-affichage-complet.php:96
 msgid "correction"
 msgstr ""
 
-#: inc/admin-functions.php:1707
+#: inc/admin-functions.php:1708 inc/chasse-functions.php:1124
+#: template-parts/chasse/chasse-affichage-complet.php:98
 #, fuzzy
 msgid "en attente"
 msgstr "En attente"
 
-#: inc/admin-functions.php:1710
+#: inc/admin-functions.php:1711 inc/chasse-functions.php:1120
+#: template-parts/chasse/chasse-affichage-complet.php:94
 #, fuzzy
 msgid "création"
 msgstr "Présentation"
 
-#: inc/admin-functions.php:1714
+#: inc/admin-functions.php:1715
 msgid "banni"
 msgstr ""
 
-#: inc/admin-functions.php:1730
+#: inc/admin-functions.php:1731
 msgid "Demande de validation et tentatives manuelles en attente"
 msgstr ""
 
-#: inc/admin-functions.php:1732
+#: inc/admin-functions.php:1733
 msgid "Demande de validation en attente"
 msgstr ""
 
-#: inc/admin-functions.php:1734
+#: inc/admin-functions.php:1735
 #, fuzzy
 msgid "Tentatives manuelles en attente de réponse"
 msgstr "Configurer les variantes de réponse"
 
-#: inc/admin-functions.php:1785
-#: template-parts/chasse/chasse-edition-main.php:469
+#: inc/admin-functions.php:1786
+#: template-parts/chasse/chasse-edition-main.php:659
 msgid "Accès refusé."
 msgstr "Accès refusé."
 
-#: inc/admin-functions.php:1792
+#: inc/admin-functions.php:1793
 msgid "ID de chasse invalide."
 msgstr "ID de chasse invalide."
 
-#: inc/admin-functions.php:1796
+#: inc/admin-functions.php:1797
 msgid "Nonce invalide."
 msgstr "Nonce invalide."
 
-#: inc/admin-functions.php:1849
+#: inc/admin-functions.php:1850
 #, fuzzy, php-format
 msgid "Votre demande de validation pour la chasse « %s » a été acceptée."
 msgstr "Votre demande de conversion a bien été envoyée."
 
-#: inc/admin-functions.php:1886
+#: inc/admin-functions.php:1887
 #, php-format
 msgid ""
 "Votre demande de validation pour la chasse « %s » nécessite des corrections."
 msgstr ""
 
-#: inc/admin-functions.php:1891
+#: inc/admin-functions.php:1892
 #, php-format
 msgid "Message de l’administrateur : %s"
 msgstr ""
 
-#: inc/admin-functions.php:1895
+#: inc/admin-functions.php:1896
 msgid "Une copie de ce message vous a été envoyée par email."
 msgstr ""
 
-#: inc/admin-functions.php:1918
+#: inc/admin-functions.php:1919
 #, php-format
 msgid "Votre chasse « %s » a été bannie."
 msgstr ""
 
+#: inc/user-functions.php:643
 msgid "Supprimer ce message"
 msgstr ""
 
+#: inc/user-functions.php:714
 msgid "Clé de message invalide."
 msgstr ""
 
-#: inc/admin-functions.php:1940
+#: inc/admin-functions.php:1941
 #, php-format
 msgid "Votre chasse « %s » a été supprimée."
 msgstr ""
@@ -283,102 +288,309 @@ msgstr ""
 "⚠️ Erreur : La date de fin ne peut pas être antérieure à la date du jour si "
 "la chasse commence maintenant."
 
-#: inc/chasse-functions.php:644
+#: inc/chasse-functions.php:617
+#, fuzzy
+msgid "Participer"
+msgstr "Participants"
+
+#: inc/chasse-functions.php:651
 msgid "Points insuffisants"
 msgstr "Points insuffisants"
 
-#: inc/chasse-functions.php:650 inc/organisateur-functions.php:273
-#: template-parts/chasse/chasse-edition-main.php:417
-#: template-parts/enigme/enigme-edition-main.php:387
+#: inc/chasse-functions.php:657 inc/organisateur-functions.php:273
+#: template-parts/enigme/enigme-edition-main.php:572
 msgid "points"
 msgstr "points"
 
-#: inc/chasse-functions.php:653
+#: inc/chasse-functions.php:660
 #, php-format
 msgid "Il vous manque %1$d %2$s pour participer à cette chasse."
 msgstr "Il vous manque %1$d %2$s pour participer à cette chasse."
 
-#: inc/chasse-functions.php:903 single-chasse.php:115
+#: inc/chasse-functions.php:780
+#: template-parts/chasse/chasse-affichage-complet.php:229
+#, fuzzy, php-format
+msgid "%d joueur"
+msgid_plural "%d joueurs"
+msgstr[0] "Nb joueurs :"
+msgstr[1] "Nb joueurs :"
+
+#: inc/chasse-functions.php:910 single-chasse.php:115
 msgid "Certaines énigmes doivent être complétées :"
 msgstr "Certaines énigmes doivent être complétées :"
 
-#: inc/edition/edition-chasse.php:48
+#: inc/chasse-functions.php:1126
+#: template-parts/chasse/chasse-affichage-complet.php:100
+msgid "révision"
+msgstr ""
+
+#: inc/chasse-functions.php:1129
+#: template-parts/chasse/chasse-affichage-complet.php:103
+msgid "en cours"
+msgstr ""
+
+#: inc/chasse-functions.php:1132
+#: template-parts/chasse/chasse-affichage-complet.php:106
+msgid "à venir"
+msgstr ""
+
+#: inc/chasse-functions.php:1134
+#: template-parts/chasse/chasse-affichage-complet.php:108
+#, fuzzy
+msgid "terminée"
+msgstr "terminée depuis %s"
+
+#: inc/edition/edition-chasse.php:58
 #, fuzzy
 msgid "Erreur lors du chargement des indices."
 msgstr "Erreur lors de la création de la chasse."
 
-#: inc/edition/edition-chasse.php:115
+#: inc/edition/edition-chasse.php:67 inc/edition/edition-enigme.php:62
+#: template-parts/chasse/partials/chasse-partial-solutions.php:76
+#: template-parts/chasse/partials/chasse-partial-solutions.php:90
+msgid "Il existe déjà une solution pour cette chasse"
+msgstr "Il existe déjà une solution pour cette chasse"
+
+#: inc/edition/edition-chasse.php:68
+#: template-parts/chasse/partials/chasse-partial-solutions.php:105
+msgid "Toutes les énigmes de la chasse ont déjà une solution"
+msgstr "Toutes les énigmes de la chasse ont déjà une solution"
+
+#: inc/edition/edition-chasse.php:135
 msgid "Aucun organisateur associé."
 msgstr "Aucun organisateur associé."
 
-#: inc/edition/edition-chasse.php:123
+#: inc/edition/edition-chasse.php:143
 msgid "Limite atteinte"
 msgstr "Limite atteinte"
 
-#: inc/edition/edition-chasse.php:126
+#: inc/edition/edition-chasse.php:146
 msgid "Accès refusé"
 msgstr "Accès refusé"
 
-#: inc/edition/edition-chasse.php:136
+#: inc/edition/edition-chasse.php:156
 msgid "Une chasse est déjà en attente de validation."
 msgstr "Une chasse est déjà en attente de validation."
 
-#: inc/edition/edition-chasse.php:149
+#: inc/edition/edition-chasse.php:169
 msgid "Erreur lors de la création de la chasse."
 msgstr "Erreur lors de la création de la chasse."
 
-#: inc/edition/edition-enigme.php:166
-msgid "Chasse non spécifiée ou invalide."
-msgstr "Chasse non spécifiée ou invalide."
+#: inc/edition/edition-core.php:147 inc/edition/edition-core.php:179
+#: assets/js/help-modal.js:19
+msgid "Fermer"
+msgstr "Fermer"
 
-#: inc/edition/edition-indice.php:45
-#, fuzzy
-msgid "Type de cible invalide."
-msgstr "ID de chasse invalide."
+#: inc/edition/edition-core.php:148
+msgid "Choisir une image"
+msgstr "Choisir une image"
 
-#: inc/edition/edition-indice.php:49
-#, fuzzy
-msgid "ID cible invalide."
-msgstr "ID de chasse invalide."
+#: inc/edition/edition-core.php:149 inc/edition/edition-core.php:188
+#: templates/myaccount/content-outils.php:33
+msgid "Modifier"
+msgstr "Modifier"
 
-#: inc/edition/edition-indice.php:53
-msgid "Utilisateur non connecté."
-msgstr ""
+#: inc/edition/edition-core.php:150 template-parts/common/indices-table.php:185
+#: template-parts/common/solutions-table.php:163 assets/js/enigme-edit.js:886
+msgid "Supprimer"
+msgstr "Supprimer"
 
-#: inc/edition/edition-indice.php:57 inc/edition/edition-indice.php:65
-#, fuzzy
-msgid "Droits insuffisants."
-msgstr "Points insuffisants"
+#: inc/edition/edition-core.php:151
+msgid "Texte de l’indice"
+msgstr "Texte de l’indice"
 
-#: inc/edition/edition-indice.php:83
+#: inc/edition/edition-core.php:152
+msgid "Immédiate"
+msgstr "Immédiate"
+
+#: inc/edition/edition-core.php:153 inc/edition/edition-core.php:184
+msgid "Différée"
+msgstr "Différée"
+
+#: inc/edition/edition-core.php:154 inc/edition/edition-core.php:186
+#: inc/enigme/reponses.php:137
+#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
+#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
+msgid "Valider"
+msgstr "Valider"
+
+#: inc/edition/edition-core.php:155
+msgid "Sélectionner une image"
+msgstr "Sélectionner une image"
+
+#: inc/edition/edition-core.php:156 inc/edition/edition-indice.php:164
+#: inc/edition/edition-indice.php:262
 #, php-format
 msgid "Indice #%d"
 msgstr "Indice #%d"
 
-#: inc/edition/edition-core.php:155
-msgid "lié à"
-msgstr "lié à"
-
-#: inc/edition/edition-core.php:155
+#: inc/edition/edition-core.php:157 inc/edition/edition-core.php:196
 msgid "liée à"
 msgstr "liée à"
 
-#: inc/edition/edition-core.php:155
+#: inc/edition/edition-core.php:158 inc/edition/edition-core.php:197
 msgid "la chasse"
 msgstr "la chasse"
 
-#: inc/edition/edition-core.php:155
+#: inc/edition/edition-core.php:159 inc/edition/edition-core.php:198
 msgid "l’énigme"
 msgstr "l’énigme"
 
-#: inc/edition/edition-indice.php:151
+#: inc/edition/edition-core.php:160 inc/edition/edition-core.php:191
+#: template-parts/chasse/partials/chasse-partial-indices.php:56
+#: template-parts/common/indices-table.php:127
+#: template-parts/common/solutions-table.php:52
+#: templates/myaccount/content-chasses.php:125
+msgid "Énigme"
+msgstr "Énigme"
+
+#: inc/edition/edition-core.php:161 inc/edition/edition-core.php:192
+msgid "Sélectionner une énigme"
+msgstr "Sélectionner une énigme"
+
+#: inc/edition/edition-core.php:162 inc/edition/edition-core.php:193
+msgid "Sélectionnez une énigme"
+msgstr "Sélectionnez une énigme"
+
+#: inc/edition/edition-core.php:163 inc/edition/edition-core.php:194
+msgid "Chargement…"
+msgstr "Chargement…"
+
+#: inc/edition/edition-core.php:164
+msgid "Au moins une image ou un texte nécessaire"
+msgstr ""
+
+#: inc/edition/edition-core.php:165 inc/edition/edition-core.php:202
+msgid "Date et heure requises"
+msgstr ""
+
+#: inc/edition/edition-core.php:166
+#, fuzzy
+msgid "Date invalide"
+msgstr "Nonce invalide."
+
+#: inc/edition/edition-core.php:167 inc/edition/edition-core.php:190
+#: assets/js/indices-pager.js:34 assets/js/indices-pager.js:83
+#: assets/js/solutions-pager.js:28 assets/js/solutions-pager.js:77
+#, fuzzy
+msgid "Erreur réseau"
+msgstr "❌ Erreur réseau"
+
+#: inc/edition/edition-core.php:180
+msgid "Texte de la solution"
+msgstr "Texte de la solution"
+
+#: inc/edition/edition-core.php:181
+msgid "Fichier"
+msgstr "Fichier"
+
+#: inc/edition/edition-core.php:182
+msgid "Disponibilité"
+msgstr "Disponibilité"
+
+#: inc/edition/edition-core.php:183
+#, fuzzy
+msgid "Fin de la chasse"
+msgstr "Terminer la chasse"
+
+#: inc/edition/edition-core.php:185
+msgid "jours"
+msgstr ""
+
+#: inc/edition/edition-core.php:187
+#: template-parts/chasse/partials/chasse-partial-solutions.php:43
+msgid "Ajouter une solution"
+msgstr "Ajouter une solution"
+
+#: inc/edition/edition-core.php:189
+msgid "Solution enregistrée."
+msgstr ""
+
+#: inc/edition/edition-core.php:195
+msgid "Ajoutez un fichier ou un texte"
+msgstr "Ajoutez un fichier ou un texte"
+
+#: inc/edition/edition-core.php:199
+msgid "Choisir un fichier"
+msgstr ""
+
+#: inc/edition/edition-core.php:200
+msgid "Aucun fichier choisi"
+msgstr "Aucun fichier choisi"
+
+#: inc/edition/edition-core.php:201
+#, fuzzy
+msgid "Supprimer le fichier"
+msgstr "Modifier la récompense"
+
+#: inc/edition/edition-enigme.php:63
+#: template-parts/chasse/partials/chasse-partial-solutions.php:63
+msgid "Il existe déjà une solution pour cette énigme"
+msgstr "Il existe déjà une solution pour cette énigme"
+
+#: inc/edition/edition-enigme.php:64
+#: template-parts/common/edition-animation.php:521 assets/js/enigme-edit.js:85
+#: assets/js/enigme-edit.js:259
+msgid "Voir toutes les solutions de la chasse"
+msgstr "Voir toutes les solutions de la chasse"
+
+#: inc/edition/edition-enigme.php:65 assets/js/enigme-edit.js:96
+#: assets/js/enigme-edit.js:257
+msgid "Voir la solution de cette énigme"
+msgstr "Voir la solution de cette énigme"
+
+#: inc/edition/edition-enigme.php:189
+msgid "Chasse non spécifiée ou invalide."
+msgstr "Chasse non spécifiée ou invalide."
+
+#: inc/edition/edition-indice.php:225 inc/edition/edition-solution.php:269
+#, fuzzy
+msgid "Type de cible invalide."
+msgstr "ID de chasse invalide."
+
+#: inc/edition/edition-indice.php:229 inc/edition/edition-solution.php:273
+#, fuzzy
+msgid "ID cible invalide."
+msgstr "ID de chasse invalide."
+
+#: inc/edition/edition-indice.php:233 inc/edition/edition-solution.php:277
+msgid "Utilisateur non connecté."
+msgstr ""
+
+#: inc/edition/edition-indice.php:237 inc/edition/edition-indice.php:245
+#: inc/edition/edition-solution.php:281 inc/edition/edition-solution.php:289
+#, fuzzy
+msgid "Droits insuffisants."
+msgstr "Points insuffisants"
+
+#: inc/edition/edition-indice.php:335 inc/edition/edition-solution.php:386
 #, fuzzy
 msgid "Action non autorisée."
 msgstr "Non autorisé"
 
-#: inc/edition/edition-indice.php:167
+#: inc/edition/edition-indice.php:351 inc/edition/edition-solution.php:402
 msgid "ID cible manquant."
 msgstr ""
+
+#: inc/edition/edition-indice.php:587
+#: template-parts/common/edition-animation.php:481 assets/js/enigme-edit.js:221
+#, fuzzy
+msgid "Voir tous les indices de la chasse"
+msgstr "Voir toutes les solutions de la chasse"
+
+#: inc/edition/edition-indice.php:588 assets/js/enigme-edit.js:220
+#, fuzzy
+msgid "Voir les indices de cette énigme"
+msgstr "Voir la solution de cette énigme"
+
+#: inc/edition/edition-solution.php:307
+msgid "Une solution existe déjà pour cet objet."
+msgstr ""
+
+#: inc/edition/edition-solution.php:322
+#, fuzzy, php-format
+msgid "Solution | %s"
+msgstr "Solutions pour %s"
 
 #: inc/enigme/affichage.php:159 inc/enigme/affichage.php:204
 msgid "Vous"
@@ -430,133 +642,98 @@ msgstr ""
 msgid "Définition du taux de résolution"
 msgstr "Définition du taux de résolution"
 
-#: inc/enigme/affichage.php:518 inc/enigme/affichage.php:1037
+#: inc/enigme/affichage.php:518 inc/enigme/affichage.php:1039
+#: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
-#: template-parts/indice/indice-edition-main.php:154
 msgid "Énigmes"
 msgstr "Énigmes"
 
-#: inc/enigme/affichage.php:546
+#: inc/enigme/affichage.php:536 inc/enigme/affichage.php:1008
+msgid "Retour"
+msgstr ""
+
+#: inc/enigme/affichage.php:548
 msgid "Afficher les statistiques"
 msgstr "Afficher les statistiques"
 
-#: inc/enigme/affichage.php:649
-#: template-parts/chasse/chasse-edition-main.php:708
+#: inc/enigme/affichage.php:651
 msgid "Indices"
 msgstr "Indices"
 
-#: template-parts/chasse/chasse-edition-main.php:708
-#: template-parts/enigme/enigme-edition-main.php:774
-#: template-parts/common/edition-animation.php:366
-#: template-parts/common/edition-animation.php:370
-#, php-format
-msgid "Indices pour %s"
-msgstr "Indices pour %s"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:35
-msgid "Ajouter un indice"
-msgstr "Ajouter un indice"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:42
-msgid "Pour…"
-msgstr "Pour…"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:56
-msgid "Cette énigme"
-msgstr "Cette énigme"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:66
-#: template-parts/chasse/partials/chasse-partial-indices.php:77
-msgid "La chasse entière"
-msgstr "La chasse entière"
-
-#: template-parts/chasse/partials/chasse-partial-indices.php:89
-msgid "Une énigme de la chasse"
-msgstr "Une énigme de la chasse"
-
-#: inc/enigme/affichage.php:677
+#: inc/enigme/affichage.php:679
+#: template-parts/chasse/chasse-affichage-complet.php:273
 #, fuzzy
 msgid "automatique"
 msgstr "Automatique"
 
-#: inc/enigme/affichage.php:678
+#: inc/enigme/affichage.php:680
+#: template-parts/chasse/chasse-affichage-complet.php:274
 #, fuzzy
 msgid "manuelle"
 msgstr "Manuelle"
 
-#: inc/enigme/affichage.php:680
+#: inc/enigme/affichage.php:682
 #, fuzzy, php-format
 msgid "Mode de validation de l'énigme : %s"
 msgstr "Modifier les images de l’énigme"
 
-#: inc/enigme/affichage.php:712
+#: inc/enigme/affichage.php:714
 #, php-format
 msgid "Solde : %d pts"
 msgstr ""
 
-#: inc/enigme/affichage.php:721
+#: inc/enigme/affichage.php:723
 #, fuzzy, php-format
 msgid "Tentatives quotidiennes : %1$d/%2$s"
 msgstr "Tentatives quotidiennes"
 
-#: inc/enigme/affichage.php:737
+#: inc/enigme/affichage.php:739
 #, php-format
 msgid "Coût par tentative : %d points."
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:120
-#: template-parts/chasse/chasse-affichage-complet.php:130
-#, php-format
-msgid "Coût de participation : %d points."
-msgstr "Coût de participation : %d points."
-
-#: inc/enigme/affichage.php:741 assets/js/reponse-automatique.js:76
-#: assets/js/reponse-automatique.js:98
+#: inc/enigme/affichage.php:743
+#: template-parts/chasse/chasse-affichage-complet.php:131
+#: template-parts/chasse/chasse-affichage-complet.php:152
+#: assets/js/reponse-automatique.js:76 assets/js/reponse-automatique.js:98
 msgid "pts"
 msgstr "pts"
 
-#: inc/enigme/affichage.php:780
+#: inc/enigme/affichage.php:782
 msgid "Voir la solution"
 msgstr "Voir la solution"
 
-#: inc/enigme/affichage.php:945 inc/enigme/affichage.php:956
-#: inc/enigme/affichage.php:1012 inc/enigme/affichage.php:1013
-#: inc/enigme/affichage.php:1026 inc/enigme/affichage.php:1027
-#: single-indice.php:27 template-parts/chasse/chasse-edition-main.php:67
-#: template-parts/chasse/chasse-edition-main.php:76
-#: template-parts/enigme/enigme-edition-main.php:94
-#: template-parts/enigme/enigme-edition-main.php:104
-#: template-parts/indice/indice-edition-main.php:59
-#: template-parts/indice/indice-edition-main.php:67
-#: template-parts/organisateur/organisateur-edition-main.php:75
-#: template-parts/organisateur/organisateur-edition-main.php:85
+#: inc/enigme/affichage.php:947 inc/enigme/affichage.php:958
+#: inc/enigme/affichage.php:1014 inc/enigme/affichage.php:1015
+#: inc/enigme/affichage.php:1028 inc/enigme/affichage.php:1029
+#: template-parts/chasse/chasse-edition-main.php:69
+#: template-parts/chasse/chasse-edition-main.php:78
+#: template-parts/enigme/enigme-edition-main.php:93
+#: template-parts/enigme/enigme-edition-main.php:103
+#: template-parts/organisateur/organisateur-edition-main.php:76
+#: template-parts/organisateur/organisateur-edition-main.php:86
 msgid "Paramètres"
 msgstr ""
 
-#: inc/enigme/affichage.php:1006
-msgid "Retour"
-msgstr ""
-
-#: inc/enigme/affichage.php:1017 inc/enigme/affichage.php:1018
+#: inc/enigme/affichage.php:1019 inc/enigme/affichage.php:1020
 #, fuzzy
 msgid "Menu énigme"
 msgstr "Texte énigme"
 
-#: inc/enigme/affichage.php:1035
+#: inc/enigme/affichage.php:1037
 #, fuzzy
 msgid "Panneau d'énigme"
 msgstr "Panneau d'édition énigme"
 
-#: inc/enigme/affichage.php:1038 inc/enigme/affichage.php:1135
-#: template-parts/chasse/chasse-edition-main.php:68
-#: template-parts/enigme/enigme-edition-main.php:95
-#: template-parts/enigme/enigme-edition-main.php:499
+#: inc/enigme/affichage.php:1040 inc/enigme/affichage.php:1137
+#: template-parts/chasse/chasse-edition-main.php:70
+#: template-parts/chasse/chasse-edition-main.php:656
+#: template-parts/enigme/enigme-edition-main.php:94
+#: template-parts/enigme/enigme-edition-main.php:645
 #: template-parts/enigme/partials/enigme-sidebar-section.php:52
-#: template-parts/indice/indice-edition-main.php:60
-#: template-parts/indice/indice-edition-main.php:218
-#: template-parts/organisateur/organisateur-edition-main.php:76
-#: template-parts/organisateur/organisateur-edition-main.php:252
+#: template-parts/organisateur/organisateur-edition-main.php:77
+#: template-parts/organisateur/organisateur-edition-main.php:328
 #: templates/myaccount/layout.php:111
 msgid "Statistiques"
 msgstr "Statistiques"
@@ -570,7 +747,7 @@ msgstr ""
 msgid "Chasse verrouillée"
 msgstr "Chasse introuvable."
 
-#: inc/enigme/cta.php:195 template-parts/enigme/enigme-edition-main.php:451
+#: inc/enigme/cta.php:195
 msgid "Pré-requis"
 msgstr "Pré-requis"
 
@@ -659,13 +836,6 @@ msgstr "Ajouter des variantes"
 #, php-format
 msgid "Solde : %1$d → %2$d pts"
 msgstr ""
-
-#: inc/enigme/reponses.php:137
-#: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:119
-#: template-parts/enigme/partials/enigme-partial-tentatives.php:68
-#: inc/edition/edition-core.php:***
-msgid "Valider"
-msgstr "Valider"
 
 #: inc/enigme/reponses.php:140
 #: template-parts/enigme/partials/enigme-partial-bloc-reponse.php:147
@@ -761,8 +931,9 @@ msgstr "Historique de vos points"
 msgid "ID"
 msgstr "ID"
 
-#: inc/gamify-functions.php:525
-#: template-parts/enigme/enigme-edition-main.php:577
+#: inc/gamify-functions.php:525 template-parts/common/indices-table.php:63
+#: template-parts/common/solutions-table.php:30
+#: template-parts/enigme/enigme-edition-main.php:723
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:35
 #: template-parts/enigme/partials/enigme-partial-tentatives.php:25
 #: templates/myaccount/content-chasses.php:124
@@ -786,32 +957,53 @@ msgstr "Variation"
 msgid "Solde"
 msgstr "Solde"
 
+#: inc/handlers/voir-fichier.php:25
+#, fuzzy
+msgid "Fichier introuvable (ID)."
+msgstr "Chasse introuvable."
+
+#: inc/handlers/voir-fichier.php:33
+#, fuzzy
+msgid "Solution introuvable."
+msgstr "Tentative introuvable."
+
+#: inc/handlers/voir-fichier.php:44
+msgid "Accès non autorisé à cette solution."
+msgstr ""
+
+#: inc/handlers/voir-fichier.php:54
+msgid "Aucun fichier PDF lié à cette solution."
+msgstr ""
+
 #: inc/organisateur-functions.php:227 inc/organisateur-functions.php:233
-#: template-parts/organisateur/organisateur-edition-main.php:308
-#: template-parts/organisateur/organisateur-edition-main.php:321
+#: template-parts/organisateur/organisateur-edition-main.php:384
+#: template-parts/organisateur/organisateur-edition-main.php:397
 msgid "Ajouter des coordonnées bancaires"
 msgstr "Ajouter des coordonnées bancaires"
 
 #: inc/organisateur-functions.php:231
-#: template-parts/chasse/chasse-edition-main.php:673
 #: template-parts/chasse/partials/chasse-partial-indices.php:97
-#: template-parts/organisateur/organisateur-edition-main.php:305
-#: template-parts/organisateur/organisateur-edition-main.php:319
-#: template-parts/organisateur/organisateur-edition-main.php:360
+#: template-parts/chasse/partials/chasse-partial-solutions.php:115
+#: template-parts/common/edition-animation.php:82
+#: template-parts/common/edition-animation.php:108
+#: template-parts/organisateur/organisateur-edition-main.php:381
+#: template-parts/organisateur/organisateur-edition-main.php:395
 msgid "Ajouter"
 msgstr "Ajouter"
 
 #: inc/organisateur-functions.php:232
-#: template-parts/chasse/chasse-edition-main.php:674
-#: template-parts/organisateur/organisateur-edition-main.php:306
-#: template-parts/organisateur/organisateur-edition-main.php:320
-#: template-parts/organisateur/organisateur-edition-main.php:361
+#: template-parts/common/edition-animation.php:83
+#: template-parts/common/edition-animation.php:109
+#: template-parts/common/indices-table.php:176
+#: template-parts/common/solutions-table.php:156
+#: template-parts/organisateur/organisateur-edition-main.php:382
+#: template-parts/organisateur/organisateur-edition-main.php:396
 msgid "Éditer"
 msgstr "Éditer"
 
 #: inc/organisateur-functions.php:234
-#: template-parts/organisateur/organisateur-edition-main.php:309
-#: template-parts/organisateur/organisateur-edition-main.php:322
+#: template-parts/organisateur/organisateur-edition-main.php:385
+#: template-parts/organisateur/organisateur-edition-main.php:398
 msgid "Modifier les coordonnées bancaires"
 msgstr "Modifier les coordonnées bancaires"
 
@@ -830,7 +1022,7 @@ msgid "Transformez vos %d points en euros."
 msgstr "Transformez vos %d points en euros."
 
 #: inc/organisateur-functions.php:262 inc/organisateur-functions.php:282
-#: template-parts/organisateur/organisateur-edition-main.php:281
+#: template-parts/organisateur/organisateur-edition-main.php:357
 msgid "Convertir"
 msgstr "Convertir"
 
@@ -952,14 +1144,14 @@ msgstr "Statistiques - Chasses au Trésor"
 msgid "Vos commandes"
 msgstr ""
 
-#: inc/user-functions.php:335
+#: inc/user-functions.php:352
 #, php-format
 msgid ""
 "Votre demande de résolution de l'énigme %s est en cours de traitement. Vous "
 "recevrez une notification dès que votre demande sera traitée."
 msgstr ""
 
-#: inc/user-functions.php:351
+#: inc/user-functions.php:371
 #, php-format
 msgid ""
 "Vos demandes de résolution d'énigmes sont en cours de traitement : %s. Vous "
@@ -967,12 +1159,12 @@ msgid ""
 msgstr ""
 
 #. translators: 1: opening anchor tag, 2: closing anchor tag
-#: inc/user-functions.php:456
+#: inc/user-functions.php:504
 #, php-format
 msgid "Vous avez des %1$sdemandes de conversion%2$s en attente."
 msgstr "Vous avez des %1$sdemandes de conversion%2$s en attente."
 
-#: inc/user-functions.php:478
+#: inc/user-functions.php:529
 msgid "Important ! Des tentatives attendent votre action :"
 msgstr ""
 
@@ -1001,104 +1193,239 @@ msgstr "Chasses au Trésor"
 msgid "C'est parti !"
 msgstr "C'est parti !"
 
-#: template-parts/chasse/chasse-edition-main.php:61
+#: template-parts/chasse/chasse-affichage-complet.php:46
+#: template-parts/chasse/chasse-affichage-complet.php:132
+#, fuzzy
+msgid "mode de fin de chasse : automatique"
+msgstr "Explication du mode automatique"
+
+#: template-parts/chasse/chasse-affichage-complet.php:47
+#: template-parts/chasse/chasse-affichage-complet.php:133
+#, fuzzy
+msgid "mode de fin de chasse : manuelle"
+msgstr "ID de chasse invalide."
+
+#: template-parts/chasse/chasse-affichage-complet.php:130
+#: template-parts/chasse/chasse-affichage-complet.php:147
+#, php-format
+msgid "Coût de participation : %d points."
+msgstr "Coût de participation : %d points."
+
+#: template-parts/chasse/chasse-affichage-complet.php:176
+#: template-parts/chasse/chasse-edition-main.php:157
+#: template-parts/chasse/chasse-edition-main.php:167
+#, fuzzy
+msgid "Image de la chasse"
+msgstr "Terminer la chasse"
+
+#: template-parts/chasse/chasse-affichage-complet.php:220
+msgid "Par"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:227
+#: template-parts/chasse/chasse-card.php:33
+#, fuzzy, php-format
+msgid "%d énigme"
+msgid_plural "%d énigmes"
+msgstr[0] "Énigmes"
+msgstr[1] "Énigmes"
+
+#: template-parts/chasse/chasse-affichage-complet.php:263
+#, fuzzy
+msgid "Limite"
+msgstr "Limitée"
+
+#: template-parts/chasse/chasse-affichage-complet.php:264
+#, fuzzy, php-format
+msgid "%d gagnants"
+msgstr "%d gagnant"
+
+#: template-parts/chasse/chasse-affichage-complet.php:269
+#, fuzzy
+msgid "Fin de chasse"
+msgstr "%d indice chasse"
+
+#: template-parts/chasse/chasse-affichage-complet.php:280
+#, fuzzy
+msgid "Accès chasse"
+msgstr "Arrêt chasse"
+
+#: template-parts/chasse/chasse-affichage-complet.php:283
+#, fuzzy, php-format
+msgid "%d points"
+msgstr "points"
+
+#: template-parts/chasse/chasse-affichage-complet.php:284
+#, fuzzy
+msgid "libre"
+msgstr "Libre"
+
+#: template-parts/chasse/chasse-affichage-complet.php:289
+#, fuzzy
+msgid "Accès énigme"
+msgstr "Visuel énigme"
+
+#: template-parts/chasse/chasse-affichage-complet.php:294
+#, php-format
+msgid "%d énigme nécessite des points pour soumettre une tentative"
+msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:305
+msgid "gratuit"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:312
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
+#: template-parts/chasse/partials/chasse-partial-participants.php:40
+msgid "Joueurs"
+msgstr "Joueurs"
+
+#: template-parts/chasse/chasse-affichage-complet.php:314
+#, fuzzy, php-format
+msgid "%d participant"
+msgid_plural "%d participants"
+msgstr[0] "Participants"
+msgstr[1] "Participants"
+
+#: template-parts/chasse/chasse-affichage-complet.php:321
+#, php-format
+msgid "%1$d joueur a trouvé %2$d énigme"
+msgid_plural "%1$d joueurs ont trouvé %2$d énigmes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:345
+msgid "Les + avancés"
+msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:363
+#, fuzzy
+msgid "Récompense :"
+msgstr "Récompense"
+
+#: template-parts/chasse/chasse-affichage-complet.php:375
+#, fuzzy
+msgid "Description complète :"
+msgstr "Description chasse"
+
+#: template-parts/chasse/chasse-card.php:48
+#, fuzzy
+msgid "En savoir plus"
+msgstr "Voir"
+
+#: template-parts/chasse/chasse-edition-main.php:63
 msgid "Panneau d'édition chasse"
 msgstr "Panneau d'édition chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:69
-#: template-parts/chasse/chasse-edition-main.php:647
-#: template-parts/enigme/enigme-edition-main.php:96
-#: template-parts/organisateur/organisateur-edition-main.php:77
-#: template-parts/organisateur/organisateur-edition-main.php:335
+#: template-parts/chasse/chasse-edition-main.php:71
+#: template-parts/common/edition-animation.php:55
+#: template-parts/enigme/enigme-edition-main.php:95
+#: template-parts/organisateur/organisateur-edition-main.php:78
 #, fuzzy
 msgid "Animation"
 msgstr "Variation"
 
-#: template-parts/chasse/chasse-edition-main.php:104
-#: template-parts/enigme/enigme-edition-main.php:128
-#: template-parts/indice/indice-edition-main.php:90
+#: template-parts/chasse/chasse-edition-main.php:106
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:29
+#: template-parts/enigme/enigme-edition-main.php:127
 #: template-parts/organisateur/organisateur-edition-main.php:110
 msgid "Titre"
 msgstr "Titre"
 
-#: template-parts/chasse/chasse-edition-main.php:126
+#: template-parts/chasse/chasse-edition-main.php:114
+#: assets/js/core/resume.js:297
+msgid "renseigner le titre de la chasse"
+msgstr "renseigner le titre de la chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:139
 #, fuzzy
 msgid "Image chasse"
 msgstr "Terminer la chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:133
-#: template-parts/indice/indice-edition-main.php:107
+#: template-parts/chasse/chasse-edition-main.php:154
 #, fuzzy
 msgid "Modifier l’image"
 msgstr "Modifier les variantes"
 
-#: template-parts/chasse/chasse-edition-main.php:135
-#: template-parts/chasse/chasse-edition-main.php:141
-#: template-parts/indice/indice-edition-main.php:109
-#: template-parts/indice/indice-edition-main.php:115
+#: template-parts/chasse/chasse-edition-main.php:160
+#: template-parts/chasse/chasse-edition-main.php:171
+#: template-parts/organisateur/organisateur-edition-main.php:165
+#: template-parts/organisateur/organisateur-edition-main.php:176
 #, fuzzy
 msgid "ajouter une image"
 msgstr "Ajouter une variante"
 
-#: template-parts/chasse/chasse-edition-main.php:154
+#: template-parts/chasse/chasse-edition-main.php:201
 msgid "Description chasse"
 msgstr "Description chasse"
 
-#: template-parts/chasse/chasse-edition-main.php:162
-#: template-parts/enigme/enigme-edition-main.php:172
-#: template-parts/enigme/enigme-edition-main.php:185
-#: template-parts/enigme/enigme-edition-main.php:202
-#: template-parts/indice/indice-edition-main.php:129
-#: template-parts/organisateur/organisateur-edition-main.php:161
-#: assets/js/enigme-edit.js:645
+#: template-parts/chasse/chasse-edition-main.php:215
+#: template-parts/enigme/enigme-edition-main.php:182
+#: template-parts/enigme/enigme-edition-main.php:195
+#: template-parts/enigme/enigme-edition-main.php:231
+#: template-parts/organisateur/organisateur-edition-main.php:218
+#: assets/js/enigme-edit.js:902
 msgid "ajouter"
 msgstr "ajouter"
 
-#: template-parts/chasse/chasse-edition-main.php:174
+#: template-parts/chasse/chasse-edition-main.php:227
 msgid "Modifier la description"
 msgstr "Modifier la description"
 
-#: template-parts/chasse/chasse-edition-main.php:175
-#: template-parts/indice/indice-edition-main.php:137
-#: template-parts/organisateur/organisateur-edition-main.php:173
-#: template-parts/organisateur/organisateur-edition-main.php:220
+#: template-parts/chasse/chasse-edition-main.php:232
+#: template-parts/organisateur/organisateur-edition-main.php:231
+#: template-parts/organisateur/organisateur-edition-main.php:292
 #: assets/js/core/helpers.js:234 assets/js/core/helpers.js:256
-#: assets/js/core/helpers.js:278 assets/js/core/resume.js:384
-#: assets/js/enigme-edit.js:743 assets/js/enigme-edit.js:988
+#: assets/js/core/helpers.js:283 assets/js/core/resume.js:378
+#: assets/js/enigme-edit.js:1001 assets/js/enigme-edit.js:1247
 msgid "modifier"
 msgstr "modifier"
 
-#: template-parts/chasse/chasse-edition-main.php:191
+#: template-parts/chasse/chasse-edition-main.php:262
 msgid "Récompense"
 msgstr "Récompense"
 
-#: template-parts/chasse/chasse-edition-main.php:227
-#: template-parts/enigme/enigme-edition-main.php:238
-#: template-parts/indice/indice-edition-main.php:148
+#: template-parts/chasse/chasse-edition-main.php:321
+#: template-parts/enigme/enigme-edition-main.php:288
 #, fuzzy
 msgid "Réglages"
 msgstr "Régler"
 
-#: template-parts/chasse/chasse-edition-main.php:239
+#: template-parts/chasse/chasse-edition-main.php:333
+msgid "Terminer la chasse"
+msgstr "Terminer la chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:335
+#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
+msgid "Gagnants"
+msgstr "Gagnants"
+
+#: template-parts/chasse/chasse-edition-main.php:343
+msgid "Valider la fin de chasse"
+msgstr "Valider la fin de chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:367
 msgid "Mode de fin"
 msgstr "Mode de fin"
 
-#: template-parts/chasse/chasse-edition-main.php:250
-#: template-parts/enigme/enigme-edition-main.php:247
+#: template-parts/chasse/chasse-edition-main.php:374
+#: template-parts/enigme/enigme-edition-main.php:315
 msgid "Automatique"
 msgstr "Automatique"
 
-#: template-parts/chasse/chasse-edition-main.php:256
-#: template-parts/enigme/enigme-edition-main.php:253
+#: template-parts/chasse/chasse-edition-main.php:380
+#: template-parts/enigme/enigme-edition-main.php:321
 msgid "Explication du mode automatique"
 msgstr "Explication du mode automatique"
 
-#: template-parts/chasse/chasse-edition-main.php:258
+#: template-parts/chasse/chasse-edition-main.php:382
 #, fuzzy
 msgid "Fin de chasse automatique"
 msgstr "Explication du mode automatique"
 
-#: template-parts/chasse/chasse-edition-main.php:259
+#: template-parts/chasse/chasse-edition-main.php:383
 #, fuzzy
 msgid ""
 "Un joueur est déclaré gagnant lorsqu’il a résolu toutes les énigmes. En mode "
@@ -1108,143 +1435,155 @@ msgstr ""
 "Un joueur devient gagnant lorsqu’il résout toutes les énigmes. La chasse "
 "s’achève dès que le nombre de gagnants prévu est atteint."
 
-#: template-parts/chasse/chasse-edition-main.php:272
-#: template-parts/enigme/enigme-edition-main.php:264
+#: template-parts/chasse/chasse-edition-main.php:400
+#: template-parts/enigme/enigme-edition-main.php:333
 msgid "Manuelle"
 msgstr "Manuelle"
 
-#: template-parts/chasse/chasse-edition-main.php:278
-#: template-parts/enigme/enigme-edition-main.php:270
+#: template-parts/chasse/chasse-edition-main.php:406
+#: template-parts/enigme/enigme-edition-main.php:339
 msgid "Explication du mode manuel"
 msgstr "Explication du mode manuel"
 
-#: template-parts/chasse/chasse-edition-main.php:280
+#: template-parts/chasse/chasse-edition-main.php:408
 #, fuzzy
 msgid "Fin de chasse manuelle"
 msgstr "ID de chasse invalide."
 
-#: template-parts/chasse/chasse-edition-main.php:281
-msgid "Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans le panneau d’édition de la chasse, onglet Animation."
-msgstr "Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans le panneau d’édition de la chasse, onglet Animation."
+#: template-parts/chasse/chasse-edition-main.php:409
+msgid ""
+"Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans "
+"le panneau d’édition de la chasse, onglet Animation."
+msgstr ""
+"Vous pouvez arrêter la chasse à tout moment grâce au bouton disponible dans "
+"le panneau d’édition de la chasse, onglet Animation."
 
-#: template-parts/chasse/chasse-edition-main.php:295
-msgid "Terminer la chasse"
-msgstr "Terminer la chasse"
-
-#: template-parts/chasse/chasse-edition-main.php:297
-#: template-parts/enigme/partials/enigme-partial-gagnants.php:21
-msgid "Gagnants"
-msgstr "Gagnants"
-
-#: template-parts/chasse/chasse-edition-main.php:305
-msgid "Valider la fin de chasse"
-msgstr "Valider la fin de chasse"
-
-#: template-parts/chasse/chasse-edition-main.php:319
+#: template-parts/chasse/chasse-edition-main.php:417
+#: template-parts/common/edition-animation.php:139
 #, php-format
 msgid "Chasse gagnée le %s par %s"
 msgstr "Chasse gagnée le %s par %s"
 
-#: template-parts/chasse/chasse-edition-main.php:448
+#: template-parts/chasse/chasse-edition-main.php:443
 msgid "Nb gagnants"
 msgstr "Gagnants"
 
-#: template-parts/chasse/chasse-edition-main.php:454
+#: template-parts/chasse/chasse-edition-main.php:449
 msgid "Illimité"
 msgstr "Illimité"
 
-#: template-parts/chasse/chasse-edition-main.php:464
+#: template-parts/chasse/chasse-edition-main.php:459
 msgid "Limité"
 msgstr "Limité"
 
-#: template-parts/chasse/chasse-edition-main.php:514
-msgid "Now"
-msgstr "Maintenant"
-
-#: template-parts/chasse/chasse-edition-main.php:524
-msgid "Later"
-msgstr "Plus tard"
-
-#: template-parts/chasse/chasse-edition-main.php:374
+#: template-parts/chasse/chasse-edition-main.php:502
 msgid "Début"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:390
-#: template-parts/chasse/chasse-edition-main.php:554
+#: template-parts/chasse/chasse-edition-main.php:508
+msgid "Now"
+msgstr "Maintenant"
+
+#: template-parts/chasse/chasse-edition-main.php:518
+msgid "Later"
+msgstr "Plus tard"
+
+#: template-parts/chasse/chasse-edition-main.php:549
 msgid "Date de fin"
 msgstr "Date de fin"
 
-#: template-parts/chasse/chasse-edition-main.php:560
+#: template-parts/chasse/chasse-edition-main.php:555
 msgid "Illimitée"
 msgstr "Illimitée"
 
-#: template-parts/chasse/chasse-edition-main.php:569
+#: template-parts/chasse/chasse-edition-main.php:564
 msgid "Limitée"
 msgstr "Limitée"
 
-#: template-parts/chasse/chasse-edition-main.php:607
-msgid "En savoir plus sur les points"
-msgstr "En savoir plus sur les points"
-
-#: template-parts/chasse/chasse-edition-main.php:610
-msgid "Coût d’accès à une chasse"
-msgstr "Coût d’accès à une chasse"
-
-#: template-parts/chasse/chasse-edition-main.php:601 template-parts/enigme/enigme-edition-main.php:434
+#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/enigme/enigme-edition-main.php:601
 msgid "Accès"
 msgstr "Accès"
 
-#: template-parts/chasse/chasse-edition-main.php:427
+#: template-parts/chasse/chasse-edition-main.php:603
+msgid "En savoir plus sur les points"
+msgstr "En savoir plus sur les points"
+
+#: inc/edition/edition-core.php:583
+msgid "Non spécifiée"
+msgstr "Non spécifiée"
+
+#: inc/edition/edition-core.php:594
+msgctxt "formatting for dates"
+msgid "j F Y"
+msgstr "j F Y"
+
+#: template-parts/chasse/chasse-edition-main.php:606
+msgid "Coût d’accès à une chasse"
+msgstr "Coût d’accès à une chasse"
+
+#: template-parts/chasse/chasse-edition-main.php:607
 msgid ""
 "Vous êtes libre de définir le coût d’accès à votre chasse : gratuit ou "
 "payant. Cet accès est indispensable pour consulter les énigmes, qui restent "
 "invisibles tant qu’il n’a pas été débloqué."
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:445
-#: template-parts/enigme/enigme-edition-main.php:394
-#: template-parts/indice/indice-edition-main.php:202
+#: template-parts/chasse/chasse-edition-main.php:617
 msgid "Gratuit"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:621
-#: template-parts/enigme/enigme-edition-main.php:517
+#: template-parts/chasse/chasse-edition-main.php:625
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:32
+#: template-parts/enigme/enigme-edition-main.php:568
+#: template-parts/organisateur/organisateur-edition-main.php:79
+#: template-parts/organisateur/organisateur-edition-main.php:340
+#: template-parts/organisateur/organisateur-edition-main.php:346
+#: templates/myaccount/content-points.php:75
+#: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
+#: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
+msgid "Points"
+msgstr "Points"
+
+#: template-parts/chasse/chasse-edition-main.php:742
+#: template-parts/enigme/enigme-edition-main.php:663
 msgid "Actualiser"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:554
-#: template-parts/enigme/enigme-edition-main.php:519
+#: template-parts/chasse/chasse-edition-main.php:744
+#: template-parts/enigme/enigme-edition-main.php:665
 msgid "Période :"
 msgstr ""
 
-#: template-parts/chasse/chasse-edition-main.php:568
-#: template-parts/enigme/enigme-edition-main.php:533
+#: template-parts/chasse/chasse-edition-main.php:758
+#: template-parts/enigme/enigme-edition-main.php:679
 msgid "Participants"
 msgstr "Participants"
 
-#: template-parts/chasse/chasse-edition-main.php:575
-#: template-parts/enigme/enigme-edition-main.php:97
-#: template-parts/enigme/enigme-edition-main.php:540
-#: template-parts/enigme/enigme-edition-main.php:578
-#: template-parts/enigme/enigme-edition-main.php:627
+#: template-parts/chasse/chasse-edition-main.php:765
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:31
+#: template-parts/enigme/enigme-edition-main.php:96
+#: template-parts/enigme/enigme-edition-main.php:686
+#: template-parts/enigme/enigme-edition-main.php:724
+#: template-parts/enigme/enigme-edition-main.php:773
 #: template-parts/enigme/partials/enigme-partial-participants.php:69
 #: templates/myaccount/content-chasses.php:108
 msgid "Tentatives"
 msgstr "Tentatives"
 
-#: template-parts/chasse/chasse-edition-main.php:582
-#: template-parts/enigme/enigme-edition-main.php:548
+#: template-parts/chasse/chasse-edition-main.php:772
+#: template-parts/enigme/enigme-edition-main.php:694
 #, fuzzy
 msgid "Points collectés"
 msgstr "Points achetés"
 
-#: template-parts/chasse/chasse-edition-main.php:589
-#: template-parts/chasse/chasse-edition-main.php:597
+#: template-parts/chasse/chasse-edition-main.php:779
+#: template-parts/chasse/chasse-edition-main.php:787
 #, fuzzy
 msgid "Taux d'engagement"
 msgstr "Trier par engagement"
 
-#: template-parts/chasse/chasse-edition-main.php:592
+#: template-parts/chasse/chasse-edition-main.php:782
 #, fuzzy
 msgid ""
 "Pourcentage moyen d’énigmes auxquelles chaque joueur a participé, par "
@@ -1253,27 +1592,18 @@ msgstr ""
 "Pourcentage moyen d’énigmes auxquelles chaque participant s’est engagé, par "
 "rapport à toutes celles proposées."
 
-#: template-parts/chasse/chasse-edition-main.php:596
+#: template-parts/chasse/chasse-edition-main.php:786
 msgid "Explication du taux d’engagement"
 msgstr "Explication du taux d’engagement"
 
-#: template-parts/chasse/chasse-edition-main.php:605
+#: template-parts/chasse/chasse-edition-main.php:795
 #: template-parts/enigme/partials/enigme-partial-participants.php:39
 msgid "Les statistiques seront disponibles une fois la chasse activée."
 msgstr "Les statistiques seront disponibles une fois la chasse activée."
 
-#: template-parts/chasse/chasse-edition-main.php:616
+#: template-parts/chasse/chasse-edition-main.php:806
 msgid "Énigmes sans validation"
 msgstr "Énigmes sans validation"
-
-#: template-parts/chasse/chasse-edition-main.php:655
-#: template-parts/organisateur/organisateur-edition-main.php:342
-msgid "Communiquez"
-msgstr "Communiquez"
-
-#: template-parts/chasse/chasse-edition-main.php:662
-msgid "Sites et réseaux de la chasse"
-msgstr "Sites et réseaux de la chasse"
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:28
 msgid "Modifier la description de la chasse"
@@ -1283,14 +1613,12 @@ msgstr "Modifier la description de la chasse"
 #: template-parts/chasse/panneaux/chasse-edition-recompense.php:16
 #: template-parts/enigme/panneaux/enigme-edition-description.php:19
 #: template-parts/enigme/panneaux/enigme-edition-images.php:12
-#: template-parts/indice/panneaux/indice-edition-description.php:19
 msgid "Fermer le panneau"
 msgstr "Fermer le panneau"
 
 #: template-parts/chasse/panneaux/chasse-edition-description.php:37
 #: template-parts/enigme/panneaux/enigme-edition-description.php:27
 #: template-parts/enigme/panneaux/enigme-edition-images.php:31
-#: template-parts/indice/panneaux/indice-edition-description.php:26
 msgid "💾 Enregistrer"
 msgstr "💾 Enregistrer"
 
@@ -1339,13 +1667,34 @@ msgstr "💾 Enregistrer"
 msgid "Supprimer la récompense"
 msgstr "Modifier la récompense"
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:40
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:30
-msgid "Joueurs"
-msgstr "Joueurs"
+#: template-parts/chasse/partials/chasse-partial-enigmes.php:33
+#: template-parts/chasse/partials/chasse-partial-participants.php:70
+msgid "Trouvées"
+msgstr "Trouvées"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:35
+msgid "Ajouter un indice"
+msgstr "Ajouter un indice"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:42
+#: template-parts/chasse/partials/chasse-partial-solutions.php:50
+msgid "Pour…"
+msgstr "Pour…"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:66
+#: template-parts/chasse/partials/chasse-partial-indices.php:77
+#: template-parts/chasse/partials/chasse-partial-solutions.php:79
+#: template-parts/chasse/partials/chasse-partial-solutions.php:93
+msgid "La chasse entière"
+msgstr "La chasse entière"
+
+#: template-parts/chasse/partials/chasse-partial-indices.php:89
+#: template-parts/chasse/partials/chasse-partial-solutions.php:108
+msgid "Une énigme de la chasse"
+msgstr "Une énigme de la chasse"
 
 #: template-parts/chasse/partials/chasse-partial-participants.php:51
-#: template-parts/enigme/enigme-edition-main.php:576
+#: template-parts/enigme/enigme-edition-main.php:722
 #: template-parts/enigme/partials/enigme-partial-gagnants.php:34
 msgid "Joueur"
 msgstr "Joueur"
@@ -1366,109 +1715,358 @@ msgstr "Participation"
 msgid "Trier par énigmes trouvées"
 msgstr "Trier par énigmes trouvées"
 
-#: template-parts/chasse/partials/chasse-partial-participants.php:70
-#: template-parts/chasse/partials/chasse-partial-enigmes.php:34
-msgid "Trouvées"
-msgstr "Trouvées"
+#: template-parts/chasse/partials/chasse-partial-solutions.php:66
+msgid "Cette énigme"
+msgstr "Cette énigme"
+
+#: template-parts/common/edition-animation.php:53
+#, fuzzy
+msgid "Animation de cette énigme"
+msgstr "Animation de cette énigme"
+
+#: template-parts/common/edition-animation.php:74
+msgid "Sites et réseaux de la chasse"
+msgstr "Sites et réseaux de la chasse"
+
+#: template-parts/common/edition-animation.php:100
+msgid "Sites et réseaux de l'organisation"
+msgstr "Sites et réseaux de l'organisation"
+
+#: template-parts/common/edition-animation.php:135
+msgid "Arrêt chasse"
+msgstr "Arrêt chasse"
+
+#: template-parts/common/edition-animation.php:154
+#, fuzzy
+msgid "Adresse de votre organisation :"
+msgstr "QR code de votre organisation"
+
+#: template-parts/common/edition-animation.php:156
+msgid "Adresse de votre chasse&nbsp;:"
+msgstr "Adresse de votre chasse&nbsp;:"
+
+#: template-parts/common/edition-animation.php:161
+#: template-parts/common/edition-animation.php:165
+msgid "QR code de votre organisation"
+msgstr "QR code de votre organisation"
+
+#: template-parts/common/edition-animation.php:161
+#: template-parts/common/edition-animation.php:172
+msgid "QR code de votre chasse"
+msgstr "QR code de votre chasse"
+
+#: template-parts/common/edition-animation.php:166
+#, fuzzy
+msgid "Partagez votre organisation en un scan"
+msgstr "Partagez votre chasse en un scan"
+
+#: template-parts/common/edition-animation.php:167
+#, fuzzy
+msgid ""
+"Facilitez l'accès à votre organisation avec un simple scan. Un QR code évite "
+"de saisir une URL et se partage facilement."
+msgstr ""
+"Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de "
+"saisir une URL et se partage facilement."
+
+#: template-parts/common/edition-animation.php:169
+#: template-parts/common/edition-animation.php:176
+msgid "Télécharger"
+msgstr "Télécharger"
+
+#: template-parts/common/edition-animation.php:173
+msgid "Partagez votre chasse en un scan"
+msgstr "Partagez votre chasse en un scan"
+
+#: template-parts/common/edition-animation.php:174
+msgid ""
+"Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de "
+"saisir une URL et se partage facilement."
+msgstr ""
+"Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de "
+"saisir une URL et se partage facilement."
+
+#: template-parts/common/edition-animation.php:335
+#: template-parts/common/indices-table.php:30
+#, fuzzy
+msgid "en création"
+msgstr "Présentation"
+
+#: template-parts/common/edition-animation.php:339
+#: template-parts/common/indices-table.php:32
+#, fuzzy
+msgid "Nouvelle chasse"
+msgstr "la chasse"
+
+#: template-parts/common/edition-animation.php:455
+#: template-parts/common/edition-animation.php:464
+#, php-format
+msgid "Indices pour %s"
+msgstr "Indices pour %s"
+
+#: template-parts/common/edition-animation.php:456
+#: template-parts/common/edition-animation.php:462
+#, fuzzy, php-format
+msgid "Indices pour toute la chasse %s"
+msgstr "Solutions pour toute la chasse %s"
+
+#: template-parts/common/edition-animation.php:493
+msgid "Sécurité des PDF de solution"
+msgstr "Sécurité des PDF de solution"
+
+#: template-parts/common/edition-animation.php:494
+msgid "Vos PDF sont conservés dans un coffre-fort numérique"
+msgstr "Vos PDF sont conservés dans un coffre-fort numérique"
+
+#: template-parts/common/edition-animation.php:496
+msgid "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
+msgstr "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
+
+#: template-parts/common/edition-animation.php:497
+msgid "Ils ne seront partagés qu'à la date que vous aurez choisie : "
+msgstr "Ils ne seront partagés qu'à la date que vous aurez choisie : "
+
+#: template-parts/common/edition-animation.php:498
+msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
+msgstr ""
+"immédiatement après la fin de la chasse ou après un délai paramétrable."
+
+#: template-parts/common/edition-animation.php:506
+#: template-parts/common/edition-animation.php:514
+#, php-format
+msgid "Solutions pour %s"
+msgstr "Solutions pour %s"
+
+#: template-parts/common/edition-animation.php:507
+#: template-parts/common/edition-animation.php:512
+#, php-format
+msgid "Solutions pour toute la chasse %s"
+msgstr "Solutions pour toute la chasse %s"
+
+#: template-parts/common/indices-table.php:34
+#, php-format
+msgid "Vous n'avez publié aucun indice attaché à %s"
+msgstr ""
+
+#: template-parts/common/indices-table.php:42
+#, php-format
+msgid "%d indice au total"
+msgid_plural "%d indices au total"
+msgstr[0] "%d indice au total"
+msgstr[1] "%d indices au total"
+
+#: template-parts/common/indices-table.php:45
+#, php-format
+msgid "%d indice chasse"
+msgid_plural "%d indices chasse"
+msgstr[0] "%d indice chasse"
+msgstr[1] "%d indices chasse"
+
+#: template-parts/common/indices-table.php:48
+#, php-format
+msgid "%d indice énigme"
+msgid_plural "%d indices énigme"
+msgstr[0] "%d indice énigme"
+msgstr[1] "%d indices énigme"
+
+#: template-parts/common/indices-table.php:64
+msgid "Indice"
+msgstr "Indice"
+
+#: template-parts/common/indices-table.php:65
+#: template-parts/common/solutions-table.php:123
+msgid "Texte"
+msgstr "Texte"
+
+#: template-parts/common/indices-table.php:66
+#, fuzzy
+msgid "Indice pour"
+msgstr "Indices pour %s"
+
+#: template-parts/common/indices-table.php:67
+#: template-parts/common/solutions-table.php:34
+#, fuzzy
+msgid "Action"
+msgstr "Présentation"
+
+#. translators: %s: scheduled date
+#: template-parts/common/indices-table.php:117
+#, php-format
+msgid "programmé le %s"
+msgstr "programmé le %s"
+
+#: template-parts/common/indices-table.php:121
+msgid "programmé"
+msgstr "programmé"
+
+#: template-parts/common/indices-table.php:150
+#: template-parts/common/solutions-table.php:114
+#, php-format
+msgid "à %s"
+msgstr "à %s"
+
+#: template-parts/common/indices-table.php:184
+#, fuzzy
+msgid "Supprimer cet indice ?"
+msgstr "Modifier la récompense"
+
+#: template-parts/common/solutions-table.php:23
+#, fuzzy
+msgid "Aucune solution publiée"
+msgstr "Aucune donnée."
+
+#: template-parts/common/solutions-table.php:31
+msgid "Solution"
+msgstr "Solution"
+
+#: template-parts/common/solutions-table.php:32
+msgid "Availability"
+msgstr ""
+
+#: template-parts/common/solutions-table.php:33
+msgid "Solution pour"
+msgstr "Solution pour"
+
+#: template-parts/common/solutions-table.php:78
+msgid "Invalid solution"
+msgstr "Solution invalide"
+
+#: template-parts/common/solutions-table.php:79
+msgid "Hunt finished"
+msgstr "Fin de chasse"
+
+#: template-parts/common/solutions-table.php:80
+msgid "Hunt end delayed"
+msgstr "Fin de chasse différée"
+
+#: template-parts/common/solutions-table.php:81
+msgid "Coming soon"
+msgstr "À venir"
+
+#: template-parts/common/solutions-table.php:82
+msgid "In progress"
+msgstr "En cours"
+
+#: template-parts/common/solutions-table.php:83
+msgid "Disabled"
+msgstr "Désactivée"
+
+#: template-parts/common/solutions-table.php:120
+msgid "PDF"
+msgstr "PDF"
+
+#: template-parts/common/solutions-table.php:132
+#, php-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: template-parts/common/solutions-table.php:132
+#, fuzzy
+msgid "at"
+msgstr "Date"
+
+#: template-parts/common/solutions-table.php:162
+#, fuzzy
+msgid "Supprimer cette solution ?"
+msgstr "Ajouter une solution"
 
 #: template-parts/common/stat-histogram-card.php:38
 msgid "Aucune donnée."
 msgstr "Aucune donnée."
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
-#: assets/js/enigme-edit.js:1616
+#: assets/js/enigme-edit.js:1533
 #, fuzzy
 msgid "Ajouter une énigme"
 msgstr "Ajouter une variante"
 
-#: template-parts/enigme/enigme-edition-main.php:87
+#: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"
 msgstr "Panneau d'édition énigme"
 
-#: template-parts/enigme/enigme-edition-main.php:91
-#: template-parts/indice/indice-edition-main.php:56
+#: template-parts/enigme/enigme-edition-main.php:90
 #, fuzzy
 msgid "Fermer les paramètres"
 msgstr "Fermer le panneau"
 
-#: template-parts/enigme/enigme-edition-main.php:112
-#: template-parts/indice/indice-edition-main.php:74
+#: template-parts/enigme/enigme-edition-main.php:111
 #, fuzzy
 msgid "Informations"
 msgstr "Inscription"
 
-#: template-parts/enigme/enigme-edition-main.php:138
+#: template-parts/enigme/enigme-edition-main.php:137
 #, fuzzy
 msgid "renseigner le titre de l’énigme"
 msgstr "renseigner le titre de l’indice"
 
-#: template-parts/enigme/enigme-edition-main.php:156
+#: template-parts/enigme/enigme-edition-main.php:161
 msgid "Illustrations"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:194
+#: template-parts/enigme/enigme-edition-main.php:219
 msgid "Texte énigme"
 msgstr "Texte énigme"
 
-#: template-parts/enigme/enigme-edition-main.php:213
+#: template-parts/enigme/enigme-edition-main.php:242
 msgid "Éditer le texte"
 msgstr "Éditer le texte"
 
-#: template-parts/enigme/enigme-edition-main.php:214
-#: template-parts/enigme/enigme-edition-main.php:350
-#: template-parts/enigme/enigme-edition-main.php:673
+#: template-parts/enigme/enigme-edition-main.php:243
+#: template-parts/enigme/enigme-edition-main.php:461
 msgid "éditer"
 msgstr "éditer"
 
-#: template-parts/enigme/enigme-edition-main.php:228
+#: template-parts/enigme/enigme-edition-main.php:270
 msgid "Sous-titre"
 msgstr "Sous-titre"
 
-#: template-parts/enigme/enigme-edition-main.php:230
+#: template-parts/enigme/enigme-edition-main.php:276
 msgid "Ajouter un sous-titre (max 100 caractères)"
 msgstr "Ajouter un sous-titre (max 100 caractères)"
 
-#: template-parts/enigme/enigme-edition-main.php:243
+#: template-parts/enigme/enigme-edition-main.php:307
 msgid "Validation"
 msgstr "Validation"
 
-#: template-parts/enigme/enigme-edition-main.php:256
+#: template-parts/enigme/enigme-edition-main.php:324
 #, fuzzy
 msgid "Validation automatique"
 msgstr "Explication du mode automatique"
 
-#: template-parts/enigme/enigme-edition-main.php:257
+#: template-parts/enigme/enigme-edition-main.php:325
 msgid ""
 "Le joueur soumet une tentative de réponse. Celle-ci est automatiquement "
 "vérifiée selon les critères définis (réponse attendue, respect de la casse, "
 "variantes), et le résultat est immédiatement communiqué au joueur."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:273
+#: template-parts/enigme/enigme-edition-main.php:342
 #, fuzzy
 msgid "Validation manuelle"
 msgstr "Validation"
 
-#: template-parts/enigme/enigme-edition-main.php:274
+#: template-parts/enigme/enigme-edition-main.php:343
 msgid ""
 "Le joueur rédige une réponse libre. Vous validez ou refusez ensuite sa "
 "tentative depuis votre espace personnel. À chaque nouvelle soumission, vous "
 "recevez une notification par email ainsi qu’un message d’alerte."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:281
+#: template-parts/enigme/enigme-edition-main.php:351
 msgid "Aucune"
 msgstr "Aucune"
 
-#: template-parts/enigme/enigme-edition-main.php:288
+#: template-parts/enigme/enigme-edition-main.php:377
 msgid "Bonne(s) réponse(s)"
 msgstr "Bonne(s) réponse(s)"
 
-#: template-parts/enigme/enigme-edition-main.php:294
+#: template-parts/enigme/enigme-edition-main.php:383
 msgid "La ou les bonnes réponses"
 msgstr "La ou les bonnes réponses"
 
-#: template-parts/enigme/enigme-edition-main.php:295
+#: template-parts/enigme/enigme-edition-main.php:384
 msgid ""
 "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — "
 "selon votre réglage de respect de la casse — résout l’énigme."
@@ -1476,93 +2074,71 @@ msgstr ""
 "Vous pouvez saisir de 1 à 5 bonnes réponses. Tout joueur qui en soumet une — "
 "selon votre réglage de respect de la casse — résout l’énigme."
 
-#: template-parts/enigme/enigme-edition-main.php:307
+#: template-parts/enigme/enigme-edition-main.php:397
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:55
 msgid "Respecter la casse"
 msgstr "Respecter la casse"
 
-#: template-parts/enigme/enigme-edition-main.php:315
+#: template-parts/enigme/enigme-edition-main.php:423
 msgid "Variantes"
 msgstr "Variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:321
+#: template-parts/enigme/enigme-edition-main.php:429
 msgid "Explication des variantes"
 msgstr "Explication des variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:324
+#: template-parts/enigme/enigme-edition-main.php:432
 #, fuzzy
 msgid "Système de variantes"
 msgstr "Ajouter des variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:325
+#: template-parts/enigme/enigme-edition-main.php:433
 msgid ""
 "Les variantes sont des réponses alternatives qui ne sont pas validées comme "
 "correctes, mais qui déclenchent un message personnalisé en retour (par "
 "exemple une aide, un indice, un lien ou tout autre contenu de votre choix)."
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:335
-#: assets/js/enigme-edit.js:915
+#: template-parts/enigme/enigme-edition-main.php:446
+#: assets/js/enigme-edit.js:1174
 #, fuzzy
 msgid "Variante"
 msgstr "Variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:336
-#: assets/js/enigme-edit.js:918
+#: template-parts/enigme/enigme-edition-main.php:447
+#: assets/js/enigme-edit.js:1177
 msgid "Message"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:349
+#: template-parts/enigme/enigme-edition-main.php:460
 msgid "Éditer les variantes"
 msgstr "Éditer les variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:354
-#: assets/js/enigme-edit.js:966
+#: template-parts/enigme/enigme-edition-main.php:465
+#: assets/js/enigme-edit.js:1225
 msgid "Ajouter des variantes"
 msgstr "Ajouter des variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:355
-#: assets/js/enigme-edit.js:967
+#: template-parts/enigme/enigme-edition-main.php:466
+#: assets/js/enigme-edit.js:1226
 msgid "ajouter des variantes"
 msgstr "ajouter des variantes"
 
-#: template-parts/enigme/enigme-edition-main.php:371
-#, fuzzy
-msgid "Coût tentative"
-msgstr "Nb tentatives :"
-
-#: template-parts/enigme/enigme-edition-main.php:377
-#, fuzzy
-msgid "Informations sur le coût des tentatives"
-msgstr "Informations sur les coordonnées bancaires"
-
-#: template-parts/enigme/enigme-edition-main.php:380
-#, fuzzy
-msgid "Tentative gratuite ou payante ?"
-msgstr "Tentative introuvable."
-
-#: template-parts/enigme/enigme-edition-main.php:381
-msgid ""
-"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
-"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
-"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:402
+#: template-parts/enigme/enigme-edition-main.php:491
 #, fuzzy
 msgid "Nb tentatives"
 msgstr "Nb tentatives :"
 
-#: template-parts/enigme/enigme-edition-main.php:408
+#: template-parts/enigme/enigme-edition-main.php:497
 msgid "Explication du nombre de tentatives"
 msgstr "Explication du nombre de tentatives"
 
-#: template-parts/enigme/enigme-edition-main.php:411
+#: template-parts/enigme/enigme-edition-main.php:500
 #, fuzzy
 msgid "Plafond nb de tentatives quotidiennes"
 msgstr "Tentatives quotidiennes"
 
-#: template-parts/enigme/enigme-edition-main.php:412
+#: template-parts/enigme/enigme-edition-main.php:501
 #, fuzzy
 msgid ""
 "Nombre maximal de tentatives quotidiennes par joueur:\n"
@@ -1575,160 +2151,77 @@ msgstr ""
 "Mode payant : tentatives illimitées.\n"
 "Mode gratuit : maximum 24 tentatives par jour."
 
-#: template-parts/enigme/enigme-edition-main.php:418
+#: template-parts/enigme/enigme-edition-main.php:513
 msgid "max par jour"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:438
+#: template-parts/enigme/enigme-edition-main.php:543
+#, fuzzy
+msgid "Coût tentative"
+msgstr "Nb tentatives :"
+
+#: template-parts/enigme/enigme-edition-main.php:549
+#, fuzzy
+msgid "Informations sur le coût des tentatives"
+msgstr "Informations sur les coordonnées bancaires"
+
+#: template-parts/enigme/enigme-edition-main.php:552
+#, fuzzy
+msgid "Tentative gratuite ou payante ?"
+msgstr "Tentative introuvable."
+
+#: template-parts/enigme/enigme-edition-main.php:553
+msgid ""
+"Vous êtes libre de définir le coût d’une tentative pour votre énigme : "
+"gratuite ou payante en points. Lorsqu’un joueur dépense des points pour "
+"soumettre une réponse, ceux-ci sont immédiatement crédités sur votre compte."
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:563
+msgid "Free"
+msgstr ""
+
+#: template-parts/enigme/enigme-edition-main.php:607
 msgid "Libre"
 msgstr "Libre"
 
-#: template-parts/enigme/enigme-edition-main.php:442
+#: template-parts/enigme/enigme-edition-main.php:612
 msgid "Date programmée"
 msgstr "Date programmée"
 
-#: template-parts/enigme/enigme-edition-main.php:455
-msgid "Aucune autre énigme disponible comme prérequis."
-msgstr "Aucune autre énigme disponible comme prérequis."
-
-#: template-parts/enigme/enigme-edition-main.php:491
+#: template-parts/enigme/enigme-edition-main.php:637
 msgid "❌ Suppression énigme"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:521
+#: template-parts/enigme/enigme-edition-main.php:667
 #, fuzzy
 msgid "Total"
 msgstr "Total €"
 
-#: template-parts/enigme/enigme-edition-main.php:522
+#: template-parts/enigme/enigme-edition-main.php:668
 msgid "Aujourd’hui"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:523
+#: template-parts/enigme/enigme-edition-main.php:669
 msgid "Semaine"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:524
+#: template-parts/enigme/enigme-edition-main.php:670
 msgid "Mois"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:556
+#: template-parts/enigme/enigme-edition-main.php:702
 #, fuzzy
 msgid "Bonnes réponses"
 msgstr "Bonne(s) réponse(s)"
 
-#: template-parts/enigme/enigme-edition-main.php:570
+#: template-parts/enigme/enigme-edition-main.php:716
 #, php-format
 msgid "Résolue par (%s) joueurs"
 msgstr ""
 
-#: template-parts/enigme/enigme-edition-main.php:575
+#: template-parts/enigme/enigme-edition-main.php:721
 msgid "Rang"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:655
-#, fuzzy
-msgid "Animation de cette énigme"
-msgstr "Animation de cette énigme"
-
-#: template-parts/enigme/enigme-edition-main.php:667
-msgid ""
-"Les solutions ne peuvent être publiées que lorsqu’une chasse est déclarée "
-"terminée. Une fois celle-ci achevée, elles restent conservées dans un coffre-"
-"fort numérique pendant le délai que vous définissez ici."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:670
-msgid "Document PDF"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:671
-#: templates/myaccount/content-outils.php:33
-msgid "Modifier"
-msgstr "Modifier"
-
-#: template-parts/enigme/enigme-edition-main.php:671
-msgid "Choisir un fichier"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:673
-msgid "Rédiger"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:675
-#, fuzzy
-msgid "aucune solution ne"
-msgstr "Aucune donnée."
-
-#: template-parts/enigme/enigme-edition-main.php:680
-#, php-format
-msgid "votre fichier %s"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:681
-#, php-format
-msgid " %d jours après la fin de la chasse, à %s"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:683
-msgid " (pdf sélectionné mais pas de fichier chargé)"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:687
-msgid "votre texte d'explication"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:688
-#, php-format
-msgid ", %d jours après la fin de la chasse, à %s"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:690
-msgid " (rédaction libre sélectionnée mais non remplie)"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:702
-#: template-parts/enigme/enigme-edition-main.php:710
-#, fuzzy
-msgid "Vider"
-msgstr "Valider"
-
-#: template-parts/enigme/enigme-edition-main.php:712
-msgid "Rédaction libre"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:720
-#, fuzzy
-msgid "Délai après fin de chasse"
-msgstr "Valider la fin de chasse"
-
-#: template-parts/enigme/enigme-edition-main.php:726
-msgid "Informations sur la publication de la solution"
-msgstr "Informations sur la publication de la solution"
-
-#: template-parts/enigme/enigme-edition-main.php:729
-#, fuzzy
-msgid "Délai de parution des solutions"
-msgstr "Définition du taux de résolution"
-
-#: template-parts/enigme/enigme-edition-main.php:745
-msgid "jours, publié à"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:760
-msgid "Vos solutions sont protégées"
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:761
-msgid "Stockées dans un espace privé, hors de portée des joueurs."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:762
-msgid "Aucun lien ne peut être trouvé ni ouvert."
-msgstr ""
-
-#: template-parts/enigme/enigme-edition-main.php:763
-msgid "Débloquées uniquement au moment choisi."
 msgstr ""
 
 #: template-parts/enigme/panneaux/enigme-edition-description.php:18
@@ -1752,12 +2245,12 @@ msgid "Configurer les variantes de réponse"
 msgstr "Configurer les variantes de réponse"
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:50
-#: assets/js/enigme-edit.js:826
+#: assets/js/enigme-edit.js:1084
 msgid "réponse déclenchant l'affichage du message"
 msgstr "réponse déclenchant l'affichage du message"
 
 #: template-parts/enigme/panneaux/enigme-edition-variantes.php:51
-#: assets/js/enigme-edit.js:829
+#: assets/js/enigme-edit.js:1087
 msgid "Message affiché au joueur"
 msgstr "Message affiché au joueur"
 
@@ -1914,62 +2407,6 @@ msgstr "🏴‍☠️ Texte (pirate)"
 msgid "🏴‍☠️ Titre (pirate)"
 msgstr "🏴‍☠️ Titre (pirate)"
 
-#: template-parts/indice/indice-edition-main.php:53
-msgid "Panneau d'édition indice"
-msgstr "Panneau d'édition indice"
-
-#: template-parts/indice/indice-edition-main.php:95
-msgid "renseigner le titre de l’indice"
-msgstr "renseigner le titre de l’indice"
-
-#: template-parts/indice/indice-edition-main.php:105
-msgid "Image"
-msgstr "Image"
-
-#: template-parts/indice/indice-edition-main.php:124
-msgid "Texte"
-msgstr "Texte"
-
-#: template-parts/indice/indice-edition-main.php:136
-#: template-parts/indice/panneaux/indice-edition-description.php:18
-msgid "Modifier le texte de l’indice"
-msgstr "Modifier le texte de l’indice"
-
-#: template-parts/indice/indice-edition-main.php:151
-msgid "Aide pour"
-msgstr "Aide pour"
-
-#: template-parts/indice/indice-edition-main.php:158
-msgid "Aucune énigme disponible."
-msgstr "Aucune énigme disponible."
-
-#: template-parts/indice/indice-edition-main.php:184
-msgid "Publication"
-msgstr "Publication"
-
-#: template-parts/indice/indice-edition-main.php:186
-#: inc/edition/edition-core.php:***
-msgid "Immédiate"
-msgstr "Immédiate"
-
-#: template-parts/indice/indice-edition-main.php:187
-#: inc/edition/edition-core.php:***
-msgid "Différée"
-msgstr "Différée"
-
-#: template-parts/indice/indice-edition-main.php:198
-msgid "(points)"
-msgstr "(points)"
-
-#: template-parts/indice/indice-edition-main.php:221
-#, fuzzy
-msgid "Statistiques à venir"
-msgstr "Statistiques"
-
-#: template-parts/indice/panneaux/indice-edition-description.php:31
-msgid "Texte de l’indice mis à jour."
-msgstr "Texte de l’indice mis à jour."
-
 #: template-parts/modals/modal-points.php:9
 msgid "À quoi servent les points ?"
 msgstr ""
@@ -1998,53 +2435,75 @@ msgid ""
 "organisateur."
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:69
+#: template-parts/organisateur/organisateur-edition-main.php:70
 msgid "Panneau d'édition organisateur"
 msgstr "Panneau d'édition organisateur"
 
-#: template-parts/organisateur/organisateur-edition-main.php:78
-#: template-parts/organisateur/organisateur-edition-main.php:264
-#: template-parts/chasse/chasse-edition-main.php:629
-#: template-parts/organisateur/organisateur-edition-main.php:270
-#: templates/myaccount/content-points.php:75
-#: templates/myaccount/content-points.php:96 templates/myaccount/layout.php:57
-#: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
-msgid "Points"
-msgstr "Points"
+#: template-parts/organisateur/organisateur-edition-main.php:120
+msgid "renseigner le titre de l’organisateur"
+msgstr "renseigner le titre de l’organisateur"
 
-#: template-parts/organisateur/organisateur-edition-main.php:153
+#: template-parts/organisateur/organisateur-edition-main.php:144
+msgid "Logo organisateur"
+msgstr "Logo organisateur"
+
+#: template-parts/organisateur/organisateur-edition-main.php:159
+msgid "Modifier le logo"
+msgstr "Modifier le logo"
+
+#: template-parts/organisateur/organisateur-edition-main.php:162
+#: template-parts/organisateur/organisateur-edition-main.php:172
+msgid "Logo de l’organisateur"
+msgstr "Logo de l’organisateur"
+
+#: template-parts/organisateur/organisateur-edition-main.php:204
 msgid "Présentation"
 msgstr "Présentation"
 
-#: template-parts/organisateur/organisateur-edition-main.php:173
+#: template-parts/organisateur/organisateur-edition-main.php:230
 msgid "Modifier la présentation"
 msgstr "Modifier la présentation"
 
-#: template-parts/organisateur/organisateur-edition-main.php:207
+#: template-parts/organisateur/organisateur-edition-main.php:265
+#, fuzzy
+msgid "Email de contact"
+msgstr "Confirmation Organisateur"
+
+#: template-parts/organisateur/organisateur-edition-main.php:279
 msgid "Informations sur l’adresse email de contact"
 msgstr "Informations sur l’adresse email de contact"
 
-#: template-parts/organisateur/organisateur-edition-main.php:209
+#: template-parts/organisateur/organisateur-edition-main.php:281
 #, fuzzy
 msgid "Email de contact organisateur"
 msgstr "Confirmation Organisateur"
 
-#: template-parts/organisateur/organisateur-edition-main.php:210
+#: template-parts/organisateur/organisateur-edition-main.php:282
 msgid ""
 "Si aucune adresse n’est renseignée, votre adresse email utilisateur est "
 "utilisée par défaut."
 msgstr ""
 
-#: template-parts/organisateur/organisateur-edition-main.php:293
-msgid "Informations sur les coordonnées bancaires"
-msgstr "Informations sur les coordonnées bancaires"
+#: template-parts/organisateur/organisateur-edition-main.php:290
+#, fuzzy
+msgid "Modifier l’adresse email de contact"
+msgstr "Informations sur l’adresse email de contact"
 
-#: template-parts/organisateur/organisateur-edition-main.php:296
+#: template-parts/organisateur/organisateur-edition-main.php:305
+msgid "exemple@domaine.com"
+msgstr ""
+
+#: template-parts/organisateur/organisateur-edition-main.php:363
+#: template-parts/organisateur/organisateur-edition-main.php:372
 #, fuzzy
 msgid "Coordonnées bancaires"
 msgstr "Ajouter des coordonnées bancaires"
 
-#: template-parts/organisateur/organisateur-edition-main.php:297
+#: template-parts/organisateur/organisateur-edition-main.php:369
+msgid "Informations sur les coordonnées bancaires"
+msgstr "Informations sur les coordonnées bancaires"
+
+#: template-parts/organisateur/organisateur-edition-main.php:373
 msgid ""
 "Ces informations sont nécessaires uniquement pour vous verser les gains "
 "issus de la conversion de vos points en euros. Nous ne prélevons jamais "
@@ -2054,30 +2513,15 @@ msgstr ""
 "issus de la conversion de vos points en euros. Nous ne prélevons jamais "
 "d'argent."
 
-#: template-parts/organisateur/organisateur-edition-main.php:352
-msgid "Sites et réseaux de l'organisation"
-msgstr "Sites et réseaux de l'organisation"
+#: template-parts/organisateur/organisateur-header.php:59
+#, fuzzy
+msgid "Voir la page de l\\u2019organisateur"
+msgstr "Logo de l’organisateur"
 
-#: template-parts/organisateur/organisateur-edition-main.php:380
-msgid "QR code de l'organisation"
-msgstr "QR code de l'organisation"
-
-#: template-parts/organisateur/organisateur-edition-main.php:381
-msgid "QR code de votre organisation"
-msgstr "QR code de votre organisation"
-
-#: template-parts/chasse/chasse-edition-main.php:863
-msgid "QR code de la chasse"
-msgstr "QR code de la chasse"
-
-#: template-parts/chasse/chasse-edition-main.php:864
-msgid "QR code de votre chasse"
-msgstr "QR code de votre chasse"
-
-#: template-parts/chasse/chasse-edition-main.php:866
-#: template-parts/organisateur/organisateur-edition-main.php:383
-msgid "Télécharger"
-msgstr "Télécharger"
+#: template-parts/organisateur/organisateur-header.php:61
+#, fuzzy
+msgid "Logo de l\\u2019organisateur"
+msgstr "Logo de l’organisateur"
 
 #: templates/myaccount/content-chasses.php:111
 #, fuzzy, php-format
@@ -2099,23 +2543,6 @@ msgid "%d bonne réponse"
 msgid_plural "%d bonnes réponses"
 msgstr[0] "Votre réponse"
 msgstr[1] "Votre réponse"
-
-#: templates/myaccount/content-chasses.php:125
-#: inc/edition/edition-core.php:158
-msgid "Énigme"
-msgstr "Énigme"
-
-#: inc/edition/edition-core.php:159
-msgid "Sélectionner une énigme"
-msgstr "Sélectionner une énigme"
-
-#: inc/edition/edition-core.php:160
-msgid "Sélectionnez une énigme"
-msgstr "Sélectionnez une énigme"
-
-#: inc/edition/edition-core.php:161
-msgid "Chargement…"
-msgstr "Chargement…"
 
 #: templates/myaccount/content-dashboard-organisateur.php:25
 msgid "Votre demande de conversion a bien été envoyée."
@@ -2299,46 +2726,42 @@ msgstr ""
 "✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien "
 "pour confirmer votre demande."
 
+#: assets/js/chasse-edit.js:328
+msgid "Voulez-vous vraiment supprimer la récompense ?"
+msgstr "Voulez-vous vraiment supprimer la récompense ?"
+
+#: assets/js/chasse-edit.js:527
+msgid "Voulez-vous vraiment arrêter la chasse ?"
+msgstr "Voulez-vous vraiment arrêter la chasse ?"
+
 #: assets/js/enigme-aside.js:15
 #, fuzzy
 msgid "Afficher le panneau"
 msgstr "Fermer le panneau"
 
-#: assets/js/enigme-edit.js:600
+#: assets/js/enigme-edit.js:857
 msgid "Ex : soleil"
 msgstr "Ex : soleil"
 
-#: assets/js/enigme-edit.js:605 assets/js/enigme-edit.js:657
+#: assets/js/enigme-edit.js:862 assets/js/enigme-edit.js:914
 #, fuzzy
 msgid "valider"
 msgstr "Invalider"
 
-#: assets/js/enigme-edit.js:629
-msgid "Supprimer"
-msgstr "Supprimer"
-
-#: assets/js/enigme-edit.js:703
+#: assets/js/enigme-edit.js:960
 #, fuzzy
 msgid "Ajouter une illustration"
 msgstr "Ajouter une variante"
 
-#: assets/js/enigme-edit.js:742 assets/js/enigme-edit.js:987
+#: assets/js/enigme-edit.js:1000 assets/js/enigme-edit.js:1246
 msgid "Modifier les variantes"
 msgstr "Modifier les variantes"
 
-#: assets/js/enigme-edit.js:878
-msgid "Enregistrement..."
-msgstr "Enregistrement..."
-
-#: assets/js/enigme-edit.js:898
-msgid "✔️ Variantes enregistrées"
-msgstr "✔️ Variantes enregistrées"
-
-#: assets/js/enigme-edit.js:1005
+#: assets/js/enigme-edit.js:1264
 msgid "❌ Erreur réseau"
 msgstr "❌ Erreur réseau"
 
-#: assets/js/enigme-edit.js:1663
+#: assets/js/enigme-edit.js:1580
 #, fuzzy
 msgid "Erreur lors de l'enregistrement de l'ordre"
 msgstr "Erreur lors de la création de la chasse."
@@ -2377,272 +2800,8 @@ msgstr "Votre réponse"
 msgid "Tentatives quotidiennes"
 msgstr "Tentatives quotidiennes"
 
-#: template-parts/chasse/chasse-edition-main.php:112
-#: assets/js/core/resume.js:322
-msgid "renseigner le titre de la chasse"
-msgstr "renseigner le titre de la chasse"
-
-#: template-parts/organisateur/organisateur-edition-main.php:120
-msgid "renseigner le titre de l’organisateur"
-msgstr "renseigner le titre de l’organisateur"
-
-#: assets/js/help-modal.js:19
-#: inc/edition/edition-core.php:***
-msgid "Fermer"
-msgstr "Fermer"
-
-#: inc/edition/edition-core.php:***
-msgid "Choisir une image"
-msgstr "Choisir une image"
-
-#: inc/edition/edition-core.php:***
-msgid "Texte de l’indice"
-msgstr "Texte de l’indice"
-
-#: inc/edition/edition-core.php:***
-msgid "Sélectionner une image"
-msgstr "Sélectionner une image"
-
-#: assets/js/chasse-edit.js:376
-msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
-msgstr "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
-
-#: assets/js/chasse-edit.js:318
-msgid "Voulez-vous vraiment supprimer la récompense ?"
-msgstr "Voulez-vous vraiment supprimer la récompense ?"
-
-#: assets/js/chasse-edit.js
-msgid "Voulez-vous vraiment arrêter la chasse ?"
-msgstr "Voulez-vous vraiment arrêter la chasse ?"
-
-#: template-parts/chasse/chasse-edition-main.php
-msgid "Arrêt chasse"
-msgstr "Arrêt chasse"
-
-#: template-parts/common/indices-table.php:69
-msgid "accessible"
-msgstr "accessible"
-
-#: template-parts/common/indices-table.php:69
-msgid "programme"
-msgstr "programmé"
-
-#: template-parts/common/indices-table.php:83
-msgid "programmé"
-msgstr "programmé"
-
-#: template-parts/common/indices-table.php:75
-msgid "programmé le %s"
-msgstr "programmé le %s"
-
-#: template-parts/common/indices-table.php:41
-#, php-format
-msgid "%d indice au total"
-msgid_plural "%d indices au total"
-msgstr[0] "%d indice au total"
-msgstr[1] "%d indices au total"
-
-#: template-parts/common/indices-table.php:44
-#, php-format
-msgid "%d indice chasse"
-msgid_plural "%d indices chasse"
-msgstr[0] "%d indice chasse"
-msgstr[1] "%d indices chasse"
-
-#: template-parts/common/indices-table.php:47
-#, php-format
-msgid "%d indice énigme"
-msgid_plural "%d indices énigme"
-msgstr[0] "%d indice énigme"
-msgstr[1] "%d indices énigme"
-
-#: template-parts/common/indices-table.php:55
-msgid "Indice"
-msgstr "Indice"
-
-#: template-parts/common/indices-table.php:136
-#, php-format
-msgid "à %s"
-msgstr "à %s"
-
-#: template-parts/chasse/chasse-edition-main.php:867 template-parts/chasse/chasse-edition-main.php:986
-msgid "Solution"
-msgstr "Solution"
-
-#: template-parts/chasse/chasse-edition-main.php:974
-msgid "Partagez votre chasse en un scan"
-msgstr "Partagez votre chasse en un scan"
-
-#: template-parts/chasse/chasse-edition-main.php:975
-msgid "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
-msgstr "Facilitez l'accès à votre chasse avec un simple scan. Un QR code évite de saisir une URL et se partage facilement."
-
-#: template-parts/chasse/chasse-edition-main.php:987
-msgid "Contenu de la solution à venir."
-msgstr "Contenu de la solution à venir."
-
-#: template-parts/chasse/chasse-edition-main.php:973
-msgid "Vos liens"
-msgstr "Vos liens"
-
-#: template-parts/chasse/chasse-edition-main.php:976
-msgid "Adresse de votre chasse&nbsp;:"
-msgstr "Adresse de votre chasse&nbsp;:"
-
-#: template-parts/common/solutions-table.php:33
-msgid "Solution pour"
-msgstr "Solution pour"
-
-#: template-parts/common/solutions-table.php:105
-msgid "PDF"
-msgstr "PDF"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Invalid solution"
-msgstr "Solution invalide"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Hunt finished"
-msgstr "Fin de chasse"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Hunt end delayed"
-msgstr "Fin de chasse différée"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Coming soon"
-msgstr "À venir"
-
-#: template-parts/common/solutions-table.php:???
-msgid "In progress"
-msgstr "En cours"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Disabled"
-msgstr "Désactivée"
-
-#: template-parts/common/solutions-table.php:???
-msgid "Coming on %s"
-msgstr "À venir le %s"
-
-#: inc/edition/edition-core.php:180
-msgid "Texte de la solution"
-msgstr "Texte de la solution"
-
-#: inc/edition/edition-core.php:181
-msgid "Fichier"
-msgstr "Fichier"
-
-#: inc/edition/edition-core.php:182
-msgid "Disponibilité"
-msgstr "Disponibilité"
-
-#: inc/edition/edition-core.php:187 template-parts/chasse/partials/chasse-partial-solutions.php:24
-msgid "Ajouter une solution"
-msgstr "Ajouter une solution"
-
-#: inc/edition/edition-core.php:195
-msgid "Ajoutez un fichier ou un texte"
-msgstr "Ajoutez un fichier ou un texte"
-
-#: inc/edition/edition-core.php:200
-msgid "Aucun fichier choisi"
-msgstr "Aucun fichier choisi"
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:47
-#: inc/edition/edition-enigme.php:62
-msgid "Il existe déjà une solution pour cette chasse"
-msgstr "Il existe déjà une solution pour cette chasse"
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:33
-#: inc/edition/edition-enigme.php:63
-msgid "Il existe déjà une solution pour cette énigme"
-msgstr "Il existe déjà une solution pour cette énigme"
-
-#: template-parts/chasse/partials/chasse-partial-solutions.php:62
-msgid "Toutes les énigmes de la chasse ont déjà une solution"
-msgstr "Toutes les énigmes de la chasse ont déjà une solution"
-
-#: template-parts/chasse/chasse-edition-main.php:987
-msgid "Sécurité des PDF de solution"
-msgstr "Sécurité des PDF de solution"
-
-#: template-parts/chasse/chasse-edition-main.php:988
-msgid "Vos PDF sont conservés dans un coffre-fort numérique"
-msgstr "Vos PDF sont conservés dans un coffre-fort numérique"
-
-#: template-parts/chasse/chasse-edition-main.php:991
-msgid "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
-msgstr "Les fichiers PDF de solution sont conservés dans un dossier protégé. "
-
-#: template-parts/chasse/chasse-edition-main.php:995
-msgid "Ils ne seront partagés qu'à la date que vous aurez choisie : "
-msgstr "Ils ne seront partagés qu'à la date que vous aurez choisie : "
-
-#: template-parts/chasse/chasse-edition-main.php:999
-msgid "immédiatement après la fin de la chasse ou après un délai paramétrable."
-msgstr "immédiatement après la fin de la chasse ou après un délai paramétrable."
-
-#: template-parts/organisateur/organisateur-edition-main.php:144
-msgid "Logo organisateur"
-msgstr "Logo organisateur"
-
-#: template-parts/organisateur/organisateur-edition-main.php:159
-msgid "Modifier le logo"
-msgstr "Modifier le logo"
-
-#: template-parts/organisateur/organisateur-edition-main.php:162
-#: template-parts/organisateur/organisateur-edition-main.php:172
-msgid "Logo de l’organisateur"
-msgstr "Logo de l’organisateur"
-
-#: template-parts/common/edition-animation.php:512
-msgid "Solutions pour toute la chasse %s"
-msgstr "Solutions pour toute la chasse %s"
-
-#: template-parts/common/edition-animation.php:514
-msgid "Solutions pour %s"
-msgstr "Solutions pour %s"
-
-#: template-parts/common/edition-animation.php:521
-#: inc/edition/edition-enigme.php:64
-msgid "Voir toutes les solutions de la chasse"
-msgstr "Voir toutes les solutions de la chasse"
-
-#: inc/edition/edition-enigme.php:65
-msgid "Voir la solution de cette énigme"
-msgstr "Voir la solution de cette énigme"
-
-#: inc/edition/edition-core.php:583
-msgid "Non spécifiée"
-msgstr "Non spécifiée"
-
-#: inc/edition/edition-core.php:594
-msgctxt "formatting for dates"
-msgid "j F Y"
-msgstr "j F Y"
-
-msgid "Unlimited"
-msgstr "Illimitée"
-
-#: inc/user-functions.php:588
-#. translators: %s: hunt title with link
-msgid "Demande pour %s en cours de traitement"
-msgstr "Demande pour %s en cours de traitement"
-
-#: template-parts/chasse/chasse-affichage-complet.php:279
-#: assets/js/chasse-edit.js:1144
-msgid "illimité"
-msgstr "illimité"
-
-#: template-parts/chasse/chasse-affichage-complet.php:281
-#: assets/js/chasse-edit.js:1147
-msgid "%d gagnant"
-msgid_plural "%d gagnants"
-msgstr[0] "%d gagnant"
-msgstr[1] "%d gagnants"
-
-#: inc/user-functions.php:693 inc/user-functions.php:711 inc/user-functions.php:736
+#: inc/user-functions.php:693 inc/user-functions.php:711
+#: inc/user-functions.php:736
 msgid "Unauthorized"
 msgstr "Non autorisé"
 
@@ -2681,3 +2840,97 @@ msgid "%d jour restant"
 msgid_plural "%d jours restants"
 msgstr[0] "%d jour restant"
 msgstr[1] "%d jours restants"
+
+#~ msgid "lié à"
+#~ msgstr "lié à"
+
+#~ msgid "Communiquez"
+#~ msgstr "Communiquez"
+
+#~ msgid "Aucune autre énigme disponible comme prérequis."
+#~ msgstr "Aucune autre énigme disponible comme prérequis."
+
+#, fuzzy
+#~ msgid "Vider"
+#~ msgstr "Valider"
+
+#, fuzzy
+#~ msgid "Délai après fin de chasse"
+#~ msgstr "Valider la fin de chasse"
+
+#~ msgid "Informations sur la publication de la solution"
+#~ msgstr "Informations sur la publication de la solution"
+
+#, fuzzy
+#~ msgid "Délai de parution des solutions"
+#~ msgstr "Définition du taux de résolution"
+
+#~ msgid "Panneau d'édition indice"
+#~ msgstr "Panneau d'édition indice"
+
+#~ msgid "renseigner le titre de l’indice"
+#~ msgstr "renseigner le titre de l’indice"
+
+#~ msgid "Image"
+#~ msgstr "Image"
+
+#~ msgid "Modifier le texte de l’indice"
+#~ msgstr "Modifier le texte de l’indice"
+
+#~ msgid "Aide pour"
+#~ msgstr "Aide pour"
+
+#~ msgid "Aucune énigme disponible."
+#~ msgstr "Aucune énigme disponible."
+
+#~ msgid "Publication"
+#~ msgstr "Publication"
+
+#~ msgid "(points)"
+#~ msgstr "(points)"
+
+#, fuzzy
+#~ msgid "Statistiques à venir"
+#~ msgstr "Statistiques"
+
+#~ msgid "Texte de l’indice mis à jour."
+#~ msgstr "Texte de l’indice mis à jour."
+
+#~ msgid "QR code de l'organisation"
+#~ msgstr "QR code de l'organisation"
+
+#~ msgid "QR code de la chasse"
+#~ msgstr "QR code de la chasse"
+
+#~ msgid "Enregistrement..."
+#~ msgstr "Enregistrement..."
+
+#~ msgid "✔️ Variantes enregistrées"
+#~ msgstr "✔️ Variantes enregistrées"
+
+#~ msgid "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+#~ msgstr "Veuillez saisir une valeur en euros comprise entre 0 et 5 000 000."
+
+#~ msgid "accessible"
+#~ msgstr "accessible"
+
+#~ msgid "programme"
+#~ msgstr "programmé"
+
+#~ msgid "Contenu de la solution à venir."
+#~ msgstr "Contenu de la solution à venir."
+
+#~ msgid "Vos liens"
+#~ msgstr "Vos liens"
+
+#~ msgid "Coming on %s"
+#~ msgstr "À venir le %s"
+
+#~ msgid "Unlimited"
+#~ msgstr "Illimitée"
+
+#~ msgid "Demande pour %s en cours de traitement"
+#~ msgstr "Demande pour %s en cours de traitement"
+
+#~ msgid "illimité"
+#~ msgstr "illimité"


### PR DESCRIPTION
## Summary
- Ajoute les messages de statut de date de chasse au modèle de traduction
- Synchronise les fichiers de traduction en_US et fr_FR

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b11b647bb88332a8828fc59bd495c8