### PR TITLE
Augmente l'espacement entre les cartes d'énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -28,7 +28,7 @@
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
-  gap: var(--space-2xl);
+  gap: var(--space-4xl);
   justify-content: center;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -29,7 +29,7 @@
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
-  gap: var(--space-2xl);
+  gap: var(--space-4xl);
   justify-content: center;
 }
 


### PR DESCRIPTION
## Résumé
- élargit l'espacement entre les cartes d'énigmes pour aérer la grille
- recompilation des styles du thème

## Tests
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2fa285ad48332990fcc5bca95c8c0