### PR TITLE
Synchroniser le cache avant l'éligibilité à la validation

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -365,8 +365,11 @@ function myaccount_maybe_add_validation_message(): void
         return;
     }
 
+    verifier_ou_mettre_a_jour_cache_complet($chasse_id);
+
     $user_id = get_current_user_id();
     if (!peut_valider_chasse($chasse_id, $user_id)) {
+        myaccount_remove_persistent_message($user_id, 'correction_info_chasse_' . $chasse_id);
         return;
     }
 


### PR DESCRIPTION
### Résumé
- synchronisation du cache complet avant l’évaluation de l’éligibilité à la validation
- retrait du message persistant lorsque la validation n’est plus possible

### Changements notables
- ajout de `verifier_ou_mettre_a_jour_cache_complet` lors du chargement d’une chasse
- nettoyage du message `correction_info_chasse` si l’utilisateur ne peut pas valider

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b1b54da49c83328a8bbb24542c9e75