### PR TITLE
Réduire le délai de repli de l'aside à 3,5s

### DIFF
--- a/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
+++ b/wp-content/themes/chassesautresor/assets/sidebar/sidebar.js
@@ -14,6 +14,7 @@
       '<span class="screen-reader-text">' + __('Afficher le panneau', 'chassesautresor-com') + '</span>';
     document.body.appendChild(opener);
     let timer = null;
+    const HIDE_DELAY = 3500;
     function hideAside() {
       aside.classList.add('is-hidden');
       opener.style.display = 'flex';
@@ -26,7 +27,7 @@
       aside.classList.remove('is-hidden');
       opener.style.display = 'none';
       if (timer) clearTimeout(timer);
-      timer = setTimeout(hideAside, 5000);
+      timer = setTimeout(hideAside, HIDE_DELAY);
     }
     opener.addEventListener('click', showAside);
     opener.addEventListener('mouseenter', showAside);
@@ -35,7 +36,7 @@
     });
     aside.addEventListener('mouseleave', () => {
       if (timer) clearTimeout(timer);
-      timer = setTimeout(hideAside, 5000);
+      timer = setTimeout(hideAside, HIDE_DELAY);
     });
     function reloadNav(chasseId) {
       if (!chasseId) return;


### PR DESCRIPTION
## Résumé
- Ajuste l'aside des énigmes/chasses pour se masquer après 3,5 s

## Changements notables
- Définit une constante `HIDE_DELAY` à 3,5 s
- Met à jour les temporisations d'ouverture/fermeture du panneau latéral

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3c39196448332b5af2f64614f0c2a