### PR TITLE
Respect mode validation for point cost display

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -160,7 +160,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
           <?php endif; ?>
             <footer class="carte-enigme-footer">
               <div class="footer-icons footer-icons-left">
-                <?php if ($cout_points > 0) : ?>
+                <?php if ($mode_validation !== 'aucune' && $cout_points > 0) : ?>
                   <span class="footer-item footer-item--points" title="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>" aria-label="<?= esc_attr(sprintf(__('Cette énigme coûte %d point(s)', 'chassesautresor-com'), $cout_points)); ?>">
                     <i class="fa-solid fa-coins" aria-hidden="true"></i>
                     <?= esc_html($cout_points); ?>


### PR DESCRIPTION
### Résumé
Masque l'affichage du coût en points lorsque l'énigme n'a pas de mode de validation.

### Changements notables
- n'affiche le coût en points que si une validation est requise

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2fcc113008332b0b301ac86c693eb