### PR TITLE
Amélioration de l’accessibilité de la navigation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -330,3 +330,9 @@ body.edition-active-chasse .chasse-enigmes-header  .liens-placeholder {
   font-size: 0.8em;
   font-weight: 500;
 }
+
+@media not all and (--bp-desktop) {
+  .chasse-layout .menu-lateral {
+    display: none;
+  }
+}

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -772,6 +772,11 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   font-weight: 500;
 }
 
+@media not all and (min-width: 1024px) {
+  .chasse-layout .menu-lateral {
+    display: none;
+  }
+}
 /* ========== 🛒 AJOUT AU PANIER ========== */
 .woocommerce a.button.add_to_cart_button {
   font-weight: 500;

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -239,6 +239,9 @@ add_action('wp_enqueue_scripts', function () {
             true
         );
         wp_set_script_translations('accordeon', 'chassesautresor-com');
+    }
+
+    if (is_singular(['enigme', 'chasse'])) {
         wp_enqueue_script(
             'enigme-panel',
             $script_dir . 'enigme-panel.js',

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -851,8 +851,9 @@ require_once __DIR__ . '/../sidebar.php';
                 }
             }
 
-            $title = esc_html(get_the_title($post->ID));
-            $link  = '<a href="' . esc_url(get_permalink($post->ID)) . '">' . $title . '</a>';
+            $title        = esc_html(get_the_title($post->ID));
+            $aria_current = $post->ID === $enigme_id ? ' aria-current="page"' : '';
+            $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
 
             $submenu_items[] = sprintf(
                 '<li class="%s" data-enigme-id="%d">%s%s%s</li>',

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -28,12 +28,13 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
     /**
      * Prepare navigation items for a hunt sidebar.
      *
-     * @param int $chasse_id Hunt identifier.
-     * @param int $user_id   Current user identifier.
+     * @param int $chasse_id         Hunt identifier.
+     * @param int $user_id           Current user identifier.
+     * @param int $current_enigme_id Current enigma identifier.
      *
-     * @return array{menu_items:array,peut_ajouter_enigme:bool,total_enigmes:int,has_incomplete_enigme:bool}
+     * @return array{menu_items:array,peut_ajouter_enigme:bool,total_enigmes:int,has_incomplete_enigme:bool,visible_ids:array}
      */
-    function sidebar_prepare_chasse_nav(int $chasse_id, int $user_id): array
+    function sidebar_prepare_chasse_nav(int $chasse_id, int $user_id, int $current_enigme_id = 0): array
     {
         $all_enigmes         = recuperer_enigmes_pour_chasse($chasse_id);
         $submenu_items       = [];
@@ -79,8 +80,13 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                 $classes = [];
             }
 
-            $title = esc_html(get_the_title($post->ID));
-            $link  = '<a href="' . esc_url(get_permalink($post->ID)) . '">' . $title . '</a>';
+            if ($post->ID === $current_enigme_id) {
+                $classes[] = 'active';
+            }
+
+            $title        = esc_html(get_the_title($post->ID));
+            $aria_current = $post->ID === $current_enigme_id ? ' aria-current="page"' : '';
+            $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
             $submenu_items[] = sprintf(
                 '<li class="%s" data-enigme-id="%d">%s</li>',
                 esc_attr(implode(' ', $classes)),
@@ -194,9 +200,11 @@ if (!function_exists('render_sidebar')) {
             'context'        => $context,
         ]);
         if ($navigation_html === '') {
-            $navigation_html = '<section class="enigme-navigation"><h3>'
+            $navigation_html = '<nav class="enigme-navigation" aria-label="'
+                . esc_attr__('Navigation des énigmes', 'chassesautresor-com')
+                . '"><h3>'
                 . esc_html__('Énigmes', 'chassesautresor-com')
-                . '</h3><ul class="enigme-menu"></ul></section>';
+                . '</h3><ul class="enigme-menu"></ul></nav>';
         }
 
         $stats_section_html = sidebar_get_section_html('stats', [

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -195,6 +195,27 @@ $sidebar_sections = render_sidebar(
 );
 ?>
 
+<?php
+echo '<header class="enigme-mobile-header">';
+echo '<div aria-hidden="true"></div>';
+echo '<div class="enigme-mobile-actions">';
+echo '<button type="button" class="enigme-mobile-panel-toggle" aria-controls="enigme-mobile-panel" aria-expanded="false" aria-label="'
+    . esc_attr__('Menu de navigation', 'chassesautresor-com') . '">';
+echo '<span class="screen-reader-text">' . esc_html__('Menu de navigation', 'chassesautresor-com') . '</span>';
+echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
+echo '</button>';
+echo '</div>';
+echo '</header>';
+
+echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
+echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';
+echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true" aria-labelledby="enigme-mobile-panel-title">';
+echo '<h2 id="enigme-mobile-panel-title" class="screen-reader-text">' . esc_html__('Navigation de la chasse', 'chassesautresor-com') . '</h2>';
+echo '<div class="enigme-mobile-panel__content">' . ($sidebar_sections['navigation'] ?? '') . '</div>';
+echo '</div>';
+echo '</div>';
+?>
+
 <div id="primary" class="content-area page-chasse-wrapper">
   <main id="main" class="site-main">
 

--- a/wp-content/themes/chassesautresor/template-parts/common/sidebar-section.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/sidebar-section.php
@@ -40,7 +40,8 @@ if ($section === 'navigation') {
         $menu_class .= ' enigme-menu--editable';
     }
 
-    echo '<section class="enigme-navigation"' . $data_chasse . ' data-context="' . esc_attr($context) . '">';
+    $aria_label = esc_attr__('Navigation des énigmes', 'chassesautresor-com');
+    echo '<nav class="enigme-navigation" aria-label="' . $aria_label . '"' . $data_chasse . ' data-context="' . esc_attr($context) . '">';
     $nav_title = $context === 'chasse'
         ? esc_html__('Énigmes', 'chassesautresor-com')
         : esc_html__('Énigmes', 'chassesautresor-com');
@@ -65,7 +66,7 @@ if ($section === 'navigation') {
                 . '</button>';
         }
     }
-    echo '</section>';
+    echo '</nav>';
     return;
 }
 


### PR DESCRIPTION
## Résumé
- navigation encapsulée dans un élément `nav` avec libellé ARIA
- lien de l’énigme courante balisé avec `aria-current`
- ajout d’un panneau mobile pour la page chasse et masquage de l’aside sur mobile

## Testing
- `npm run build:css`
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2dc559aa883329bd2d83bd2e7aeef