### PR TITLE
Use localized AJAX URL for sidebar

### DIFF
--- a/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
+++ b/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
@@ -42,7 +42,7 @@
       const data = new URLSearchParams();
       data.append('action', 'chasse_recuperer_navigation');
       data.append('chasse_id', chasseId);
-      fetch('/wp-admin/admin-ajax.php', {
+      fetch(sidebarData.ajaxUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: data

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -256,6 +256,9 @@ add_action('wp_enqueue_scripts', function () {
             filemtime($theme_path . '/assets/sidebar/sidebar.js'),
             true
         );
+        wp_localize_script('sidebar', 'sidebarData', [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+        ]);
         wp_enqueue_script(
             'sidebar-menu-toggle',
             $sidebar_dir . 'menu-toggle.js',


### PR DESCRIPTION
## Résumé
- Utilise une URL AJAX localisée pour recharger la navigation de la barre latérale.

## Changements
- Localise l'URL AJAX du script `sidebar` via `wp_localize_script`.
- Remplace l'appel `fetch` côté client par la variable `sidebarData.ajaxUrl`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2d17fad3483329d4a9fd33f4d5f81