### PR TITLE
Améliore l'affichage des cartes d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -70,21 +70,6 @@
   position: relative;
 }
 
-
-.carte-enigme-badges {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: flex;
-  gap: var(--space-xxs);
-  z-index: 1;
-}
-
-.carte-enigme-badges .badge-cout,
-.carte-enigme-badges .badge-validation {
-  position: static;
-}
-
 .etat-bloquee_chasse .carte-core,
 .etat-bloquee_date .carte-core,
 .etat-bloquee_pre_requis .carte-core,
@@ -173,9 +158,10 @@
   overflow: hidden;
 }
 
+
 .carte-enigme-footer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
@@ -199,6 +185,12 @@
 .carte-enigme-footer svg {
   width: 1em;
   height: 1em;
+  fill: currentColor;
+}
+
+.carte-enigme-footer .fa-circle-info {
+  color: var(--color-gris-3);
+  opacity: 0.6;
 }
 
 .carte-enigme-image img,

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -166,7 +166,7 @@
   padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
   font-size: 0.875rem;
-  color: var(--color-gris-3);
+  color: var(--color-text-secondary);
 }
 
 .carte-enigme-footer .footer-icons {
@@ -178,7 +178,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-xxs);
-  opacity: 0.6;
+  opacity: 0.8;
 }
 
 .carte-enigme-footer i,
@@ -188,9 +188,14 @@
   fill: currentColor;
 }
 
+.carte-enigme-footer .footer-item--points {
+  color: var(--color-secondary);
+  opacity: 1;
+}
+
 .carte-enigme-footer .fa-circle-info {
-  color: var(--color-gris-3);
-  opacity: 0.6;
+  color: inherit;
+  opacity: 0.8;
 }
 
 .carte-enigme-image img,

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -28,7 +28,7 @@
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
-  gap: var(--space-xl);
+  gap: var(--space-2xl);
   justify-content: center;
 }
 
@@ -70,11 +70,19 @@
   position: relative;
 }
 
-.carte-enigme .badge-validation {
+
+.carte-enigme-badges {
   position: absolute;
   top: 10px;
-  left: 10px;
+  right: 10px;
+  display: flex;
+  gap: var(--space-xxs);
   z-index: 1;
+}
+
+.carte-enigme-badges .badge-cout,
+.carte-enigme-badges .badge-validation {
+  position: static;
 }
 
 .etat-bloquee_chasse .carte-core,
@@ -108,11 +116,7 @@
   flex: 2;
 }
 
-.carte-enigme-image .badge-cout {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-}
+
 
 .carte-enigme-lien {
   display: flex;
@@ -162,14 +166,16 @@
   margin: 0;
   padding: var(--space-xs) var(--space-md);
   flex: 0.5;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .carte-enigme-footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
@@ -177,8 +183,7 @@
   color: var(--color-gris-3);
 }
 
-.carte-enigme-footer .footer-left,
-.carte-enigme-footer .footer-right {
+.carte-enigme-footer .footer-icons {
   display: flex;
   gap: var(--space-sm);
 }
@@ -187,6 +192,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-xxs);
+  opacity: 0.6;
 }
 
 .carte-enigme-footer i,

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -150,12 +150,14 @@
 .carte-enigme h3 {
   margin: 0;
   padding: var(--space-xs) var(--space-md);
-  flex: 0.5;
   text-align: center;
+  line-height: 1.3;
+  height: calc(1.3em * 2);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -141,12 +141,14 @@
 .carte-enigme h3 {
   margin: 0;
   padding: var(--space-xs) var(--space-md);
-  flex: 0.5;
   text-align: center;
+  line-height: 1.3;
+  height: 2.6em;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .carte-enigme-footer {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -29,7 +29,7 @@
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
-  gap: var(--space-xl);
+  gap: var(--space-2xl);
   justify-content: center;
 }
 
@@ -69,11 +69,18 @@
   position: relative;
 }
 
-.carte-enigme .badge-validation {
+.carte-enigme-badges {
   position: absolute;
   top: 10px;
-  left: 10px;
+  right: 10px;
+  display: flex;
+  gap: var(--space-xxs);
   z-index: 1;
+}
+
+.carte-enigme-badges .badge-cout,
+.carte-enigme-badges .badge-validation {
+  position: static;
 }
 
 .etat-bloquee_chasse .carte-core,
@@ -105,12 +112,6 @@
   overflow: hidden;
   position: relative;
   flex: 2;
-}
-
-.carte-enigme-image .badge-cout {
-  position: absolute;
-  top: 10px;
-  right: 10px;
 }
 
 .carte-enigme-lien {
@@ -155,14 +156,16 @@
   margin: 0;
   padding: var(--space-xs) var(--space-md);
   flex: 0.5;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .carte-enigme-footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
@@ -170,8 +173,7 @@
   color: var(--color-gris-3);
 }
 
-.carte-enigme-footer .footer-left,
-.carte-enigme-footer .footer-right {
+.carte-enigme-footer .footer-icons {
   display: flex;
   gap: var(--space-sm);
 }
@@ -180,6 +182,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-xxs);
+  opacity: 0.6;
 }
 
 .carte-enigme-footer i,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -69,20 +69,6 @@
   position: relative;
 }
 
