### PR TITLE
Fix overlay covering extra space on enigma cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -105,7 +105,7 @@
   height: 180px;
   overflow: hidden;
   position: relative;
-  flex: 2;
+  flex: 0 0 180px;
 }
 
 .carte-enigme-image .badge-cout {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -104,7 +104,7 @@
   height: 180px;
   overflow: hidden;
   position: relative;
-  flex: 2;
+  flex: 0 0 180px;
 }
 
 .carte-enigme-image .badge-cout {


### PR DESCRIPTION
### Résumé
- Empêche l'overlay des cartes énigmes d'occuper l'espace sous l'image lorsque le titre est long.
- Regénère la feuille de style compilée.

### Changements notables
- Ajustement du conteneur d'image des cartes énigmes pour fixer sa hauteur.
- Rebuild du CSS distribué.

### Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2920ef7bc8332b1e1001cb502b1c7