### PR TITLE
feat: add skeleton loading cards for paginated lists

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/pager.js
@@ -37,6 +37,9 @@ document.addEventListener('DOMContentLoaded', () => {
       select.value = String(current);
     }
     pager.dispatchEvent(
+      new CustomEvent('pager:loading', { detail: { page: current }, bubbles: true })
+    );
+    pager.dispatchEvent(
       new CustomEvent('pager:change', { detail: { page: current }, bubbles: true })
     );
   });
@@ -52,6 +55,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const page = parseInt(select.value, 10);
     pager.dataset.current = String(page);
+    pager.dispatchEvent(
+      new CustomEvent('pager:loading', { detail: { page }, bubbles: true })
+    );
     pager.dispatchEvent(
       new CustomEvent('pager:change', { detail: { page }, bubbles: true })
     );

--- a/wp-content/themes/chassesautresor/assets/js/core/skeleton.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/skeleton.js
@@ -1,0 +1,31 @@
+/**
+ * Display skeleton cards in lists while loading new data.
+ */
+(function () {
+  function createSkeletonCard() {
+    const el = document.createElement('article');
+    el.className = 'carte carte-skeleton';
+    el.innerHTML = '<div class="carte-core"><div class="skeleton-img"></div><h3 class="skeleton-text"></h3></div>';
+    return el;
+  }
+
+  function showSkeleton(grid, count) {
+    const frag = document.createDocumentFragment();
+    for (let i = 0; i < count; i++) {
+      frag.appendChild(createSkeletonCard());
+    }
+    grid.innerHTML = '';
+    grid.appendChild(frag);
+  }
+
+  document.addEventListener('pager:loading', (e) => {
+    const wrapper = e.target.closest('.list-with-skeleton');
+    if (!wrapper) return;
+    const grid = wrapper.querySelector('.cards-grid');
+    if (!grid) return;
+    const count = parseInt(wrapper.dataset.skeletonCount || '3', 10);
+    showSkeleton(grid, count);
+  });
+
+  window.ctaSkeleton = { showSkeleton };
+})();

--- a/wp-content/themes/chassesautresor/assets/scss/_skeleton.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_skeleton.scss
@@ -1,0 +1,37 @@
+/* Skeleton card styles */
+
+.carte-skeleton {
+    position: relative;
+    overflow: hidden;
+    background-color: #e5e5e5;
+    border-radius: 4px;
+}
+
+.carte-skeleton::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent);
+    animation: skeleton-shimmer 1.5s infinite;
+}
+
+.carte-skeleton .skeleton-img {
+    width: 100%;
+    padding-top: 56%;
+    background-color: #dcdcdc;
+}
+
+.carte-skeleton .skeleton-text {
+    height: 1rem;
+    margin: 0.5rem;
+    background-color: #dcdcdc;
+}
+
+@keyframes skeleton-shimmer {
+    100% {
+        transform: translateX(100%);
+    }
+}

--- a/wp-content/themes/chassesautresor/assets/scss/main.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/main.scss
@@ -2,6 +2,7 @@
 @import "chasse";
 @import "commerce";
 @import "components";
+@import "skeleton";
 @import "aside";
 @import "edition";
 @import "enigme";

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1836,6 +1836,42 @@ a.addtoany_share span {
   font-weight: 600;
 }
 
+/* Skeleton card styles */
+.carte-skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: #e5e5e5;
+  border-radius: 4px;
+}
+
+.carte-skeleton::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+  animation: skeleton-shimmer 1.5s infinite;
+}
+
+.carte-skeleton .skeleton-img {
+  width: 100%;
+  padding-top: 56%;
+  background-color: #dcdcdc;
+}
+
+.carte-skeleton .skeleton-text {
+  height: 1rem;
+  margin: 0.5rem;
+  background-color: #dcdcdc;
+}
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
 /* Core styles for reusable asides */
 .menu-lateral {
   background-color: rgba(var(--aside-bg-rgb, 238, 238, 238), var(--aside-opacity, 0.4));

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -178,6 +178,13 @@ function charger_scripts_personnalises() {
       true
     );
     wp_enqueue_script(
+      'list-skeleton',
+      $theme_dir . 'core/skeleton.js',
+      ['pager'],
+      filemtime(get_stylesheet_directory() . '/assets/js/core/skeleton.js'),
+      true
+    );
+    wp_enqueue_script(
       'organisateurs-pager',
       $theme_dir . 'organisateurs-pager.js',
       ['pager'],


### PR DESCRIPTION
## Résumé
- ajoute un composant de cartes skeleton
- émet un évènement `pager:loading` lors des changements de page
- intègre les styles skeleton et leur chargement côté thème

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b28db3de70833292ca184dea667483