### PR TITLE
Rend l’icône d’information d’ajout d’énigme visible

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -323,6 +323,17 @@
   z-index: 2;
 }
 
+.carte-ajout-wrapper .carte-help-icon {
+  color: var(--color-background-button);
+  border-color: var(--color-background-button);
+}
+
+.carte-ajout-wrapper .carte-help-icon:hover,
+.carte-ajout-wrapper .carte-help-icon:focus {
+  color: var(--color-background-button-hover);
+  border-color: var(--color-background-button-hover);
+}
+
 
 /* ========== ✅ Indicateurs de complétion ========== */
 .carte-complete {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -321,6 +321,17 @@
   z-index: 2;
 }
 
+.carte-ajout-wrapper .carte-help-icon {
+  color: var(--color-background-button);
+  border-color: var(--color-background-button);
+}
+
+.carte-ajout-wrapper .carte-help-icon:hover,
+.carte-ajout-wrapper .carte-help-icon:focus {
+  color: var(--color-background-button-hover);
+  border-color: var(--color-background-button-hover);
+}
+
 /* ========== ✅ Indicateurs de complétion ========== */
 .carte-complete {
   border: 2px solid var(--color-editor-success);


### PR DESCRIPTION
## Résumé
- Améliore la visibilité de l’icône d’information sur la carte d’ajout d’énigme.

## Changements notables
- Style rouge appliqué à l’icône d’aide avec survol plus foncé.

## Testing
- `npm install`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1f97bb62c8332a5aec47b0ad38777