### PR TITLE
Renforce la lisibilité du menu latéral

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -2,7 +2,7 @@
 .menu-lateral {
   background-color: rgba(
     var(--aside-bg-rgb, 238, 238, 238),
-    var(--aside-opacity, 0.4)
+    var(--aside-opacity, 0.85)
   );
   padding: var(--space-md);
   padding-bottom: 0;
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - var(--space-md));
-  color: rgba(var(--color-white-rgb, 255, 255, 255), 0.4);
+  color: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   overflow-y: auto;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1884,7 +1884,7 @@ a.addtoany_share span {
 }
 /* Core styles for reusable asides */
 .menu-lateral {
-  background-color: rgba(var(--aside-bg-rgb, 238, 238, 238), var(--aside-opacity, 0.4));
+  background-color: rgba(var(--aside-bg-rgb, 238, 238, 238), var(--aside-opacity, 0.85));
   padding: var(--space-md);
   padding-bottom: 0;
   border-radius: 6px;
@@ -1892,7 +1892,7 @@ a.addtoany_share span {
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - var(--space-md));
-  color: rgba(var(--color-white-rgb, 255, 255, 255), 0.4);
+  color: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   overflow-y: auto;
 }


### PR DESCRIPTION
Renforce la lisibilité du menu latéral.

- Augmente l'opacité du fond de l'aside.
- Renforce la couleur du texte pour un meilleur contraste.

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2dd646ac88332af643a53167b3499