### PR TITLE
Masquer l'icône d'édition de chasse pour les utilisateurs non autorisés

### DIFF
--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -221,18 +221,25 @@ if (!function_exists('render_sidebar')) {
         if ($chasse_id) {
             $url_chasse = get_permalink($chasse_id);
             $titre      = get_the_title($chasse_id);
-            $edit_url   = function_exists('add_query_arg')
-                ? add_query_arg(
-                    ['edition' => 'open', 'tab' => 'param'],
-                    $url_chasse
-                )
-                : $url_chasse . '?edition=open&tab=param';
+            $can_edit   = function_exists('utilisateur_peut_voir_panneau')
+                ? utilisateur_peut_voir_panneau($chasse_id)
+                : false;
+
             echo '<h2 class="menu-lateral__title"><a href="' . esc_url($url_chasse) . '">' . esc_html($titre) . '</a></h2>';
-            echo '<a class="menu-lateral__edition-toggle enigme-menu__edit" href="'
-                . esc_url($edit_url)
-                . '" aria-label="'
-                . esc_attr__('Paramètres', 'chassesautresor-com')
-                . '"><i class="fa-solid fa-gear"></i></a>';
+
+            if ($can_edit) {
+                $edit_url = function_exists('add_query_arg')
+                    ? add_query_arg(
+                        ['edition' => 'open', 'tab' => 'param'],
+                        $url_chasse
+                    )
+                    : $url_chasse . '?edition=open&tab=param';
+                echo '<a class="menu-lateral__edition-toggle enigme-menu__edit" href="'
+                    . esc_url($edit_url)
+                    . '" aria-label="'
+                    . esc_attr__('Paramètres', 'chassesautresor-com')
+                    . '"><i class="fa-solid fa-gear"></i></a>';
+            }
         }
         echo '</div>';
 


### PR DESCRIPTION
### Résumé
- cache l'icône de réglage dans l'aside chasse lorsque l'utilisateur n'a pas accès au panneau d'édition

### Changements notables
- vérification de `utilisateur_peut_voir_panneau` avant d'afficher le lien d'édition de la chasse

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3e3fae5f48332b4cdb1ffd70d430d