### PR TITLE
fix: replace overlay help icon with warning badge

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -295,6 +295,8 @@
   color: var(--color-background);
   position: relative;
   cursor: pointer;
+  width: 100%;
+  height: 100%;
 }
 
 .carte-ajout-enigme:hover {
@@ -385,34 +387,6 @@
   text-align: center;
   gap: var(--space-xs);
   padding: 0 var(--space-md);
-}
-
-.carte-ajout-wrapper {
-  position: relative;
-  height: 100%;
-}
-
-.carte-ajout-wrapper .carte-ajout-enigme {
-  width: 100%;
-  height: 100%;
-}
-
-.carte-ajout-wrapper .help-icon-button {
-  position: absolute;
-  top: var(--space-xs);
-  right: var(--space-xs);
-  z-index: 2;
-}
-
-.carte-ajout-wrapper .carte-help-icon {
-  color: var(--color-gris-3);
-  border-color: var(--color-gris-3);
-}
-
-.carte-ajout-wrapper .carte-help-icon:hover,
-.carte-ajout-wrapper .carte-help-icon:focus {
-  color: var(--color-gris-3);
-  border-color: var(--color-gris-3);
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -286,6 +286,8 @@
   color: var(--color-background);
   position: relative;
   cursor: pointer;
+  width: 100%;
+  height: 100%;
 }
 
 .carte-ajout-enigme:hover {
@@ -375,34 +377,6 @@
   text-align: center;
   gap: var(--space-xs);
   padding: 0 var(--space-md);
-}
-
-.carte-ajout-wrapper {
-  position: relative;
-  height: 100%;
-}
-
-.carte-ajout-wrapper .carte-ajout-enigme {
-  width: 100%;
-  height: 100%;
-}
-
-.carte-ajout-wrapper .help-icon-button {
-  position: absolute;
-  top: var(--space-xs);
-  right: var(--space-xs);
-  z-index: 2;
-}
-
-.carte-ajout-wrapper .carte-help-icon {
-  color: var(--color-gris-3);
-  border-color: var(--color-gris-3);
-}
-
-.carte-ajout-wrapper .carte-help-icon:hover,
-.carte-ajout-wrapper .carte-help-icon:focus {
-  color: var(--color-gris-3);
-  border-color: var(--color-gris-3);
 }
 
 /* ========== ✅ Indicateurs de complétion ========== */

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -38,50 +38,37 @@ if ($use_button) : ?>
 endif;
 
 ?>
-<div class="carte-ajout-wrapper">
+<?php
+$classes = [
+    'carte',
+    'carte-enigme',
+    'carte-ajout-enigme',
+    $has_enigmes ? 'etat-suivante' : 'etat-vide',
+];
+if ($disabled) {
+    $classes[] = 'disabled';
+}
+if ($highlight_pulse) {
+    $classes[] = 'pulsation';
+}
+?>
+<button
+    type="button"
+    id="carte-ajout-enigme"
+    class="<?php echo esc_attr(implode(' ', $classes)); ?>"
+    data-post-id="0"
+    aria-label="<?php echo esc_attr__('Ajouter une énigme', 'chassesautresor-com'); ?>"
+    <?php echo $disabled ? 'disabled' : ''; ?>
+    onclick="if(!this.hasAttribute('disabled')){window.location.href='<?php echo $ajout_url; ?>';}"
+>
     <?php if ($show_help_icon) : ?>
-        <?php
-        get_template_part(
-            'template-parts/common/help-icon',
-            null,
-            [
-                'aria_label' => __('Validation en ligne nécessaire', 'chassesautresor-com'),
-                'title'      => __('Validation en ligne nécessaire', 'chassesautresor-com'),
-                'message'    => __('Votre chasse se termine automatiquement ; ajoutez une énigme à validation manuelle ou automatique.', 'chassesautresor-com'),
-                'variant'    => 'info',
-                'classes'    => 'carte-help-icon',
-                'background' => 'light',
-            ]
-        );
-        ?>
+        <span class="warning-icon" aria-label="<?php echo esc_attr__('Validation en ligne nécessaire', 'chassesautresor-com'); ?>" title="<?php echo esc_attr__('Validation en ligne nécessaire', 'chassesautresor-com'); ?>">
+            <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+        </span>
     <?php endif; ?>
-    <?php
-    $classes = [
-        'carte',
-        'carte-enigme',
-        'carte-ajout-enigme',
-        $has_enigmes ? 'etat-suivante' : 'etat-vide',
-    ];
-    if ($disabled) {
-        $classes[] = 'disabled';
-    }
-    if ($highlight_pulse) {
-        $classes[] = 'pulsation';
-    }
-    ?>
-    <button
-        type="button"
-        id="carte-ajout-enigme"
-        class="<?php echo esc_attr(implode(' ', $classes)); ?>"
-        data-post-id="0"
-        aria-label="<?php echo esc_attr__('Ajouter une énigme', 'chassesautresor-com'); ?>"
-        <?php echo $disabled ? 'disabled' : ''; ?>
-        onclick="if(!this.hasAttribute('disabled')){window.location.href='<?php echo $ajout_url; ?>';}"
-    >
-        <div class="carte-core">
-            <i class="fa-solid fa-circle-plus" aria-hidden="true"></i>
-            <span class="carte-ajout-libelle"><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
-        </div>
-    </button>
-</div>
+    <div class="carte-core">
+        <i class="fa-solid fa-circle-plus" aria-hidden="true"></i>
+        <span class="carte-ajout-libelle"><?php echo esc_html__('Ajouter une énigme', 'chassesautresor-com'); ?></span>
+    </div>
+</button>
 


### PR DESCRIPTION
## Résumé
- retire l'overlay sur la carte d'ajout d'énigme
- affiche l'icône d'information comme badge orange

## Changements notables
- remplacement de l'enveloppe `carte-ajout-wrapper` par un bouton direct
- ajout d'une icône `warning-icon` pour indiquer la validation en ligne
- suppression des styles liés à l'ancien overlay et adaptation du SCSS/CSS

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2fe8291008332af783bfd349297a2