### PR TITLE
feat: section Énigmes dynamique

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -619,8 +619,11 @@ span.champ-obligatoire {
 .titre-enigmes-wrapper {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
+  text-align: center;
+  width: 100%;
   gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
 }
 
 /* 🔄 Loading spinner for pager */

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -618,8 +618,9 @@ span.champ-obligatoire {
 
 .titre-enigmes-wrapper {
   display: flex;
-  align-items: center;
-  gap: var(--space-md);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
 }
 
 /* 🔄 Loading spinner for pager */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6660,8 +6660,9 @@ span.champ-obligatoire {
 
 .titre-enigmes-wrapper {
   display: flex;
-  align-items: center;
-  gap: var(--space-md);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
 }
 
 /* 🔄 Loading spinner for pager */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6661,8 +6661,11 @@ span.champ-obligatoire {
 .titre-enigmes-wrapper {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
+  text-align: center;
+  width: 100%;
   gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
 }
 
 /* 🔄 Loading spinner for pager */

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -661,9 +661,55 @@ msgstr ""
 #: template-parts/chasse/chasse-edition-main.php:815
 #: template-parts/chasse/partials/chasse-partial-participants.php:53
 #: template-parts/enigme/partials/enigme-sidebar-section.php:37
-#: single-chasse.php:133
+#: single-chasse.php:222
 msgid "Énigmes"
 msgstr ""
+
+#: single-chasse.php:222
+#, php-format
+msgid "Énigmes de %s"
+msgstr ""
+
+#: single-chasse.php:128
+msgid "La chasse est terminée. Vous pouvez revoir toutes les énigmes ainsi que leurs solutions et indices."
+msgstr ""
+
+#: single-chasse.php:131
+msgid "La chasse est terminée. Les énigmes restent consultables."
+msgstr ""
+
+#: single-chasse.php:134
+#, php-format
+msgid "Les énigmes seront affichées au début de la chasse, le %s."
+msgstr ""
+
+#: single-chasse.php:141
+#, php-format
+msgid "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
+msgstr ""
+
+#: single-chasse.php:145
+msgid "Voici les énigmes de cette chasse."
+msgstr ""
+
+#: single-chasse.php:149
+#, php-format
+msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
+msgstr ""
+
+#: single-chasse.php:125
+#: single-chasse.php:126
+msgid "énigme résolue"
+msgid_plural "énigmes résolues"
+msgstr[0] ""
+msgstr[1] ""
+
+#: single-chasse.php:125
+#: single-chasse.php:126
+msgid "engagée"
+msgid_plural "engagées"
+msgstr[0] ""
+msgstr[1] ""
 
 #: inc/enigme/affichage.php:536
 #: inc/enigme/affichage.php:1008

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -697,6 +697,10 @@ msgstr ""
 msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 msgstr ""
 
+#: single-chasse.php:159
+msgid "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
+msgstr ""
+
 #: single-chasse.php:125
 #: single-chasse.php:126
 msgid "énigme résolue"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -680,6 +680,10 @@ msgstr "Here are the riddles of this hunt."
 msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 msgstr "Progress: %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 
+#: single-chasse.php:159
+msgid "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
+msgstr "Here are your riddles: add, edit, or delete them as needed!"
+
 #: single-chasse.php:125
 #: single-chasse.php:126
 msgid "énigme résolue"

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -648,6 +648,52 @@ msgstr "Definition of the resolution rate"
 msgid "Énigmes"
 msgstr "Riddles"
 
+#: single-chasse.php:222
+#, php-format
+msgid "Énigmes de %s"
+msgstr "Riddles of %s"
+
+#: single-chasse.php:128
+msgid "La chasse est terminée. Vous pouvez revoir toutes les énigmes ainsi que leurs solutions et indices."
+msgstr "The hunt is over. You can review all riddles along with their solutions and hints."
+
+#: single-chasse.php:131
+msgid "La chasse est terminée. Les énigmes restent consultables."
+msgstr "The hunt is over. The riddles remain accessible."
+
+#: single-chasse.php:134
+#, php-format
+msgid "Les énigmes seront affichées au début de la chasse, le %s."
+msgstr "Riddles will be displayed at the start of the hunt on %s."
+
+#: single-chasse.php:141
+#, php-format
+msgid "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
+msgstr "Here are the riddles of this hunt. Solve them for a chance to win %s."
+
+#: single-chasse.php:145
+msgid "Voici les énigmes de cette chasse."
+msgstr "Here are the riddles of this hunt."
+
+#: single-chasse.php:149
+#, php-format
+msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
+msgstr "Progress: %1$d/%2$d %3$s — %4$d/%5$d %6$s."
+
+#: single-chasse.php:125
+#: single-chasse.php:126
+msgid "énigme résolue"
+msgid_plural "énigmes résolues"
+msgstr[0] "solved riddle"
+msgstr[1] "solved riddles"
+
+#: single-chasse.php:125
+#: single-chasse.php:126
+msgid "engagée"
+msgid_plural "engagées"
+msgstr[0] "engaged"
+msgstr[1] "engaged"
+
 #: inc/enigme/affichage.php:536 inc/enigme/affichage.php:1008
 msgid "Retour"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -650,6 +650,52 @@ msgstr "Définition du taux de résolution"
 msgid "Énigmes"
 msgstr "Énigmes"
 
+#: single-chasse.php:222
+#, php-format
+msgid "Énigmes de %s"
+msgstr "Énigmes de %s"
+
+#: single-chasse.php:128
+msgid "La chasse est terminée. Vous pouvez revoir toutes les énigmes ainsi que leurs solutions et indices."
+msgstr "La chasse est terminée. Vous pouvez revoir toutes les énigmes ainsi que leurs solutions et indices."
+
+#: single-chasse.php:131
+msgid "La chasse est terminée. Les énigmes restent consultables."
+msgstr "La chasse est terminée. Les énigmes restent consultables."
+
+#: single-chasse.php:134
+#, php-format
+msgid "Les énigmes seront affichées au début de la chasse, le %s."
+msgstr "Les énigmes seront affichées au début de la chasse, le %s."
+
+#: single-chasse.php:141
+#, php-format
+msgid "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
+msgstr "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
+
+#: single-chasse.php:145
+msgid "Voici les énigmes de cette chasse."
+msgstr "Voici les énigmes de cette chasse."
+
+#: single-chasse.php:149
+#, php-format
+msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
+msgstr "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
+
+#: single-chasse.php:125
+#: single-chasse.php:126
+msgid "énigme résolue"
+msgid_plural "énigmes résolues"
+msgstr[0] "énigme résolue"
+msgstr[1] "énigmes résolues"
+
+#: single-chasse.php:125
+#: single-chasse.php:126
+msgid "engagée"
+msgid_plural "engagées"
+msgstr[0] "engagée"
+msgstr[1] "engagées"
+
 #: inc/enigme/affichage.php:536 inc/enigme/affichage.php:1008
 msgid "Retour"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -682,6 +682,10 @@ msgstr "Voici les énigmes de cette chasse."
 msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 msgstr "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 
+#: single-chasse.php:159
+msgid "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
+msgstr "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
+
 #: single-chasse.php:125
 #: single-chasse.php:126
 msgid "énigme résolue"

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -157,6 +157,22 @@ if ($statut === 'termine') {
     }
 }
 
+if (
+    $enigmes_intro === ''
+    && $est_orga_associe
+    && in_array($statut, ['en_cours', 'payante'], true)
+    && $nb_engagees === 0
+) {
+    if ($titre_recompense) {
+        $enigmes_intro = sprintf(
+            esc_html__('Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s.', 'chassesautresor-com'),
+            esc_html($titre_recompense)
+        );
+    } else {
+        $enigmes_intro = esc_html__('Voici les énigmes de cette chasse.', 'chassesautresor-com');
+    }
+}
+
 get_header();
 cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
 

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -62,7 +62,49 @@ $image_raw = $infos_chasse['image_raw'];
 $image_id  = $infos_chasse['image_id'];
 $image_url = $infos_chasse['image_url'];
 
+
 $enigmes_resolues = compter_enigmes_resolues($chasse_id, $user_id);
+
+$enigmes_associees = $infos_chasse['enigmes_associees'];
+$total_enigmes    = count($enigmes_associees);
+$validables       = [];
+foreach ($enigmes_associees as $eid) {
+    if (get_field('enigme_mode_validation', $eid) !== 'aucune') {
+        $validables[] = $eid;
+    }
+}
+$nb_resolvables = count($validables);
+
+$nb_engagees = 0;
+if ($user_id && $total_enigmes > 0) {
+    global $wpdb;
+    $placeholders = implode(',', array_fill(0, $total_enigmes, '%d'));
+    $sql          = "SELECT COUNT(DISTINCT enigme_id) FROM {$wpdb->prefix}engagements WHERE user_id = %d AND enigme_id IN ($placeholders)";
+    $nb_engagees  = (int) $wpdb->get_var($wpdb->prepare($sql, array_merge([$user_id], $enigmes_associees)));
+}
+
+$has_solutions = function_exists('solution_existe_pour_objet')
+    ? solution_existe_pour_objet($chasse_id, 'chasse')
+    : false;
+$has_indices = function_exists('prochain_rang_indice')
+    ? prochain_rang_indice($chasse_id, 'chasse') > 1
+    : false;
+if (!$has_solutions || !$has_indices) {
+    foreach ($enigmes_associees as $eid) {
+        if (!$has_solutions && function_exists('solution_existe_pour_objet') && solution_existe_pour_objet($eid, 'enigme')) {
+            $has_solutions = true;
+        }
+        if (!$has_indices && function_exists('prochain_rang_indice') && prochain_rang_indice($eid, 'enigme') > 1) {
+            $has_indices = true;
+        }
+        if ($has_solutions && $has_indices) {
+            break;
+        }
+    }
+}
+
+$titre_chasse   = get_the_title($chasse_id);
+$enigmes_intro  = '';
 
 $mode_fin = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
 $statut = $infos_chasse['statut'];
@@ -79,6 +121,41 @@ $needs_validatable_message = $statut === 'revision'
 $statut_validation = $infos_chasse['statut_validation'];
 $nb_joueurs = $infos_chasse['nb_joueurs'];
 $sidebar_data = sidebar_prepare_chasse_nav($chasse_id, $user_id);
+
+$solved_label  = _n('énigme résolue', 'énigmes résolues', $enigmes_resolues, 'chassesautresor-com');
+$engaged_label = _n('engagée', 'engagées', $nb_engagees, 'chassesautresor-com');
+
+if ($statut === 'termine') {
+    $enigmes_intro = ($has_solutions || $has_indices)
+        ? esc_html__('La chasse est terminée. Vous pouvez revoir toutes les énigmes ainsi que leurs solutions et indices.', 'chassesautresor-com')
+        : esc_html__('La chasse est terminée. Les énigmes restent consultables.', 'chassesautresor-com');
+} elseif ($statut === 'a_venir') {
+    $enigmes_intro = sprintf(
+        esc_html__('Les énigmes seront affichées au début de la chasse, le %s.', 'chassesautresor-com'),
+        esc_html($date_debut_formatee)
+    );
+} elseif (in_array($statut, ['en_cours', 'payante'], true) && $statut_validation === 'valide') {
+    if ($nb_engagees === 0) {
+        if ($titre_recompense) {
+            $enigmes_intro = sprintf(
+                esc_html__('Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s.', 'chassesautresor-com'),
+                esc_html($titre_recompense)
+            );
+        } else {
+            $enigmes_intro = esc_html__('Voici les énigmes de cette chasse.', 'chassesautresor-com');
+        }
+    } else {
+        $enigmes_intro = sprintf(
+            esc_html__('Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s.', 'chassesautresor-com'),
+            $enigmes_resolues,
+            $nb_resolvables,
+            esc_html($solved_label),
+            $nb_engagees,
+            $total_enigmes,
+            esc_html($engaged_label)
+        );
+    }
+}
 
 get_header();
 cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
@@ -142,7 +219,11 @@ $sidebar_sections = render_sidebar(
     <!-- 🧩 Liste des énigmes -->
     <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">
         <div class="titre-enigmes-wrapper">
-            <h2><?= esc_html__('Énigmes', 'chassesautresor-com'); ?></h2>
+            <h2><?php printf(esc_html__('Énigmes de %s', 'chassesautresor-com'), esc_html($titre_chasse)); ?></h2>
+            <?php if ($enigmes_intro !== '') : ?>
+                <p class="enigmes-intro"><?= $enigmes_intro; ?></p>
+            <?php endif; ?>
+            <div class="separateur-3"></div>
         </div>
         <div id="liste-enigmes" class="chasse-enigmes-liste">
             <?php

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -155,6 +155,11 @@ if ($statut === 'termine') {
             esc_html($engaged_label)
         );
     }
+} elseif ($est_orga_associe && in_array($statut_validation, ['creation', 'correction'], true)) {
+    $enigmes_intro = esc_html__(
+        'Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !',
+        'chassesautresor-com'
+    );
 }
 
 if (


### PR DESCRIPTION
## Résumé
- bloc "Énigmes" enrichi avec titre de chasse et messages contextuels
- style du titre revu avec séparateur visuel
- traductions mises à jour pour les nouveaux textes

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2d15819a48332ad3fc536ba315cf3