### PR TITLE
Affichage d'icônes dans le menu des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -53,26 +53,13 @@
   align-items: center;
   width: 100%;
   margin-bottom: var(--space-xxs);
-  padding-left: calc(var(--space-md) + 16px);
+  padding-left: var(--space-md);
   --bullet-fill: var(--etat-enigme-menu-en-cours);
   --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
 .enigme-menu--editable li {
   cursor: grab;
-}
-
-.enigme-menu li::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 16px;
-  width: 8px;
-  height: 8px;
-  background-color: var(--bullet-fill);
-  box-shadow: 0 0 0 1px var(--bullet-outline);
-  transform: translateY(-50%);
-  border-radius: 50%;
 }
 
 .enigme-menu--editable li .enigme-menu__handle {
@@ -96,8 +83,9 @@
 .enigme-menu li > a:not(.enigme-menu__edit) {
   display: flex;
   align-items: center;
+  gap: var(--space-sm);
   flex: 1;
-  padding: var(--space-xxs) calc(var(--space-sm) + 1.5em);
+  padding: var(--space-xxs) calc(var(--space-sm) + 1.5em) var(--space-xxs) var(--space-sm);
   font-weight: 600;
   font-size: 0.9rem;
   color: inherit;
@@ -119,6 +107,40 @@
 
 .enigme-menu li > a:not(.enigme-menu__edit):visited {
   color: inherit;
+}
+
+.enigme-menu__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--bullet-fill);
+}
+
+.enigme-menu__icon svg,
+.enigme-menu__icon i {
+  width: 100%;
+  height: 100%;
+  color: var(--bullet-fill);
+  stroke: var(--bullet-fill);
+  fill: var(--bullet-fill);
+}
+
+.enigme-menu__icon--circle {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--bullet-fill);
+  box-shadow: 0 0 0 1px var(--bullet-outline);
+}
+
+.enigme-menu__cost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .enigme-menu:not(.enigme-menu--editable) li.bloquee > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4928,26 +4928,13 @@ body.panneau-ouvert::before {
   align-items: center;
   width: 100%;
   margin-bottom: var(--space-xxs);
-  padding-left: calc(var(--space-md) + 16px);
+  padding-left: var(--space-md);
   --bullet-fill: var(--etat-enigme-menu-en-cours);
   --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
 .enigme-menu--editable li {
   cursor: grab;
-}
-
-.enigme-menu li::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 16px;
-  width: 8px;
-  height: 8px;
-  background-color: var(--bullet-fill);
-  box-shadow: 0 0 0 1px var(--bullet-outline);
-  transform: translateY(-50%);
-  border-radius: 50%;
 }
 
 .enigme-menu--editable li .enigme-menu__handle {
@@ -4971,8 +4958,9 @@ body.panneau-ouvert::before {
 .enigme-menu li > a:not(.enigme-menu__edit) {
   display: flex;
   align-items: center;
+  gap: var(--space-sm);
   flex: 1;
-  padding: var(--space-xxs) calc(var(--space-sm) + 1.5em);
+  padding: var(--space-xxs) calc(var(--space-sm) + 1.5em) var(--space-xxs) var(--space-sm);
   font-weight: 600;
   font-size: 0.9rem;
   color: inherit;
@@ -4994,6 +4982,40 @@ body.panneau-ouvert::before {
 
 .enigme-menu li > a:not(.enigme-menu__edit):visited {
   color: inherit;
+}
+
+.enigme-menu__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--bullet-fill);
+}
+
+.enigme-menu__icon svg,
+.enigme-menu__icon i {
+  width: 100%;
+  height: 100%;
+  color: var(--bullet-fill);
+  stroke: var(--bullet-fill);
+  fill: var(--bullet-fill);
+}
+
+.enigme-menu__icon--circle {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--bullet-fill);
+  box-shadow: 0 0 0 1px var(--bullet-outline);
+}
+
+.enigme-menu__cost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .enigme-menu:not(.enigme-menu--editable) li.bloquee > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -771,8 +771,9 @@ require_once __DIR__ . '/../sidebar.php';
             $classes = [];
 
             if (!$skip_checks) {
-                $etat_sys       = get_field('enigme_cache_etat_systeme', $post->ID) ?? 'accessible';
-                $condition_acces = get_field('enigme_acces_condition', $post->ID) ?? 'immediat';
+                $etat_sys_initial = get_field('enigme_cache_etat_systeme', $post->ID) ?? 'accessible';
+                $etat_sys         = $etat_sys_initial;
+                $condition_acces  = get_field('enigme_acces_condition', $post->ID) ?? 'immediat';
 
                 if (in_array($etat_sys, ['invalide', 'cache_invalide'], true)) {
                     continue;
@@ -819,6 +820,10 @@ require_once __DIR__ . '/../sidebar.php';
                         $classes[] = 'non-engagee';
                     }
                 }
+
+                if ($etat_sys_initial === 'bloquee_pre_requis') {
+                    $classes[] = 'bloquee';
+                }
             }
 
             if ($post->ID === $enigme_id) {
@@ -851,9 +856,32 @@ require_once __DIR__ . '/../sidebar.php';
                 }
             }
 
-            $title        = esc_html(get_the_title($post->ID));
-            $aria_current = $post->ID === $enigme_id ? ' aria-current="page"' : '';
-            $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
+            $title         = esc_html(get_the_title($post->ID));
+            $aria_current  = $post->ID === $enigme_id ? ' aria-current="page"' : '';
+            $mode_validation = get_field('enigme_mode_validation', $post->ID) ?? 'aucune';
+            $cout_points     = (int) get_field('enigme_tentative_cout_points', $post->ID);
+
+            $icon_html = '<span class="enigme-menu__icon enigme-menu__icon--circle" aria-hidden="true"></span>';
+            if ($etat_sys_initial === 'bloquee_date') {
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . get_svg_icon('hourglass') . '</span>';
+            } elseif ($etat_sys_initial === 'bloquee_pre_requis') {
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . get_svg_icon('lock') . '</span>';
+            } elseif ($mode_validation === 'automatique') {
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-bolt"></i></span>';
+            } elseif ($mode_validation === 'manuelle') {
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-envelope"></i></span>';
+            }
+
+            $cost_html = '';
+            if ($mode_validation !== 'aucune' && $cout_points > 0) {
+                $cost_html = '<span class="enigme-menu__cost" aria-hidden="true"><i class="fa-solid fa-coins"></i></span>';
+            }
+
+            $link = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>'
+                . $icon_html
+                . '<span class="enigme-menu__title">' . $title . '</span>'
+                . $cost_html
+                . '</a>';
 
             $submenu_items[] = sprintf(
                 '<li class="%s" data-enigme-id="%d">%s%s%s</li>',


### PR DESCRIPTION
## Résumé
- améliore le menu latéral des énigmes en affichant des icônes selon le mode de validation ou l'état de l'énigme
- indique le coût d'une tentative via une icône de pièce
- adapte le style des éléments pour intégrer ces nouvelles icônes

## Changements notables
- ajout de la logique d'icônes pour le mode de validation, les prérequis et la date programmée
- affichage de l'icône de coût des tentatives
- refonte CSS du menu des énigmes avec prise en charge des icônes

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d0da62fc833283454a9f49ecc56d