### PR TITLE
Carte d'ajout d'énigme : bordure pointillée et hover neutre

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -216,7 +216,12 @@
 }
 
 .carte-ajout-enigme:hover {
+  background: var(--color-text-primary);
+  color: var(--color-background);
   border-style: solid;
+  border-color: var(--color-editor-border);
+  transform: translateY(-4px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
 .carte-ajout-enigme:focus-visible {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -196,7 +196,7 @@
   padding: var(--space-xl);
   min-height: 140px;
   text-align: center;
-  border: 2px dashed var(--color-editor-border);
+  border: 2px dashed var(--color-background-button);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
   position: relative;
@@ -208,7 +208,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  border: 2px dashed var(--color-editor-border);
+  border: 2px dashed var(--color-background-button);
   background: var(--color-text-primary);
   color: var(--color-background);
   position: relative;
@@ -219,7 +219,7 @@
   background: var(--color-text-primary);
   color: var(--color-background);
   border-style: solid;
-  border-color: var(--color-editor-border);
+  border-color: var(--color-background-button);
   transform: translateY(-4px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -215,7 +215,12 @@
 }
 
 .carte-ajout-enigme:hover {
+  background: var(--color-text-primary);
+  color: var(--color-background);
   border-style: solid;
+  border-color: var(--color-editor-border);
+  transform: translateY(-4px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
 .carte-ajout-enigme:focus-visible {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -195,7 +195,7 @@
   padding: var(--space-xl);
   min-height: 140px;
   text-align: center;
-  border: 2px dashed var(--color-editor-border);
+  border: 2px dashed var(--color-background-button);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
   position: relative;
@@ -207,7 +207,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  border: 2px dashed var(--color-editor-border);
+  border: 2px dashed var(--color-background-button);
   background: var(--color-text-primary);
   color: var(--color-background);
   position: relative;
@@ -218,7 +218,7 @@
   background: var(--color-text-primary);
   color: var(--color-background);
   border-style: solid;
-  border-color: var(--color-editor-border);
+  border-color: var(--color-background-button);
   transform: translateY(-4px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
Ajout des pointillés et ajustement du hover sur la carte d'ajout d'énigme.

- Uniformise la bordure en pointillés de la carte d'ajout.
- Supprime le fond bleu du :hover et applique un léger relief.

### Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c22ecbe8833280c61fc14c01111c