### PR TITLE
Fix unlimited winners option not saving

### DIFF
--- a/tests/js/nb-gagnants.test.js
+++ b/tests/js/nb-gagnants.test.js
@@ -1,0 +1,61 @@
+describe('initChampNbGagnants', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <li class="edition-row champ-nb-gagnants" data-post-id="1" data-champ="chasse_infos_nb_max_gagants" data-cpt="chasse">
+        <div class="champ-mode-options">
+          <span class="toggle-option">Illimité</span>
+          <label class="switch-control">
+            <input type="checkbox" id="nb-gagnants-limite" checked>
+            <span class="switch-slider"></span>
+          </label>
+          <span class="toggle-option">Limité</span>
+          <div class="nb-gagnants-actions">
+            <input type="number" id="chasse-nb-gagnants" value="2" class="champ-input champ-number">
+          </div>
+        </div>
+      </li>
+      <span class="nb-gagnants-affichage" data-post-id="1"></span>
+    `;
+
+    global.modifierChampSimple = jest.fn(() => Promise.resolve(true));
+    global.wp = { i18n: { __: s => s, _n: (s, p, n) => (n > 1 ? p : s), sprintf: (str, ...args) => str.replace('%d', args[0]) } };
+    jest.resetModules();
+    jest.useFakeTimers();
+    require('../../wp-content/themes/chassesautresor/assets/js/chasse-edit.js');
+    global.modifierChampSimple.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  test('enregistre le nombre puis l\'option illimité', async () => {
+    const input = document.getElementById('chasse-nb-gagnants');
+    const toggle = document.getElementById('nb-gagnants-limite');
+
+    input.value = '5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    jest.runAllTimers();
+    await Promise.resolve();
+
+    expect(global.modifierChampSimple).toHaveBeenCalledWith(
+      'caracteristiques.chasse_infos_nb_max_gagants',
+      5,
+      '1',
+      'chasse'
+    );
+
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+  
+    expect(global.modifierChampSimple).toHaveBeenCalledWith(
+      'caracteristiques.chasse_infos_nb_max_gagants',
+      0,
+      '1',
+      'chasse'
+    );
+    expect(document.querySelector('.nb-gagnants-affichage').textContent).toMatch(/illimité/i);
+  });
+});

--- a/tests/js/nb-gagnants.test.js
+++ b/tests/js/nb-gagnants.test.js
@@ -2,15 +2,17 @@ describe('initChampNbGagnants', () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <li class="edition-row champ-nb-gagnants" data-post-id="1" data-champ="chasse_infos_nb_max_gagants" data-cpt="chasse">
-        <div class="champ-mode-options">
-          <span class="toggle-option">Illimité</span>
-          <label class="switch-control">
-            <input type="checkbox" id="nb-gagnants-limite" checked>
-            <span class="switch-slider"></span>
-          </label>
-          <span class="toggle-option">Limité</span>
-          <div class="nb-gagnants-actions">
-            <input type="number" id="chasse-nb-gagnants" value="2" class="champ-input champ-number">
+        <div class="edition-row-content">
+          <div class="champ-mode-options">
+            <span class="toggle-option">Illimité</span>
+            <label class="switch-control">
+              <input type="checkbox" id="nb-gagnants-limite" checked>
+              <span class="switch-slider"></span>
+            </label>
+            <span class="toggle-option">Limité</span>
+            <div class="nb-gagnants-actions">
+              <input type="number" id="chasse-nb-gagnants" value="2" class="champ-input champ-number">
+            </div>
           </div>
         </div>
       </li>
@@ -57,5 +59,7 @@ describe('initChampNbGagnants', () => {
       'chasse'
     );
     expect(document.querySelector('.nb-gagnants-affichage').textContent).toMatch(/illimité/i);
+    const status = document.querySelector('.champ-status');
+    expect(status.closest('.nb-gagnants-actions')).toBeNull();
   });
 });

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -996,20 +996,25 @@ function initChampNbGagnants() {
 
   let timerDebounce;
 
-  let status = inputNb.nextElementSibling;
-  if (!status || !status.classList.contains('champ-status')) {
+  let status = li.querySelector('.champ-status');
+  const content = li.querySelector('.edition-row-content');
+  if (!status) {
     status = document.createElement('span');
     status.className = 'champ-status';
-    inputNb.insertAdjacentElement('afterend', status);
+  }
+  if (content && status.parentElement !== content) {
+    content.appendChild(status);
   }
 
   function enregistrer(valeur) {
-    if (!postId) return;
+    if (!postId || !status) return;
     status.innerHTML = '<i class="fa-solid fa-spinner fa-spin" aria-hidden="true"></i>';
-    modifierChampSimple(champ, valeur, postId, cpt).then(success => {
+    modifierChampSimple(champ, valeur, postId, cpt).then((success) => {
       if (success) {
         status.innerHTML = '<i class="fa-solid fa-check" aria-hidden="true"></i>';
-        setTimeout(() => { status.innerHTML = ''; }, 1000);
+        setTimeout(() => {
+          status.innerHTML = '';
+        }, 1000);
       } else {
         status.innerHTML = '';
       }

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -987,13 +987,36 @@ function initChampNbGagnants() {
   const inputNb = document.getElementById('chasse-nb-gagnants');
   const toggleLimite = document.getElementById('nb-gagnants-limite');
   const actions = inputNb?.closest('.nb-gagnants-actions');
-
   if (!inputNb || !toggleLimite || !actions) return;
+
+  const li = inputNb.closest('li');
+  const postId = li?.dataset.postId;
+  const champ = 'caracteristiques.chasse_infos_nb_max_gagants';
+  const cpt = li?.dataset.cpt || 'chasse';
 
   let timerDebounce;
 
-  function updateVisibility() {
-    const postId = inputNb.closest('li').dataset.postId;
+  let status = inputNb.nextElementSibling;
+  if (!status || !status.classList.contains('champ-status')) {
+    status = document.createElement('span');
+    status.className = 'champ-status';
+    inputNb.insertAdjacentElement('afterend', status);
+  }
+
+  function enregistrer(valeur) {
+    if (!postId) return;
+    status.innerHTML = '<i class="fa-solid fa-spinner fa-spin" aria-hidden="true"></i>';
+    modifierChampSimple(champ, valeur, postId, cpt).then(success => {
+      if (success) {
+        status.innerHTML = '<i class="fa-solid fa-check" aria-hidden="true"></i>';
+        setTimeout(() => { status.innerHTML = ''; }, 1000);
+      } else {
+        status.innerHTML = '';
+      }
+    });
+  }
+
+  function updateVisibility(save = false) {
     if (!postId) return;
 
     if (toggleLimite.checked) {
@@ -1012,15 +1035,15 @@ function initChampNbGagnants() {
       inputNb.disabled = true;
       inputNb.value = '0';
       mettreAJourAffichageNbGagnants(postId, 0);
+      if (save) enregistrer(0);
     }
   }
 
-  toggleLimite.addEventListener('change', updateVisibility);
+  toggleLimite.addEventListener('change', () => updateVisibility(true));
 
   inputNb.addEventListener('input', function () {
     if (!toggleLimite.checked) return;
 
-    const postId = inputNb.closest('li').dataset.postId;
     if (!postId) return;
 
     clearTimeout(timerDebounce);
@@ -1031,6 +1054,7 @@ function initChampNbGagnants() {
         inputNb.value = '1';
       }
       mettreAJourAffichageNbGagnants(postId, valeur);
+      enregistrer(valeur);
     }, 500);
   });
 


### PR DESCRIPTION
## Résumé
- Corrige l'enregistrement de l'option "illimité" pour les gagnants et affiche un statut visuel
- Ajoute un test garantissant la sauvegarde du nombre de gagnants et du mode illimité

## Changements notables
- Ajout d'un appel AJAX via `modifierChampSimple` avec retour visuel
- Enregistrement immédiat lors du basculement vers l'option illimitée
- Nouveau test Jest pour `initChampNbGagnants`

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b190bf0cb08332baaf36f42ffd28dd