### PR TITLE
Ajout d'un mini-footer aux cartes énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -114,7 +114,6 @@
 
 .carte-enigme-lien {
   display: block;
-  height: 100%;
   color: inherit;
   text-decoration: none;
   position: relative;

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -43,6 +43,8 @@
   transition: transform 0.2s, box-shadow 0.2s;
   min-height: 350px;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 
@@ -63,9 +65,9 @@
   display: flex;
   flex-direction: column;
   padding: 0;
-  height: 100%;
+  flex: 1;
   border: 1px solid var(--color-gris-3);
-  position: relative
+  position: relative;
 }
 
 .carte-enigme .badge-validation {
@@ -113,10 +115,13 @@
 }
 
 .carte-enigme-lien {
-  display: block;
+  display: flex;
+  flex-direction: column;
   color: inherit;
   text-decoration: none;
   position: relative;
+  height: 100%;
+  flex: 1;
 }
 
 .carte-enigme-overlay {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -163,6 +163,33 @@
   justify-content: center;
 }
 
+.carte-enigme-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-xs) var(--space-md);
+  min-height: var(--space-3xl);
+  font-size: 0.875rem;
+}
+
+.carte-enigme-footer .footer-left,
+.carte-enigme-footer .footer-right {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.carte-enigme-footer .footer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
+.carte-enigme-footer i,
+.carte-enigme-footer svg {
+  width: 1em;
+  height: 1em;
+}
+
 .carte-enigme-image img,
 .carte-ligne__image img {
   width: 100%;

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -171,10 +171,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-xs) var(--space-md);
+  padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
   font-size: 0.875rem;
-  color: var(--color-background);
+  color: var(--color-gris-3);
 }
 
 .carte-enigme-footer .footer-left,

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -170,6 +170,7 @@
   padding: var(--space-xs) var(--space-md);
   min-height: var(--space-3xl);
   font-size: 0.875rem;
+  color: var(--color-background);
 }
 
 .carte-enigme-footer .footer-left,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -113,7 +113,6 @@
 
 .carte-enigme-lien {
   display: block;
-  height: 100%;
   color: inherit;
   text-decoration: none;
   position: relative;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -156,6 +156,33 @@
   justify-content: center;
 }
 
