### PR TITLE
Filter visible enigmas in menu rendering

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -1,6 +1,7 @@
 <?php
 defined('ABSPATH') || exit;
 require_once __DIR__ . '/../sidebar.php';
+require_once __DIR__ . '/utils.php';
 
     // ==================================================
     // 🎨 AFFICHAGE STYLISÉ DES ÉNIGMES
@@ -756,6 +757,10 @@ require_once __DIR__ . '/../sidebar.php';
         $peut_ajouter_enigme = false;
         if ($chasse_id && function_exists('utilisateur_peut_ajouter_enigme')) {
             $peut_ajouter_enigme = utilisateur_peut_ajouter_enigme($chasse_id);
+        }
+
+        if (!$is_privileged) {
+            $liste = filter_visible_enigmes($liste, $user_id);
         }
 
         foreach ($liste as $post) {


### PR DESCRIPTION
Assure que le menu des énigmes respecte les mêmes règles de visibilité que la page chasse.

- Ajout de l'inclusion de `utils.php` pour accéder aux fonctions de filtrage.
- Application de `filter_visible_enigmes()` avant de générer les éléments de menu.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3dfcb9eec833293b1d537dd1df427