### PR TITLE
Uniformiser l'ajout d'énigmes via une carte dédiée

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -179,9 +179,6 @@ window.mettreAJourResumeInfos = function () {
   if (typeof window.mettreAJourCarteAjoutEnigme === 'function') {
     window.mettreAJourCarteAjoutEnigme();
   }
-  if (typeof window.mettreAJourBoutonAjoutEnigme === 'function') {
-    window.mettreAJourBoutonAjoutEnigme();
-  }
   if (typeof window.mettreAJourEtatIntroChasse === 'function') {
     window.mettreAJourEtatIntroChasse();
   }

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -1495,48 +1495,6 @@ function initPagerTentatives() {
 }
 
 // ==============================
-// ➕ Affichage dynamique du bouton d'ajout d'énigme
-// ==============================
-  window.mettreAJourBoutonAjoutEnigme = function () {
-    const nav = document.querySelector('.enigme-navigation');
-    if (!nav) return;
-    const menu = nav.querySelector('.enigme-menu');
-    if (!menu || !menu.classList.contains('enigme-menu--editable')) return;
-
-    nav.querySelectorAll('#carte-ajout-enigme').forEach((btn) => btn.remove());
-
-    const chasseId = nav.dataset.chasseId;
-    if (!chasseId) return;
-
-    const data = new FormData();
-    data.append('action', 'verifier_enigmes_completes');
-    data.append('chasse_id', chasseId);
-
-
-    fetch(window.ajaxurl, {
-      method: 'POST',
-      credentials: 'same-origin',
-      body: data
-    })
-      .then((r) => r.json())
-      .then((res) => {
-        if (!res.success || res.data.has_incomplete || nav.querySelector('#carte-ajout-enigme')) {
-          return;
-        }
-
-        const link = document.createElement('a');
-        link.id = 'carte-ajout-enigme';
-        link.dataset.postId = '0';
-        link.href = `${window.location.origin}/creer-enigme/?chasse_id=${chasseId}`;
-        link.innerHTML =
-          '<i class="fa-solid fa-circle-plus fa-lg" aria-hidden="true"></i>' +
-          `<span>${wp.i18n.__('Ajouter une énigme', 'chassesautresor-com')}</span>`;
-        nav.insertBefore(link, menu);
-      })
-      .catch(() => {});
-  };
-
-// ==============================
 // 🔀 Réordonnancement des énigmes
 // ==============================
 function initEnigmeReorder() {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -187,7 +187,6 @@
 }
 
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */
-.carte-ajout-enigme,
 .carte-ajout-chasse {
   display: flex;
   align-items: center;
@@ -203,9 +202,13 @@
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
+.carte-ajout-enigme {
+  display: block;
+  position: relative;
+}
+
 .carte-ajout-chasse .carte-ligne__image,
-.carte-ajout-chasse .carte-ligne__contenu,
-.carte-ajout-enigme .contenu-carte {
+.carte-ajout-chasse .carte-ligne__contenu {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -186,7 +186,6 @@
 }
 
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */
-.carte-ajout-enigme,
 .carte-ajout-chasse {
   display: flex;
   align-items: center;
@@ -202,9 +201,13 @@
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
+.carte-ajout-enigme {
+  display: block;
+  position: relative;
+}
+
 .carte-ajout-chasse .carte-ligne__image,
-.carte-ajout-chasse .carte-ligne__contenu,
-.carte-ajout-enigme .contenu-carte {
+.carte-ajout-chasse .carte-ligne__contenu {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -28,18 +28,29 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
     <span><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
   </a>
 <?php else : ?>
-  <a
-    href="<?php echo $ajout_url; ?>"
-    id="carte-ajout-enigme"
-    class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?><?php echo $highlight_pulse ? ' pulsation' : ''; ?>"
-    data-post-id="0">
-    <div class="contenu-carte">
-      ➕ <?php echo $has_enigmes ? 'Ajouter une énigme' : 'Créer la première énigme'; ?>
-    </div>
-    <div class="overlay-message">
-      <i class="fa-solid fa-circle-info"></i>
-      <p>Complétez d’abord : titre, image, description</p>
-    </div>
-  </a>
+    <a
+        href="<?php echo $ajout_url; ?>"
+        id="carte-ajout-enigme"
+        class="carte carte-enigme carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?><?php echo $highlight_pulse ? ' pulsation' : ''; ?>"
+        data-post-id="0">
+        <div class="carte-core">
+            <div class="carte-enigme-image">
+                <div class="enigme-placeholder">
+                    <i class="fa-solid fa-circle-plus fa-3x" aria-hidden="true"></i>
+                </div>
+                <div class="carte-enigme-cta">
+                    <span class="bouton-cta bouton-cta--color">
+                        <?php echo $has_enigmes
+                            ? esc_html__('Ajouter une énigme', 'chassesautresor-com')
+                            : esc_html__('Créer la première énigme', 'chassesautresor-com'); ?>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <div class="overlay-message">
+            <i class="fa-solid fa-circle-info"></i>
+            <p><?php echo esc_html__('Complétez d’abord : titre, image, description', 'chassesautresor-com'); ?></p>
+        </div>
+    </a>
 <?php endif; ?>
 

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -130,7 +130,7 @@ foreach ($posts as $p) {
 
     <?php
     // ➕ CTA pour ajouter une énigme si besoin
-    if (utilisateur_peut_ajouter_enigme($chasse_id, $utilisateur_id) && !$has_incomplete && !$has_enigmes) {
+    if (utilisateur_peut_ajouter_enigme($chasse_id, $utilisateur_id) && !$has_incomplete) {
       verifier_ou_mettre_a_jour_cache_complet($chasse_id);
       $complete = (bool) get_field('chasse_cache_complet', $chasse_id);
 


### PR DESCRIPTION
## Résumé
Uniformise la création d'énigmes en remplaçant le bouton "+" par une carte d'ajout homogène avec les autres cartes.

## Changements notables
- Carte d'ajout d’énigme toujours affichée avec libellé dynamique (première ou nouvelle énigme).
- Harmonisation du style de la carte d'ajout avec les cartes d’énigme et CTA rouge.
- Suppression du bouton « + » dans la navigation des énigmes.

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1aab6cfb08332b10ee0d37dd0f655