### PR TITLE
feat: refine chasse navigation

### DIFF
--- a/tests/SidebarPrepareChasseNavTest.php
+++ b/tests/SidebarPrepareChasseNavTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+if (!function_exists('get_field')) {
+    function get_field($key, $post_id)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('utilisateur_peut_ajouter_enigme')) {
+    function utilisateur_peut_ajouter_enigme($chasse_id)
+    {
+        return false;
+    }
+}
+
+if (!function_exists('utilisateur_est_engage_dans_enigme')) {
+    function utilisateur_est_engage_dans_enigme($user_id, $enigme_id)
+    {
+        return false;
+    }
+}
+
+if (!function_exists('get_the_title')) {
+    function get_the_title($id)
+    {
+        return 'Enigme ' . $id;
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($id)
+    {
+        return '#';
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($text)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback)
+    {
+    }
+}
+
+if (!function_exists('user_can')) {
+    function user_can($user_id, $cap)
+    {
+        return $GLOBALS['is_admin'] ?? false;
+    }
+}
+
+if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+    function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+    {
+        return $GLOBALS['is_orga_assoc'] ?? false;
+    }
+}
+
+if (!function_exists('recuperer_enigmes_pour_chasse')) {
+    function recuperer_enigmes_pour_chasse($chasse_id)
+    {
+        return [
+            (object) ['ID' => 1],
+            (object) ['ID' => 2],
+        ];
+    }
+}
+
+if (!function_exists('get_cta_enigme')) {
+    function get_cta_enigme($enigme_id, $user_id)
+    {
+        return $GLOBALS['ctas'][$enigme_id];
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/sidebar.php';
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SidebarPrepareChasseNavTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['ctas'] = [
+            1 => [
+                'etat_systeme'      => 'accessible',
+                'statut_utilisateur' => 'non_commencee',
+            ],
+            2 => [
+                'etat_systeme'      => 'bloquee_pre_requis',
+                'statut_utilisateur' => 'non_commencee',
+            ],
+        ];
+
+        $GLOBALS['is_admin'] = false;
+        $GLOBALS['is_orga_assoc'] = false;
+    }
+
+    public function test_player_skips_blocked_enigma(): void
+    {
+        $data = sidebar_prepare_chasse_nav(10, 5);
+
+        $this->assertSame([1], $data['visible_ids']);
+    }
+
+    public function test_admin_sees_all_enigmas(): void
+    {
+        $GLOBALS['is_admin'] = true;
+
+        $data = sidebar_prepare_chasse_nav(10, 5);
+
+        $this->assertSame([1, 2], $data['visible_ids']);
+    }
+
+    public function test_associated_organizer_sees_all_enigmas(): void
+    {
+        $GLOBALS['is_orga_assoc'] = true;
+
+        $data = sidebar_prepare_chasse_nav(10, 5);
+
+        $this->assertSame([1, 2], $data['visible_ids']);
+    }
+}
+

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -52,18 +52,29 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
             ? utilisateur_peut_ajouter_enigme($chasse_id)
             : false;
 
+        $is_privileged = user_can($user_id, 'manage_options')
+            || (
+                function_exists('utilisateur_est_organisateur_associe_a_chasse')
+                && utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+            );
+
         $visible_ids = [];
 
         foreach ($all_enigmes as $post) {
             $cta = get_cta_enigme($post->ID, $user_id);
 
-            if (in_array($cta['etat_systeme'], ['bloquee_date', 'bloquee_pre_requis'], true)) {
+            if (
+                !$is_privileged
+                && in_array($cta['etat_systeme'], ['bloquee_date', 'bloquee_pre_requis'], true)
+            ) {
                 continue;
             }
 
             $classes = [];
 
-            if ($cta['etat_systeme'] === 'bloquee_chasse') {
+            if (in_array($cta['etat_systeme'], ['bloquee_date', 'bloquee_pre_requis'], true)) {
+                $classes[] = 'bloquee';
+            } elseif ($cta['etat_systeme'] === 'bloquee_chasse') {
                 if (!get_field('enigme_cache_complet', $post->ID)) {
                     $classes[] = 'incomplete';
                 } else {


### PR DESCRIPTION
## Summary
- remplace le filtrage des énigmes visibles par un contrôle via CTA
- ajoute le calcul de la classe de puce selon l'état de chaque énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3ee63e1448332ae32d7943061fddf