### PR TITLE
Corrige l'affichage illimité des gagnants

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -992,22 +992,27 @@ function initChampNbGagnants() {
     if (toggleLimite.checked) {
       actions.style.display = '';
       inputNb.disabled = false;
-      if (parseInt(inputNb.value.trim(), 10) === 0 || inputNb.value.trim() === '') {
+      if (
+        parseInt(inputNb.value.trim(), 10) === 0 ||
+        inputNb.value.trim() === ''
+      ) {
         inputNb.value = '1';
       }
+      inputNb.dispatchEvent(new Event('input', { bubbles: true }));
+      mettreAJourAffichageNbGagnants(postId, inputNb.value.trim());
     } else {
       actions.style.display = 'none';
       inputNb.disabled = true;
       inputNb.value = '0';
+      mettreAJourAffichageNbGagnants(postId, 0);
     }
-
-    inputNb.dispatchEvent(new Event('input', { bubbles: true }));
-    mettreAJourAffichageNbGagnants(postId, inputNb.value.trim());
   }
 
   toggleLimite.addEventListener('change', updateVisibility);
 
   inputNb.addEventListener('input', function () {
+    if (!toggleLimite.checked) return;
+
     const postId = inputNb.closest('li').dataset.postId;
     if (!postId) return;
 


### PR DESCRIPTION
## Résumé
- Ajuste la logique du champ de gagnants pour éviter le retour à 1 gagnant lorsque la limite est désactivée

## Changements notables
- Empêche l'envoi d'événement `input` et met l'affichage à 0 lorsque la limite de gagnants est désactivée
- Ignore les saisies lorsque le champ est désactivé afin de conserver l'état « illimitée »

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b14d90e630833299a62b2118ebe664