### PR TITLE
Corrige l'absence du bouton d'édition du texte d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -383,7 +383,7 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
 
     const champTexte = ligne.querySelector('.champ-texte');
     if (champTexte) {
-      champTexte.after(bouton);
+      champTexte.appendChild(bouton);
     } else {
       ligne.appendChild(bouton);
     }

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -94,7 +94,7 @@ window.mettreAJourResumeInfos = function () {
       const champ = ligne.dataset.champ;
       const blocEdition = document.querySelector(`.champ-enigme[data-champ="${champ}"]`);
 
-      let estRempli = false;
+      let estRempli = blocEdition && !blocEdition.classList.contains('champ-vide');
 
       // Règles spécifiques pour les énigmes
       if (champ === 'post_title') {

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1168,6 +1168,7 @@ li.ligne-logo .champ-modifier {
 
 .resume-infos li.champ-description .champ-texte-contenu,
 .resume-infos li.champ-wysiwyg .champ-texte-contenu {
+  flex: 1;
   display: inline;
 }
 
@@ -1179,8 +1180,8 @@ li.ligne-logo .champ-modifier {
 }
 
 
-.resume-infos li.champ-description .champ-texte + .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte + .champ-modifier {
+.resume-infos li.champ-description .champ-texte .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
   transform: none;
   margin-left: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1179,8 +1179,8 @@ li.ligne-logo .champ-modifier {
 }
 
 
-.resume-infos li.champ-description .champ-texte-contenu .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte-contenu .champ-modifier {
+.resume-infos li.champ-description .champ-texte .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
   transform: none;
   margin-left: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1179,8 +1179,8 @@ li.ligne-logo .champ-modifier {
 }
 
 
-.resume-infos li.champ-description .champ-texte .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
+.resume-infos li.champ-description .champ-texte + .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte + .champ-modifier {
   transform: none;
   margin-left: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1168,7 +1168,6 @@ li.ligne-logo .champ-modifier {
 
 .resume-infos li.champ-description .champ-texte-contenu,
 .resume-infos li.champ-wysiwyg .champ-texte-contenu {
-  flex: 1;
   display: inline;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3197,8 +3197,8 @@ li.ligne-logo .champ-modifier {
   height: 40px;
 }
 
-.resume-infos li.champ-description .champ-texte .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
+.resume-infos li.champ-description .champ-texte + .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte + .champ-modifier {
   transform: none;
   margin-left: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3197,8 +3197,8 @@ li.ligne-logo .champ-modifier {
   height: 40px;
 }
 
-.resume-infos li.champ-description .champ-texte-contenu .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte-contenu .champ-modifier {
+.resume-infos li.champ-description .champ-texte .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
   transform: none;
   margin-left: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3187,7 +3187,6 @@ li.ligne-logo .champ-modifier {
 
 .resume-infos li.champ-description .champ-texte-contenu,
 .resume-infos li.champ-wysiwyg .champ-texte-contenu {
-  flex: 1;
   display: inline;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3187,6 +3187,7 @@ li.ligne-logo .champ-modifier {
 
 .resume-infos li.champ-description .champ-texte-contenu,
 .resume-infos li.champ-wysiwyg .champ-texte-contenu {
+  flex: 1;
   display: inline;
 }
 
@@ -3197,8 +3198,8 @@ li.ligne-logo .champ-modifier {
   height: 40px;
 }
 
-.resume-infos li.champ-description .champ-texte + .champ-modifier,
-.resume-infos li.champ-wysiwyg .champ-texte + .champ-modifier {
+.resume-infos li.champ-description .champ-texte .champ-modifier,
+.resume-infos li.champ-wysiwyg .champ-texte .champ-modifier {
   transform: none;
   margin-left: 0.3rem;
 }

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -234,16 +234,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                 <?php else : ?>
                                   <span class="champ-texte-contenu">
                                     <?= esc_html(wp_trim_words(wp_strip_all_tags($texte_enigme), 25)); ?>
-                                    <?php if ($peut_editer) : ?>
-                                      <button type="button" class="champ-modifier ouvrir-panneau-description"
-                                        data-champ="enigme_visuel_texte"
-                                        data-cpt="enigme"
-                                        data-post-id="<?= esc_attr($enigme_id); ?>"
-                                        aria-label="<?= esc_attr__('Éditer le texte', 'chassesautresor-com'); ?>">
-                                        <?= esc_html__('éditer', 'chassesautresor-com'); ?>
-                                      </button>
-                                    <?php endif; ?>
                                   </span>
+                                  <?php if ($peut_editer) : ?>
+                                    <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                      data-champ="enigme_visuel_texte"
+                                      data-cpt="enigme"
+                                      data-post-id="<?= esc_attr($enigme_id); ?>"
+                                      aria-label="<?= esc_attr__('Éditer le texte', 'chassesautresor-com'); ?>">
+                                      <?= esc_html__('éditer', 'chassesautresor-com'); ?>
+                                    </button>
+                                  <?php endif; ?>
                                 <?php endif; ?>
                               </div>
                               <div class="champ-feedback"></div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -235,17 +235,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                   <span class="champ-texte-contenu">
                                     <?= esc_html(wp_trim_words(wp_strip_all_tags($texte_enigme), 25)); ?>
                                   </span>
-                                  <?php if ($peut_editer) : ?>
-                                    <button type="button" class="champ-modifier ouvrir-panneau-description"
-                                      data-champ="enigme_visuel_texte"
-                                      data-cpt="enigme"
-                                      data-post-id="<?= esc_attr($enigme_id); ?>"
-                                      aria-label="<?= esc_attr__('Éditer le texte', 'chassesautresor-com'); ?>">
-                                      <?= esc_html__('éditer', 'chassesautresor-com'); ?>
-                                    </button>
-                                  <?php endif; ?>
                                 <?php endif; ?>
                               </div>
+                              <?php if ($peut_editer && !empty(trim($texte_enigme))) : ?>
+                                <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                  data-champ="enigme_visuel_texte"
+                                  data-cpt="enigme"
+                                  data-post-id="<?= esc_attr($enigme_id); ?>"
+                                  aria-label="<?= esc_attr__('Éditer le texte', 'chassesautresor-com'); ?>">
+                                  <?= esc_html__('éditer', 'chassesautresor-com'); ?>
+                                </button>
+                              <?php endif; ?>
                               <div class="champ-feedback"></div>
                               <?php
                           },

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -235,17 +235,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                                   <span class="champ-texte-contenu">
                                     <?= esc_html(wp_trim_words(wp_strip_all_tags($texte_enigme), 25)); ?>
                                   </span>
+                                  <?php if ($peut_editer) : ?>
+                                    <button type="button" class="champ-modifier ouvrir-panneau-description"
+                                      data-champ="enigme_visuel_texte"
+                                      data-cpt="enigme"
+                                      data-post-id="<?= esc_attr($enigme_id); ?>"
+                                      aria-label="<?= esc_attr__('Éditer le texte', 'chassesautresor-com'); ?>">
+                                      <?= esc_html__('éditer', 'chassesautresor-com'); ?>
+                                    </button>
+                                  <?php endif; ?>
                                 <?php endif; ?>
                               </div>
-                              <?php if ($peut_editer && !empty(trim($texte_enigme))) : ?>
-                                <button type="button" class="champ-modifier ouvrir-panneau-description"
-                                  data-champ="enigme_visuel_texte"
-                                  data-cpt="enigme"
-                                  data-post-id="<?= esc_attr($enigme_id); ?>"
-                                  aria-label="<?= esc_attr__('Éditer le texte', 'chassesautresor-com'); ?>">
-                                  <?= esc_html__('éditer', 'chassesautresor-com'); ?>
-                                </button>
-                              <?php endif; ?>
                               <div class="champ-feedback"></div>
                               <?php
                           },


### PR DESCRIPTION
## Résumé
- affiche toujours le bouton d’édition du texte d’énigme
- met à jour le style associé et recompile les CSS

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1c54325bc8332bde3fe4edbefe43b