-.carte-enigme-badges {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: flex;
-  gap: var(--space-xxs);
-  z-index: 1;
-}
-
-.carte-enigme-badges .badge-cout,
-.carte-enigme-badges .badge-validation {
-  position: static;
-}
-
 .etat-bloquee_chasse .carte-core,
 .etat-bloquee_date .carte-core,
 .etat-bloquee_pre_requis .carte-core,
@@ -165,7 +151,7 @@
 
 .carte-enigme-footer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
@@ -189,6 +175,12 @@
 .carte-enigme-footer svg {
   width: 1em;
   height: 1em;
+  fill: currentColor;
+}
+
+.carte-enigme-footer .fa-circle-info {
+  color: var(--color-gris-3);
+  opacity: 0.6;
 }
 
 .carte-enigme-image img,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -156,7 +156,7 @@
   padding: var(--space-xs) var(--space-md) 0;
   min-height: var(--space-3xl);
   font-size: 0.875rem;
-  color: var(--color-gris-3);
+  color: var(--color-text-secondary);
 }
 
 .carte-enigme-footer .footer-icons {
@@ -168,7 +168,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-xxs);
-  opacity: 0.6;
+  opacity: 0.8;
 }
 
 .carte-enigme-footer i,
@@ -178,9 +178,14 @@
   fill: currentColor;
 }
 
+.carte-enigme-footer .footer-item--points {
+  color: var(--color-secondary);
+  opacity: 1;
+}
+
 .carte-enigme-footer .fa-circle-info {
-  color: var(--color-gris-3);
-  opacity: 0.6;
+  color: inherit;
+  opacity: 0.8;
 }
 
 .carte-enigme-image img,

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -161,7 +161,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
             <footer class="carte-enigme-footer">
               <div class="footer-icons footer-icons-left">
                 <?php if ($cout_points > 0) : ?>
