### PR TITLE
Affichage dynamique du coût des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1278,7 +1278,8 @@ msgstr ""
 msgid "Par"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:227
+#: template-parts/chasse/chasse-affichage-complet.php:355
+#: template-parts/chasse/chasse-affichage-complet.php:355
 #: template-parts/chasse/chasse-card.php:33
 #, php-format
 msgid "%d énigme"
@@ -1286,47 +1287,36 @@ msgid_plural "%d énigmes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:263
+#: template-parts/chasse/chasse-affichage-complet.php:309
 msgid "Limite"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:264
+#: template-parts/chasse/chasse-affichage-complet.php:310
 #, php-format
 msgid "%d gagnant"
 msgid_plural "%d gagnants"
 msgstr[0] ""
 msgstr[1] ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:269
+#: template-parts/chasse/chasse-affichage-complet.php:319
 msgid "Fin de chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:280
+#: template-parts/chasse/chasse-affichage-complet.php:331
 msgid "Accès chasse"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:283
+#: template-parts/chasse/chasse-affichage-complet.php:333
 #, php-format
 msgid "%d points"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:284
+#: template-parts/chasse/chasse-affichage-complet.php:334
 msgid "libre"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:289
-msgid "Accès énigme"
-msgstr ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:294
-#, php-format
-msgid "%d énigme nécessite des points pour soumettre une tentative"
-msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
-msgstr[0] ""
-msgstr[1] ""
-
-#: template-parts/chasse/chasse-affichage-complet.php:305
-msgid "gratuit"
+#: template-parts/chasse/chasse-affichage-complet.php:345
+msgid "Points requis"
 msgstr ""
 
 #: template-parts/chasse/chasse-affichage-complet.php:312
@@ -1563,6 +1553,7 @@ msgid "Vous êtes libre de définir le coût d’accès à votre chasse : gratui
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:617
+#: template-parts/chasse/chasse-affichage-complet.php:364
 msgid "Gratuit"
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1267,6 +1267,7 @@ msgid "Par"
 msgstr "By"
 
 #: template-parts/chasse/chasse-affichage-complet.php:227
+#: template-parts/chasse/chasse-affichage-complet.php:355
 #: template-parts/chasse/chasse-card.php:33
 #, php-format
 msgid "%d énigme"
@@ -1274,7 +1275,7 @@ msgid_plural "%d énigmes"
 msgstr[0] "%d puzzle"
 msgstr[1] "%d puzzles"
 
-#: template-parts/chasse/chasse-affichage-complet.php:263
+#: template-parts/chasse/chasse-affichage-complet.php:309
 msgid "Limite"
 msgstr "Limit"
 
@@ -1302,18 +1303,6 @@ msgstr "%d points"
 msgid "libre"
 msgstr "free"
 
-#: template-parts/chasse/chasse-affichage-complet.php:289
-msgid "Accès énigme"
-msgstr "Riddle access"
-
-#: template-parts/chasse/chasse-affichage-complet.php:294
-#, php-format
-msgid "%d énigme nécessite des points pour soumettre une tentative"
-msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
-msgstr[0] "%d puzzle requires points to submit an attempt"
-msgstr[1] "%d puzzles require points to submit an attempt"
-
-#: template-parts/chasse/chasse-affichage-complet.php:305
 msgid "gratuit"
 msgstr "free"
 
@@ -1564,6 +1553,7 @@ msgstr ""
 "unlocked."
 
 #: template-parts/chasse/chasse-edition-main.php:617
+#: template-parts/chasse/chasse-affichage-complet.php:364
 msgid "Gratuit"
 msgstr "Free"
 
@@ -1578,6 +1568,10 @@ msgstr "Free"
 #: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
 msgid "Points"
 msgstr "Points"
+
+#: template-parts/chasse/chasse-affichage-complet.php:345
+msgid "Points requis"
+msgstr "Points required"
 
 #: template-parts/chasse/chasse-edition-main.php:742
 #: template-parts/enigme/enigme-edition-main.php:663

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1273,13 +1273,13 @@ msgstr "Terminer la chasse"
 msgid "Par"
 msgstr ""
 
