### PR TITLE
fix: translate unlimited winners

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1281,7 +1281,7 @@ function mettreAJourAffichageNbGagnants(postId, nb) {
 
   const valeur = parseInt(nb, 10);
   if (valeur === 0) {
-    nbGagnantsAffichage.textContent = wp.i18n.__('illimité', 'chassesautresor-com');
+    nbGagnantsAffichage.textContent = wp.i18n.__('illimitée', 'chassesautresor-com');
   } else {
     nbGagnantsAffichage.textContent = wp.i18n.sprintf(
       wp.i18n._n('%d gagnant', '%d gagnants', valeur, 'chassesautresor-com'),

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -303,7 +303,7 @@ if ($edition_active && !$est_complet) {
                 <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
                 <span class="caracteristique-valeur nb-gagnants-affichage" data-post-id="<?= esc_attr($chasse_id); ?>">
                   <?php if ((int) $nb_max === 0) : ?>
-                    <?= esc_html__('illimité', 'chassesautresor-com'); ?>
+                    <?= esc_html__('illimitée', 'chassesautresor-com'); ?>
                   <?php else : ?>
                     <?= esc_html(sprintf(_n('%d gagnant', '%d gagnants', $nb_max, 'chassesautresor-com'), $nb_max)); ?>
                   <?php endif; ?>


### PR DESCRIPTION
## Summary
- corrige la traduction de la valeur illimitée pour le nombre de gagnants
- synchronise la mise à jour dynamique avec la chaîne traduite

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b14a599a64833299e03f13d7548eb4