### PR TITLE
Restaure l'option pré-requis dans l'accès aux énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -435,15 +435,9 @@ function initEnigmeEdit() {
     });
   });
 
-  initChampAccesDate();
+  initChampAccesCondition();
+  initChampPreRequis();
   initChampCoutPoints();
-
-  if (enigmeId) {
-    const accesToggle = document.getElementById('enigme-acces-toggle');
-    accesToggle?.addEventListener('change', () => {
-      forcerRecalculStatutEnigme(enigmeId);
-    });
-  }
 
   initPanneauVariantes();
   initPagerTentatives();
@@ -683,38 +677,50 @@ function initChampNbTentatives() {
 // ================================
 // 🔓 Gestion du champ d'accès (Libre / Date programmée)
 // ================================
-function initChampAccesDate() {
-  const toggle = document.getElementById('enigme-acces-toggle');
-  const hidden = document.getElementById('enigme_acces_condition');
+function initChampAccesCondition() {
+  const radios = document.querySelectorAll('input[name="acf[enigme_acces_condition]"]');
   const blocDate = document.getElementById('champ-enigme-date');
   const inputDate = blocDate?.querySelector('input');
-  if (!toggle || !hidden || !blocDate || !inputDate) return;
+  const blocPre = document.getElementById('champ-enigme-pre-requis');
+  if (!radios.length || !blocDate || !inputDate || !blocPre) return;
 
-  const bloc = hidden.closest('[data-champ]');
+  const bloc = document.querySelector('[data-champ="enigme_acces_condition"]');
   const postId = bloc?.dataset.postId;
   const cpt = bloc?.dataset.cpt || 'enigme';
 
   function appliquerEtat() {
-    if (toggle.checked) {
-      hidden.value = 'date_programmee';
+    const valeur = document.querySelector('input[name="acf[enigme_acces_condition]"]:checked')?.value || 'immediat';
+    if (valeur === 'date_programmee') {
       blocDate.classList.remove('cache');
+      blocPre.classList.add('cache');
       inputDate.disabled = false;
-    } else {
-      hidden.value = 'immediat';
+    } else if (valeur === 'pre_requis') {
+      blocPre.classList.remove('cache');
       blocDate.classList.add('cache');
+      inputDate.disabled = true;
+    } else {
+      blocDate.classList.add('cache');
+      blocPre.classList.add('cache');
       inputDate.disabled = true;
     }
   }
 
-  function enregistrer() {
+  function enregistrer(valeur) {
     if (!postId) return;
-    modifierChampSimple('enigme_acces_condition', hidden.value, postId, cpt);
+    modifierChampSimple('enigme_acces_condition', valeur, postId, cpt);
   }
 
-  toggle.addEventListener('change', () => {
-    appliquerEtat();
-    enregistrer();
+  radios.forEach(radio => {
+    radio.addEventListener('change', () => {
+      const valeur = radio.value;
+      appliquerEtat();
+      enregistrer(valeur);
+      if (typeof window.forcerRecalculStatutEnigme === 'function' && postId) {
+        window.forcerRecalculStatutEnigme(postId);
+      }
+    });
   });
+
   appliquerEtat();
 }
 // ================================


### PR DESCRIPTION
## Résumé
- rétablit l'édition de l'accès avec les choix Libre, Date programmée ou Pré-requis
- affiche les énigmes éligibles comme pré-requis lorsque l'option est activée
- met à jour le script d'édition pour gérer le nouveau contrôle segmenté

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1f98747808332b0c14b71f87c5e58