### PR TITLE
Optimise le chargement du panneau latéral

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Le projet utilise plusieurs tables SQL dédiées pour suivre l'activité des jou
 - `wp_indices_deblocages` trace le déblocage des indices et les points dépensés.
 - `wp_user_points` inclut la valeur `indice` dans le champ `origin_type` pour comptabiliser ces dépenses.
 
+## Performances du panneau latéral
+
+Le script `assets/sidebar/sidebar.js` instrumente l'affichage du panneau grâce à
+`performance.mark` et `performance.measure`. Analysez ces mesures dans les outils
+de développement pour suivre le délai d'apparition du panneau. Selon les
+résultats, ajustez la limite d'éléments visibles via le filtre
+`enigme_menu_max_visible` ou adaptez la stratégie de cache.
+
 ## Création d’indice
 
 Un endpoint dédié permet de créer rapidement un indice :

--- a/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
+++ b/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
@@ -1,5 +1,6 @@
 (function() {
   function init() {
+    performance.mark('sidebar-init');
     const aside = document.querySelector('.menu-lateral');
     if (!aside) return;
     const bp = getComputedStyle(document.documentElement)
@@ -14,6 +15,7 @@
       '<span class="screen-reader-text">' + __('Afficher le panneau', 'chassesautresor-com') + '</span>';
     document.body.appendChild(opener);
     let timer = null;
+    let revealed = false;
     function hideAside() {
       aside.classList.add('is-hidden');
       opener.style.display = 'flex';
@@ -23,6 +25,11 @@
       }
     }
     function showAside() {
+      if (!revealed) {
+        performance.mark('sidebar-visible');
+        performance.measure('sidebar-time-to-visible', 'sidebar-init', 'sidebar-visible');
+        revealed = true;
+      }
       aside.classList.remove('is-hidden');
       opener.style.display = 'none';
       if (timer) clearTimeout(timer);

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -250,26 +250,6 @@ add_action('wp_enqueue_scripts', function () {
             true
         );
     }
-    $sidebar_dir = $theme_uri . '/assets/sidebar/';
-    if (is_singular(['enigme', 'chasse'])) {
-        wp_enqueue_script(
-            'sidebar',
-            $sidebar_dir . 'sidebar.js',
-            [],
-            filemtime($theme_path . '/assets/sidebar/sidebar.js'),
-            true
-        );
-        wp_localize_script('sidebar', 'sidebarData', [
-            'ajaxUrl' => admin_url('admin-ajax.php'),
-        ]);
-        wp_enqueue_script(
-            'sidebar-menu-toggle',
-            $sidebar_dir . 'menu-toggle.js',
-            [],
-            filemtime($theme_path . '/assets/sidebar/menu-toggle.js'),
-            true
-        );
-    }
 });
 
 add_action('wp_enqueue_scripts', function () {

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -870,16 +870,22 @@ require_once __DIR__ . '/../sidebar.php';
         }
 
         echo '<div class="container container--xl-full enigme-layout">';
-        $sidebar_sections = render_sidebar(
-            'enigme',
-            $enigme_id,
-            $edition_active,
-            $chasse_id,
-            $menu_items,
-            $peut_ajouter_enigme,
-            $total_enigmes,
-            $has_incomplete_enigme
-        );
+        $sidebar_sections = [
+            'navigation' => '',
+            'stats'      => '',
+        ];
+        if (function_exists('render_sidebar')) {
+            $sidebar_sections = render_sidebar(
+                'enigme',
+                $enigme_id,
+                $edition_active,
+                $chasse_id,
+                $menu_items,
+                $peut_ajouter_enigme,
+                $total_enigmes,
+                $has_incomplete_enigme
+            );
+        }
 
         $retour_url   = $chasse_id ? get_permalink($chasse_id) : home_url('/');
         $settings_icon = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none"'

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -153,6 +153,29 @@ if (!function_exists('render_sidebar')) {
         int $total_enigmes = 0,
         bool $has_incomplete_enigme = false
     ): array {
+        if (function_exists('wp_script_is') && !wp_script_is('sidebar', 'enqueued')) {
+            $theme_path  = get_template_directory();
+            $theme_uri   = get_template_directory_uri();
+            $sidebar_dir = $theme_uri . '/assets/sidebar/';
+            wp_enqueue_script(
+                'sidebar',
+                $sidebar_dir . 'sidebar.js',
+                [],
+                filemtime($theme_path . '/assets/sidebar/sidebar.js'),
+                true
+            );
+            wp_localize_script('sidebar', 'sidebarData', [
+                'ajaxUrl' => admin_url('admin-ajax.php'),
+            ]);
+            wp_enqueue_script(
+                'sidebar-menu-toggle',
+                $sidebar_dir . 'menu-toggle.js',
+                [],
+                filemtime($theme_path . '/assets/sidebar/menu-toggle.js'),
+                true
+            );
+            wp_script_add_data('sidebar-menu-toggle', 'defer', true);
+        }
         if ($context === 'enigme') {
             $mode    = get_field('enigme_mode_validation', $enigme_id);
             $user_id = get_current_user_id();
@@ -185,6 +208,8 @@ if (!function_exists('render_sidebar')) {
             $ajout_html = ob_get_clean();
         }
 
+        // Adjust this limit if performance marks reveal slow rendering. The value
+        // can be filtered via 'enigme_menu_max_visible'.
         $max_visible   = function_exists('apply_filters')
             ? (int) apply_filters('enigme_menu_max_visible', 10)
             : 10;

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -183,16 +183,22 @@ cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NO
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
 echo '<div class="container container--xl-full chasse-layout">';
-$sidebar_sections = render_sidebar(
-    'chasse',
-    0,
-    $edition_active,
-    $chasse_id,
-    $sidebar_data['menu_items'],
-    $sidebar_data['peut_ajouter_enigme'],
-    $sidebar_data['total_enigmes'],
-    $sidebar_data['has_incomplete_enigme']
-);
+$sidebar_sections = [
+    'navigation' => '',
+    'stats'      => '',
+];
+if (function_exists('render_sidebar')) {
+    $sidebar_sections = render_sidebar(
+        'chasse',
+        0,
+        $edition_active,
+        $chasse_id,
+        $sidebar_data['menu_items'],
+        $sidebar_data['peut_ajouter_enigme'],
+        $sidebar_data['total_enigmes'],
+        $sidebar_data['has_incomplete_enigme']
+    );
+}
 ?>
 
 <?php


### PR DESCRIPTION
## Résumé
- Charge `sidebar.js` uniquement lorsque `render_sidebar()` est invoqué.
- Ajoute des marques de performance pour suivre l'affichage du panneau.
- Diffère les scripts secondaires comme `menu-toggle.js`.

## Modifications notables
- Enqueue conditionnelle de `sidebar.js` et `menu-toggle.js` avec `defer`.
- Instrumentation `performance.mark`/`measure` dans `sidebar.js`.
- Documentation sur l'ajustement de `enigme_menu_max_visible`.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2eda1dc9c8332bbf715c96fa18319