### PR TITLE
Remove full description label from hunt reward

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -402,7 +402,7 @@ if ($edition_active && !$est_complet) {
                 </h3>
 
                 <?php if (!empty($lot)) : ?>
-                    <p><strong><?= esc_html__('Description complète :', 'chassesautresor-com'); ?></strong><br><?= wp_kses_post($lot); ?></p>
+                    <p><?= wp_kses_post($lot); ?></p>
                 <?php endif; ?>
             </div>
         <?php endif; ?>


### PR DESCRIPTION
## Résumé
- Retire l'intitulé "Description complète" de la fiche chasse

## Changements notables
- Nettoie l'affichage de la récompense en supprimant le label de description

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b11eacedf4833296912e16eafdd320