### PR TITLE
Remove duplicate translations in PO files

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -789,11 +789,6 @@ msgstr "Statistics"
 msgid "À venir"
 msgstr ""
 
-#: inc/enigme/cta.php:194
-#, fuzzy
-msgid "Chasse verrouillée"
-msgstr "Hunting not found."
-
 #: inc/enigme/cta.php:195
 msgid "Pré-requis"
 msgstr "Requirements"
@@ -1126,7 +1121,7 @@ msgstr "Canceled"
 msgid "Refusé"
 msgstr "Denied"
 
-#: inc/organisateur-functions.php:457 inc/organisateur-functions.php:559
+#: inc/organisateur-functions.php:457 inc/organisateur-functions.php:559 inc/enigme/cta.php:276
 msgid "En attente"
 msgstr "Pending"
 
@@ -3110,7 +3105,7 @@ msgstr "Login required"
 msgid "Énigme disponible plus tard"
 msgstr "Puzzle available later"
 
-#: inc/enigme/visuels.php:420 inc/enigme/cta.php:210
+#: inc/enigme/cta.php:194 inc/enigme/cta.php:210 inc/enigme/visuels.php:420
 msgid "Chasse verrouillée"
 msgstr "Hunt locked"
 
@@ -3161,10 +3156,6 @@ msgstr "Review"
 #: inc/enigme/cta.php:261
 msgid "Résolue"
 msgstr "Solved"
-
-#: inc/enigme/cta.php:276
-msgid "En attente"
-msgstr "Pending"
 
 #: inc/enigme/cta.php:280
 msgid "Soumise"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -793,11 +793,6 @@ msgstr "Statistiques"
 msgid "À venir"
 msgstr ""
 
-#: inc/enigme/cta.php:194
-#, fuzzy
-msgid "Chasse verrouillée"
-msgstr "Chasse introuvable."
-
 #: inc/enigme/cta.php:195
 msgid "Pré-requis"
 msgstr "Pré-requis"
@@ -1131,7 +1126,7 @@ msgstr "Annulé"
 msgid "Refusé"
 msgstr "Refusé"
 
-#: inc/organisateur-functions.php:457 inc/organisateur-functions.php:559
+#: inc/organisateur-functions.php:457 inc/organisateur-functions.php:559 inc/enigme/cta.php:276
 msgid "En attente"
 msgstr "En attente"
 
@@ -3074,7 +3069,7 @@ msgstr "Connexion requise"
 msgid "Énigme disponible plus tard"
 msgstr "Énigme disponible plus tard"
 
-#: inc/enigme/visuels.php:420 inc/enigme/cta.php:210
+#: inc/enigme/cta.php:194 inc/enigme/cta.php:210 inc/enigme/visuels.php:420
 msgid "Chasse verrouillée"
 msgstr "Chasse verrouillée"
 
@@ -3125,10 +3120,6 @@ msgstr "Revoir"
 #: inc/enigme/cta.php:261
 msgid "Résolue"
 msgstr "Résolue"
-
-#: inc/enigme/cta.php:276
-msgid "En attente"
-msgstr "En attente"
 
 #: inc/enigme/cta.php:280
 msgid "Soumise"


### PR DESCRIPTION
## Summary
- fusion des entrées dupliquées pour "Chasse verrouillée" dans les fichiers de traduction
- fusion des entrées dupliquées pour "En attente" dans les fichiers de traduction
- vérification de la compilation des fichiers PO

## Testing
- `msgfmt wp-content/themes/chassesautresor/languages/*.po -o /dev/null`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3170d9c3883329dacc17206114267