### PR TITLE
Fix hunt image padding misalignment

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -37,7 +37,7 @@
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
   flex: 0 0 auto;
-  padding: var(--space-xs);
+  padding: 0;
   width: fit-content;
   max-width: 100%;
   margin: 0 auto;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -319,7 +319,7 @@
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
   flex: 0 0 auto;
-  padding: var(--space-xs);
+  padding: 0;
   width: -moz-fit-content;
   width: fit-content;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- corrige l’alignement du champ « hunt image » en supprimant son padding

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b11f63bdc48332b9880d364effceb5