### PR TITLE
Neutraliser la bordure des cartes d'ajout

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -232,7 +232,7 @@
   padding: var(--space-xl);
   min-height: 140px;
   text-align: center;
-  border: 2px dashed var(--color-background-button);
+  border: 2px dashed var(--color-gris-3);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
   position: relative;
@@ -244,7 +244,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  border: 2px dashed var(--color-background-button);
+  border: 2px dashed var(--color-gris-3);
   background: var(--color-text-primary);
   color: var(--color-background);
   position: relative;
@@ -255,7 +255,7 @@
   background: var(--color-text-primary);
   color: var(--color-background);
   border-style: solid;
-  border-color: var(--color-background-button);
+  border-color: var(--color-gris-3);
   transform: translateY(-4px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
@@ -283,7 +283,7 @@
 }
 
 .carte-ajout-enigme .carte-core i {
-  color: var(--color-background-button);
+  color: var(--color-gris-3);
   font-size: 28px;
 }
 
@@ -360,14 +360,14 @@
 }
 
 .carte-ajout-wrapper .carte-help-icon {
-  color: var(--color-background-button);
-  border-color: var(--color-background-button);
+  color: var(--color-gris-3);
+  border-color: var(--color-gris-3);
 }
 
 .carte-ajout-wrapper .carte-help-icon:hover,
 .carte-ajout-wrapper .carte-help-icon:focus {
-  color: var(--color-background-button-hover);
-  border-color: var(--color-background-button-hover);
+  color: var(--color-gris-3);
+  border-color: var(--color-gris-3);
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -226,7 +226,7 @@
   padding: var(--space-xl);
   min-height: 140px;
   text-align: center;
-  border: 2px dashed var(--color-background-button);
+  border: 2px dashed var(--color-gris-3);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
   position: relative;
@@ -238,7 +238,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  border: 2px dashed var(--color-background-button);
+  border: 2px dashed var(--color-gris-3);
   background: var(--color-text-primary);
   color: var(--color-background);
   position: relative;
@@ -249,7 +249,7 @@
   background: var(--color-text-primary);
   color: var(--color-background);
   border-style: solid;
-  border-color: var(--color-background-button);
+  border-color: var(--color-gris-3);
   transform: translateY(-4px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
@@ -277,7 +277,7 @@
 }
 
 .carte-ajout-enigme .carte-core i {
-  color: var(--color-background-button);
+  color: var(--color-gris-3);
   font-size: 28px;
 }
 
@@ -353,14 +353,14 @@
 }
 
 .carte-ajout-wrapper .carte-help-icon {
-  color: var(--color-background-button);
-  border-color: var(--color-background-button);
+  color: var(--color-gris-3);
+  border-color: var(--color-gris-3);
 }
 
 .carte-ajout-wrapper .carte-help-icon:hover,
 .carte-ajout-wrapper .carte-help-icon:focus {
-  color: var(--color-background-button-hover);
-  border-color: var(--color-background-button-hover);
+  color: var(--color-gris-3);
+  border-color: var(--color-gris-3);
 }
 
 /* ========== ✅ Indicateurs de complétion ========== */


### PR DESCRIPTION
## Résumé
- Harmonise la bordure et les icônes des cartes d'ajout avec une teinte grise neutre
- Recompile les styles SCSS en CSS

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `curl -I http://127.0.0.1:8080/wp-content/themes/chassesautresor/dist/style.css`


------
https://chatgpt.com/codex/tasks/task_e_68b27b7f5900833290e29cdc68015228