### PR TITLE
Corrige l’affichage de la limite de gagnants

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1293,7 +1293,7 @@ function mettreAJourAffichageNbGagnants(postId, nb) {
 
   const valeur = parseInt(nb, 10);
   if (valeur === 0) {
-    nbGagnantsAffichage.textContent = wp.i18n.__('illimité', 'chassesautresor-com');
+    nbGagnantsAffichage.textContent = wp.i18n.__('illimitée', 'chassesautresor-com');
   } else {
     nbGagnantsAffichage.textContent = wp.i18n.sprintf(
       wp.i18n._n('%d gagnant', '%d gagnants', valeur, 'chassesautresor-com'),

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -299,11 +299,11 @@ if ($edition_active && !$est_complet) {
             <?php endif; ?>
             <?php if ($mode_fin === 'automatique') : ?>
               <div class="caracteristique caracteristique-limite">
-                <span class="caracteristique-icone" aria-hidden="true">🚫</span>
-                <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
+                <span class="caracteristique-icone" aria-hidden="true">👥</span>
+                <span class="caracteristique-label"><?= esc_html__('Gagnants', 'chassesautresor-com'); ?></span>
                 <span class="caracteristique-valeur nb-gagnants-affichage" data-post-id="<?= esc_attr($chasse_id); ?>">
                   <?php if ((int) $nb_max === 0) : ?>
-                    <?= esc_html__('illimité', 'chassesautresor-com'); ?>
+                    <?= esc_html__('illimitée', 'chassesautresor-com'); ?>
                   <?php else : ?>
                     <?= esc_html(sprintf(_n('%d gagnant', '%d gagnants', $nb_max, 'chassesautresor-com'), $nb_max)); ?>
                   <?php endif; ?>


### PR DESCRIPTION
## Résumé
- Ajuste l’affichage du nombre de gagnants et son icône

## Changements notables
- Icône de groupe pour la caractéristique limite
- Libellé « Gagnants » avec traduction « illimitée » corrigée
- Mise à jour du script d’édition pour respecter la traduction

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b152ccd0fc8332a1bec8df6202c832