### PR TITLE
Corrige le chargement des scripts du panneau latéral

### DIFF
--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -154,8 +154,8 @@ if (!function_exists('render_sidebar')) {
         bool $has_incomplete_enigme = false
     ): array {
         if (function_exists('wp_script_is') && !wp_script_is('sidebar', 'enqueued')) {
-            $theme_path  = get_template_directory();
-            $theme_uri   = get_template_directory_uri();
+            $theme_path  = get_stylesheet_directory();
+            $theme_uri   = get_stylesheet_directory_uri();
             $sidebar_dir = $theme_uri . '/assets/sidebar/';
             wp_enqueue_script(
                 'sidebar',


### PR DESCRIPTION
## Résumé
Corrige l’auto-repli du menu latéral en chargeant les scripts depuis le thème enfant.

## Modifications
- Pointe `sidebar.js` et `menu-toggle.js` vers les répertoires du thème enfant.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2efedf418833288f8080ba3cfb6a6