### PR TITLE
Remove overlay from add riddle card

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1245,32 +1245,12 @@ window.mettreAJourCarteAjoutEnigme = function () {
     return li && li.classList.contains('champ-vide');
   });
 
-  let overlay = carte.querySelector('.overlay-message');
-
   if (incomplets.length === 0) {
     carte.classList.remove('disabled');
     carte.removeAttribute('disabled');
-    overlay?.remove();
   } else {
     carte.classList.add('disabled');
     carte.setAttribute('disabled', 'disabled');
-    const texte = incomplets.map(sel => {
-      if (sel.includes('post_title')) return 'titre';
-      if (sel.includes('image')) return 'image';
-      if (sel.includes('description')) return 'description';
-      return 'champ requis';
-    }).join(', ');
-
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.className = 'overlay-message';
-      carte.appendChild(overlay);
-    }
-
-    overlay.innerHTML = `
-      <i class="fa-solid fa-circle-info"></i>
-      <p>Complétez d’abord : ${texte}</p>
-    `;
   }
 };
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -367,8 +367,7 @@
   color: var(--color-secondary);
 }
 
-.carte-ajout-chasse .overlay-message,
-.carte-ajout-enigme .overlay-message {
+.carte-ajout-chasse .overlay-message {
   position: absolute;
   top: 0;
   left: 0;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -357,8 +357,7 @@
   color: var(--color-secondary);
 }
 
-.carte-ajout-chasse .overlay-message,
-.carte-ajout-enigme .overlay-message {
+.carte-ajout-chasse .overlay-message {
   position: absolute;
   top: 0;
   left: 0;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -35,10 +35,24 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
         );
         ?>
     <?php endif; ?>
+    <?php
+    $classes = [
+        'carte',
+        'carte-enigme',
+        'carte-ajout-enigme',
+        $has_enigmes ? 'etat-suivante' : 'etat-vide',
+    ];
+    if ($disabled) {
+        $classes[] = 'disabled';
+    }
+    if ($highlight_pulse) {
+        $classes[] = 'pulsation';
+    }
+    ?>
     <button
         type="button"
         id="carte-ajout-enigme"
-        class="carte carte-enigme carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?><?php echo $highlight_pulse ? ' pulsation' : ''; ?>"
+        class="<?php echo esc_attr(implode(' ', $classes)); ?>"
         data-post-id="0"
         aria-label="<?php echo esc_attr__('Ajouter une énigme', 'chassesautresor-com'); ?>"
         <?php echo $disabled ? 'disabled' : ''; ?>
@@ -47,10 +61,6 @@ $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-eni
         <div class="carte-core">
             <i class="fa-solid fa-circle-plus" aria-hidden="true"></i>
             <span class="carte-ajout-libelle"><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
-        </div>
-        <div class="overlay-message">
-            <i class="fa-solid fa-circle-info"></i>
-            <p><?php echo esc_html__('Complétez d’abord : titre, image, description', 'chassesautresor-com'); ?></p>
         </div>
     </button>
 </div>


### PR DESCRIPTION
Supprime l'overlay affiché sur la carte d'ajout d'énigme.

- Nettoie le template pour ne plus inclure l'overlay et génère proprement les classes.
- Simplifie la logique JS pour gérer uniquement l'état disabled.
- Met à jour les styles compilés.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ce83ed5c8332923efdb93ba735bb