### PR TITLE
chore: ajuster la taille de l’icône de carte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -289,7 +289,7 @@
 
 @media (min-width: 768px) {
   .carte-ajout-enigme .carte-core i {
-    font-size: 36px;
+    font-size: 32px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -283,7 +283,7 @@
 
 @media (min-width: 768px) {
   .carte-ajout-enigme .carte-core i {
-    font-size: 36px;
+    font-size: 32px;
   }
 }
 .carte-ajout-enigme .carte-ajout-libelle {


### PR DESCRIPTION
## Résumé
- ajuste la taille de l’icône de la carte d’ajout d’énigme sur grand écran
- recompile les styles SCSS

## Changements notables
- icône de la carte d’ajout d’énigme passe à 32px au-dessus de 768px

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27d04f7e88332b58e701af8d64390