### PR TITLE
Alignement vertical du titre des cartes énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -149,7 +149,7 @@
 
 .carte-enigme h3 {
   margin: 0;
-  padding: var(--space-xs) var(--space-md);
+  padding: 0 var(--space-md);
   text-align: center;
   line-height: 1.3;
   height: 3em;

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -151,12 +151,17 @@
   margin: 0;
   padding: 0 var(--space-md);
   text-align: center;
-  line-height: 1.3;
   height: 3em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.carte-enigme h3 .carte-enigme-titre {
+  line-height: 1.3;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  -webkit-box-pack: center;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -152,10 +152,11 @@
   padding: var(--space-xs) var(--space-md);
   text-align: center;
   line-height: 1.3;
-  height: calc(1.3em * 2);
+  height: 3em;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  -webkit-box-pack: center;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -143,10 +143,11 @@
   padding: var(--space-xs) var(--space-md);
   text-align: center;
   line-height: 1.3;
-  height: 2.6em;
+  height: 3em;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  -webkit-box-pack: center;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -140,7 +140,7 @@
 
 .carte-enigme h3 {
   margin: 0;
-  padding: var(--space-xs) var(--space-md);
+  padding: 0 var(--space-md);
   text-align: center;
   line-height: 1.3;
   height: 3em;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -142,12 +142,17 @@
   margin: 0;
   padding: 0 var(--space-md);
   text-align: center;
-  line-height: 1.3;
   height: 3em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.carte-enigme h3 .carte-enigme-titre {
+  line-height: 1.3;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  -webkit-box-pack: center;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -144,7 +144,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
                   </div>
 
                 <?php if ($mapping_visuel['image_reelle']) : ?>
-                  <h3><?= esc_html($titre); ?></h3>
+                  <h3><span class="carte-enigme-titre"><?= esc_html($titre); ?></span></h3>
                 <?php endif; ?>
 
                 <?php if (!empty($mapping_visuel['disponible_le'])) : ?>


### PR DESCRIPTION
## Résumé
- ajuste la hauteur du titre des cartes d'énigme et centre son contenu verticalement

## Modifications notables
- hausse de la hauteur du titre à 3em
- centrage vertical du texte dans les titres de carte

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b2b6e72cdc8332b304b0b53fcbdb80