### PR TITLE
Fix i18n for hunt details

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -34,9 +34,9 @@ function recuperer_infos_chasse($chasse_id)
 {
     $champs = get_fields($chasse_id);
     return [
-        'lot' => $champs['lot'] ?? 'Non spécifié',
-        'date_de_debut' => $champs['date_de_debut'] ?? 'Non spécifiée',
-        'date_de_fin' => $champs['date_de_fin'] ?? 'Non spécifiée',
+        'lot' => $champs['lot'] ?? esc_html__('Non spécifié', 'chassesautresor-com'),
+        'date_de_debut' => $champs['date_de_debut'] ?? esc_html__('Non spécifiée', 'chassesautresor-com'),
+        'date_de_fin' => $champs['date_de_fin'] ?? esc_html__('Non spécifiée', 'chassesautresor-com'),
     ];
 }
 
@@ -487,9 +487,9 @@ function afficher_chasse_associee_callback()
     if (!$chasse) return ''; // 🚫 Pas de chasse associée
 
     $infos_chasse = recuperer_infos_chasse($chasse->ID) ?: [
-        'lot' => 'Non spécifié',
-        'date_de_debut' => 'Non spécifiée',
-        'date_de_fin' => 'Non spécifiée',
+        'lot' => esc_html__('Non spécifié', 'chassesautresor-com'),
+        'date_de_debut' => esc_html__('Non spécifiée', 'chassesautresor-com'),
+        'date_de_fin' => esc_html__('Non spécifiée', 'chassesautresor-com'),
     ];
 
     $lien_discord = get_field('lien_discord', $chasse->ID);
@@ -770,7 +770,7 @@ function formater_nombre_joueurs(int $nombre): string
     $quantite = ($nombre === 0 || $nombre === 1) ? 1 : $nombre;
 
     return sprintf(
-        _n('%d joueur', '%d joueurs', $quantite, 'chassesautresor'),
+        _n('%d joueur', '%d joueurs', $quantite, 'chassesautresor-com'),
         $nombre
     );
 }
@@ -1097,7 +1097,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     $illimitee         = $champs['illimitee'];
 
     $date_debut_affichage = formater_date($date_debut);
-    $date_fin_affichage   = $illimitee ? 'Illimitée' : ($date_fin ? formater_date($date_fin) : 'Non spécifiée');
+    $date_fin_affichage   = $illimitee
+        ? esc_html__('Illimitée', 'chassesautresor-com')
+        : ($date_fin ? formater_date($date_fin) : esc_html__('Non spécifiée', 'chassesautresor-com'));
 
     $nb_joueurs       = compter_joueurs_engages_chasse($chasse_id);
     $nb_joueurs_label = formater_nombre_joueurs($nb_joueurs);

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -39,7 +39,9 @@ $date_decouverte = $champs['date_decouverte'];
 $current_stored_statut = $champs['current_stored_statut'];
 
 $date_debut_formatee = formater_date($date_debut);
-$date_fin_formatee = $illimitee ? 'Illimitée' : ($date_fin ? formater_date($date_fin) : 'Non spécifiée');
+$date_fin_formatee = $illimitee
+    ? esc_html__('Illimitée', 'chassesautresor-com')
+    : ($date_fin ? formater_date($date_fin) : esc_html__('Non spécifiée', 'chassesautresor-com'));
 $date_decouverte_formatee = $date_decouverte ? formater_date($date_decouverte) : '';
 
 $timestamp_debut = convertir_en_timestamp($date_debut);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -46,7 +46,9 @@ $nb_joueurs        = $infos_chasse['nb_joueurs'];
 
 // Dates
 $date_debut_formatee = formater_date($date_debut);
-$date_fin_formatee = $illimitee ? 'Illimitée' : ($date_fin ? formater_date($date_fin) : 'Non spécifiée');
+$date_fin_formatee = $illimitee
+    ? esc_html__('Illimitée', 'chassesautresor-com')
+    : ($date_fin ? formater_date($date_fin) : esc_html__('Non spécifiée', 'chassesautresor-com'));
 
 // Edition
 $edition_active = utilisateur_peut_modifier_post($chasse_id);


### PR DESCRIPTION
## Résumé
- Corrige la traduction des libellés dynamiques sur les fiches de chasse

## Changements notables
- Internationalise les valeurs par défaut et l'intitulé de fin des chasses
- Utilise le bon domaine de traduction pour le nombre de joueurs affiché
- Harmonise l'usage des fonctions de traduction dans les templates de chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1a48ff83483328456a83e56c34997