### PR TITLE
feat: pastille or pour chasses éligibles à validation

### DIFF
--- a/tests/MyAccountOrganizerNavTest.php
+++ b/tests/MyAccountOrganizerNavTest.php
@@ -34,6 +34,7 @@ class MyAccountOrganizerNavTest extends TestCase
         eval('function recuperer_ids_enigmes_pour_chasse($cid){return [200];}');
         eval('function get_permalink($id){return "https://example.com/post-$id";}');
         eval('function get_the_title($id){return "Post $id";}');
+        eval('function peut_valider_chasse($cid,$uid){return false;}');
 
         require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/myaccount-functions.php';
 
@@ -41,6 +42,34 @@ class MyAccountOrganizerNavTest extends TestCase
 
         $this->assertNotNull($nav);
         $this->assertSame('https://example.com/post-200', $nav['chasses'][0]['enigmes'][0]['url']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_chasse_eligible_has_special_status(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/');
+        }
+
+        eval('function get_organisateur_from_user($user_id){return 99;}');
+        eval('function get_post_status($post_id){$s=[99=>"publish",100=>"pending"];return $s[$post_id]??"publish";}');
+        eval('function get_field($key,$id){$f=[99=>["organisateur_cache_complet"=>true],100=>["chasse_cache_statut_validation"=>"creation","chasse_cache_complet"=>true]];return $f[$id][$key]??null;}');
+        eval('function get_posts($args=[]){return [(object)["ID"=>100]];}');
+        eval('function recuperer_enigmes_tentatives_en_attente($org){return [];}');
+        eval('function recuperer_ids_enigmes_pour_chasse($cid){return []; }');
+        eval('function get_permalink($id){return "https://example.com/post-$id";}');
+        eval('function get_the_title($id){return "Post $id";}');
+        eval('function peut_valider_chasse($cid,$uid){return true;}');
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/myaccount-functions.php';
+
+        $nav = myaccount_get_organizer_nav(1);
+
+        $this->assertNotNull($nav);
+        $this->assertStringContainsString('status-eligible', $nav['chasses'][0]['classes']);
     }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -155,6 +155,12 @@
     --status-bullet: var(--etat-enigme-menu-succes);
 }
 
+.dashboard-nav-link.status-eligible,
+.dashboard-nav-sublink.status-eligible,
+.dashboard-nav-subitem.status-eligible {
+    --status-bullet: var(--etat-enigme-menu-eligible);
+}
+
 .myaccount-main {
     flex: 1;
     display: flex;

--- a/wp-content/themes/chassesautresor/assets/scss/_variables.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_variables.scss
@@ -75,6 +75,7 @@
   --etat-enigme-menu-succes: var(--color-success);
   --etat-enigme-menu-non-engagee: transparent;
   --etat-enigme-menu-incomplete: var(--color-error);
+  --etat-enigme-menu-eligible: var(--color-primary); /* chasse éligible à validation */
 
   /* Asides */
   --aside-bg-rgb: 238, 238, 238;            /* 🎨 Couleur de fond des asides : gris clair du nuancier (var(--color-grey-light)) */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7520,6 +7520,12 @@ footer .site-footer-primary-section-3 {
   --status-bullet: var(--etat-enigme-menu-succes);
 }
 
+.dashboard-nav-link.status-eligible,
+.dashboard-nav-sublink.status-eligible,
+.dashboard-nav-subitem.status-eligible {
+  --status-bullet: var(--etat-enigme-menu-eligible);
+}
+
 .myaccount-main {
   flex: 1;
   display: flex;
@@ -8842,6 +8848,7 @@ section#presentation .presentation-fermer {
   --etat-enigme-menu-succes: var(--color-success);
   --etat-enigme-menu-non-engagee: transparent;
   --etat-enigme-menu-incomplete: var(--color-error);
+  --etat-enigme-menu-eligible: var(--color-primary); /* chasse éligible à validation */
   /* Asides */
   --aside-bg-rgb: 238, 238, 238; /* 🎨 Couleur de fond des asides : gris clair du nuancier (var(--color-grey-light)) */
   --aside-border-color: var(--color-grey-medium); /* 🖊 Couleur de bordure des asides */

--- a/wp-content/themes/chassesautresor/dist/variables.css
+++ b/wp-content/themes/chassesautresor/dist/variables.css
@@ -66,6 +66,7 @@
   --etat-enigme-menu-succes: var(--color-success);
   --etat-enigme-menu-non-engagee: transparent;
   --etat-enigme-menu-incomplete: var(--color-error);
+  --etat-enigme-menu-eligible: var(--color-primary); /* chasse éligible à validation */
   /* Asides */
   --aside-bg-rgb: 238, 238, 238; /* 🎨 Couleur de fond des asides : gris clair du nuancier (var(--color-grey-light)) */
   --aside-border-color: var(--color-grey-medium); /* 🖊 Couleur de bordure des asides */

--- a/wp-content/themes/chassesautresor/inc/myaccount-functions.php
+++ b/wp-content/themes/chassesautresor/inc/myaccount-functions.php
@@ -92,6 +92,10 @@ function myaccount_get_organizer_nav(int $user_id): ?array
             }
         }
 
+        if (function_exists('peut_valider_chasse') && peut_valider_chasse($chasse->ID, $user_id)) {
+            $classes .= ' status-eligible';
+        }
+
         $chasse_item = [
             'title'        => get_the_title($chasse->ID),
             'url'          => get_permalink($chasse->ID),


### PR DESCRIPTION
## Résumé
- signaler les chasses pouvant demander une validation via une pastille dorée
- nouveau statut `status-eligible` dans la navigation organisateur
- couverture de test pour la classe `status-eligible`

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b148e31d548332b4daff638aa06e70