### PR TITLE
Ajout d'une icône d'info pour la validation en ligne

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -241,6 +241,13 @@
   z-index: 1;
 }
 
+.carte-ajout-enigme .ajout-enigme-help {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  z-index: 2;
+}
+
 .carte-ajout-enigme .carte-core i {
   color: var(--color-background-button);
   font-size: 28px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -240,6 +240,13 @@
   z-index: 1;
 }
 
+.carte-ajout-enigme .ajout-enigme-help {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  z-index: 2;
+}
+
 .carte-ajout-enigme .carte-core i {
   color: var(--color-background-button);
   font-size: 28px;

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1948,9 +1948,12 @@ msgstr "No data."
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
 #: assets/js/enigme-edit.js:1533
-#, fuzzy
 msgid "Ajouter une énigme"
-msgstr "add an image"
+msgstr "Add a riddle"
+
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:0
+msgid "Validation en ligne nécessaire"
+msgstr "Online validation required"
 
 #: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1978,9 +1978,12 @@ msgstr "Aucune donnée."
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
 #: assets/js/enigme-edit.js:1533
-#, fuzzy
 msgid "Ajouter une énigme"
-msgstr "Ajouter une variante"
+msgstr "Ajouter une énigme"
+
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:0
+msgid "Validation en ligne nécessaire"
+msgstr "Validation en ligne nécessaire"
 
 #: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -110,19 +110,6 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     ?>
 
     <?php
-
-    if ($est_orga_associe && $needs_validatable_message) {
-        echo '<div class="cta-chasse">';
-        $msg = __(
-            'Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique.',
-            'chassesautresor-com'
-        );
-        echo '<p>⚠️ ' . esc_html($msg) . '</p>';
-        echo '</div>';
-    }
-    ?>
-
-    <?php
     if (current_user_can('administrator') && $statut_validation === 'en_attente') {
       get_template_part('template-parts/chasse/chasse-validation-actions', null, [
         'chasse_id' => $chasse_id,
@@ -158,9 +145,10 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
             <h2>Énigmes</h2>
             <?php if ($peut_ajouter_enigme && $total_enigmes > 0 && !$has_incomplete_enigme) :
                 get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
-                    'has_enigmes' => true,
-                    'chasse_id'   => $chasse_id,
-                    'use_button'  => true,
+                    'has_enigmes'             => true,
+                    'chasse_id'               => $chasse_id,
+                    'use_button'              => true,
+                    'needs_validatable_message'=> $est_orga_associe && $needs_validatable_message,
                 ]);
             endif; ?>
         </div>
@@ -170,6 +158,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
                 'chasse_id'       => $chasse_id,
                 'est_orga_associe'=> $est_orga_associe,
                 'infos_chasse'    => $infos_chasse,
+                'needs_validatable_message'=> $est_orga_associe && $needs_validatable_message,
             ]);
             ?>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -11,6 +11,7 @@ $has_enigmes     = $args['has_enigmes'] ?? false;
 $chasse_id       = $args['chasse_id'] ?? null;
 $disabled        = $args['disabled'] ?? true;
 $highlight_pulse = $args['highlight_pulse'] ?? false;
+$needs_validatable_message = $args['needs_validatable_message'] ?? false;
 
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
@@ -31,6 +32,19 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
         <i class="fa-solid fa-circle-plus" aria-hidden="true"></i>
         <span class="carte-ajout-libelle"><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
     </div>
+    <?php if ($needs_validatable_message) :
+        get_template_part(
+            'template-parts/common/help-icon',
+            null,
+            [
+                'aria_label' => __('Validation en ligne nécessaire', 'chassesautresor-com'),
+                'title'      => __('Validation en ligne nécessaire', 'chassesautresor-com'),
+                'message'    => __('Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique.', 'chassesautresor-com'),
+                'variant'    => 'info',
+                'classes'    => 'ajout-enigme-help',
+            ]
+        );
+    endif; ?>
     <div class="overlay-message">
         <i class="fa-solid fa-circle-info"></i>
         <p><?php echo esc_html__('Complétez d’abord : titre, image, description', 'chassesautresor-com'); ?></p>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -11,6 +11,7 @@ $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
+$needs_validatable_message = $args['needs_validatable_message'] ?? false;
 
 $utilisateur_id = get_current_user_id();
 
@@ -155,6 +156,7 @@ foreach ($posts as $p) {
         'disabled'        => !$complete,
         'highlight_pulse' => $highlight_pulse,
         'use_button'      => false,
+        'needs_validatable_message'=> $needs_validatable_message,
       ]);
     }
     ?>


### PR DESCRIPTION
## Summary
- affiche une icône d'information sur la carte d'ajout d'énigme lorsque la chasse nécessite une énigme validable
- ajoute le style associé et les traductions

## Testing
- `source ./setup-env.sh`
- `npm install`
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1c053bc6883328b29e7a3aab0b5e0