### PR TITLE
Personnalise la page de connexion

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/login.css
+++ b/wp-content/themes/chassesautresor/assets/css/login.css
@@ -1,0 +1,60 @@
+/* Styles personnalisés pour l'interface de connexion */
+:root {
+    --color-background: #0B132B;
+    --color-background-dark: #060A1F;
+    --color-primary: #FFD700;
+    --color-secondary: #E1A95F;
+    --color-text-primary: #F5F5DC;
+    --color-background-button: #880000;
+    --color-background-button-hover: #a00000;
+    --font-main: 'Poppins', sans-serif;
+}
+
+body.login {
+    background-color: var(--color-background);
+    font-family: var(--font-main);
+    color: var(--color-text-primary);
+}
+
+body.login #login {
+    width: 100%;
+    max-width: 320px;
+    padding: 1rem;
+}
+
+body.login #loginform {
+    background-color: var(--color-background-dark);
+    border: 1px solid var(--color-primary);
+}
+
+body.login label {
+    color: var(--color-text-primary);
+}
+
+body.login a {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+body.login a:hover,
+body.login a:focus {
+    color: var(--color-secondary);
+}
+
+body.login #wp-submit {
+    background-color: var(--color-background-button);
+    border: none;
+    color: var(--color-text-primary);
+    width: 100%;
+    padding: 0.5rem;
+}
+
+body.login #wp-submit:hover {
+    background-color: var(--color-background-button-hover);
+}
+
+@media (min-width: 768px) {
+    body.login #login {
+        max-width: 360px;
+    }
+}

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -274,7 +274,25 @@ add_action('wp_enqueue_scripts', function () {
     }
 }, 20);
 
+/**
+ * Enqueues custom styles for the login page.
+ *
+ * @return void
+ */
+function cta_enqueue_login_styles(): void
+{
+    $theme_uri  = get_stylesheet_directory_uri();
+    $theme_path = get_stylesheet_directory();
+    $css_rel    = '/assets/css/login.css';
 
+    wp_enqueue_style(
+        'cta-login',
+        $theme_uri . $css_rel,
+        [],
+        filemtime($theme_path . $css_rel)
+    );
+}
+add_action('login_enqueue_scripts', 'cta_enqueue_login_styles');
 
 // ----------------------------------------------------------
 // 📂 Chargement des fichiers fonctionnels organisés


### PR DESCRIPTION
Personnalise la page de connexion avec les couleurs du thème.

- Ajout d'une feuille de style `login.css` reprenant le nuancier et la typographie.
- Chargement du style sur l'écran de connexion via `login_enqueue_scripts`.

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b12db712c883329091c64e90ae06c3