### PR TITLE
Fix persistent correction messages after validation request

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -320,18 +320,24 @@ function myaccount_remove_persistent_message(int $user_id, string $key): void
  */
 function myaccount_clear_correction_message(int $chasse_id): void
 {
-    $current = get_current_user_id();
-    $organisateur_id = get_organisateur_from_chasse($chasse_id);
-    $users = $organisateur_id ? (array) get_field('utilisateurs_associes', $organisateur_id) : [];
+    $current          = get_current_user_id();
+    $organisateur_id  = get_organisateur_from_chasse($chasse_id);
+    $users            = $organisateur_id ? (array) get_field('utilisateurs_associes', $organisateur_id) : [];
 
-    $user_ids = array_unique(array_merge([
-        $current,
-    ], array_map(
+    $user_ids = array_map(
         static function ($uid) {
             return is_object($uid) ? (int) $uid->ID : (int) $uid;
         },
         $users
-    )));
+    );
+
+    $user_ids[] = $current;
+
+    if ($organisateur_id) {
+        $user_ids[] = (int) $organisateur_id;
+    }
+
+    $user_ids = array_unique($user_ids);
 
     foreach ($user_ids as $uid) {
         myaccount_remove_persistent_message($uid, 'correction_chasse_' . $chasse_id);

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -420,11 +420,19 @@ class MyAccountMessagesTest extends TestCase
                 'correction_chasse_123' => ['text' => 'X', 'type' => 'info'],
             ]
         );
+        update_user_meta(
+            99,
+            '_myaccount_messages',
+            [
+                'correction_chasse_123' => ['text' => 'X', 'type' => 'info'],
+            ]
+        );
 
         myaccount_clear_correction_message(123);
 
         $this->assertSame([], get_user_meta(1, '_myaccount_messages', true));
         $this->assertSame([], get_user_meta(2, '_myaccount_messages', true));
+        $this->assertSame([], get_user_meta(99, '_myaccount_messages', true));
     }
 
     public function test_scoped_message_only_on_related_pages(): void


### PR DESCRIPTION
## Résumé
- corrige la suppression incomplète du message de correction lors d’une nouvelle demande de validation
- étend les tests pour couvrir l’organisateur principal

## Changements notables
- supprime le message pour tous les comptes liés à la chasse
- ajoute un test garantissant la suppression pour l’organisateur et les co-organisateurs

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3d425a8bc833290ddfc720e3f7aa3