### PR TITLE
Allow logged in users to bypass site password

### DIFF
--- a/wp-content/mu-plugins/site-password.php
+++ b/wp-content/mu-plugins/site-password.php
@@ -55,9 +55,10 @@ function ca_site_password_protection(): void
     status_header(401);
     header('Content-Type: text/html; charset=utf-8');
 
-    $svg_url = esc_url(home_url('/assets/svg/pirate-skull.svg'));
+    $svg_url    = esc_url(home_url('/assets/svg/pirate-skull.svg'));
+    $style_url  = esc_url(get_stylesheet_directory_uri() . '/dist/style.css');
 
-    $styles  = '.ca-site-password-wrapper{'
+    $styles = '.ca-site-password-wrapper{'
         . 'display:flex;'
         . 'min-height:100vh;'
         . 'align-items:center;'
@@ -66,10 +67,21 @@ function ca_site_password_protection(): void
         . 'color:var(--color-text-primary);'
         . 'font-family:var(--font-main);'
         . '}'
-        . '.ca-site-password-form{text-align:center;}'
+        . '.ca-site-password-form{'
+        . 'text-align:center;'
+        . 'display:flex;'
+        . 'flex-direction:column;'
+        . 'align-items:center;'
+        . 'gap:var(--space-md);'
+        . 'font-size:var(--space-lg);'
+        . '}'
+        . '.ca-site-password-form label{'
+        . 'display:flex;'
+        . 'flex-direction:column;'
+        . 'gap:var(--space-xs);'
+        . '}'
         . '.ca-site-password-form input[type="password"]{'
         . 'padding:var(--space-sm) var(--space-md);'
-        . 'margin-bottom:var(--space-md);'
         . 'border:1px solid var(--color-grey-dark);'
         . 'border-radius:4px;'
         . 'background:var(--color-background);'
@@ -85,12 +97,13 @@ function ca_site_password_protection(): void
         . '}'
         . '.ca-site-password-form button:hover{background:var(--color-background-button-hover);}'
         . '.ca-site-password-error{color:var(--color-error);}'
-        . '.ca-site-password-logo{width:150px;display:block;margin:0 auto var(--space-md);}'
-        . '';
+        . '.ca-site-password-logo{width:150px;display:block;margin:0 auto var(--space-md);}';
 
     echo '<!doctype html><html><head><meta charset="utf-8"><title>'
         . esc_html__('Protected Site', 'chassesautresor-com')
-        . '</title><style>'
+        . '</title><link rel="stylesheet" href="'
+        . $style_url
+        . '"><style>'
         . $styles
         . '</style></head><body><div class="ca-site-password-wrapper">'
         . '<form class="ca-site-password-form" method="post">'
@@ -98,13 +111,13 @@ function ca_site_password_protection(): void
         . $svg_url
         . '" alt="'
         . esc_attr__('Pirate skull', 'chassesautresor-com')
-        . '"><p><label>'
+        . '"><label>'
         . esc_html__('Password:', 'chassesautresor-com')
         . ' <input type="password" name="'
         . esc_attr($field)
-        . '"></label></p><p><button type="submit">'
+        . '"></label><button type="submit">'
         . esc_html__('Submit', 'chassesautresor-com')
-        . '</button></p>'
+        . '</button>'
         . ($error_message ? '<p class="ca-site-password-error">' . $error_message . '</p>' : '')
         . '</form></div></body></html>';
 

--- a/wp-content/mu-plugins/site-password.php
+++ b/wp-content/mu-plugins/site-password.php
@@ -14,8 +14,12 @@ function ca_site_password_protection(): void
         return;
     }
 
