### PR TITLE
Remplace l’avertissement par une icône d’information

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -241,6 +241,12 @@
   z-index: 1;
 }
 
+.carte-ajout-enigme .help-icon-button {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+}
+
 .carte-ajout-enigme .carte-core i {
   color: var(--color-background-button);
   font-size: 28px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -240,6 +240,12 @@
   z-index: 1;
 }
 
+.carte-ajout-enigme .help-icon-button {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+}
+
 .carte-ajout-enigme .carte-core i {
   color: var(--color-background-button);
   font-size: 28px;

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1167,8 +1167,12 @@ msgstr ""
 msgid "Chasse introuvable."
 msgstr ""
 
-#: single-chasse.php:135
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:40
 msgid "Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique."
+msgstr ""
+
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:38
+msgid "Validation en ligne nécessaire"
 msgstr ""
 
 #: single-chasse.php:167

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1167,13 +1167,17 @@ msgstr ""
 msgid "Chasse introuvable."
 msgstr "Hunting not found."
 
-#: single-chasse.php:135
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:40
 msgid ""
 "Votre chasse se termine automatiquement ; ajoutez une énigme à validation "
 "manuelle ou automatique."
 msgstr ""
 "Your hunt ends automatically; add a manually or automatically validated "
 "puzzle."
+
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:38
+msgid "Validation en ligne nécessaire"
+msgstr "Online validation required"
 
 #: single-chasse.php:167
 #, fuzzy

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1172,13 +1172,17 @@ msgstr ""
 msgid "Chasse introuvable."
 msgstr "Chasse introuvable."
 
-#: single-chasse.php:135
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:40
 msgid ""
 "Votre chasse se termine automatiquement ; ajoutez une énigme à validation "
 "manuelle ou automatique."
 msgstr ""
 "Votre chasse se termine automatiquement ; ajoutez une énigme à validation "
 "manuelle ou automatique."
+
+#: template-parts/enigme/chasse-partial-ajout-enigme.php:38
+msgid "Validation en ligne nécessaire"
+msgstr "Validation en ligne nécessaire"
 
 #: single-chasse.php:167
 #, fuzzy

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -98,19 +98,6 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     ?>
 
     <?php
-
-    if ($est_orga_associe && $needs_validatable_message) {
-        echo '<div class="cta-chasse">';
-        $msg = __(
-            'Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique.',
-            'chassesautresor-com'
-        );
-        echo '<p>⚠️ ' . esc_html($msg) . '</p>';
-        echo '</div>';
-    }
-    ?>
-
-    <?php
     if (current_user_can('administrator') && $statut_validation === 'en_attente') {
       get_template_part('template-parts/chasse/chasse-validation-actions', null, [
         'chasse_id' => $chasse_id,
@@ -122,8 +109,13 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         <?php $error_message = sanitize_text_field(wp_unslash($_GET['erreur'])); ?>
         <?php if ($error_message === 'points_insuffisants') : ?>
             <div class="message-erreur" role="alert" aria-live="assertive">
-                ❌ <?= esc_html__('Vous n’avez pas assez de points pour engager cette énigme.', 'chassesautresor-com'); ?>
-                <a href="<?= esc_url(home_url('/boutique')); ?>"><?= esc_html__('Accéder à la boutique', 'chassesautresor-com'); ?></a>
+                ❌ <?= esc_html__(
+                    'Vous n’avez pas assez de points pour engager cette énigme.',
+                    'chassesautresor-com'
+                ); ?>
+                <a href="<?= esc_url(home_url('/boutique')); ?>">
+                    <?= esc_html__('Accéder à la boutique', 'chassesautresor-com'); ?>
+                </a>
             </div>
         <?php else : ?>
             <div class="message-erreur" role="alert" aria-live="assertive">
@@ -148,9 +140,10 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
         <div id="liste-enigmes" class="chasse-enigmes-liste">
             <?php
             get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [
-                'chasse_id'       => $chasse_id,
-                'est_orga_associe'=> $est_orga_associe,
-                'infos_chasse'    => $infos_chasse,
+                'chasse_id'                => $chasse_id,
+                'est_orga_associe'        => $est_orga_associe,
+                'infos_chasse'            => $infos_chasse,
+                'needs_validatable_message' => $needs_validatable_message,
             ]);
             ?>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -11,6 +11,7 @@ $has_enigmes     = $args['has_enigmes'] ?? false;
 $chasse_id       = $args['chasse_id'] ?? null;
 $disabled        = $args['disabled'] ?? true;
 $highlight_pulse = $args['highlight_pulse'] ?? false;
+$show_info_icon  = $args['show_info_icon'] ?? false;
 
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
@@ -28,6 +29,24 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
     onclick="if(!this.hasAttribute('disabled')){window.location.href='<?php echo $ajout_url; ?>';}"
 >
     <div class="carte-core">
+        <?php if ($show_info_icon) : ?>
+            <?php
+            get_template_part(
+                'template-parts/common/help-icon',
+                null,
+                [
+                    'aria_label' => __('Validation en ligne nécessaire', 'chassesautresor-com'),
+                    'title'      => __('Validation en ligne nécessaire', 'chassesautresor-com'),
+                    'message'    => __(
+                        'Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle '
+                        . 'ou automatique.',
+                        'chassesautresor-com'
+                    ),
+                    'variant'    => 'info',
+                ]
+            );
+            ?>
+        <?php endif; ?>
         <i class="fa-solid fa-circle-plus" aria-hidden="true"></i>
         <span class="carte-ajout-libelle"><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
     </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -17,7 +17,9 @@ $utilisateur_id = get_current_user_id();
 // 🔒 Vérification d'accès à la chasse
 if (!chasse_est_visible_pour_utilisateur($chasse_id, $utilisateur_id)) return;
 
-$est_orga_associe = $args['est_orga_associe'] ?? utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+$est_orga_associe = $args['est_orga_associe']
+    ?? utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+$needs_validatable_message = $args['needs_validatable_message'] ?? false;
 
 $autorise_boucle = (
   user_can($utilisateur_id, 'manage_options') ||
@@ -120,11 +122,15 @@ foreach ($posts as $p) {
             </div>
           <?php endif; ?>
         </div>
-        <?php if ($classe_completion === 'carte-incomplete') : ?>
-          <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
-            <i class="fa-solid fa-exclamation" aria-hidden="true"></i>
-          </span>
-        <?php endif; ?>
+          <?php if ($classe_completion === 'carte-incomplete') : ?>
+            <span
+              class="warning-icon"
+              aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>"
+              title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>"
+            >
+              <i class="fa-solid fa-exclamation" aria-hidden="true"></i>
+            </span>
+          <?php endif; ?>
       </article>
     <?php endforeach; ?>
 
@@ -149,13 +155,18 @@ foreach ($posts as $p) {
         }
       }
 
-      get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
-        'has_enigmes'     => $has_enigmes,
-        'chasse_id'       => $chasse_id,
-        'disabled'        => !$complete,
-        'highlight_pulse' => $highlight_pulse,
-        'use_button'      => false,
-      ]);
+      get_template_part(
+          'template-parts/enigme/chasse-partial-ajout-enigme',
+          null,
+          [
+              'has_enigmes'     => $has_enigmes,
+              'chasse_id'       => $chasse_id,
+              'disabled'        => !$complete,
+              'highlight_pulse' => $highlight_pulse,
+              'use_button'      => false,
+              'show_info_icon'  => ($est_orga_associe && $needs_validatable_message),
+          ]
+      );
     }
     ?>
   </div>


### PR DESCRIPTION
## Résumé
- affiche une icône d’information lors de l’ajout d’une énigme sans validation
- passe les paramètres nécessaires aux templates et met à jour les traductions
- ajoute le style pour positionner l’icône dans la carte

## Testing
- `npm install`
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1c294e0b08332b121d3230a9e5161