### PR TITLE
Corrige la taille de l'image de chasse après édition

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -131,13 +131,20 @@ window.mettreAJourTitreMenuEnigme = function (valeur) {
  *
  * @param {string} cpt - Le nom du CPT (ex. "organisateur", "chasse", "enigme")
  * @param {number|string} postId - L’ID du post
- * @param {string} nouvelleUrl - L’URL de l’image mise à jour
+ * @param {string} nouvelleUrl - L’URL de l’image mise à jour pour l’affichage
+ * @param {string} [fullUrl=nouvelleUrl] - L’URL de l’image originale pour la lightbox
  */
-function mettreAJourVisuelCPT(cpt, postId, nouvelleUrl) {
-  document.querySelectorAll(`img.visuel-cpt[data-cpt="${cpt}"][data-post-id="${postId}"]`)
+function mettreAJourVisuelCPT(cpt, postId, nouvelleUrl, fullUrl = nouvelleUrl) {
+  document
+    .querySelectorAll(`img.visuel-cpt[data-cpt="${cpt}"][data-post-id="${postId}"]`)
     .forEach(img => {
       img.src = nouvelleUrl;
       img.srcset = nouvelleUrl;
+
+      const lien = img.closest('a');
+      if (lien) {
+        lien.href = fullUrl;
+      }
     });
 }
 

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -35,7 +35,9 @@ function initChampImage(bloc) {
       const selection = frame.state().get('selection').first();
       const id = selection?.id;
       const fullUrl = selection?.attributes?.url;
-      const mediumUrl = selection?.attributes?.sizes?.medium?.url || fullUrl;
+      const ficheUrl =
+        selection?.attributes?.sizes?.['chasse-fiche']?.url || fullUrl;
+      const mediumUrl = selection?.attributes?.sizes?.medium?.url || ficheUrl;
       const thumbUrl = selection?.attributes?.sizes?.thumbnail?.url || mediumUrl;
       if (!id || !fullUrl) return;
 
@@ -78,7 +80,7 @@ function initChampImage(bloc) {
               window.mettreAJourResumeInfos();
             }
             if (typeof window.mettreAJourVisuelCPT === 'function') {
-              mettreAJourVisuelCPT(cpt, postId, mediumUrl);
+              mettreAJourVisuelCPT(cpt, postId, ficheUrl);
             }
           } else {
             if (feedback) {

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -80,7 +80,7 @@ function initChampImage(bloc) {
               window.mettreAJourResumeInfos();
             }
             if (typeof window.mettreAJourVisuelCPT === 'function') {
-              mettreAJourVisuelCPT(cpt, postId, ficheUrl);
+              mettreAJourVisuelCPT(cpt, postId, ficheUrl, fullUrl);
             }
           } else {
             if (feedback) {


### PR DESCRIPTION
## Résumé
- corrige l'utilisation d'une image trop petite lors de l'édition d'une chasse

## Modifications
- charge désormais le format `chasse-fiche` pour rafraîchir l'image principale

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b2014bb0788332a867757c57975830