+.carte-enigme-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-xs) var(--space-md);
+  min-height: var(--space-3xl);
+  font-size: 0.875rem;
+}
+
+.carte-enigme-footer .footer-left,
+.carte-enigme-footer .footer-right {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.carte-enigme-footer .footer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
+.carte-enigme-footer i,
+.carte-enigme-footer svg {
+  width: 1em;
+  height: 1em;
+}
+
 .carte-enigme-image img,
 .carte-ligne__image img {
   width: 100%;
@@ -6608,92 +6635,6 @@ span.champ-obligatoire {
    🎨 VARIABLES
    ================================================== */
 /* ========== 🧱 COULEURS GLOBALES ========== */
-/* ========== ✏️ COULEURS ORGY ========== */
-.mode-edition {
-  /* 📝 Nuancier d’édition */
-  --color-editor-background: #F1F3F4; /* 🎭 Fond général : gris clair neutre */
-  --color-editor-border: #DADCE0; /* 🏛️ Bordures, séparateurs */
-  --color-editor-text: #202124; /* 🖋️ Texte principal */
-  --color-editor-text-muted: #5F6368; /* 📎 Texte secondaire : aide, état inactif */
-  --color-editor-heading: #1F1F1F; /* 📌 Titres, zones importantes */
-  --color-editor-accent: #1A73E8; /* 🔹 Accent principal : liens, icônes interactives */
-  --color-editor-error: #D93025; /* ⚠️ Message d’erreur */
-  --color-editor-success: #188038; /* ✅ Message de validation */
-  --color-editor-success-hover: #0F5E2C; /* ✅ Hover validation */
-  --color-editor-field-hover: #E8F0FE; /* 💠 Fond des champs actifs / survolés */
-  --color-editor-placeholder: #9AA0A6; /* 💬 Placeholder ou aide contextuelle */
-  --editor-label-width: 309px; /* 📏 Largeur minimale des labels dans les panneaux */
-  --editor-icon-width: 1rem; /* 📏 Largeur des icônes dans les panneaux */
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .mode-edition {
-    --editor-label-width: 220px;
-  }
-}
-@media not all and (min-width: 768px) {
-  .mode-edition {
-    --editor-label-width: 165px;
-  }
-}
-@media not all and (min-width: 480px) {
-  .mode-edition {
-    --editor-label-width: 135px;
-  }
-}
-/* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */
-.mode-edition {
-  /* dérivés HSL (triplets) de tes variables existantes */
-  --editor-background-hsl: 200 12% 95%; /* = #F1F3F4 → var(--color-editor-background) */
-  --editor-border-hsl: 220 09% 87%; /* = #DADCE0 → var(--color-editor-border) */
-  --editor-text-hsl: 225 06% 13%; /* = #202124 → var(--color-editor-text) */
-  --editor-text-muted-hsl: 213 05% 39%; /* = #5F6368 → var(--color-editor-text-muted) */
-  --editor-heading-hsl: 0 00% 12%; /* = #1F1F1F → var(--color-editor-heading) */
-  --editor-accent-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-accent) */
-  --editor-error-hsl: 4 71% 50%; /* = #D93025 → var(--color-editor-error) */
-  --editor-success-hsl: 138 68% 30%; /* = #188038 → var(--color-editor-success) */
-  --editor-field-hover-hsl: 218 92% 95%; /* = #E8F0FE → var(--color-editor-field-hover) */
-  --editor-placeholder-hsl: 210 06% 63%; /* = #9AA0A6 → var(--color-editor-placeholder) */
-}
-
-/* 🎨 Tokens shadcn/ui attendus (utilisés comme hsl(var(--token))) */
-.mode-edition {
-  --background: var(--editor-background-hsl);
-  --foreground: var(--editor-text-hsl);
-  --card: 0 0% 100%;
-  --card-foreground: var(--editor-text-hsl);
-  --popover: 0 0% 100%;
-  --popover-foreground: var(--editor-text-hsl);
-  --primary: var(--editor-accent-hsl); /* ou var(--editor-button-hsl) */
-  --primary-foreground: 0 0% 100%;
-  /* Secondary — choisis UNE des deux variantes */
-  /* Variante A (neutre) */
-  --secondary: var(--editor-background-hsl);
-  --secondary-foreground: var(--editor-text-hsl);
-  /* Variante B (bleuté) — décommente ces 2 lignes et commente celles de la variante A
-  --secondary: var(--editor-field-hover-hsl);
-  --secondary-foreground: var(--editor-button-hover-hsl);
-  */
-  --muted: var(--editor-background-hsl);
-  --muted-foreground: var(--editor-text-muted-hsl);
-  --accent: var(--editor-field-hover-hsl);
-  --accent-foreground: var(--editor-button-hover-hsl);
-  --destructive: var(--editor-error-hsl);
-  --destructive-foreground: 0 0% 100%;
-  --border: var(--editor-border-hsl);
-  --input: var(--editor-border-hsl);
-  --ring: var(--editor-accent-hsl);
-  /* utilitaires */
-  --placeholder: var(--editor-placeholder-hsl);
-  --heading: var(--editor-heading-hsl);
-  /* séries pour graphiques */
-  --chart-1: var(--editor-accent-hsl);
-  --chart-2: var(--editor-success-hsl);
-  --chart-3: var(--editor-error-hsl);
-  --chart-4: var(--editor-button-hover-hsl);
-  --chart-5: var(--editor-text-muted-hsl);
-}
-
 /* ========== 🎞️ TRANSITIONS GLOBALES ========== */
 /* ==================================================
    📸 MEDIAS
@@ -9077,4 +9018,91 @@ section#presentation .presentation-fermer {
   --color-editor-button-hover: #1558B0; /*       Hover bouton */
   --editor-button-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-button) */
   --editor-button-hover-hsl: 214 79% 39%; /* = #1558B0 → var(--color-editor-button-hover) */
+}
+
+/* 📝 Nuancier d’édition */
+.mode-edition {
+  --color-editor-background: #F1F3F4; /* 🎭 Fond général : gris clair neutre */
+  --color-editor-border: #DADCE0; /* 🏛️ Bordures, séparateurs */
+  --color-editor-text: #202124; /* 🖋️ Texte principal */
+  --color-editor-text-muted: #5F6368; /* 📎 Texte secondaire : aide, état inactif */
+  --color-editor-heading: #1F1F1F; /* 📌 Titres, zones importantes */
+  --color-editor-accent: #1A73E8; /* 🔹 Accent principal : liens, icônes interactives */
+  --color-editor-error: #D93025; /* ⚠️ Message d’erreur */
+  --color-editor-success: #188038; /* ✅ Message de validation */
+  --color-editor-success-hover: #0F5E2C; /* ✅ Hover validation */
+  --color-editor-field-hover: #E8F0FE; /* 💠 Fond des champs actifs / survolés */
+  --color-editor-placeholder: #9AA0A6; /* 💬 Placeholder ou aide contextuelle */
+  --editor-label-width: 309px; /* 📏 Largeur minimale des labels dans les panneaux */
+  --editor-icon-width: 1rem; /* 📏 Largeur des icônes dans les panneaux */
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .mode-edition {
+    --editor-label-width: 220px;
+  }
+}
+@media not all and (min-width: 768px) {
+  .mode-edition {
+    --editor-label-width: 165px;
+  }
+}
+@media not all and (min-width: 480px) {
+  .mode-edition {
+    --editor-label-width: 135px;
+  }
+}
+/* 🔗 Bridge HSL ↔️ nuancier existant (ne remplace rien) */
+.mode-edition {
+  /* dérivés HSL (triplets) de tes variables existantes */
+  --editor-background-hsl: 200 12% 95%; /* = #F1F3F4 → var(--color-editor-background) */
+  --editor-border-hsl: 220 09% 87%; /* = #DADCE0 → var(--color-editor-border) */
+  --editor-text-hsl: 225 06% 13%; /* = #202124 → var(--color-editor-text) */
+  --editor-text-muted-hsl: 213 05% 39%; /* = #5F6368 → var(--color-editor-text-muted) */
+  --editor-heading-hsl: 0 00% 12%; /* = #1F1F1F → var(--color-editor-heading) */
+  --editor-accent-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-accent) */
+  --editor-button-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-button) */
+  --editor-button-hover-hsl: 214 79% 39%; /* = #1558B0 → var(--color-editor-button-hover) */
+  --editor-error-hsl: 4 71% 50%; /* = #D93025 → var(--color-editor-error) */
+  --editor-success-hsl: 138 68% 30%; /* = #188038 → var(--color-editor-success) */
+  --editor-field-hover-hsl: 218 92% 95%; /* = #E8F0FE → var(--color-editor-field-hover) */
+  --editor-placeholder-hsl: 210 06% 63%; /* = #9AA0A6 → var(--color-editor-placeholder) */
+}
+
+/* 🎨 Tokens shadcn/ui attendus (utilisés comme hsl(var(--token))) */
+.mode-edition {
+  --background: var(--editor-background-hsl);
+  --foreground: var(--editor-text-hsl);
+  --card: 0 0% 100%;
+  --card-foreground: var(--editor-text-hsl);
+  --popover: 0 0% 100%;
+  --popover-foreground: var(--editor-text-hsl);
+  --primary: var(--editor-accent-hsl); /* ou var(--editor-button-hsl) */
+  --primary-foreground: 0 0% 100%;
+  /* Secondary — choisis UNE des deux variantes */
+  /* Variante A (neutre) */
+  --secondary: var(--editor-background-hsl);
+  --secondary-foreground: var(--editor-text-hsl);
+  /* Variante B (bleuté) — décommente ces 2 lignes et commente celles de la variante A
+  --secondary: var(--editor-field-hover-hsl);
+  --secondary-foreground: var(--editor-button-hover-hsl);
+  */
+  --muted: var(--editor-background-hsl);
+  --muted-foreground: var(--editor-text-muted-hsl);
+  --accent: var(--editor-field-hover-hsl);
+  --accent-foreground: var(--editor-button-hover-hsl);
+  --destructive: var(--editor-error-hsl);
+  --destructive-foreground: 0 0% 100%;
+  --border: var(--editor-border-hsl);
+  --input: var(--editor-border-hsl);
+  --ring: var(--editor-accent-hsl);
+  /* utilitaires */
+  --placeholder: var(--editor-placeholder-hsl);
+  --heading: var(--editor-heading-hsl);
+  /* séries pour graphiques */
+  --chart-1: var(--editor-accent-hsl);
+  --chart-2: var(--editor-success-hsl);
+  --chart-3: var(--editor-error-hsl);
+  --chart-4: var(--editor-button-hover-hsl);
+  --chart-5: var(--editor-text-muted-hsl);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -44,6 +44,8 @@
   transition: transform 0.2s, box-shadow 0.2s;
   min-height: 350px;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .carte-enigme:hover,
@@ -62,7 +64,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
-  height: 100%;
+  flex: 1;
   border: 1px solid var(--color-gris-3);
   position: relative;
 }
