### PR TITLE
Fix hunt characteristics translations

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1223,8 +1223,10 @@ msgstr ""
 
 #: template-parts/chasse/chasse-affichage-complet.php:264
 #, php-format
-msgid "%d gagnants"
-msgstr ""
+msgid "%d gagnant"
+msgid_plural "%d gagnants"
+msgstr[0] ""
+msgstr[1] ""
 
 #: template-parts/chasse/chasse-affichage-complet.php:269
 msgid "Fin de chasse"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1229,8 +1229,10 @@ msgstr "Limit"
 
 #: template-parts/chasse/chasse-affichage-complet.php:264
 #, php-format
-msgid "%d gagnants"
-msgstr "%d winners"
+msgid "%d gagnant"
+msgid_plural "%d gagnants"
+msgstr[0] "%d winner"
+msgstr[1] "%d winners"
 
 #: template-parts/chasse/chasse-affichage-complet.php:269
 msgid "Fin de chasse"
@@ -1241,9 +1243,9 @@ msgid "Accès chasse"
 msgstr "Hunt access"
 
 #: template-parts/chasse/chasse-affichage-complet.php:283
-#, fuzzy, php-format
+#, php-format
 msgid "%d points"
-msgstr "points"
+msgstr "%d points"
 
 #: template-parts/chasse/chasse-affichage-complet.php:284
 msgid "libre"
@@ -1257,8 +1259,8 @@ msgstr "Riddle access"
 #, php-format
 msgid "%d énigme nécessite des points pour soumettre une tentative"
 msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d puzzle requires points to submit an attempt"
+msgstr[1] "%d puzzles require points to submit an attempt"
 
 #: template-parts/chasse/chasse-affichage-complet.php:305
 msgid "gratuit"


### PR DESCRIPTION
## Résumé
- Corrige des traductions manquantes pour les caractéristiques de chasse

## Changements notables
- Ajout des formes singulier/pluriel pour les gagnants
- Traductions complétées pour les points et l'accès aux énigmes

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b11e2191808332a18a4e768ec213b9