### PR TITLE
Affiner l’apparence des cartes d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -172,10 +172,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-xxs) var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
   font-size: 0.95rem;
   color: var(--color-text-secondary);
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .carte-enigme-footer .footer-icons {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -45,6 +45,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  padding: 0;
 }
 
 
@@ -66,7 +67,6 @@
   flex-direction: column;
   padding: 0;
   flex: 1;
-  border: 1px solid var(--color-gris-3);
   position: relative;
 }
 
@@ -164,6 +164,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-transform: none;
 }
 
 
@@ -171,10 +172,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-xs) var(--space-md) 0;
-  min-height: var(--space-3xl);
-  font-size: 0.875rem;
+  padding: var(--space-xxs) var(--space-sm);
+  font-size: 0.95rem;
   color: var(--color-text-secondary);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .carte-enigme-footer .footer-icons {
@@ -187,13 +188,15 @@
   align-items: center;
   gap: var(--space-xxs);
   opacity: 0.8;
+  line-height: 1;
 }
 
 .carte-enigme-footer i,
 .carte-enigme-footer svg {
-  width: 1em;
-  height: 1em;
+  width: 1.1em;
+  height: 1.1em;
   fill: currentColor;
+  display: block;
 }
 
 .carte-enigme-footer .footer-item--points {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -46,6 +46,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  padding: 0;
 }
 
 .carte-enigme:hover,
@@ -65,7 +66,6 @@
   flex-direction: column;
   padding: 0;
   flex: 1;
-  border: 1px solid var(--color-gris-3);
   position: relative;
 }
 
@@ -155,16 +155,17 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-transform: none;
 }
 
 .carte-enigme-footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-xs) var(--space-md) 0;
-  min-height: var(--space-3xl);
-  font-size: 0.875rem;
+  padding: var(--space-xxs) var(--space-sm);
+  font-size: 0.95rem;
   color: var(--color-text-secondary);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .carte-enigme-footer .footer-icons {
@@ -177,13 +178,15 @@
   align-items: center;
   gap: var(--space-xxs);
   opacity: 0.8;
+  line-height: 1;
 }
 
 .carte-enigme-footer i,
 .carte-enigme-footer svg {
-  width: 1em;
-  height: 1em;
+  width: 1.1em;
+  height: 1.1em;
   fill: currentColor;
+  display: block;
 }
 
 .carte-enigme-footer .footer-item--points {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -162,10 +162,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-xxs) var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
   font-size: 0.95rem;
   color: var(--color-text-secondary);
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .carte-enigme-footer .footer-icons {


### PR DESCRIPTION
## Résumé
- Ajuste l’affichage des cartes d’énigme avec un titre non capitalisé et un footer plus léger
- Améliore la lisibilité du footer (fond, taille de police et icônes)

## Modifications notables
- Normalisation de la capitalisation des titres d’énigme
- Footer des cartes : fond éclairci, dimensions réduites et alignement affiné
- Suppression de la bordure interne des cartes

## Tests
- `npm ci`
- `node build-css.js`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2d07fdef08332a7aabdb277104c0d