@@ -112,10 +114,13 @@
 }
 
 .carte-enigme-lien {
-  display: block;
+  display: flex;
+  flex-direction: column;
   color: inherit;
   text-decoration: none;
   position: relative;
+  height: 100%;
+  flex: 1;
 }
 
 .carte-enigme-overlay {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -164,10 +164,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-xs) var(--space-md);
+  padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
   font-size: 0.875rem;
-  color: var(--color-background);
+  color: var(--color-gris-3);
 }
 
 .carte-enigme-footer .footer-left,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -163,6 +163,7 @@
   padding: var(--space-xs) var(--space-md);
   min-height: var(--space-3xl);
   font-size: 0.875rem;
+  color: var(--color-background);
 }
 
 .carte-enigme-footer .footer-left,

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2729,3 +2729,15 @@ msgid "%d jour"
 msgid_plural "%d jours"
 msgstr[0] ""
 msgstr[1] ""
+
+#: wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php:178
+msgid "nombre de participants à cette énigme"
+msgstr ""
+
+#: wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php:182
+msgid "nombre de joueurs ayant trouvé la bonne réponse"
+msgstr ""
+
+#: wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php:189
+msgid "tentatives quotidiennes utilisées"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2282,6 +2282,18 @@ msgstr "No participants engaged."
 msgid "Liste participants"
 msgstr "Participants list"
 
