### PR TITLE
feat: permettre l'annulation lors de la création d'une énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -161,7 +161,7 @@ function initEnigmeEdit() {
       document.body.classList.contains('edition-active-enigme') &&
       panneauEdition &&
       !panneauEdition.contains(e.target) &&
-      !e.target.closest('.toggle-mode-edition-enigme')
+      !e.target.closest('#toggle-mode-edition-enigme, .toggle-mode-edition-enigme')
     ) {
       cancelEdition();
     }

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -115,6 +115,19 @@ function initEnigmeEdit() {
     '#toggle-mode-edition-enigme, .toggle-mode-edition-enigme'
   );
   panneauEdition = document.querySelector('.edition-panel-enigme');
+  const cancelBtn = panneauEdition?.querySelector('.panneau-annuler');
+  const cancelUrl = panneauEdition?.dataset.cancelUrl;
+
+  function cancelEdition() {
+    if (cancelUrl) {
+      window.location.href = cancelUrl;
+      return;
+    }
+    document.body.classList.remove('edition-active-enigme');
+    document.body.classList.remove('panneau-ouvert');
+    document.body.classList.remove('mode-edition');
+    document.activeElement?.blur();
+  }
 
   // ==============================
   // 🛠️ Contrôles panneau principal
@@ -135,6 +148,23 @@ function initEnigmeEdit() {
     document.body.classList.remove('panneau-ouvert');
     document.body.classList.remove('mode-edition');
     document.activeElement?.blur();
+  });
+
+  cancelBtn?.addEventListener('click', cancelEdition);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && document.body.classList.contains('edition-active-enigme')) {
+      cancelEdition();
+    }
+  });
+  document.addEventListener('click', (e) => {
+    if (
+      document.body.classList.contains('edition-active-enigme') &&
+      panneauEdition &&
+      !panneauEdition.contains(e.target) &&
+      !e.target.closest('.toggle-mode-edition-enigme')
+    ) {
+      cancelEdition();
+    }
   });
 
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -159,11 +159,17 @@ function initEnigmeEdit() {
     }
   });
   document.addEventListener('click', (e) => {
+    const path = e.composedPath?.() || [];
+    const clickInside =
+      panneauEdition &&
+      (panneauEdition.contains(e.target) || path.includes(panneauEdition));
+    const onToggle = e.target.closest(
+      '#toggle-mode-edition-enigme, .toggle-mode-edition-enigme'
+    );
     if (
       document.body.classList.contains('edition-active-enigme') &&
-      panneauEdition &&
-      !panneauEdition.contains(e.target) &&
-      !e.target.closest('#toggle-mode-edition-enigme, .toggle-mode-edition-enigme')
+      !clickInside &&
+      !onToggle
     ) {
       cancelEdition();
     }

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -132,7 +132,9 @@ function initEnigmeEdit() {
   // ==============================
   // 🛠️ Contrôles panneau principal
   // ==============================
-  const toggleEdition = () => {
+  const toggleEdition = (e) => {
+    e?.preventDefault();
+    e?.stopPropagation();
     document.body.classList.toggle('edition-active-enigme');
     document.body.classList.toggle('panneau-ouvert');
     document.body.classList.toggle('mode-edition');

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -42,6 +42,7 @@ $enigme_status = get_post_status($enigme_id);
 $chasse_validation = $chasse_id ? get_field('chasse_cache_statut_validation', $chasse_id) : '';
 $stats_locked = in_array($chasse_validation, ['creation', 'en_attente', 'correction'], true)
     || $enigme_status !== 'publish';
+$cancel_url = $chasse_id ? get_permalink($chasse_id) : home_url('/');
 
 $nb_variantes   = 0;
 $variantes_list = [];
@@ -75,7 +76,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
 }
 ?>
 <?php if ($peut_modifier) : ?>
-  <section class="edition-panel edition-panel-enigme edition-panel-modal" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+  <section class="edition-panel edition-panel-enigme edition-panel-modal" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-cancel-url="<?= esc_url($cancel_url); ?>">
     <div id="erreur-global"
       style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
@@ -87,8 +88,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
             <span class="titre-objet" data-cpt="enigme"><?= esc_html($titre); ?></span>
           </h2>
 
-        <button type="button" class="panneau-fermer" aria-label="<?= esc_attr__('Fermer les paramètres', 'chassesautresor-com'); ?>">✖</button>
-      </div>
+          <button type="button" class="panneau-annuler bouton-secondaire"><?= esc_html__('Annuler', 'chassesautresor-com'); ?></button>
+          <button type="button" class="panneau-fermer" aria-label="<?= esc_attr__('Fermer les paramètres', 'chassesautresor-com'); ?>">✖</button>
+        </div>
       <div class="edition-tabs">
         <button class="edition-tab active" data-target="enigme-tab-param"><?= esc_html__('Paramètres', 'chassesautresor-com'); ?></button>
         <button class="edition-tab" data-target="enigme-tab-stats"><?= esc_html__('Statistiques', 'chassesautresor-com'); ?></button>


### PR DESCRIPTION
## Résumé
- ajoute un bouton d'annulation au panneau d'édition d'énigme
- annule aussi via Échap ou clic hors du panneau

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2052f74ec8332a69f1bd31136a651