### PR TITLE
Limite l'affichage du menu d'énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-menu-toggle.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-menu-toggle.js
@@ -1,0 +1,21 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.enigme-menu__toggle').forEach(function (button) {
+            var overflow = button.previousElementSibling;
+            if (!overflow) {
+                return;
+            }
+
+            button.addEventListener('click', function () {
+                var isHidden = overflow.hasAttribute('hidden');
+                if (isHidden) {
+                    overflow.removeAttribute('hidden');
+                    button.setAttribute('aria-expanded', 'true');
+                } else {
+                    overflow.setAttribute('hidden', '');
+                    button.setAttribute('aria-expanded', 'false');
+                }
+            });
+        });
+    });
+})();

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -290,6 +290,36 @@ li.active .enigme-menu__edit {
   background-color: rgba(255, 215, 0, 0.2);
 }
 
+.enigme-menu--overflow {
+  margin-top: 0;
+}
+
+.enigme-menu__toggle {
+  margin-top: var(--space-sm);
+  background: none;
+  border: 0;
+  color: var(--color-accent);
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  transition: color 0.2s;
+}
+
+.enigme-menu__toggle[aria-expanded='true'] {
+  color: var(--color-primary);
+}
+
+.enigme-menu--overflow[hidden] + .enigme-menu__toggle::before {
+  content: '';
+  position: absolute;
+  top: -16px;
+  left: 0;
+  width: 100%;
+  height: 16px;
+  background: linear-gradient(to bottom, rgba(11, 19, 43, 0), var(--color-background));
+  pointer-events: none;
+}
+
 @keyframes enigme-menu-spin {
   from {
     transform: translateY(-50%) rotate(0deg);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5146,6 +5146,36 @@ li.active .enigme-menu__edit {
   background-color: rgba(255, 215, 0, 0.2);
 }
 
+.enigme-menu--overflow {
+  margin-top: 0;
+}
+
+.enigme-menu__toggle {
+  margin-top: var(--space-sm);
+  background: none;
+  border: 0;
+  color: var(--color-accent);
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  transition: color 0.2s;
+}
+
+.enigme-menu__toggle[aria-expanded=true] {
+  color: var(--color-primary);
+}
+
+.enigme-menu--overflow[hidden] + .enigme-menu__toggle::before {
+  content: "";
+  position: absolute;
+  top: -16px;
+  left: 0;
+  width: 100%;
+  height: 16px;
+  background: linear-gradient(to bottom, rgba(11, 19, 43, 0), var(--color-background));
+  pointer-events: none;
+}
+
 @keyframes enigme-menu-spin {
   from {
     transform: translateY(-50%) rotate(0deg);

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -253,6 +253,13 @@ add_action('wp_enqueue_scripts', function () {
             filemtime($theme_path . '/assets/js/enigme-aside.js'),
             true
         );
+        wp_enqueue_script(
+            'enigme-menu-toggle',
+            $script_dir . 'enigme-menu-toggle.js',
+            [],
+            filemtime($theme_path . '/assets/js/enigme-menu-toggle.js'),
+            true
+        );
     }
 });
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -507,11 +507,18 @@ defined('ABSPATH') || exit;
             $ajout_html = ob_get_clean();
         }
 
+        $max_visible   = function_exists('apply_filters')
+            ? (int) apply_filters('enigme_menu_max_visible', 10)
+            : 10;
+        $visible_items = array_slice($menu_items, 0, $max_visible);
+        $hidden_items  = array_slice($menu_items, $max_visible);
+
         $navigation_html = enigme_get_sidebar_section_html('navigation', [
-            'menu_items'    => $menu_items,
-            'edition_active'=> $edition_active,
-            'chasse_id'     => $chasse_id,
-            'ajout_html'    => $ajout_html,
+            'visible_items'  => $visible_items,
+            'hidden_items'   => $hidden_items,
+            'edition_active' => $edition_active,
+            'chasse_id'      => $chasse_id,
+            'ajout_html'     => $ajout_html,
         ]);
         if ($navigation_html === '') {
             $navigation_html = '<section class="enigme-navigation"><h3>'

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-sidebar-section.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-sidebar-section.php
@@ -4,7 +4,8 @@
  *
  * @param array $args {
  *     @type string $section       Section à afficher : 'navigation' ou 'stats'.
- *     @type array  $menu_items    Éléments de menu.
+ *     @type array  $visible_items Éléments de menu visibles.
+ *     @type array  $hidden_items  Éléments de menu masqués.
  *     @type bool   $edition_active Mode édition actif.
  *     @type int    $chasse_id     Identifiant de la chasse liée.
  *     @type string $ajout_html    HTML du lien d'ajout d'énigme.
@@ -28,20 +29,33 @@ if ($section === 'navigation') {
             echo '<div class="enigme-chasse-logo">' . $logo . '</div>';
         }
     }
-    $data_chasse = $args['chasse_id'] ? ' data-chasse-id="' . intval($args['chasse_id']) . '"' : '';
-    $menu_class  = 'enigme-menu';
+    $data_chasse   = $args['chasse_id'] ? ' data-chasse-id="' . intval($args['chasse_id']) . '"' : '';
+    $menu_class    = 'enigme-menu';
+    $visible_items = $args['visible_items'] ?? [];
+    $hidden_items  = $args['hidden_items'] ?? [];
+
     if (!empty($args['edition_active'])) {
         $menu_class .= ' enigme-menu--editable';
     }
+
     echo '<section class="enigme-navigation"' . $data_chasse . '>';
     echo '<h3>' . esc_html__('Énigmes', 'chassesautresor-com') . '</h3>';
     if (!empty($args['ajout_html'])) {
         echo $args['ajout_html'];
     }
-    if (empty($args['menu_items'])) {
+
+    if (empty($visible_items) && empty($hidden_items)) {
         echo '<p class="enigme-navigation__empty">' . esc_html__('Aucune énigme disponible', 'chassesautresor-com') . '</p>';
     } else {
-        echo '<ul class="' . esc_attr($menu_class) . '">' . implode('', $args['menu_items']) . '</ul>';
+        echo '<ul class="' . esc_attr($menu_class) . '">' . implode('', $visible_items) . '</ul>';
+        if (!empty($hidden_items)) {
+            echo '<ul class="' . esc_attr($menu_class . ' enigme-menu--overflow') . '" hidden>'
+                . implode('', $hidden_items)
+                . '</ul>';
+            echo '<button class="enigme-menu__toggle" type="button" aria-expanded="false">'
+                . esc_html__('Afficher plus', 'chassesautresor-com')
+                . '</button>';
+        }
     }
     echo '</section>';
     return;


### PR DESCRIPTION
## Résumé
- limite le nombre d’énigmes visibles dans le menu latéral
- ajoute un bouton pour afficher les éléments masqués
- applique les styles et le script nécessaires

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2b712ad9c8332bac0292c5af7e083