### PR TITLE
feat: add hunt title edit link

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -53,8 +53,12 @@
 
 .menu-lateral__edition-toggle {
   position: absolute;
-  top: var(--space-sm);
   right: var(--space-sm);
+}
+
+.menu-lateral__header:hover .menu-lateral__edition-toggle,
+.menu-lateral__header:focus-within .menu-lateral__edition-toggle {
+  opacity: 1;
 }
 
 .menu-lateral__title a {

--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -56,9 +56,15 @@
   right: var(--space-sm);
 }
 
+.menu-lateral__header .menu-lateral__edition-toggle {
+  color: var(--color-white);
+  transition: color 0.2s ease-in-out;
+}
+
 .menu-lateral__header:hover .menu-lateral__edition-toggle,
 .menu-lateral__header:focus-within .menu-lateral__edition-toggle {
   opacity: 1;
+  color: var(--color-grey-light);
 }
 
 .menu-lateral__title a {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1913,8 +1913,12 @@ a.addtoany_share span {
 
 .menu-lateral__edition-toggle {
   position: absolute;
-  top: var(--space-sm);
   right: var(--space-sm);
+}
+
+.menu-lateral__header:hover .menu-lateral__edition-toggle,
+.menu-lateral__header:focus-within .menu-lateral__edition-toggle {
+  opacity: 1;
 }
 
 .menu-lateral__title a {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1916,9 +1916,15 @@ a.addtoany_share span {
   right: var(--space-sm);
 }
 
+.menu-lateral__header .menu-lateral__edition-toggle {
+  color: var(--color-white);
+  transition: color 0.2s ease-in-out;
+}
+
 .menu-lateral__header:hover .menu-lateral__edition-toggle,
 .menu-lateral__header:focus-within .menu-lateral__edition-toggle {
   opacity: 1;
+  color: var(--color-grey-light);
 }
 
 .menu-lateral__title a {

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -221,7 +221,18 @@ if (!function_exists('render_sidebar')) {
         if ($chasse_id) {
             $url_chasse = get_permalink($chasse_id);
             $titre      = get_the_title($chasse_id);
+            $edit_url   = function_exists('add_query_arg')
+                ? add_query_arg(
+                    ['edition' => 'open', 'tab' => 'param'],
+                    $url_chasse
+                )
+                : $url_chasse . '?edition=open&tab=param';
             echo '<h2 class="menu-lateral__title"><a href="' . esc_url($url_chasse) . '">' . esc_html($titre) . '</a></h2>';
+            echo '<a class="menu-lateral__edition-toggle enigme-menu__edit" href="'
+                . esc_url($edit_url)
+                . '" aria-label="'
+                . esc_attr__('Paramètres', 'chassesautresor-com')
+                . '"><i class="fa-solid fa-gear"></i></a>';
         }
         echo '</div>';
 


### PR DESCRIPTION
## Résumé
- ajout d’un lien d’édition sur le titre de chasse dans l’aside
- affichage de l’icône d’édition au survol du bandeau

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3c7b7c3208332a0b7d9f17d0dab69