### PR TITLE
Hide riddle text label in edit panel

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/panneaux/enigme-edition-description.php
@@ -20,17 +20,25 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
     </header>
 
     <?php
+    $hide_label = static function (array $field): array {
+        $field['wrapper']['class'] = trim(($field['wrapper']['class'] ?? '') . ' acf-hide-label');
+        return $field;
+    };
+    add_filter('acf/prepare_field/name=enigme_visuel_texte', $hide_label);
+
     acf_form([
-      'post_id'             => $enigme_id,
-      'fields'              => ['enigme_visuel_texte'],
-      'form'                => true,
-      'submit_value'        => __( '💾 Enregistrer', 'chassesautresor-com' ),
-      'html_submit_button'  => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
-      'html_before_fields'  => '<div class="champ-wrapper">',
-      'html_after_fields'   => '</div>',
-      'return' => add_query_arg('panneau', 'description-enigme', get_permalink()),
-      'updated_message'     => __( 'Texte de l’énigme mis à jour.', 'chassesautresor-com' )
+        'post_id'            => $enigme_id,
+        'fields'             => ['enigme_visuel_texte'],
+        'form'               => true,
+        'submit_value'       => __('💾 Enregistrer', 'chassesautresor-com'),
+        'html_submit_button' => '<div class="panneau-lateral__actions"><button type="submit" class="bouton-enregistrer-description bouton-enregistrer-liens">%s</button></div>',
+        'html_before_fields' => '<div class="champ-wrapper">',
+        'html_after_fields'  => '</div>',
+        'return'             => add_query_arg('panneau', 'description-enigme', get_permalink()),
+        'updated_message'    => __('Texte de l’énigme mis à jour.', 'chassesautresor-com'),
     ]);
+
+    remove_filter('acf/prepare_field/name=enigme_visuel_texte', $hide_label);
     ?>
 
   </div>


### PR DESCRIPTION
### Résumé
- Masque le label « Texte énigme » dans le panneau latéral d’édition d’une énigme afin de simplifier l’interface.

### Changements notables
- Ajout d’un filtre ACF pour ajouter la classe `acf-hide-label` au champ `enigme_visuel_texte` dans le panneau d’édition correspondant.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1c365ebcc83328093e93cfbf0af3f