### PR TITLE
Clarify CTA and riddle access for non-participants

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -686,11 +686,11 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
             $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
             $html .= sprintf(
-                '<button type="submit" class="bouton-cta">%s</button>',
+                '<button type="submit" class="bouton-cta bouton-cta--color">%s</button>',
                 esc_html__('Participer', 'chassesautresor-com')
             );
             $html .= '</form>';
-            $message = __('Accès libre à cette chasse. Les tentatives seront tarifées individuellement.', 'chassesautresor-com');
+            $message = '';
             $type    = 'engager';
         }
     } elseif ($statut === 'termine') {

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -683,21 +683,25 @@ msgstr ""
 msgid "Les énigmes seront affichées au début de la chasse, le %s."
 msgstr ""
 
-#: single-chasse.php:141
+#: single-chasse.php:142
 #, php-format
 msgid "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
 msgstr ""
 
-#: single-chasse.php:145
+#: single-chasse.php:146
 msgid "Voici les énigmes de cette chasse."
 msgstr ""
 
 #: single-chasse.php:149
+msgid "L'accès aux énigmes est réservé aux participants de chasse. Inscrivez-vous !"
+msgstr ""
+
+#: single-chasse.php:153
 #, php-format
 msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 msgstr ""
 
-#: single-chasse.php:159
+#: single-chasse.php:163
 msgid "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
 msgstr ""
 

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -672,21 +672,25 @@ msgstr "The hunt is over. The riddles remain accessible."
 msgid "Les énigmes seront affichées au début de la chasse, le %s."
 msgstr "Riddles will be displayed at the start of the hunt on %s."
 
-#: single-chasse.php:141
+#: single-chasse.php:142
 #, php-format
 msgid "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
 msgstr "Here are the riddles of this hunt. Solve them for a chance to win %s."
 
-#: single-chasse.php:145
+#: single-chasse.php:146
 msgid "Voici les énigmes de cette chasse."
 msgstr "Here are the riddles of this hunt."
 
 #: single-chasse.php:149
+msgid "L'accès aux énigmes est réservé aux participants de chasse. Inscrivez-vous !"
+msgstr "Access to the riddles is reserved for hunt participants. Sign up!"
+
+#: single-chasse.php:153
 #, php-format
 msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 msgstr "Progress: %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 
-#: single-chasse.php:159
+#: single-chasse.php:163
 msgid "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
 msgstr "Here are your riddles: add, edit, or delete them as needed!"
 

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -673,21 +673,25 @@ msgstr "La chasse est terminée. Les énigmes restent consultables."
 msgid "Les énigmes seront affichées au début de la chasse, le %s."
 msgstr "Les énigmes seront affichées au début de la chasse, le %s."
 
-#: single-chasse.php:141
+#: single-chasse.php:142
 #, php-format
 msgid "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
 msgstr "Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s."
 
-#: single-chasse.php:145
+#: single-chasse.php:146
 msgid "Voici les énigmes de cette chasse."
 msgstr "Voici les énigmes de cette chasse."
 
 #: single-chasse.php:149
+msgid "L'accès aux énigmes est réservé aux participants de chasse. Inscrivez-vous !"
+msgstr "L'accès aux énigmes est réservé aux participants de chasse. Inscrivez-vous !"
+
+#: single-chasse.php:153
 #, php-format
 msgid "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 msgstr "Progression : %1$d/%2$d %3$s — %4$d/%5$d %6$s."
 
-#: single-chasse.php:159
+#: single-chasse.php:163
 msgid "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
 msgstr "Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !"
 

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -136,13 +136,17 @@ if ($statut === 'termine') {
     );
 } elseif (in_array($statut, ['en_cours', 'payante'], true) && $statut_validation === 'valide') {
     if ($nb_engagees === 0) {
-        if ($titre_recompense) {
-            $enigmes_intro = sprintf(
-                esc_html__('Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s.', 'chassesautresor-com'),
-                esc_html($titre_recompense)
-            );
+        if ($est_orga_associe) {
+            if ($titre_recompense) {
+                $enigmes_intro = sprintf(
+                    esc_html__('Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s.', 'chassesautresor-com'),
+                    esc_html($titre_recompense)
+                );
+            } else {
+                $enigmes_intro = esc_html__('Voici les énigmes de cette chasse.', 'chassesautresor-com');
+            }
         } else {
-            $enigmes_intro = esc_html__('Voici les énigmes de cette chasse.', 'chassesautresor-com');
+            $enigmes_intro = esc_html__('L\'accès aux énigmes est réservé aux participants de chasse. Inscrivez-vous !', 'chassesautresor-com');
         }
     } else {
         $enigmes_intro = sprintf(
@@ -160,22 +164,6 @@ if ($statut === 'termine') {
         'Voici vos énigmes : ajoutez, modifiez ou supprimez celles dont vous n’avez plus besoin !',
         'chassesautresor-com'
     );
-}
-
-if (
-    $enigmes_intro === ''
-    && $est_orga_associe
-    && in_array($statut, ['en_cours', 'payante'], true)
-    && $nb_engagees === 0
-) {
-    if ($titre_recompense) {
-        $enigmes_intro = sprintf(
-            esc_html__('Voici les énigmes de cette chasse. Résolvez-les pour tenter de remporter %s.', 'chassesautresor-com'),
-            esc_html($titre_recompense)
-        );
-    } else {
-        $enigmes_intro = esc_html__('Voici les énigmes de cette chasse.', 'chassesautresor-com');
-    }
 }
 
 if (!is_user_logged_in()) {


### PR DESCRIPTION
Correction du CTA des chasses et du message d'accès aux énigmes pour les joueurs non engagés.

- suppression du message d'accès libre et ajout de la couleur d'action au bouton
- affichage d'un message incitant à l'inscription pour accéder aux énigmes
- mise à jour des fichiers de traduction

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3df9deddc83329236bdb0e18c7cd7