### PR TITLE
feat: bouton d'ajout d'énigme dans l'aside

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -92,6 +92,41 @@
   border-bottom: 1px solid rgba(var(--color-grey-light-rgb, 220, 220, 220), 0.15);
 }
 
+.enigme-navigation__ajout {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.enigme-navigation__ajout-bouton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: none;
+  border: none;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.enigme-navigation__ajout-bouton:hover {
+  color: var(--color-primary);
+}
+
+.enigme-navigation__ajout-lien {
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.enigme-navigation__ajout-lien:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
 .menu-lateral section + section:not(.enigme-statistiques) {
   margin-top: var(--space-lg);
   padding-top: var(--space-lg);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1973,6 +1973,41 @@ a.addtoany_share span {
   border-bottom: 1px solid rgba(var(--color-grey-light-rgb, 220, 220, 220), 0.15);
 }
 
+.enigme-navigation__ajout {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.enigme-navigation__ajout-bouton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: none;
+  border: none;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.enigme-navigation__ajout-bouton:hover {
+  color: var(--color-primary);
+}
+
+.enigme-navigation__ajout-lien {
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.enigme-navigation__ajout-lien:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
 .menu-lateral section + section:not(.enigme-statistiques) {
   margin-top: var(--space-lg);
   padding-top: var(--space-lg);

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -12,10 +12,30 @@ $chasse_id       = $args['chasse_id'] ?? null;
 $disabled        = $args['disabled'] ?? true;
 $highlight_pulse = $args['highlight_pulse'] ?? false;
 $show_help_icon  = $args['show_help_icon'] ?? false;
+$use_button      = $args['use_button'] ?? false;
 
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
 $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-enigme/')));
+
+if ($use_button) : ?>
+<div class="enigme-navigation__ajout">
+    <a
+        href="<?php echo $ajout_url; ?>"
+        id="carte-ajout-enigme"
+        class="enigme-navigation__ajout-bouton"
+        data-post-id="0"
+    >
+        <i class="fa-solid fa-circle-plus fa-lg" aria-hidden="true"></i>
+        <span class="screen-reader-text"><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
+    </a>
+    <a href="<?php echo $ajout_url; ?>" class="enigme-navigation__ajout-lien">
+        <?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?>
+    </a>
+</div>
+<?php
+    return;
+endif;
 
 ?>
 <div class="carte-ajout-wrapper">


### PR DESCRIPTION
## Résumé
- ajout d'un bouton pour créer une énigme depuis le menu latéral
- stylisation dédiée et recompilation des styles

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2d3df6fd88332989228520fd6945a