### PR TITLE
Reorder CTA before description on chasse page

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -284,16 +284,6 @@ if ($edition_active && !$est_complet) {
         <div class="trait-droite"></div>
       </div>
         <?php
-        get_template_part(
-            'template-parts/chasse/chasse-partial-description',
-            null,
-            [
-                'description' => $infos_chasse['description'] ?? '',
-            ]
-        );
-        ?>
-
-        <?php
         $cta_data = $infos_chasse['cta_data'] ?? [];
         ?>
         <div class="chasse-cta-section cta-chasse">
@@ -384,7 +374,17 @@ if ($edition_active && !$est_complet) {
               <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
             </div>
           <?php endif; ?>
-        </div>
+          </div>
+
+        <?php
+        get_template_part(
+            'template-parts/chasse/chasse-partial-description',
+            null,
+            [
+                'description' => $infos_chasse['description'] ?? '',
+            ]
+        );
+        ?>
 
         <?php if (!empty($titre_recompense) || (float) $valeur_recompense > 0 || !empty($lot)) : ?>
             <div class="chasse-lot-complet" style="margin-top: 30px;">


### PR DESCRIPTION
## Résumé
- Affiche la section d'appel à l'action avant la description de la chasse

## Changements notables
- Reordonne les blocs de détails pour placer la section CTA avant la description

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b12df53048833299f88ca2d91f4681