### PR TITLE
Restore sidebar auto-hide and toggle functionality

### DIFF
--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -153,28 +153,39 @@ if (!function_exists('render_sidebar')) {
         int $total_enigmes = 0,
         bool $has_incomplete_enigme = false
     ): array {
-        if (function_exists('wp_script_is') && !wp_script_is('sidebar', 'enqueued')) {
+        if (
+            function_exists('wp_script_is')
+            && !wp_script_is('chassesautresor-sidebar', 'enqueued')
+        ) {
             $theme_path  = get_template_directory();
             $theme_uri   = get_template_directory_uri();
             $sidebar_dir = $theme_uri . '/assets/sidebar/';
             wp_enqueue_script(
-                'sidebar',
+                'chassesautresor-sidebar',
                 $sidebar_dir . 'sidebar.js',
                 [],
                 filemtime($theme_path . '/assets/sidebar/sidebar.js'),
                 true
             );
-            wp_localize_script('sidebar', 'sidebarData', [
-                'ajaxUrl' => admin_url('admin-ajax.php'),
-            ]);
+            wp_localize_script(
+                'chassesautresor-sidebar',
+                'sidebarData',
+                [
+                    'ajaxUrl' => admin_url('admin-ajax.php'),
+                ]
+            );
             wp_enqueue_script(
-                'sidebar-menu-toggle',
+                'chassesautresor-sidebar-menu-toggle',
                 $sidebar_dir . 'menu-toggle.js',
                 [],
                 filemtime($theme_path . '/assets/sidebar/menu-toggle.js'),
                 true
             );
-            wp_script_add_data('sidebar-menu-toggle', 'defer', true);
+            wp_script_add_data(
+                'chassesautresor-sidebar-menu-toggle',
+                'defer',
+                true
+            );
         }
         if ($context === 'enigme') {
             $mode    = get_field('enigme_mode_validation', $enigme_id);


### PR DESCRIPTION
Résumé: Corrige le repli automatique du panneau latéral et la bascule des éléments cachés.

- Renommé les handles de scripts du panneau pour éviter les conflits.
- Rétabli le masquage automatique de l’aside après un délai et le bouton « Afficher plus ».

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb0271b88332a6efa6c04ddad347