### PR TITLE
refactor: centralize enigma visibility filtering

### DIFF
--- a/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
+++ b/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
@@ -55,6 +55,9 @@
           if (menu) {
             menu.innerHTML = res.data.html;
           }
+          if (nav && Array.isArray(res.data.ids)) {
+            nav.dataset.visibleIds = res.data.ids.join(',');
+          }
         });
     }
     document.addEventListener('enigmeDebloquee', () => {

--- a/wp-content/themes/chassesautresor/inc/enigme/utils.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/utils.php
@@ -21,3 +21,29 @@ function enigme_is_paid(int $enigme_id): bool
 
     return $cost > 0 && $mode !== 'aucune';
 }
+
+/**
+ * Filter a list of enigmas to those visible to a user.
+ *
+ * The list can contain either WP_Post objects or IDs.
+ *
+ * @param array $enigmes  List of enigmas (WP_Post|int).
+ * @param int   $user_id  Current user ID.
+ * @return array          Filtered list preserving original items.
+ */
+function filter_visible_enigmes(array $enigmes, int $user_id): array
+{
+    return array_values(array_filter($enigmes, static function ($post) use ($user_id) {
+        $id = is_object($post) ? (int) $post->ID : (int) $post;
+
+        if (get_post_status($id) !== 'publish') {
+            return false;
+        }
+
+        if (!get_field('enigme_cache_complet', $id)) {
+            return false;
+        }
+
+        return enigme_est_visible_pour($user_id, $id);
+    }));
+}


### PR DESCRIPTION
## Résumé
- Centralise le filtrage de visibilité des énigmes via `filter_visible_enigmes()`
- Utilise ce filtre pour générer la navigation des chasses et exposer les IDs visibles
- Retourne les IDs d’énigmes visibles dans l’AJAX et les transmet au script client

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2ceecee208332a6dd87e2cf5d9fdd