### PR TITLE
Align hunt sidebar with enigma visibility rules

### DIFF
--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -59,20 +59,7 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
         if ($is_privileged) {
             $liste = $all_enigmes;
         } else {
-            $is_engage_dans_chasse = function_exists('utilisateur_est_engage_dans_chasse')
-                ? utilisateur_est_engage_dans_chasse($user_id, $chasse_id)
-                : false;
-
-            $liste = array_values(
-                array_filter(
-                    $all_enigmes,
-                    static function ($post) use ($is_engage_dans_chasse) {
-                        return $is_engage_dans_chasse
-                            && get_post_status($post->ID) === 'publish'
-                            && (bool) get_field('enigme_cache_complet', $post->ID);
-                    }
-                )
-            );
+            $liste = filter_visible_enigmes($all_enigmes, $user_id);
         }
 
         $visible_ids = [];


### PR DESCRIPTION
Aligne la navigation des chasses sur la logique de visibilité des énigmes.

- Utilise `filter_visible_enigmes` pour ne lister que les énigmes réellement visibles dans la barre latérale des chasses

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b3ea06729083328aa84f02ce7d4ef6