### PR TITLE
Ajout du badge de points sur les cartes énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -99,6 +99,12 @@
   flex: 2;
 }
 
+.carte-enigme-image .badge-cout {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .carte-ligne__image {
   width: 300px;
   height: auto;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -98,6 +98,12 @@
   flex: 2;
 }
 
+.carte-enigme-image .badge-cout {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .carte-ligne__image {
   width: 300px;
   height: auto;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -83,6 +83,7 @@ foreach ($posts as $p) {
 
       $classes_carte = trim("carte carte-enigme $classe_completion $classe_cta");
       $mapping_visuel = get_mapping_visuel_enigme($enigme_id);
+      $cout_points    = (int) get_field('enigme_tentative_cout_points', $enigme_id);
     ?>
       <article class="<?= esc_attr($classes_carte); ?>">
         <div class="carte-core">
@@ -102,6 +103,11 @@ foreach ($posts as $p) {
                 }
                 ?>
               </div>
+            <?php endif; ?>
+            <?php if ($cout_points > 0) : ?>
+              <span class="badge-cout" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
+                <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
+              </span>
             <?php endif; ?>
             <?php if (!in_array($cta['type'], ['bloquee', 'invalide', 'cache_invalide', 'erreur'], true)) { ?>
               <div class="carte-enigme-cta">


### PR DESCRIPTION
## Résumé
- affiche le coût en points sur chaque carte énigme de la page chasse
- ajoute le style positionné pour le badge de points

## Changements notables
- Affichage du badge de points dans la boucle des énigmes
- Positionnement du badge en haut à droite de la carte

## Testing
- `source ./setup-env.sh && echo env-ready`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b26f80cb388332b6814409e442cff0