-    $field    = 'ca_site_password';
-    $password = 'rosebud';
+    $field          = 'ca_site_password';
+    $password       = 'rosebud';
+    $attempt_field  = 'ca_site_password_attempts';
+    $max_attempts   = 10;
+    $attempts       = isset($_COOKIE[$attempt_field]) ? (int) $_COOKIE[$attempt_field] : 0;
+    $error_message  = '';
 
     if (
         isset($_COOKIE[$field])
@@ -26,21 +30,83 @@ function ca_site_password_protection(): void
 
     if (
         isset($_POST[$field])
-        && strcasecmp($_POST[$field], $password) === 0
+        && is_string($_POST[$field])
     ) {
-        setcookie($field, $password, time() + DAY_IN_SECONDS, '/');
-        return;
+        if (strcasecmp($_POST[$field], $password) === 0) {
+            setcookie($field, $password, time() + DAY_IN_SECONDS, '/');
+            setcookie($attempt_field, '', time() - DAY_IN_SECONDS, '/');
+
+            return;
+        }
+
+        $attempts++;
+        setcookie($attempt_field, (string) $attempts, time() + DAY_IN_SECONDS, '/');
+        $error_message = esc_html__('Incorrect password.', 'chassesautresor-com');
+    }
+
+    if ($attempts >= $max_attempts) {
+        status_header(403);
+        header('Content-Type: text/html; charset=utf-8');
+
+        echo '<p>' . esc_html__('Too many attempts. Please try again later.', 'chassesautresor-com') . '</p>';
+        exit;
     }
 
     status_header(401);
     header('Content-Type: text/html; charset=utf-8');
 
-    echo '<form method="post">'
-        . '<p><label>'
+    $svg_url = esc_url(home_url('/assets/svg/pirate-skull.svg'));
+
+    $styles  = '.ca-site-password-wrapper{'
+        . 'display:flex;'
+        . 'min-height:100vh;'
+        . 'align-items:center;'
+        . 'justify-content:center;'
+        . 'background:var(--color-background);'
+        . 'color:var(--color-text-primary);'
+        . 'font-family:var(--font-main);'
+        . '}'
+        . '.ca-site-password-form{text-align:center;}'
+        . '.ca-site-password-form input[type="password"]{'
+        . 'padding:var(--space-sm) var(--space-md);'
+        . 'margin-bottom:var(--space-md);'
+        . 'border:1px solid var(--color-grey-dark);'
+        . 'border-radius:4px;'
+        . 'background:var(--color-background);'
+        . 'color:var(--color-text-primary);'
+        . '}'
+        . '.ca-site-password-form button{'
+        . 'background:var(--color-background-button);'
+        . 'color:var(--color-white);'
+        . 'padding:var(--space-sm) var(--space-md);'
+        . 'border:none;'
+        . 'border-radius:4px;'
+        . 'cursor:pointer;'
+        . '}'
+        . '.ca-site-password-form button:hover{background:var(--color-background-button-hover);}'
+        . '.ca-site-password-error{color:var(--color-error);}'
+        . '.ca-site-password-logo{width:150px;display:block;margin:0 auto var(--space-md);}'
+        . '';
+
+    echo '<!doctype html><html><head><meta charset="utf-8"><title>'
+        . esc_html__('Protected Site', 'chassesautresor-com')
+        . '</title><style>'
+        . $styles
+        . '</style></head><body><div class="ca-site-password-wrapper">'
+        . '<form class="ca-site-password-form" method="post">'
+        . '<img class="ca-site-password-logo" src="'
+        . $svg_url
+        . '" alt="'
+        . esc_attr__('Pirate skull', 'chassesautresor-com')
+        . '"><p><label>'
         . esc_html__('Password:', 'chassesautresor-com')
-        . ' <input type="password" name="' . esc_attr($field) . '"></label></p>'
-        . '<p><input type="submit" value="' . esc_attr__('Submit', 'chassesautresor-com') . '"></p>'
-        . '</form>';
+        . ' <input type="password" name="'
+        . esc_attr($field)
+        . '"></label></p><p><button type="submit">'
+        . esc_html__('Submit', 'chassesautresor-com')
+        . '</button></p>'
+        . ($error_message ? '<p class="ca-site-password-error">' . $error_message . '</p>' : '')
+        . '</form></div></body></html>';
 
     exit;
 }

--- a/wp-content/mu-plugins/site-password.php
+++ b/wp-content/mu-plugins/site-password.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: Site Password Protection
+ * Description: Protects the site with a global password.
+ */
+
+function ca_site_password_protection(): void
+{
+    if (PHP_SAPI === 'cli' || (defined('WP_INSTALLING') && WP_INSTALLING)) {
+        return;
+    }
+
+    if (is_user_logged_in()) {
+        return;
+    }
+
+    $field    = 'ca_site_password';
+    $password = 'rosebud';
+
+    if (
+        isset($_COOKIE[$field])
+        && strcasecmp($_COOKIE[$field], $password) === 0
+    ) {
+        return;
+    }
+
+    if (
+        isset($_POST[$field])
+        && strcasecmp($_POST[$field], $password) === 0
+    ) {
+        setcookie($field, $password, time() + DAY_IN_SECONDS, '/');
+        return;
+    }
+
+    status_header(401);
+    header('Content-Type: text/html; charset=utf-8');
+
+    echo '<form method="post">'
+        . '<p><label>'
+        . esc_html__('Password:', 'chassesautresor-com')
+        . ' <input type="password" name="' . esc_attr($field) . '"></label></p>'
+        . '<p><input type="submit" value="' . esc_attr__('Submit', 'chassesautresor-com') . '"></p>'
+        . '</form>';
+
+    exit;
+}
+
+add_action('init', 'ca_site_password_protection');


### PR DESCRIPTION
### Résumé
- Exclut les utilisateurs connectés de la protection par mot de passe globale

### Changements notables
- Ignore le contrôle de mot de passe quand `is_user_logged_in()` retourne vrai

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2ab1754e08332bd6bd01ba8a0e14a