-                  <span class="footer-item" title="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
+                  <span class="footer-item footer-item--points" title="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
                     <i class="fa-solid fa-coins" aria-hidden="true"></i>
                     <?= esc_html($cout_points); ?>
                   </span>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -134,25 +134,6 @@ if (!function_exists('compter_tentatives_du_jour')) {
                         ?>
                       </div>
                     <?php endif; ?>
-                    <?php if ($cout_points > 0 || in_array($mode_validation, ['automatique', 'manuelle'], true)) : ?>
-                      <div class="carte-enigme-badges">
-                        <?php if ($cout_points > 0) : ?>
-                          <span class="badge-cout" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
-                            <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
-                          </span>
-                        <?php endif; ?>
-                        <?php if (in_array($mode_validation, ['automatique', 'manuelle'], true)) :
-                            $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
-                            $label = $mode_validation === 'automatique'
-                                ? esc_html__('Mode de validation : automatique', 'chassesautresor-com')
-                                : esc_html__('Mode de validation : manuel', 'chassesautresor-com');
-                        ?>
-                          <span class="badge-validation" title="<?= esc_attr($label); ?>" aria-label="<?= esc_attr($label); ?>">
-                            <i class="fa-solid <?= esc_attr($icon); ?>" aria-hidden="true"></i>
-                          </span>
-                        <?php endif; ?>
-                      </div>
-                    <?php endif; ?>
                     <?php if ($linkable) : ?>
                       <span class="carte-enigme-overlay" aria-hidden="true">
                         <span class="carte-enigme-bouton <?= esc_attr($classes_bouton); ?>">
@@ -178,7 +159,25 @@ if (!function_exists('compter_tentatives_du_jour')) {
             </div>
           <?php endif; ?>
             <footer class="carte-enigme-footer">
-              <div class="footer-icons">
+              <div class="footer-icons footer-icons-left">
+                <?php if ($cout_points > 0) : ?>
+                  <span class="footer-item" title="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
+                    <i class="fa-solid fa-coins" aria-hidden="true"></i>
+                    <?= esc_html($cout_points); ?>
+                  </span>
+                <?php endif; ?>
+                <?php if (in_array($mode_validation, ['automatique', 'manuelle'], true)) :
+                  $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+                  $label = $mode_validation === 'automatique'
+                    ? esc_html__('Mode de validation : automatique', 'chassesautresor-com')
+                    : esc_html__('Mode de validation : manuel', 'chassesautresor-com');
+                ?>
+                  <span class="footer-item" title="<?= esc_attr($label); ?>" aria-label="<?= esc_attr($label); ?>">
+                    <i class="fa-solid <?= esc_attr($icon); ?>" aria-hidden="true"></i>
+                  </span>
+                <?php endif; ?>
+              </div>
+              <div class="footer-icons footer-icons-right">
                 <span class="footer-item" title="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>">
                   <i class="fa-solid fa-users" aria-hidden="true"></i>
                   <?= esc_html($nb_participants); ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -112,51 +112,55 @@ if (!function_exists('compter_tentatives_du_jour')) {
         : 0;
     ?>
         <article class="<?= esc_attr($classes_carte); ?>">
-          <?php if ($linkable) : ?>
-            <a href="<?= esc_url($cta['url']); ?>" class="carte-enigme-lien" aria-label="<?= esc_attr($aria_label); ?>">
-          <?php else : ?>
-            <div class="carte-enigme-lien carte-enigme-lien--disabled">
-          <?php endif; ?>
-              <?php if (in_array($mode_validation, ['automatique', 'manuelle'], true)) :
-                  $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
-                  $label = $mode_validation === 'automatique'
-                      ? esc_html__('Mode de validation : automatique', 'chassesautresor-com')
-                      : esc_html__('Mode de validation : manuel', 'chassesautresor-com');
-              ?>
-                  <span class="badge-validation" title="<?= esc_attr($label); ?>" aria-label="<?= esc_attr($label); ?>">
-                      <i class="fa-solid <?= esc_attr($icon); ?>" aria-hidden="true"></i>
-                  </span>
-              <?php endif; ?>
-              <div class="carte-core">
-                <div class="carte-enigme-image <?= esc_attr($mapping_visuel['filtre'] ?? ''); ?>" title="<?= esc_attr($mapping_visuel['sens'] ?? ''); ?>">
-                  <?php if ($mapping_visuel['image_reelle']) : ?>
-                    <?php afficher_picture_vignette_enigme($enigme_id, 'Vignette de l’énigme', ['medium']); ?>
-                  <?php else : ?>
-                    <div class="enigme-placeholder">
-                      <?php
-                      $svg = $mapping_visuel['fallback_svg'] ?? 'warning.svg';
-                      $svg_path = get_stylesheet_directory() . '/assets/svg/' . $svg;
-                      if (file_exists($svg_path)) {
-                          echo file_get_contents($svg_path);
-                      } else {
-                          echo '<div class="svg-manquant">🕳</div>';
-                      }
-                      ?>
-                    </div>
-                  <?php endif; ?>
-                  <?php if ($cout_points > 0) : ?>
-                    <span class="badge-cout" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
-                      <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
-                    </span>
-                  <?php endif; ?>
-                  <?php if ($linkable) : ?>
-                    <span class="carte-enigme-overlay" aria-hidden="true">
-                      <span class="carte-enigme-bouton <?= esc_attr($classes_bouton); ?>">
-                        <?= esc_html($cta['label']); ?>
+            <?php if ($linkable) : ?>
+              <a href="<?= esc_url($cta['url']); ?>" class="carte-enigme-lien" aria-label="<?= esc_attr($aria_label); ?>">
+            <?php else : ?>
+              <div class="carte-enigme-lien carte-enigme-lien--disabled">
+            <?php endif; ?>
+                <div class="carte-core">
+                  <div class="carte-enigme-image <?= esc_attr($mapping_visuel['filtre'] ?? ''); ?>" title="<?= esc_attr($mapping_visuel['sens'] ?? ''); ?>">
+                    <?php if ($mapping_visuel['image_reelle']) : ?>
+                      <?php afficher_picture_vignette_enigme($enigme_id, 'Vignette de l’énigme', ['medium']); ?>
+                    <?php else : ?>
+                      <div class="enigme-placeholder">
+                        <?php
+                        $svg = $mapping_visuel['fallback_svg'] ?? 'warning.svg';
+                        $svg_path = get_stylesheet_directory() . '/assets/svg/' . $svg;
+                        if (file_exists($svg_path)) {
+                            echo file_get_contents($svg_path);
+                        } else {
+                            echo '<div class="svg-manquant">🕳</div>';
+                        }
+                        ?>
+                      </div>
+                    <?php endif; ?>
+                    <?php if ($cout_points > 0 || in_array($mode_validation, ['automatique', 'manuelle'], true)) : ?>
+                      <div class="carte-enigme-badges">
+                        <?php if ($cout_points > 0) : ?>
+                          <span class="badge-cout" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
+                            <?= esc_html($cout_points . ' ' . __('pts', 'chassesautresor-com')); ?>
+                          </span>
+                        <?php endif; ?>
+                        <?php if (in_array($mode_validation, ['automatique', 'manuelle'], true)) :
+                            $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+                            $label = $mode_validation === 'automatique'
+                                ? esc_html__('Mode de validation : automatique', 'chassesautresor-com')
+                                : esc_html__('Mode de validation : manuel', 'chassesautresor-com');
+                        ?>
+                          <span class="badge-validation" title="<?= esc_attr($label); ?>" aria-label="<?= esc_attr($label); ?>">
+                            <i class="fa-solid <?= esc_attr($icon); ?>" aria-hidden="true"></i>
+                          </span>
+                        <?php endif; ?>
+                      </div>
+                    <?php endif; ?>
+                    <?php if ($linkable) : ?>
+                      <span class="carte-enigme-overlay" aria-hidden="true">
+                        <span class="carte-enigme-bouton <?= esc_attr($classes_bouton); ?>">
+                          <?= esc_html($cta['label']); ?>
+                        </span>
                       </span>
-                    </span>
-                  <?php endif; ?>
-                </div>
+                    <?php endif; ?>
+                  </div>
 
                 <?php if ($mapping_visuel['image_reelle']) : ?>
                   <h3><?= esc_html($titre); ?></h3>
@@ -173,28 +177,26 @@ if (!function_exists('compter_tentatives_du_jour')) {
           <?php else : ?>
             </div>
           <?php endif; ?>
-          <footer class="carte-enigme-footer">
-            <div class="footer-left">
-              <span class="footer-item" title="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>">
-                <i class="fa-solid fa-users" aria-hidden="true"></i>
-                <?= esc_html($nb_participants); ?>
-              </span>
-              <?php if ($mode_validation !== 'aucune') : ?>
-                <span class="footer-item" title="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>">
-                  <?= get_svg_icon('idea'); ?>
-                  <?= esc_html($nb_resolutions); ?>
+            <footer class="carte-enigme-footer">
+              <div class="footer-icons">
+                <span class="footer-item" title="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de participants à cette énigme', 'chassesautresor-com'); ?>">
+                  <i class="fa-solid fa-users" aria-hidden="true"></i>
+                  <?= esc_html($nb_participants); ?>
                 </span>
-              <?php endif; ?>
-            </div>
-            <div class="footer-right">
-              <?php if ($mode_validation === 'automatique' && $tentatives_max > 0) : ?>
-                <span class="footer-item" title="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>">
-                  <i class="fa-solid fa-repeat" aria-hidden="true"></i>
-                  <?= esc_html($tentatives_utilisees . '/' . $tentatives_max); ?>
-                </span>
-              <?php endif; ?>
-            </div>
-          </footer>
+                <?php if ($mode_validation !== 'aucune') : ?>
+                  <span class="footer-item" title="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('nombre de joueurs ayant trouvé la bonne réponse', 'chassesautresor-com'); ?>">
+                    <?= get_svg_icon('idea'); ?>
+                    <?= esc_html($nb_resolutions); ?>
+                  </span>
+                <?php endif; ?>
+                <?php if ($mode_validation === 'automatique' && $tentatives_max > 0) : ?>
+                  <span class="footer-item" title="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>" aria-label="<?= esc_attr__('tentatives quotidiennes utilisées', 'chassesautresor-com'); ?>">
+                    <i class="fa-solid fa-repeat" aria-hidden="true"></i>
+                    <?= esc_html($tentatives_utilisees . '/' . $tentatives_max); ?>
+                  </span>
+                <?php endif; ?>
+              </div>
+            </footer>
           <?php if ($classe_completion === 'carte-incomplete') : ?>
             <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
               <i class="fa-solid fa-exclamation" aria-hidden="true"></i>


### PR DESCRIPTION
## Résumé
- améliore l'espacement entre les cartes d'énigme
- regroupe les badges de coût et de validation en haut à droite
- regroupe les icônes de pied de carte à droite avec une visibilité réduite

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b294c0e1f08332bbf598416b5947a3