-#: template-parts/chasse/chasse-affichage-complet.php:227
+#: template-parts/chasse/chasse-affichage-complet.php:355
 #: template-parts/chasse/chasse-card.php:33
-#, fuzzy, php-format
+#, php-format
 msgid "%d énigme"
 msgid_plural "%d énigmes"
-msgstr[0] "Énigmes"
-msgstr[1] "Énigmes"
+msgstr[0] "%d énigme"
+msgstr[1] "%d énigmes"
 
 #: template-parts/chasse/chasse-affichage-complet.php:263
 #, fuzzy
@@ -1311,21 +1311,9 @@ msgstr "points"
 msgid "libre"
 msgstr "Libre"
 
-#: template-parts/chasse/chasse-affichage-complet.php:289
-#, fuzzy
-msgid "Accès énigme"
-msgstr "Visuel énigme"
-
-#: template-parts/chasse/chasse-affichage-complet.php:294
-#, php-format
-msgid "%d énigme nécessite des points pour soumettre une tentative"
-msgid_plural "%d énigmes nécessitent des points pour soumettre une tentative"
-msgstr[0] ""
-msgstr[1] ""
-
 #: template-parts/chasse/chasse-affichage-complet.php:305
 msgid "gratuit"
-msgstr ""
+msgstr "gratuit"
 
 #: template-parts/chasse/chasse-affichage-complet.php:312
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:30
@@ -1581,8 +1569,9 @@ msgid ""
 msgstr ""
 
 #: template-parts/chasse/chasse-edition-main.php:617
+#: template-parts/chasse/chasse-affichage-complet.php:364
 msgid "Gratuit"
-msgstr ""
+msgstr "Gratuit"
 
 #: template-parts/chasse/chasse-edition-main.php:625
 #: template-parts/chasse/partials/chasse-partial-enigmes.php:32
@@ -1595,6 +1584,10 @@ msgstr ""
 #: templates/myaccount/layout.php:58 templates/myaccount/layout.php:160
 msgid "Points"
 msgstr "Points"
+
+#: template-parts/chasse/chasse-affichage-complet.php:345
+msgid "Points requis"
+msgstr "Points requis"
 
 #: template-parts/chasse/chasse-edition-main.php:742
 #: template-parts/enigme/enigme-edition-main.php:663

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -340,23 +340,28 @@ if ($edition_active && !$est_complet) {
 
             <div class="caracteristique caracteristique-acces-enigme">
               <span class="caracteristique-icone" aria-hidden="true">🧩</span>
-              <span class="caracteristique-label"><?= esc_html__('Accès énigme', 'chassesautresor-com'); ?></span>
+              <span class="caracteristique-label">
+                <?php if ($nb_enigmes_payantes > 0) : ?>
+                  <?= esc_html__('Points requis', 'chassesautresor-com'); ?>
+                <?php else : ?>
+                  <?= esc_html__('Tentatives', 'chassesautresor-com'); ?>
+                <?php endif; ?>
+              </span>
               <span class="caracteristique-valeur">
                 <?php if ($nb_enigmes_payantes > 0) : ?>
-                  <?php
-                  $txt_enigme_payante = sprintf(
-                      _n(
-                          '%d énigme nécessite des points pour soumettre une tentative',
-                          '%d énigmes nécessitent des points pour soumettre une tentative',
-                          $nb_enigmes_payantes,
-                          'chassesautresor-com'
-                      ),
-                      $nb_enigmes_payantes
-                  );
-                  ?>
-                  <?= esc_html($txt_enigme_payante); ?>
+                  <?= esc_html(
+                      sprintf(
+                          _n(
+                              '%d énigme',
+                              '%d énigmes',
+                              $nb_enigmes_payantes,
+                              'chassesautresor-com'
+                          ),
+                          $nb_enigmes_payantes
+                      )
+                  ); ?>
                 <?php else : ?>
-                  <?= esc_html__('gratuit', 'chassesautresor-com'); ?>
+                  <?= esc_html__('Gratuit', 'chassesautresor-com'); ?>
                 <?php endif; ?>
               </span>
             </div>


### PR DESCRIPTION
## Résumé
- ajuste le libellé et le message selon le coût des tentatives d'énigme
- ajoute les traductions associées et corrige la pluralisation

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3c254fdf483329c1044a379553282