### PR TITLE
Redirect guests from account page

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -81,6 +81,25 @@ function cta_handle_language() {
 add_action( 'init', 'cta_handle_language' );
 
 /**
+ * Redirects non-logged-in users requesting `/mon-compte` to the login page.
+ *
+ * @return void
+ */
+function cta_redirect_account_page_for_guests() {
+    if ( is_user_logged_in() ) {
+        return;
+    }
+
+    $request_path = wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH );
+
+    if ( 0 === strpos( $request_path, '/mon-compte' ) ) {
+        wp_safe_redirect( wp_login_url() );
+        exit;
+    }
+}
+add_action( 'init', 'cta_redirect_account_page_for_guests' );
+
+/**
  * Renders the language switcher in the header.
  *
  * @param string $row    Header builder row.

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -93,7 +93,8 @@ function cta_redirect_account_page_for_guests() {
     $request_path = wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH );
 
     if ( 0 === strpos( $request_path, '/mon-compte' ) ) {
-        wp_safe_redirect( wp_login_url() );
+        $current_url = home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ) );
+        wp_safe_redirect( wp_login_url( $current_url ) );
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- Redirige les visiteurs non connectés de `/mon-compte` vers la page de connexion

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `curl -I http://localhost:8888/mon-compte` *(échec : erreur 500, base de données manquante)*

------
https://chatgpt.com/codex/tasks/task_e_68b129b9d8288332bb050d4e9e26a3ae