### PR TITLE
Ajout d'une option d'annulation pour les bonnes réponses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -919,17 +919,55 @@ function initChampBonnesReponses() {
         valider.className = 'champ-modifier bonne-reponse-valider';
         valider.textContent = wp.i18n.__('valider', 'chassesautresor-com');
 
+        const annuler = document.createElement('button');
+        annuler.type = 'button';
+        annuler.className = 'bonne-reponse-annuler';
+        annuler.setAttribute('aria-label', wp.i18n.__('Annuler', 'chassesautresor-com'));
+        annuler.textContent = '×';
+
+        const cleanup = () => {
+          input.remove();
+          valider.remove();
+          annuler.remove();
+          document.removeEventListener('click', outsideClick);
+          document.removeEventListener('keydown', escHandler);
+          wrapper.appendChild(btnAjout);
+        };
+
+        const outsideClick = (e) => {
+          if (!wrapper.contains(e.target)) {
+            cleanup();
+          }
+        };
+
+        const escHandler = (e) => {
+          if (e.key === 'Escape') {
+            cleanup();
+          }
+        };
+
+        annuler.addEventListener('click', (e) => {
+          e.stopPropagation();
+          cleanup();
+        });
+
         valider.addEventListener('click', () => {
           const val = input.value.trim();
           if (!val) return;
           reponses.push(val);
+          document.removeEventListener('click', outsideClick);
+          document.removeEventListener('keydown', escHandler);
           sauvegarder().then((ok) => {
             if (ok) render();
           });
         });
 
+        document.addEventListener('click', outsideClick);
+        document.addEventListener('keydown', escHandler);
+
         wrapper.appendChild(input);
         wrapper.appendChild(valider);
+        wrapper.appendChild(annuler);
         input.focus();
       });
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -907,7 +907,8 @@ function initChampBonnesReponses() {
       btnAjout.className = 'champ-modifier bonne-reponse-ajouter';
       btnAjout.textContent = wp.i18n.__('ajouter', 'chassesautresor-com');
 
-      btnAjout.addEventListener('click', () => {
+      btnAjout.addEventListener('click', (e) => {
+        e.stopPropagation();
         btnAjout.remove();
         const input = document.createElement('input');
         input.type = 'text';

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -645,6 +645,13 @@ body .header-img-modifiable .icone-modif {
   cursor: pointer;
 }
 
+.bonne-reponse-annuler {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 .bonne-reponse-valider.btn-obligatoire {
   background-color: var(--color-editor-error);
   color: #fff;

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -632,6 +632,12 @@ body .header-img-modifiable .icone-modif {
   align-items: center;
 }
 
+.champ-casse {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-md);
+}
+
 .bonne-reponse-etiquette {
   display: inline-flex;
   align-items: center;
@@ -650,6 +656,7 @@ body .header-img-modifiable .icone-modif {
   background: none;
   padding: 0;
   cursor: pointer;
+  color: var(--color-editor-error);
 }
 
 .bonne-reponse-valider.btn-obligatoire {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2777,6 +2777,13 @@ body .header-img-modifiable .icone-modif {
   cursor: pointer;
 }
 
+.bonne-reponse-annuler {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 .bonne-reponse-valider.btn-obligatoire {
   background-color: var(--color-editor-error);
   color: #fff;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2764,6 +2764,12 @@ body .header-img-modifiable .icone-modif {
   align-items: center;
 }
 
+.champ-casse {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-md);
+}
+
 .bonne-reponse-etiquette {
   display: inline-flex;
   align-items: center;
@@ -2782,6 +2788,7 @@ body .header-img-modifiable .icone-modif {
   background: none;
   padding: 0;
   cursor: pointer;
+  color: var(--color-editor-error);
 }
 
 .bonne-reponse-valider.btn-obligatoire {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -393,7 +393,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                     'content' => function () use ($reponses, $casse, $peut_editer, $enigme_id) {
                         ?>
                         <div class="bonnes-reponses-wrapper<?= empty($reponses) ? ' champ-vide-obligatoire' : ''; ?>"></div>
-                        <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1" style="display: inline-flex; align-items: center;">
+                        <div class="champ-enigme champ-casse <?= $casse ? 'champ-rempli' : 'champ-vide'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_reponse_casse" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" data-no-edit="1">
                             <label style="display: flex; align-items: center; gap: 4px;"><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> <?= esc_html__('Respecter la casse', 'chassesautresor-com'); ?></label>
                             <div class="champ-feedback"></div>
                         </div>


### PR DESCRIPTION
## Résumé
Ajoute une icône pour annuler l'ajout d'une bonne réponse et permet l'annulation via Échap ou clic en dehors.

## Modifications notables
- Ajout d'un bouton « Annuler » et prise en charge d'Échap ou du clic extérieur lors de l'ajout de bonnes réponses.
- Style dédié pour l'icône d'annulation.

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26def18b8833294ba2e1a80207743