+#: template-parts/enigme/chasse-partial-boucle-enigmes.php:178
+msgid "nombre de participants à cette énigme"
+msgstr "number of participants for this puzzle"
+
+#: template-parts/enigme/chasse-partial-boucle-enigmes.php:182
+msgid "nombre de joueurs ayant trouvé la bonne réponse"
+msgstr "number of players who found the correct answer"
+
+#: template-parts/enigme/chasse-partial-boucle-enigmes.php:189
+msgid "tentatives quotidiennes utilisées"
+msgstr "daily attempts used"
+
 #: template-parts/enigme/partials/enigme-partial-participants.php:51
 msgid "Nom"
 msgstr "Name"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2313,6 +2313,18 @@ msgstr "Aucun participant engagé."
 msgid "Liste participants"
 msgstr "Liste participants"
 
+#: template-parts/enigme/chasse-partial-boucle-enigmes.php:178
+msgid "nombre de participants à cette énigme"
+msgstr "nombre de participants à cette énigme"
+
+#: template-parts/enigme/chasse-partial-boucle-enigmes.php:182
+msgid "nombre de joueurs ayant trouvé la bonne réponse"
+msgstr "nombre de joueurs ayant trouvé la bonne réponse"
+
+#: template-parts/enigme/chasse-partial-boucle-enigmes.php:189
+msgid "tentatives quotidiennes utilisées"
+msgstr "tentatives quotidiennes utilisées"
+
 #: template-parts/enigme/partials/enigme-partial-participants.php:51
 msgid "Nom"
 msgstr "Nom"

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -107,7 +107,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
       $nb_participants = enigme_compter_joueurs_engages($enigme_id);
       $nb_resolutions  = enigme_compter_bonnes_solutions($enigme_id);
       $tentatives_max  = (int) get_field('enigme_tentative_max', $enigme_id);
