### PR TITLE
Fix obsolete enigme-aside references in translations

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2663,7 +2663,7 @@ msgstr ""
 msgid "Voulez-vous vraiment arrêter la chasse ?"
 msgstr ""
 
-#: assets/js/enigme-aside.js:15
+#: assets/sidebar/sidebar.js:14
 msgid "Afficher le panneau"
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2747,10 +2747,9 @@ msgstr "Do you really want to delete the reward?"
 msgid "Voulez-vous vraiment arrêter la chasse ?"
 msgstr "Do you really want to end the hunt?"
 
-#: assets/js/enigme-aside.js:15
-#, fuzzy
+#: assets/sidebar/sidebar.js:14
 msgid "Afficher le panneau"
-msgstr "Close the panel."
+msgstr "Show the panel"
 
 #: assets/js/enigme-edit.js:857
 msgid "Ex : soleil"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2789,10 +2789,9 @@ msgstr "Voulez-vous vraiment supprimer la récompense ?"
 msgid "Voulez-vous vraiment arrêter la chasse ?"
 msgstr "Voulez-vous vraiment arrêter la chasse ?"
 
-#: assets/js/enigme-aside.js:15
-#, fuzzy
+#: assets/sidebar/sidebar.js:14
 msgid "Afficher le panneau"
-msgstr "Fermer le panneau"
+msgstr "Afficher le panneau"
 
 #: assets/js/enigme-edit.js:857
 msgid "Ex : soleil"


### PR DESCRIPTION
## Summary
- Supprime les références obsolètes au script `enigme-aside` dans les fichiers de langue
- Met à jour les traductions anglaises et françaises pour "Afficher le panneau"
- Recompile les fichiers `.mo` pour synchroniser les traductions

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `msgfmt wp-content/themes/chassesautresor/languages/en_US.po -o wp-content/themes/chassesautresor/languages/en_US.mo`
- `msgfmt wp-content/themes/chassesautresor/languages/fr_FR.po -o wp-content/themes/chassesautresor/languages/fr_FR.mo`


------
https://chatgpt.com/codex/tasks/task_e_68b3c4e15aa88332a48488939f9e4d22