### PR TITLE
Hide cost badge for enigmas without validation

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -160,7 +160,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
           <?php endif; ?>
             <footer class="carte-enigme-footer">
               <div class="footer-icons footer-icons-left">
-                <?php if ($cout_points > 0) : ?>
+                <?php if ($mode_validation !== 'aucune' && $cout_points > 0) : ?>
                   <span class="footer-item footer-item--points" title="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
                     <i class="fa-solid fa-coins" aria-hidden="true"></i>
                     <?= esc_html($cout_points); ?>


### PR DESCRIPTION
## Summary
- Supprime l'affichage du badge de points pour les énigmes sans validation

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9ff854483328f606bdc92bccac1