-      $tentatives_utilisees = $tentatives_max > 0
+      $tentatives_utilisees = ($tentatives_max > 0 && $mode_validation === 'automatique')
         ? compter_tentatives_du_jour($utilisateur_id, $enigme_id)
         : 0;
     ?>
@@ -179,13 +179,15 @@ if (!function_exists('compter_tentatives_du_jour')) {
                 <i class="fa-solid fa-users" aria-hidden="true"></i>
                 <?= esc_html($nb_participants); ?>
               </span>
-              <span class="footer-item" title="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>">
-                <?= get_svg_icon('idea'); ?>
-                <?= esc_html($nb_resolutions); ?>
-              </span>
+              <?php if ($mode_validation !== 'aucune') : ?>
+                <span class="footer-item" title="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>">
+                  <?= get_svg_icon('idea'); ?>
+                  <?= esc_html($nb_resolutions); ?>
+                </span>
+              <?php endif; ?>
             </div>
             <div class="footer-right">
-              <?php if ($tentatives_max > 0) : ?>
+              <?php if ($mode_validation === 'automatique' && $tentatives_max > 0) : ?>
                 <span class="footer-item" title="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>">
                   <i class="fa-solid fa-repeat" aria-hidden="true"></i>
                   <?= esc_html($tentatives_utilisees . '/' . $tentatives_max); ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -56,6 +56,14 @@ foreach ($posts as $p) {
     break;
   }
 }
+
+if (!function_exists('enigme_compter_joueurs_engages')) {
+  require_once get_stylesheet_directory() . '/inc/enigme/stats.php';
+}
+
+if (!function_exists('compter_tentatives_du_jour')) {
+  require_once get_stylesheet_directory() . '/inc/enigme/tentatives.php';
+}
 ?>
 
 <div class="bloc-enigmes-chasse">
@@ -96,6 +104,12 @@ foreach ($posts as $p) {
       $classes_carte = trim("carte carte-enigme $classe_completion $classe_cta");
       $mapping_visuel = get_mapping_visuel_enigme($enigme_id);
       $cout_points    = (int) get_field('enigme_tentative_cout_points', $enigme_id);
+      $nb_participants = enigme_compter_joueurs_engages($enigme_id);
+      $nb_resolutions  = enigme_compter_bonnes_solutions($enigme_id);
+      $tentatives_max  = (int) get_field('enigme_tentative_max', $enigme_id);
+      $tentatives_utilisees = $tentatives_max > 0
+        ? compter_tentatives_du_jour($utilisateur_id, $enigme_id)
+        : 0;
     ?>
         <article class="<?= esc_attr($classes_carte); ?>">
           <?php if ($linkable) : ?>
@@ -159,6 +173,26 @@ foreach ($posts as $p) {
           <?php else : ?>
             </div>
           <?php endif; ?>
+          <footer class="carte-enigme-footer">
+            <div class="footer-left">
+              <span class="footer-item" title="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>">
+                <i class="fa-solid fa-users" aria-hidden="true"></i>
+                <?= esc_html($nb_participants); ?>
+              </span>
+              <span class="footer-item" title="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>">
+                <?= get_svg_icon('idea'); ?>
+                <?= esc_html($nb_resolutions); ?>
+              </span>
+            </div>
+            <div class="footer-right">
+              <?php if ($tentatives_max > 0) : ?>
+                <span class="footer-item" title="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>">
+                  <i class="fa-solid fa-repeat" aria-hidden="true"></i>
+                  <?= esc_html($tentatives_utilisees . '/' . $tentatives_max); ?>
+                </span>
+              <?php endif; ?>
+            </div>
+          </footer>
           <?php if ($classe_completion === 'carte-incomplete') : ?>
             <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
               <i class="fa-solid fa-exclamation" aria-hidden="true"></i>


### PR DESCRIPTION
## Résumé
- Uniformisation des cartes énigme avec un mini-footer affichant participants, résolutions et tentatives journalières
- Ajout des styles associés et des entrées de traduction

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2857ffaac83329ff1a458239a680c