### PR TITLE
Improve enigme card reorder dragover handling

### DIFF
--- a/tests/js/enigme-cards-reorder.test.js
+++ b/tests/js/enigme-cards-reorder.test.js
@@ -17,9 +17,11 @@ describe('enigme-cards-reorder dragover behavior', () => {
     const card2 = document.getElementById('card2');
     card2.getBoundingClientRect = () => ({ left: 100, top: 0, width: 100, height: 100 });
 
-    const dataTransfer = {};
+    const dataTransfer = { setData: jest.fn() };
     const dragstart = new Event('dragstart', { bubbles: true });
     dragstart.dataTransfer = dataTransfer;
+    Object.defineProperty(dragstart, 'clientX', { value: 0 });
+    Object.defineProperty(dragstart, 'clientY', { value: 0 });
     card1.dispatchEvent(dragstart);
 
     const dragoverAt = (x, y) => {

--- a/tests/js/enigme-cards-reorder.test.js
+++ b/tests/js/enigme-cards-reorder.test.js
@@ -1,0 +1,47 @@
+describe('enigme-cards-reorder dragover behavior', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="cards-grid" data-chasse-id="1">
+        <div id="card1" class="carte-enigme" data-enigme-id="1" draggable="true"></div>
+        <div id="card2" class="carte-enigme" data-enigme-id="2" draggable="true"></div>
+      </div>`;
+    global.wp = { i18n: { __: (s) => s } };
+    jest.resetModules();
+    require('../../wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('reorders based on dominant axis', () => {
+    const grid = document.querySelector('.cards-grid');
+    const card1 = document.getElementById('card1');
+    const card2 = document.getElementById('card2');
+    card2.getBoundingClientRect = () => ({ left: 100, top: 0, width: 100, height: 100 });
+
+    const dataTransfer = {};
+    const dragstart = new Event('dragstart', { bubbles: true });
+    dragstart.dataTransfer = dataTransfer;
+    card1.dispatchEvent(dragstart);
+
+    const dragoverAt = (x, y) => {
+      const ev = new Event('dragover', { bubbles: true });
+      ev.dataTransfer = dataTransfer;
+      ev.preventDefault = () => {};
+      Object.defineProperty(ev, 'clientX', { value: x });
+      Object.defineProperty(ev, 'clientY', { value: y });
+      card2.dispatchEvent(ev);
+    };
+
+    dragoverAt(200, 10);
+    expect(Array.from(grid.children).map((el) => el.id)).toEqual(['card2', 'card1']);
+
+    dragoverAt(100, 10);
+    expect(Array.from(grid.children).map((el) => el.id)).toEqual(['card1', 'card2']);
+
+    dragoverAt(150, 200);
+    expect(Array.from(grid.children).map((el) => el.id)).toEqual(['card2', 'card1']);
+
+    dragoverAt(150, -50);
+    expect(Array.from(grid.children).map((el) => el.id)).toEqual(['card1', 'card2']);
+  });
+});
+

--- a/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
@@ -5,15 +5,24 @@ function initEnigmeCardsReorder() {
   const grid = document.querySelector('.cards-grid');
   if (!grid) return;
 
+  grid
+    .querySelectorAll('.carte-enigme a')
+    .forEach((a) => a.setAttribute('draggable', 'false'));
+
   const addCard = grid.querySelector('#carte-ajout-enigme');
   const addWrapper = addCard?.closest('.carte-ajout-wrapper');
   let dragged = null;
+  let startX = 0;
+  let startY = 0;
 
   grid.addEventListener('dragstart', (e) => {
     const card = e.target.closest('.carte-enigme');
     if (!card || card.id === 'carte-ajout-enigme') return;
     dragged = card;
+    startX = e.clientX;
+    startY = e.clientY;
     e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', '');
     grid.classList.add('dragging');
     dragged.classList.add('dragging');
   });
@@ -29,12 +38,8 @@ function initEnigmeCardsReorder() {
     const rect = target.getBoundingClientRect();
     const centerX = rect.left + rect.width / 2;
     const centerY = rect.top + rect.height / 2;
-    const deltaX = e.clientX - centerX;
-    const deltaY = e.clientY - centerY;
-    const next =
-      Math.abs(deltaX) > Math.abs(deltaY)
-        ? e.clientX > centerX
-        : e.clientY > centerY;
+    const horizontal = Math.abs(e.clientX - startX) > Math.abs(e.clientY - startY);
+    const next = horizontal ? e.clientX > centerX : e.clientY > centerY;
     grid.insertBefore(dragged, next ? target.nextSibling : target);
   });
 

--- a/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
@@ -27,7 +27,14 @@ function initEnigmeCardsReorder() {
     grid.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
     target.classList.add('drag-over');
     const rect = target.getBoundingClientRect();
-    const next = e.clientY > rect.top + rect.height / 2;
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const deltaX = e.clientX - centerX;
+    const deltaY = e.clientY - centerY;
+    const next =
+      Math.abs(deltaX) > Math.abs(deltaY)
+        ? e.clientX > centerX
+        : e.clientY > centerY;
     grid.insertBefore(dragged, next ? target.nextSibling : target);
   });
 


### PR DESCRIPTION
## Résumé
- ajuste le drag des cartes d'énigme pour tenir compte de l'axe dominant
- ajoute un test jest vérifiant le réordonnancement sur les axes horizontal et vertical

## Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b314a3fa508332a3498fcfcaf3edc2