### PR TITLE
feat: activer le réordonnancement des cartes d'énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
@@ -6,6 +6,7 @@ function initEnigmeCardsReorder() {
   if (!grid) return;
 
   const addCard = grid.querySelector('#carte-ajout-enigme');
+  const addWrapper = addCard?.closest('.carte-ajout-wrapper');
   let dragged = null;
 
   grid.addEventListener('dragstart', (e) => {
@@ -20,6 +21,7 @@ function initEnigmeCardsReorder() {
   grid.addEventListener('dragover', (e) => {
     e.preventDefault();
     if (!dragged) return;
+    e.dataTransfer.dropEffect = 'move';
     const target = e.target.closest('.carte-enigme');
     if (!target || target === dragged || target.id === 'carte-ajout-enigme') return;
     grid.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
@@ -30,15 +32,17 @@ function initEnigmeCardsReorder() {
   });
 
   const ensureAddLast = () => {
-    if (addCard) {
+    if (addWrapper) {
+      grid.appendChild(addWrapper);
+    } else if (addCard) {
       grid.appendChild(addCard);
     }
   };
 
   const saveOrder = () => {
-    const order = Array.from(grid.querySelectorAll('.carte-enigme'))
-      .filter((el) => el.id !== 'carte-ajout-enigme')
-      .map((el) => el.dataset.enigmeId);
+    const order = Array.from(
+      grid.querySelectorAll('.carte-enigme[data-enigme-id]')
+    ).map((el) => el.dataset.enigmeId);
     if (!order.length) return;
     const fd = new FormData();
     fd.append('action', 'reordonner_enigmes');

--- a/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
@@ -1,0 +1,85 @@
+/**
+ * Reorder enigme cards within the cards grid.
+ */
+function initEnigmeCardsReorder() {
+  const grid = document.querySelector('.cards-grid');
+  if (!grid) return;
+
+  const addCard = grid.querySelector('#carte-ajout-enigme');
+  let dragged = null;
+
+  grid.addEventListener('dragstart', (e) => {
+    const card = e.target.closest('.carte-enigme');
+    if (!card || card.id === 'carte-ajout-enigme') return;
+    dragged = card;
+    e.dataTransfer.effectAllowed = 'move';
+    grid.classList.add('dragging');
+    dragged.classList.add('dragging');
+  });
+
+  grid.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    if (!dragged) return;
+    const target = e.target.closest('.carte-enigme');
+    if (!target || target === dragged || target.id === 'carte-ajout-enigme') return;
+    grid.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
+    target.classList.add('drag-over');
+    const rect = target.getBoundingClientRect();
+    const next = e.clientY > rect.top + rect.height / 2;
+    grid.insertBefore(dragged, next ? target.nextSibling : target);
+  });
+
+  const ensureAddLast = () => {
+    if (addCard) {
+      grid.appendChild(addCard);
+    }
+  };
+
+  const saveOrder = () => {
+    const order = Array.from(grid.querySelectorAll('.carte-enigme'))
+      .filter((el) => el.id !== 'carte-ajout-enigme')
+      .map((el) => el.dataset.enigmeId);
+    if (!order.length) return;
+    const fd = new FormData();
+    fd.append('action', 'reordonner_enigmes');
+    fd.append('chasse_id', grid.dataset.chasseId);
+    order.forEach((id) => fd.append('ordre[]', id));
+    fetch(window.ajaxurl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: fd,
+    })
+      .then((r) => r.json())
+      .then((res) => {
+        if (!res.success) {
+          alert(wp.i18n.__("Erreur lors de l'enregistrement de l'ordre", 'chassesautresor-com'));
+        }
+      })
+      .catch(() => {
+        alert(wp.i18n.__("Erreur lors de l'enregistrement de l'ordre", 'chassesautresor-com'));
+      });
+  };
+
+  const cleanClasses = () => {
+    grid.classList.remove('dragging');
+    grid.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
+    dragged?.classList.remove('dragging');
+  };
+
+  grid.addEventListener('drop', (e) => {
+    e.preventDefault();
+    cleanClasses();
+    ensureAddLast();
+    saveOrder();
+    dragged = null;
+  });
+
+  grid.addEventListener('dragend', () => {
+    cleanClasses();
+    ensureAddLast();
+    saveOrder();
+    dragged = null;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initEnigmeCardsReorder);

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -270,6 +270,7 @@ li.active .enigme-menu__edit {
     background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
     color: var(--color-white);
     pointer-events: none;
+    z-index: 10;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -254,6 +254,25 @@ li.active .enigme-menu__edit {
   cursor: grabbing;
 }
 
+.carte-enigme {
+  position: relative;
+
+  &-handle {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
+    color: var(--color-white);
+    pointer-events: none;
+  }
+}
+
 .carte-enigme[draggable='true'] {
   cursor: grab;
   user-select: none;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -247,6 +247,22 @@ li.active .enigme-menu__edit {
   background-color: rgba(255, 215, 0, 0.2);
 }
 
+.cards-grid.dragging {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: -2px;
+  background-color: rgba(255, 215, 0, 0.1);
+}
+
+.carte-enigme.dragging {
+  opacity: 0.5;
+}
+
+.carte-enigme.drag-over {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: -2px;
+  background-color: rgba(255, 215, 0, 0.2);
+}
+
 .enigme-menu--overflow {
   margin-top: 0;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -250,17 +250,33 @@ li.active .enigme-menu__edit {
 .cards-grid.dragging {
   outline: 2px dashed var(--color-accent);
   outline-offset: -2px;
-  background-color: rgba(255, 215, 0, 0.1);
+  background-color: rgba(255, 215, 0, 0.05);
+  cursor: grabbing;
+}
+
+.carte-enigme[draggable='true'] {
+  cursor: grab;
+  user-select: none;
+}
+
+.cards-grid.dragging .carte-enigme:not(.dragging) {
+  opacity: 0.7;
 }
 
 .carte-enigme.dragging {
-  opacity: 0.5;
+  opacity: 0.6;
+  cursor: grabbing;
+  transform: scale(0.95);
+  box-shadow: 0 0 0 4px var(--color-accent);
+  z-index: 2;
 }
 
 .carte-enigme.drag-over {
   outline: 2px dashed var(--color-accent);
-  outline-offset: -2px;
-  background-color: rgba(255, 215, 0, 0.2);
+  outline-offset: -4px;
+  background-color: rgba(255, 215, 0, 0.15);
+  transform: scale(1.03);
+  box-shadow: 0 0 0 4px var(--color-accent);
 }
 
 .enigme-menu--overflow {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5164,6 +5164,24 @@ li.active .enigme-menu__edit {
   cursor: grabbing;
 }
 
+.carte-enigme {
+  position: relative;
+}
+.carte-enigme-handle {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
+  color: var(--color-white);
+  pointer-events: none;
+}
+
 .carte-enigme[draggable=true] {
   cursor: grab;
   -webkit-user-select: none;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5160,17 +5160,35 @@ li.active .enigme-menu__edit {
 .cards-grid.dragging {
   outline: 2px dashed var(--color-accent);
   outline-offset: -2px;
-  background-color: rgba(255, 215, 0, 0.1);
+  background-color: rgba(255, 215, 0, 0.05);
+  cursor: grabbing;
+}
+
+.carte-enigme[draggable=true] {
+  cursor: grab;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.cards-grid.dragging .carte-enigme:not(.dragging) {
+  opacity: 0.7;
 }
 
 .carte-enigme.dragging {
-  opacity: 0.5;
+  opacity: 0.6;
+  cursor: grabbing;
+  transform: scale(0.95);
+  box-shadow: 0 0 0 4px var(--color-accent);
+  z-index: 2;
 }
 
 .carte-enigme.drag-over {
   outline: 2px dashed var(--color-accent);
-  outline-offset: -2px;
-  background-color: rgba(255, 215, 0, 0.2);
+  outline-offset: -4px;
+  background-color: rgba(255, 215, 0, 0.15);
+  transform: scale(1.03);
+  box-shadow: 0 0 0 4px var(--color-accent);
 }
 
 .enigme-menu--overflow {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5157,6 +5157,22 @@ li.active .enigme-menu__edit {
   background-color: rgba(255, 215, 0, 0.2);
 }
 
+.cards-grid.dragging {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: -2px;
+  background-color: rgba(255, 215, 0, 0.1);
+}
+
+.carte-enigme.dragging {
+  opacity: 0.5;
+}
+
+.carte-enigme.drag-over {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: -2px;
+  background-color: rgba(255, 215, 0, 0.2);
+}
+
 .enigme-menu--overflow {
   margin-top: 0;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5180,6 +5180,7 @@ li.active .enigme-menu__edit {
   background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
   color: var(--color-white);
   pointer-events: none;
+  z-index: 10;
 }
 
 .carte-enigme[draggable=true] {

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -162,6 +162,16 @@ function charger_scripts_personnalises() {
       filemtime(get_stylesheet_directory() . '/assets/js/validation-admin.js'),
       true
     );
+    if (is_singular('chasse')) {
+      wp_enqueue_script(
+        'enigme-cards-reorder',
+        $theme_dir . 'enigme-cards-reorder.js',
+        ['wp-i18n'],
+        filemtime(get_stylesheet_directory() . '/assets/js/enigme-cards-reorder.js'),
+        true
+      );
+      wp_set_script_translations('enigme-cards-reorder', 'chassesautresor-com');
+    }
     wp_enqueue_script(
       'tri-organisateurs',
       $theme_dir . 'tri-organisateurs.js',

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -67,7 +67,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
 ?>
 
 <div class="bloc-enigmes-chasse">
-  <div class="cards-grid">
+  <div class="cards-grid" data-chasse-id="<?= esc_attr($chasse_id); ?>">
     <?php foreach ($posts_visibles as $post):
       $enigme_id = $post->ID;
       $titre = get_the_title($enigme_id);
@@ -111,7 +111,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
         ? compter_tentatives_du_jour($utilisateur_id, $enigme_id)
         : 0;
     ?>
-        <article class="<?= esc_attr($classes_carte); ?>">
+        <article class="<?= esc_attr($classes_carte); ?>" data-enigme-id="<?= esc_attr($enigme_id); ?>" draggable="true">
             <?php if ($linkable) : ?>
               <a href="<?= esc_url($cta['url']); ?>" class="carte-enigme-lien" aria-label="<?= esc_attr($aria_label); ?>">
             <?php else : ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -112,6 +112,7 @@ if (!function_exists('compter_tentatives_du_jour')) {
         : 0;
     ?>
         <article class="<?= esc_attr($classes_carte); ?>" data-enigme-id="<?= esc_attr($enigme_id); ?>" draggable="true">
+            <span class="carte-enigme-handle" aria-hidden="true"><i class="fa-solid fa-up-down-left-right"></i></span>
             <?php if ($linkable) : ?>
               <a href="<?= esc_url($cta['url']); ?>" class="carte-enigme-lien" aria-label="<?= esc_attr($aria_label); ?>">
             <?php else : ?>


### PR DESCRIPTION
## Résumé
- permet de trier les cartes d'énigme par glisser-déposer
- persiste l'ordre via l'action AJAX `reordonner_enigmes`
- applique des styles de glisser-déposer sur la grille et les cartes

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b302c6d1d883329e2a224f8791600a