### PR TITLE
Supprimer l'icône de retour de l'aside chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -45,25 +45,6 @@
   gap: var(--space-sm);
 }
 
-.menu-lateral__back {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: var(--space-xs);
-  color: inherit;
-  text-decoration: none;
-  background: none;
-  border: 1px solid rgba(var(--color-white-rgb, 255, 255, 255), 0.5);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.menu-lateral__back svg {
-  width: 1rem;
-  height: 1rem;
-}
-
 .menu-lateral__title {
   font-size: 1.5rem;
   margin: 0;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1905,25 +1905,6 @@ a.addtoany_share span {
   gap: var(--space-sm);
 }
 
-.menu-lateral__back {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: var(--space-xs);
-  color: inherit;
-  text-decoration: none;
-  background: none;
-  border: 1px solid rgba(var(--color-white-rgb, 255, 255, 255), 0.5);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.menu-lateral__back svg {
-  width: 1rem;
-  height: 1rem;
-}
-
 .menu-lateral__title {
   font-size: 1.5rem;
   margin: 0;

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -219,10 +219,8 @@ if (!function_exists('render_sidebar')) {
 
         echo '<div class="menu-lateral__header">';
         if ($chasse_id) {
-            $url_chasse  = get_permalink($chasse_id);
-            $titre       = get_the_title($chasse_id);
-            $retour_icon = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>';
-            echo '<a class="menu-lateral__back" href="' . esc_url($url_chasse) . '"><span class="screen-reader-text">' . esc_html__("Retour", "chassesautresor-com") . '</span>' . $retour_icon . '</a>';
+            $url_chasse = get_permalink($chasse_id);
+            $titre      = get_the_title($chasse_id);
             echo '<h2 class="menu-lateral__title"><a href="' . esc_url($url_chasse) . '">' . esc_html($titre) . '</a></h2>';
         }
         echo '</div>';


### PR DESCRIPTION
## Résumé
- retire l'icône de retour devant le titre de la chasse
- nettoie le style associé à cette icône

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c2a85f848332b938ba8d39079cef