### PR TITLE
fix: add English translations for hunt details

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: chassesautresor.com 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/chassesautresor\n"
 "POT-Creation-Date: 2025-08-28T06:27:25+00:00\n"
-"PO-Revision-Date: 2025-08-23 08:28+0000\n"
+"PO-Revision-Date: 2025-08-29 03:57+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en_US\n"
@@ -2780,8 +2780,8 @@ msgstr "unlimited"
 #: assets/js/chasse-edit.js:806 assets/js/chasse-edit.js:815
 msgid "%d jour à attendre"
 msgid_plural "%d jours à attendre"
-msgstr[0] "%d day to wait"
-msgstr[1] "%d days to wait"
+msgstr[0] "%d day to go"
+msgstr[1] "%d days to go"
 
 #: template-parts/chasse/chasse-affichage-complet.php:70
 #: assets/js/chasse-edit.js:802


### PR DESCRIPTION
## Résumé
- complémente la traduction anglaise des caractéristiques de chasse

## Changements notables
- adapte la traduction pour l'attente avant le début
- met à jour la date de révision du fichier de langue anglais

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b124a4ca288332958d079cfcbbabc8