### PR TITLE
Fix missing puzzle translations on hunt pages

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -648,6 +648,7 @@ msgstr ""
 #: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
+#: single-chasse.php:133
 msgid "Énigmes"
 msgstr ""
 
@@ -2677,6 +2678,7 @@ msgid "Section not found"
 msgstr ""
 
 #: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+#: wp-content/themes/chassesautresor/inc/user-functions.php:384
 msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -644,6 +644,7 @@ msgstr "Definition of the resolution rate"
 #: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
+#: single-chasse.php:133
 msgid "Énigmes"
 msgstr "Riddles"
 
@@ -1953,9 +1954,8 @@ msgstr "No data."
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
 #: assets/js/enigme-edit.js:1533
-#, fuzzy
 msgid "Ajouter une énigme"
-msgstr "add an image"
+msgstr "Add a riddle"
 
 #: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"
@@ -2769,6 +2769,7 @@ msgid "Section not found"
 msgstr "Section not found"
 
 #: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+#: wp-content/themes/chassesautresor/inc/user-functions.php:384
 msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
 msgstr "Your hunt is eligible for a %1$svalidation request%2$s."
 

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -646,6 +646,7 @@ msgstr "Définition du taux de résolution"
 #: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
+#: single-chasse.php:133
 msgid "Énigmes"
 msgstr "Énigmes"
 
@@ -1983,9 +1984,8 @@ msgstr "Aucune donnée."
 
 #: template-parts/enigme/chasse-partial-ajout-enigme.php:28
 #: assets/js/enigme-edit.js:1533
-#, fuzzy
 msgid "Ajouter une énigme"
-msgstr "Ajouter une variante"
+msgstr "Ajouter une énigme"
 
 #: template-parts/enigme/enigme-edition-main.php:86
 msgid "Panneau d'édition énigme"
@@ -2815,6 +2815,7 @@ msgid "Section not found"
 msgstr "Section introuvable"
 
 #: wp-content/themes/chassesautresor/inc/admin-functions.php:1910
+#: wp-content/themes/chassesautresor/inc/user-functions.php:384
 msgid "Votre chasse est éligible à une %1$sdemande de validation%2$s."
 msgstr "Votre chasse est éligible à une %1$sdemande de validation%2$s."
 

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -130,7 +130,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
     <!-- 🧩 Liste des énigmes -->
     <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">
         <div class="titre-enigmes-wrapper">
-            <h2>Énigmes</h2>
+            <h2><?= esc_html__('Énigmes', 'chassesautresor-com'); ?></h2>
         </div>
         <div id="liste-enigmes" class="chasse-enigmes-liste">
             <?php


### PR DESCRIPTION
## Summary
- Rend le titre « Énigmes » traduisible sur la page de chasse
- Corrige les traductions de « Ajouter une énigme » en français et en anglais
- Met à jour le fichier POT avec la référence du template de chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b27899e7d48332a9dd5897cd9ce86b