### PR TITLE
feat: support horizontal card reorder

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
@@ -1,0 +1,42 @@
+(function () {
+  document.querySelectorAll('.cards-grid').forEach((grid) => {
+    grid.querySelectorAll('.carte').forEach((card) => {
+      card.draggable = true;
+    });
+
+    let dragged = null;
+
+    grid.addEventListener('dragstart', (e) => {
+      dragged = e.target.closest('.carte');
+      if (dragged) {
+        if (e.dataTransfer) {
+          e.dataTransfer.effectAllowed = 'move';
+        }
+        dragged.classList.add('dragging');
+      }
+    });
+
+    grid.addEventListener('dragend', () => {
+      if (dragged) {
+        dragged.classList.remove('dragging');
+      }
+      dragged = null;
+      grid.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
+    });
+
+    grid.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      const target = e.target.closest('.carte');
+      if (!dragged || !target || dragged === target) return;
+
+      grid.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
+      target.classList.add('drag-over');
+
+      const rect = target.getBoundingClientRect();
+      const shouldInsertAfter =
+        e.clientY > rect.top + rect.height / 2 || e.clientX > rect.left + rect.width / 2;
+
+      grid.insertBefore(dragged, shouldInsertAfter ? target.nextSibling : target);
+    });
+  });
+})();


### PR DESCRIPTION
## Résumé
Permet le repositionnement horizontal des cartes d'énigmes.

## Changements notables
- Détermine l'insertion selon la position du pointeur dans la grille de cartes.
- Active le glisser-déposer sur chaque `.cards-grid`.

## Testing
- `npm ci`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`
- Simulation Node.js du glisser-déposer

------
https://chatgpt.com/codex/tasks/task_e_68b30c8fb54483328ae05685fb355dea