### PR TITLE
feat: afficher les icônes de validation dans le menu des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -185,6 +185,31 @@ li.active .enigme-menu__edit {
   }
 }
 
+.enigme-menu li.validation-automatique::before,
+.enigme-menu li.validation-manuelle::before {
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  background: none;
+  box-shadow: none;
+  border-radius: 0;
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bullet-fill);
+}
+
+.enigme-menu li.validation-automatique::before {
+  content: '\f0e7';
+}
+
+.enigme-menu li.validation-manuelle::before {
+  content: '\f0e0';
+}
+
 .enigme-menu li.en-attente {
   --bullet-fill: var(--etat-enigme-menu-en-attente);
   --bullet-outline: var(--etat-enigme-menu-en-attente);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5058,6 +5058,31 @@ li.active .enigme-menu__edit {
     transform: scale(1.1);
   }
 }
+.enigme-menu li.validation-automatique::before,
+.enigme-menu li.validation-manuelle::before {
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  background: none;
+  box-shadow: none;
+  border-radius: 0;
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bullet-fill);
+}
+
+.enigme-menu li.validation-automatique::before {
+  content: "\f0e7";
+}
+
+.enigme-menu li.validation-manuelle::before {
+  content: "\f0e0";
+}
+
 .enigme-menu li.en-attente {
   --bullet-fill: var(--etat-enigme-menu-en-attente);
   --bullet-outline: var(--etat-enigme-menu-en-attente);

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -821,6 +821,14 @@ require_once __DIR__ . '/../sidebar.php';
                 }
             }
 
+            // Ajoute une classe selon le mode de validation de l'énigme
+            $mode_validation = get_field('enigme_mode_validation', $post->ID) ?? 'aucune';
+            if ($mode_validation === 'automatique') {
+                $classes[] = 'validation-automatique';
+            } elseif ($mode_validation === 'manuelle') {
+                $classes[] = 'validation-manuelle';
+            }
+
             if ($post->ID === $enigme_id) {
                 $classes[] = 'active';
             }


### PR DESCRIPTION
## Résumé
- affiche une icône d'éclair ou d'enveloppe selon le mode de validation
- ajoute les classes PHP correspondantes pour chaque énigme
- régénère la feuille de style du thème

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3d9450f588332b471ee1651281094