### PR TITLE
CTA de connexion rouge sans message pour les chasses

### DIFF
--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -83,5 +83,18 @@ class GenererCtaChasseTest extends TestCase
             $cta
         );
     }
+
+    public function test_guest_gets_login_cta_without_message(): void
+    {
+        $cta = generer_cta_chasse(123, 0);
+        $this->assertSame(
+            [
+                'cta_html'    => '<a href="https://example.com/mon-compte" class="bouton-cta bouton-cta--color">S\'identifier</a>',
+                'cta_message' => '',
+                'type'        => 'connexion',
+            ],
+            $cta
+        );
+    }
 }
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -604,11 +604,11 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     if (!$user_id) {
         return [
             'cta_html'    => sprintf(
-                '<a href="%s" class="bouton-cta">%s</a>',
+                '<a href="%s" class="bouton-cta bouton-cta--color">%s</a>',
                 esc_url(site_url('/mon-compte')),
                 esc_html__('S\'identifier', 'chassesautresor-com')
             ),
-            'cta_message' => __('Vous devez être identifié pour participer à cette chasse', 'chassesautresor-com'),
+            'cta_message' => '',
             'type'        => 'connexion',
         ];
     }


### PR DESCRIPTION
## Résumé
- Supprime le message imposant l'identification pour participer à une chasse
- Met le bouton de connexion en rouge pour les utilisateurs anonymes
- Ajoute un test couvrant le CTA de connexion

## Testing
- `source ./setup-env.sh`
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3b6249f30833285e7020baaa4d0ea