### PR TITLE
docs: documenter personnalisation de wp-login

### DIFF
--- a/wp-content/themes/chassesautresor/docs/README.md
+++ b/wp-content/themes/chassesautresor/docs/README.md
@@ -9,6 +9,7 @@ Ce répertoire rassemble des documents complémentaires au thème.
 - [Traductions du thème](traductions.md)
 - [Panneau d'édition : Paramètres d'énigme](panneau-enigme-parametres.md)
 - [Panneau d'édition : Paramètres de chasse](panneau-chasse-parametres.md)
+- [Connexion personnalisée](login.md)
 
 Toutes les nouvelles chaînes de texte doivent utiliser les fonctions d'internationalisation de WordPress avec le domaine `chassesautresor-com`.
 

--- a/wp-content/themes/chassesautresor/docs/login.md
+++ b/wp-content/themes/chassesautresor/docs/login.md
@@ -1,0 +1,16 @@
+# Connexion personnalisée
+
+Ce thème personnalise la page de connexion WordPress afin d'assurer une expérience cohérente avec le site.
+
+## Redirection WooCommerce
+
+Les utilisateurs non connectés qui accèdent à une page "Mon compte" de WooCommerce sont redirigés vers `wp-login.php`. L'URL demandée est conservée pour que l'utilisateur y soit renvoyé après authentification.
+
+## Feuille de style dédiée
+
+La feuille de style `assets/css/login.css` est chargée sur `wp-login.php` afin d'ajuster l'apparence du formulaire de connexion.
+
+## Lien « Créer un compte »
+
+Un lien "Créer un compte" est ajouté sous le formulaire de connexion pour faciliter l'inscription des nouveaux utilisateurs.
+


### PR DESCRIPTION
## Résumé
- Documente la redirection de WooCommerce vers wp-login.php
- Explique le chargement de assets/css/login.css
- Mentionne l’ajout du lien « Créer un compte » sur wp-login.php

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b13c51d29883329aad9da745232e75