### PR TITLE
Mets en évidence le CTA d'énigme avec la couleur d'engagement

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/cta.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/cta.php
@@ -320,7 +320,7 @@ function render_cta_enigme(array $cta, int $enigme_id): void
 {
     $statut = $cta['statut_utilisateur'] ?? '';
     $classes_bouton = in_array($statut, ['non_commencee', 'echouee', 'abandonnee', 'soumis'], true)
-        ? 'bouton bouton-cta'
+        ? 'bouton bouton-cta bouton-cta--color'
         : 'bouton bouton-secondaire';
 
     switch ($cta['action']) {


### PR DESCRIPTION
## Résumé
- met en évidence le bouton "Voir l’énigme" en appliquant la couleur d’engagement

## Changements notables
- ajoute la classe `bouton-cta--color` aux CTA d’énigmes pour les rendre plus visibles

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1feffdf3883329c9437e19bdfb41c