### PR TITLE
Affichage du badge de validation sur les cartes énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -68,6 +68,13 @@
   position: relative
 }
 
+.carte-enigme .badge-validation {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1;
+}
+
 .etat-bloquee_chasse .carte-core,
 .etat-bloquee_date .carte-core,
 .etat-bloquee_pre_requis .carte-core,

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -601,6 +601,20 @@ a.ajout-link:focus-visible {
    🏷️ BADGES
    ================================================== */
 
+/* ========== ✔️ BADGE VALIDATION ========== */
+
+.badge-validation {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-grey-light);
+    color: var(--color-text-fond-clair);
+    font-size: 0.75rem;
+}
+
 /* ========== 🟢 BADGE ROND ========== */
 
 .badge-rond {

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -412,18 +412,6 @@ li.active .enigme-menu__edit {
   align-items: center;
 }
 
-.participation .badge-validation {
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: var(--color-grey-light);
-  color: var(--color-text-fond-clair);
-  font-size: 0.75rem;
-}
-
 .zone-reponse form {
   display: flex;
   flex-direction: column;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -67,6 +67,13 @@
   position: relative;
 }
 
+.carte-enigme .badge-validation {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1;
+}
+
 .etat-bloquee_chasse .carte-core,
 .etat-bloquee_date .carte-core,
 .etat-bloquee_pre_requis .carte-core,
@@ -1282,6 +1289,19 @@ a.ajout-link:focus-visible {
 /* ==================================================
    🏷️ BADGES
    ================================================== */
+/* ========== ✔️ BADGE VALIDATION ========== */
+.badge-validation {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
+  font-size: 0.75rem;
+}
+
 /* ========== 🟢 BADGE ROND ========== */
 .badge-rond {
   margin: 0;
@@ -5123,18 +5143,6 @@ li.active .enigme-menu__edit {
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
-
-.participation .badge-validation {
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: var(--color-grey-light);
-  color: var(--color-text-fond-clair);
-  font-size: 0.75rem;
 }
 
 .zone-reponse form {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -66,6 +66,7 @@ foreach ($posts as $p) {
       $cta = get_cta_enigme($enigme_id, $utilisateur_id);
       $type_cta = $cta['type'] ?? 'inconnu';
       $classe_cta = 'cta-' . sanitize_html_class($type_cta);
+        $mode_validation = get_field('enigme_mode_validation', $enigme_id);
 
       // 🔍 Vérification bordure admin/orga
       $statut_enigme = get_post_status($enigme_id);
@@ -84,8 +85,18 @@ foreach ($posts as $p) {
       $classes_carte = trim("carte carte-enigme $classe_completion $classe_cta");
       $mapping_visuel = get_mapping_visuel_enigme($enigme_id);
     ?>
-      <article class="<?= esc_attr($classes_carte); ?>">
-        <div class="carte-core">
+        <article class="<?= esc_attr($classes_carte); ?>">
+            <?php if (in_array($mode_validation, ['automatique', 'manuelle'], true)) :
+                $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+                $label = $mode_validation === 'automatique'
+                    ? esc_html__('Mode de validation : automatique', 'chassesautresor-com')
+                    : esc_html__('Mode de validation : manuel', 'chassesautresor-com');
+            ?>
+                <span class="badge-validation" title="<?= esc_attr($label); ?>" aria-label="<?= esc_attr($label); ?>">
+                    <i class="fa-solid <?= esc_attr($icon); ?>" aria-hidden="true"></i>
+                </span>
+            <?php endif; ?>
+            <div class="carte-core">
           <div class="carte-enigme-image <?= esc_attr($mapping_visuel['filtre'] ?? ''); ?>"
             title="<?= esc_attr($mapping_visuel['sens'] ?? '') ?>">
             <?php if ($mapping_visuel['image_reelle']) : ?>


### PR DESCRIPTION
## Résumé
- ajout du badge de mode de validation sur chaque carte d'énigme
- factorisation des styles du badge de validation et positionnement en haut à gauche

## Testing
- `npm run build:css`
- `npm test`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b26cbf5c248332b92bbdf301f5e6b6