### PR TITLE
Fix duplicate entry in French translation file

### DIFF
--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2944,5 +2944,3 @@ msgstr "Politique de confidentialité"
 #~ msgid "Demande pour %s en cours de traitement"
 #~ msgstr "Demande pour %s en cours de traitement"
 
-#~ msgid "illimité"
-#~ msgstr "illimité"


### PR DESCRIPTION
## Résumé
- corrige la définition en double de "illimité" dans le fichier de traduction

## Changements notables
- suppression d'une entrée obsolète du fichier `fr_FR.po`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `msgfmt wp-content/themes/chassesautresor/languages/fr_FR.po -o /tmp/fr_FR.mo`


------
https://chatgpt.com/codex/tasks/task_e_68b1404ee0b08332a50ca238bdaaf793