### PR TITLE
Aligner les classes du menu des énigmes avec les états documentés

### DIFF
--- a/tests/EnigmeMenuVisibilityTest.php
+++ b/tests/EnigmeMenuVisibilityTest.php
@@ -33,6 +33,13 @@ if (!function_exists('est_organisateur')) {
     }
 }
 
+if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+    function utilisateur_est_engage_dans_chasse($user_id, $chasse_id)
+    {
+        return $GLOBALS['is_engaged'] ?? false;
+    }
+}
+
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/affichage.php';
 
 /**
@@ -49,6 +56,7 @@ class EnigmeMenuVisibilityTest extends TestCase
         $GLOBALS['is_admin'] = false;
         $GLOBALS['is_associated'] = false;
         $GLOBALS['is_organizer'] = false;
+        $GLOBALS['is_engaged'] = true;
     }
 
     public function test_menu_visible_for_associated_organizer(): void
@@ -62,5 +70,17 @@ class EnigmeMenuVisibilityTest extends TestCase
     public function test_menu_hidden_for_other_roles_in_revision(): void
     {
         $this->assertFalse(enigme_user_can_see_menu(1, 2, 'revision'));
+    }
+
+    public function test_menu_hidden_for_non_engaged_user(): void
+    {
+        $GLOBALS['is_engaged'] = false;
+        $this->assertFalse(enigme_user_can_see_menu(1, 2, 'en_cours'));
+    }
+
+    public function test_menu_hidden_for_anonymous_user(): void
+    {
+        $GLOBALS['is_engaged'] = false;
+        $this->assertFalse(enigme_user_can_see_menu(0, 2, 'en_cours'));
     }
 }

--- a/tests/SidebarPrepareChasseNavTest.php
+++ b/tests/SidebarPrepareChasseNavTest.php
@@ -291,9 +291,9 @@ class SidebarPrepareChasseNavTest extends TestCase
         $items = $data['menu_items'];
 
         $this->assertStringContainsString('enigme-menu__icon--bullet', $items[0]);
-        $this->assertStringContainsString('fa-bolt', $items[1]);
-        $this->assertStringContainsString('fa-envelope', $items[2]);
-        $this->assertStringContainsString('fa-coins', $items[2]);
+        $this->assertStringContainsString('Réponse automatique', $items[1]);
+        $this->assertStringContainsString('validation manuelle', $items[2]);
+        $this->assertStringContainsString("l'accès à cette chasse nécessite des points", $items[2]);
         $this->assertStringContainsString('hourglass', $items[3]);
         $this->assertStringContainsString('lock', $items[4]);
     }

--- a/tests/SidebarPrepareChasseNavTest.php
+++ b/tests/SidebarPrepareChasseNavTest.php
@@ -293,9 +293,56 @@ class SidebarPrepareChasseNavTest extends TestCase
         $this->assertStringContainsString('fa-eye', $items[0]);
         $this->assertStringContainsString('fa-bolt', $items[1]);
         $this->assertStringContainsString('fa-envelope', $items[2]);
-        $this->assertStringContainsString("l'accès à cette chasse nécessite des points", $items[2]);
+        $this->assertStringContainsString('<span class="enigme-menu__cost"', $items[2]);
         $this->assertStringContainsString('hourglass', $items[3]);
         $this->assertStringContainsString('lock', $items[4]);
+    }
+
+    public function test_menu_item_icons_for_associated_organizer(): void
+    {
+        $GLOBALS['is_orga_assoc'] = true;
+        $GLOBALS['posts']        = [
+            (object) ['ID' => 1],
+            (object) ['ID' => 2],
+            (object) ['ID' => 3],
+        ];
+
+        $GLOBALS['ctas'] = [
+            1 => [
+                'etat_systeme'       => 'accessible',
+                'statut_utilisateur' => 'en_cours',
+            ],
+            2 => [
+                'etat_systeme'       => 'accessible',
+                'statut_utilisateur' => 'en_cours',
+            ],
+            3 => [
+                'etat_systeme'       => 'accessible',
+                'statut_utilisateur' => 'en_cours',
+            ],
+        ];
+
+        $GLOBALS['get_field_values'] = [
+            1 => [
+                'enigme_mode_validation'       => 'aucune',
+                'enigme_tentative_cout_points' => 0,
+            ],
+            2 => [
+                'enigme_mode_validation'       => 'automatique',
+                'enigme_tentative_cout_points' => 0,
+            ],
+            3 => [
+                'enigme_mode_validation'       => 'manuelle',
+                'enigme_tentative_cout_points' => 5,
+            ],
+        ];
+
+        $data  = sidebar_prepare_chasse_nav(10, 5);
+        $items = $data['menu_items'];
+
+        $this->assertStringContainsString('fa-bolt', $items[1]);
+        $this->assertStringContainsString('fa-envelope', $items[2]);
+        $this->assertStringContainsString('<span class="enigme-menu__cost"', $items[2]);
     }
 }
 

--- a/tests/SidebarPrepareChasseNavTest.php
+++ b/tests/SidebarPrepareChasseNavTest.php
@@ -290,9 +290,9 @@ class SidebarPrepareChasseNavTest extends TestCase
         $data  = sidebar_prepare_chasse_nav(10, 5);
         $items = $data['menu_items'];
 
-        $this->assertStringContainsString('enigme-menu__icon--bullet', $items[0]);
-        $this->assertStringContainsString('Réponse automatique', $items[1]);
-        $this->assertStringContainsString('validation manuelle', $items[2]);
+        $this->assertStringContainsString('fa-eye', $items[0]);
+        $this->assertStringContainsString('fa-bolt', $items[1]);
+        $this->assertStringContainsString('fa-envelope', $items[2]);
         $this->assertStringContainsString("l'accès à cette chasse nécessite des points", $items[2]);
         $this->assertStringContainsString('hourglass', $items[3]);
         $this->assertStringContainsString('lock', $items[4]);

--- a/tests/SidebarPrepareChasseNavTest.php
+++ b/tests/SidebarPrepareChasseNavTest.php
@@ -190,18 +190,112 @@ class SidebarPrepareChasseNavTest extends TestCase
             ],
         ];
 
-        $GLOBALS['engagements'] = [1 => true];
-        $GLOBALS['get_field_values'] = [6 => ['enigme_cache_complet' => false]];
+        $GLOBALS['engagements']      = [1 => true];
+        $GLOBALS['get_field_values'] = [
+            1 => [
+                'enigme_tentative_cout_points' => 0,
+                'enigme_mode_validation'       => 'aucune',
+            ],
+            2 => [
+                'enigme_tentative_cout_points' => 0,
+                'enigme_mode_validation'       => 'aucune',
+            ],
+            3 => [
+                'enigme_tentative_cout_points' => 0,
+                'enigme_mode_validation'       => 'aucune',
+            ],
+            4 => [
+                'enigme_tentative_cout_points' => 0,
+                'enigme_mode_validation'       => 'aucune',
+            ],
+            5 => [
+                'enigme_tentative_cout_points' => 0,
+                'enigme_mode_validation'       => 'aucune',
+            ],
+            6 => [
+                'enigme_cache_complet'         => false,
+                'enigme_tentative_cout_points' => 0,
+                'enigme_mode_validation'       => 'aucune',
+            ],
+        ];
 
         $data = sidebar_prepare_chasse_nav(10, 5);
         $items = $data['menu_items'];
 
-        $this->assertStringNotContainsString('class=', $items[0]);
+        $this->assertStringContainsString('<li data-enigme-id="1">', $items[0]);
         $this->assertStringContainsString('class="non-engagee"', $items[1]);
         $this->assertStringContainsString('class="succes"', $items[2]);
         $this->assertStringContainsString('class="bloquee"', $items[3]);
         $this->assertStringContainsString('class="en-attente"', $items[4]);
         $this->assertStringContainsString('class="incomplete"', $items[5]);
+    }
+
+    public function test_menu_item_icons_are_displayed(): void
+    {
+        $GLOBALS['is_admin'] = true;
+        $GLOBALS['posts']    = [
+            (object) ['ID' => 1],
+            (object) ['ID' => 2],
+            (object) ['ID' => 3],
+            (object) ['ID' => 4],
+            (object) ['ID' => 5],
+        ];
+
+        $GLOBALS['ctas'] = [
+            1 => [
+                'etat_systeme'       => 'accessible',
+                'statut_utilisateur' => 'en_cours',
+            ],
+            2 => [
+                'etat_systeme'       => 'accessible',
+                'statut_utilisateur' => 'en_cours',
+            ],
+            3 => [
+                'etat_systeme'       => 'accessible',
+                'statut_utilisateur' => 'en_cours',
+            ],
+            4 => [
+                'etat_systeme'       => 'bloquee_date',
+                'statut_utilisateur' => 'non_commencee',
+            ],
+            5 => [
+                'etat_systeme'       => 'bloquee_pre_requis',
+                'statut_utilisateur' => 'non_commencee',
+            ],
+        ];
+
+        $GLOBALS['get_field_values'] = [
+            1 => [
+                'enigme_mode_validation'       => 'aucune',
+                'enigme_tentative_cout_points' => 0,
+            ],
+            2 => [
+                'enigme_mode_validation'       => 'automatique',
+                'enigme_tentative_cout_points' => 0,
+            ],
+            3 => [
+                'enigme_mode_validation'       => 'manuelle',
+                'enigme_tentative_cout_points' => 5,
+            ],
+            4 => [
+                'enigme_mode_validation'       => 'aucune',
+                'enigme_tentative_cout_points' => 0,
+            ],
+            5 => [
+                'enigme_mode_validation'       => 'aucune',
+                'enigme_tentative_cout_points' => 0,
+            ],
+        ];
+
+        $data  = sidebar_prepare_chasse_nav(10, 5);
+        $items = $data['menu_items'];
+
+        $this->assertStringContainsString('enigme-menu__icon--bullet', $items[0]);
+        $this->assertStringContainsString('fa-bolt', $items[1]);
+        $this->assertStringContainsString('fa-envelope', $items[2]);
+        $this->assertStringContainsString('fa-coins', $items[2]);
+        $this->assertStringContainsString('hourglass', $items[3]);
+        $this->assertStringContainsString('lock', $items[4]);
     }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -58,17 +58,35 @@
   --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
-.enigme-menu li::before {
-  content: '';
+.enigme-menu__icon {
   position: absolute;
   top: 50%;
   left: 16px;
   width: 8px;
   height: 8px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bullet-fill);
+}
+
+.enigme-menu__icon--bullet {
+  border-radius: 50%;
   background-color: var(--bullet-fill);
   box-shadow: 0 0 0 1px var(--bullet-outline);
-  transform: translateY(-50%);
-  border-radius: 50%;
+}
+
+.enigme-menu__icon svg,
+.enigme-menu__icon i {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+.enigme-menu__cost {
+  margin-left: var(--space-xs);
+  color: var(--bullet-fill);
 }
 
 .enigme-menu li > a:not(.enigme-menu__edit) {
@@ -156,15 +174,14 @@ li.active .enigme-menu__edit {
   --bullet-outline: var(--etat-enigme-menu-en-attente);
 }
 
-.enigme-menu li.en-attente::before {
+.enigme-menu__icon--spinner {
   box-sizing: border-box;
   width: 8px;
   height: 8px;
-  border: 2px solid var(--etat-enigme-menu-en-attente);
+  border: 2px solid var(--bullet-fill);
   border-top-color: transparent;
   border-radius: 50%;
   background-color: transparent;
-  box-shadow: none;
   animation: enigme-menu-spin 0.6s linear infinite;
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -55,7 +55,6 @@
   margin-bottom: var(--space-xxs);
   padding-left: calc(var(--space-md) + 16px);
   --bullet-fill: var(--etat-enigme-menu-en-cours);
-  --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
 .enigme-menu__icon {
@@ -71,16 +70,8 @@
   color: var(--bullet-fill);
 }
 
-.enigme-menu__icon--bullet {
-  left: 20px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: var(--bullet-fill);
-  box-shadow: 0 0 0 1px var(--bullet-outline);
-}
-
-.enigme-menu__icon svg {
+.enigme-menu__icon svg,
+.enigme-menu__icon i {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -132,7 +123,6 @@
 
 .enigme-menu li.bloquee {
   --bullet-fill: var(--etat-enigme-menu-bloquee);
-  --bullet-outline: var(--etat-enigme-menu-bloquee);
 }
 
 
@@ -180,7 +170,6 @@ li.active .enigme-menu__edit {
 
 .enigme-menu li.en-attente {
   --bullet-fill: var(--etat-enigme-menu-en-attente);
-  --bullet-outline: var(--etat-enigme-menu-en-attente);
 }
 
 .enigme-menu__icon--spinner {
@@ -196,7 +185,6 @@ li.active .enigme-menu__edit {
 
 .enigme-menu li.succes {
   --bullet-fill: var(--etat-enigme-menu-succes);
-  --bullet-outline: var(--etat-enigme-menu-succes);
 }
 
 
@@ -210,7 +198,6 @@ li.active .enigme-menu__edit {
 
 .enigme-menu li.incomplete {
   --bullet-fill: var(--etat-enigme-menu-incomplete);
-  --bullet-outline: var(--etat-enigme-menu-incomplete);
 }
 
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -62,8 +62,8 @@
   position: absolute;
   top: 50%;
   left: 16px;
-  width: 8px;
-  height: 8px;
+  width: 16px;
+  height: 16px;
   transform: translateY(-50%);
   display: flex;
   align-items: center;
@@ -72,13 +72,15 @@
 }
 
 .enigme-menu__icon--bullet {
+  left: 20px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background-color: var(--bullet-fill);
   box-shadow: 0 0 0 1px var(--bullet-outline);
 }
 
-.enigme-menu__icon svg,
-.enigme-menu__icon i {
+.enigme-menu__icon svg {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -87,6 +89,13 @@
 .enigme-menu__cost {
   margin-left: var(--space-xs);
   color: var(--bullet-fill);
+  display: inline-flex;
+}
+
+.enigme-menu__cost svg {
+  width: 1em;
+  height: 1em;
+  fill: currentColor;
 }
 
 .enigme-menu li > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4937,8 +4937,8 @@ body.panneau-ouvert::before {
   position: absolute;
   top: 50%;
   left: 16px;
-  width: 8px;
-  height: 8px;
+  width: 16px;
+  height: 16px;
   transform: translateY(-50%);
   display: flex;
   align-items: center;
@@ -4947,13 +4947,15 @@ body.panneau-ouvert::before {
 }
 
 .enigme-menu__icon--bullet {
+  left: 20px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background-color: var(--bullet-fill);
   box-shadow: 0 0 0 1px var(--bullet-outline);
 }
 
-.enigme-menu__icon svg,
-.enigme-menu__icon i {
+.enigme-menu__icon svg {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -4962,6 +4964,13 @@ body.panneau-ouvert::before {
 .enigme-menu__cost {
   margin-left: var(--space-xs);
   color: var(--bullet-fill);
+  display: inline-flex;
+}
+
+.enigme-menu__cost svg {
+  width: 1em;
+  height: 1em;
+  fill: currentColor;
 }
 
 .enigme-menu li > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4930,7 +4930,6 @@ body.panneau-ouvert::before {
   margin-bottom: var(--space-xxs);
   padding-left: calc(var(--space-md) + 16px);
   --bullet-fill: var(--etat-enigme-menu-en-cours);
-  --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
 .enigme-menu__icon {
@@ -4946,16 +4945,8 @@ body.panneau-ouvert::before {
   color: var(--bullet-fill);
 }
 
-.enigme-menu__icon--bullet {
-  left: 20px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: var(--bullet-fill);
-  box-shadow: 0 0 0 1px var(--bullet-outline);
-}
-
-.enigme-menu__icon svg {
+.enigme-menu__icon svg,
+.enigme-menu__icon i {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -5006,7 +4997,6 @@ body.panneau-ouvert::before {
 
 .enigme-menu li.bloquee {
   --bullet-fill: var(--etat-enigme-menu-bloquee);
-  --bullet-outline: var(--etat-enigme-menu-bloquee);
 }
 
 .enigme-menu__edit {
@@ -5052,7 +5042,6 @@ li.active .enigme-menu__edit {
 }
 .enigme-menu li.en-attente {
   --bullet-fill: var(--etat-enigme-menu-en-attente);
-  --bullet-outline: var(--etat-enigme-menu-en-attente);
 }
 
 .enigme-menu__icon--spinner {
@@ -5068,7 +5057,6 @@ li.active .enigme-menu__edit {
 
 .enigme-menu li.succes {
   --bullet-fill: var(--etat-enigme-menu-succes);
-  --bullet-outline: var(--etat-enigme-menu-succes);
 }
 
 .enigme-menu li.non-engagee > a:not(.enigme-menu__edit) {
@@ -5081,7 +5069,6 @@ li.active .enigme-menu__edit {
 
 .enigme-menu li.incomplete {
   --bullet-fill: var(--etat-enigme-menu-incomplete);
-  --bullet-outline: var(--etat-enigme-menu-incomplete);
 }
 
 .enigme-menu li.active > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4933,17 +4933,35 @@ body.panneau-ouvert::before {
   --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
-.enigme-menu li::before {
-  content: "";
+.enigme-menu__icon {
   position: absolute;
   top: 50%;
   left: 16px;
   width: 8px;
   height: 8px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bullet-fill);
+}
+
+.enigme-menu__icon--bullet {
+  border-radius: 50%;
   background-color: var(--bullet-fill);
   box-shadow: 0 0 0 1px var(--bullet-outline);
-  transform: translateY(-50%);
-  border-radius: 50%;
+}
+
+.enigme-menu__icon svg,
+.enigme-menu__icon i {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+.enigme-menu__cost {
+  margin-left: var(--space-xs);
+  color: var(--bullet-fill);
 }
 
 .enigme-menu li > a:not(.enigme-menu__edit) {
@@ -5028,15 +5046,14 @@ li.active .enigme-menu__edit {
   --bullet-outline: var(--etat-enigme-menu-en-attente);
 }
 
-.enigme-menu li.en-attente::before {
+.enigme-menu__icon--spinner {
   box-sizing: border-box;
   width: 8px;
   height: 8px;
-  border: 2px solid var(--etat-enigme-menu-en-attente);
+  border: 2px solid var(--bullet-fill);
   border-top-color: transparent;
   border-radius: 50%;
   background-color: transparent;
-  box-shadow: none;
   animation: enigme-menu-spin 0.6s linear infinite;
 }
 

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -88,6 +88,7 @@ function charger_fontawesome() {
     wp_enqueue_style('fontawesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.css', [], null);
 }
 add_action('wp_enqueue_scripts', 'charger_fontawesome');
+add_action('admin_enqueue_scripts', 'charger_fontawesome');
 
 /**
  * Ajoute une classe CSS "role-xx" au body de l'interface admin en fonction des rôles de l'utilisateur.

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -150,7 +150,7 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
             $aria_current = $post->ID === $current_enigme_id ? ' aria-current="page"' : '';
             $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
 
-            $icon_html = '<span class="enigme-menu__icon enigme-menu__icon--bullet" aria-hidden="true"></span>';
+            $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-eye"></i></span>';
 
             if ($cta['statut_utilisateur'] === 'soumis') {
                 $icon_html = '<span class="enigme-menu__icon enigme-menu__icon--spinner" aria-hidden="true"></span>';
@@ -164,13 +164,9 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                 $svg  = str_replace('stroke="#000000"', 'stroke="currentColor"', $svg);
                 $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
             } elseif ($mode_validation === 'automatique') {
-                $path = $svg_dir . 'reply-auto.svg';
-                $svg  = file_exists($path) ? file_get_contents($path) : '';
-                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-bolt"></i></span>';
             } elseif ($mode_validation === 'manuelle') {
-                $path = $svg_dir . 'reply-mail.svg';
-                $svg  = file_exists($path) ? file_get_contents($path) : '';
-                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-envelope"></i></span>';
             }
 
             $class_attr = $classes

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -142,7 +142,9 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
 
             $title = esc_html(get_the_title($post->ID));
             if ($cout_points > 0) {
-                $title .= '<i class="fa-solid fa-coins enigme-menu__cost" aria-hidden="true"></i>';
+                $coin_path = $svg_dir . 'coins-points.svg';
+                $coin_svg  = file_exists($coin_path) ? file_get_contents($coin_path) : '';
+                $title    .= '<span class="enigme-menu__cost" aria-hidden="true">' . $coin_svg . '</span>';
             }
 
             $aria_current = $post->ID === $current_enigme_id ? ' aria-current="page"' : '';
@@ -162,9 +164,13 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                 $svg  = str_replace('stroke="#000000"', 'stroke="currentColor"', $svg);
                 $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
             } elseif ($mode_validation === 'automatique') {
-                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-bolt"></i></span>';
+                $path = $svg_dir . 'reply-auto.svg';
+                $svg  = file_exists($path) ? file_get_contents($path) : '';
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
             } elseif ($mode_validation === 'manuelle') {
-                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-envelope"></i></span>';
+                $path = $svg_dir . 'reply-mail.svg';
+                $svg  = file_exists($path) ? file_get_contents($path) : '';
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
             }
 
             $class_attr = $classes

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -139,9 +139,14 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
             $title        = esc_html(get_the_title($post->ID));
             $aria_current = $post->ID === $current_enigme_id ? ' aria-current="page"' : '';
             $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
+
+            $class_attr = $classes
+                ? ' class="' . esc_attr(implode(' ', $classes)) . '"'
+                : '';
+
             $submenu_items[] = sprintf(
-                '<li class="%s" data-enigme-id="%d">%s%s</li>',
-                esc_attr(implode(' ', $classes)),
+                '<li%s data-enigme-id="%d">%s%s</li>',
+                $class_attr,
                 $post->ID,
                 $link,
                 $edit

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -64,6 +64,7 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
             );
 
         $visible_ids = [];
+        $svg_dir     = dirname(__DIR__) . '/assets/svg/';
 
         foreach ($all_enigmes as $post) {
             $cta = function_exists('get_cta_enigme')
@@ -136,18 +137,45 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                 }
             }
 
-            $title        = esc_html(get_the_title($post->ID));
+            $mode_validation = (string) get_field('enigme_mode_validation', $post->ID);
+            $cout_points     = (int) get_field('enigme_tentative_cout_points', $post->ID);
+
+            $title = esc_html(get_the_title($post->ID));
+            if ($cout_points > 0) {
+                $title .= '<i class="fa-solid fa-coins enigme-menu__cost" aria-hidden="true"></i>';
+            }
+
             $aria_current = $post->ID === $current_enigme_id ? ' aria-current="page"' : '';
             $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
+
+            $icon_html = '<span class="enigme-menu__icon enigme-menu__icon--bullet" aria-hidden="true"></span>';
+
+            if ($cta['statut_utilisateur'] === 'soumis') {
+                $icon_html = '<span class="enigme-menu__icon enigme-menu__icon--spinner" aria-hidden="true"></span>';
+            } elseif ($cta['etat_systeme'] === 'bloquee_date') {
+                $path = $svg_dir . 'hourglass.svg';
+                $svg  = file_exists($path) ? file_get_contents($path) : '';
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
+            } elseif ($cta['etat_systeme'] === 'bloquee_pre_requis') {
+                $path = $svg_dir . 'lock.svg';
+                $svg  = file_exists($path) ? file_get_contents($path) : '';
+                $svg  = str_replace('stroke="#000000"', 'stroke="currentColor"', $svg);
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true">' . $svg . '</span>';
+            } elseif ($mode_validation === 'automatique') {
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-bolt"></i></span>';
+            } elseif ($mode_validation === 'manuelle') {
+                $icon_html = '<span class="enigme-menu__icon" aria-hidden="true"><i class="fa-solid fa-envelope"></i></span>';
+            }
 
             $class_attr = $classes
                 ? ' class="' . esc_attr(implode(' ', $classes)) . '"'
                 : '';
 
             $submenu_items[] = sprintf(
-                '<li%s data-enigme-id="%d">%s%s</li>',
+                '<li%s data-enigme-id="%d">%s%s%s</li>',
                 $class_attr,
                 $post->ID,
+                $icon_html,
                 $link,
                 $edit
             );

--- a/wp-content/themes/chassesautresor/notices/etat-enigme-menu.md
+++ b/wp-content/themes/chassesautresor/notices/etat-enigme-menu.md
@@ -16,5 +16,5 @@ Référence centralisée des états utilisés pour les pastilles du menu des én
 Pour ajouter un nouvel état :
 
 1. Déclarer la couleur dans `variables.css` via `--etat-enigme-menu-NOUVEL_ETAT`.
-2. Ajouter la classe `.NOUVEL_ETAT` dans `enigme.css` en utilisant cette variable pour `--bullet-fill` et `--bullet-outline`.
+2. Ajouter la classe `.NOUVEL_ETAT` dans `enigme.css` en utilisant cette variable pour `--bullet-fill`.
 3. Utiliser la classe dans le menu ou toute autre interface.

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -119,11 +119,20 @@ $needs_validatable_message = $statut === 'revision'
 
 $statut_validation = $infos_chasse['statut_validation'];
 $nb_joueurs = $infos_chasse['nb_joueurs'];
-$sidebar_data = sidebar_prepare_chasse_nav(
-    $chasse_id,
-    $user_id,
-    0
-);
+$has_sidebar_access = $user_id > 0 && utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
+$sidebar_data = [
+    'menu_items'           => [],
+    'peut_ajouter_enigme'  => false,
+    'total_enigmes'        => 0,
+    'has_incomplete_enigme' => false,
+];
+if ($has_sidebar_access) {
+    $sidebar_data = sidebar_prepare_chasse_nav(
+        $chasse_id,
+        $user_id,
+        0
+    );
+}
 
 $solved_label  = _n('énigme résolue', 'énigmes résolues', $enigmes_resolues, 'chassesautresor-com');
 $engaged_label = _n('engagée', 'engagées', $nb_engagees, 'chassesautresor-com');
@@ -189,36 +198,36 @@ cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NO
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
 echo '<div class="container container--xl-full chasse-layout">';
-$sidebar_sections = render_sidebar(
-    'chasse',
-    0,
-    $chasse_id,
-    $sidebar_data['menu_items'],
-    $sidebar_data['peut_ajouter_enigme'],
-    $sidebar_data['total_enigmes'],
-    $sidebar_data['has_incomplete_enigme']
-);
-?>
+$sidebar_sections = ['navigation' => '', 'stats' => ''];
+if ($has_sidebar_access) {
+    $sidebar_sections = render_sidebar(
+        'chasse',
+        0,
+        $chasse_id,
+        $sidebar_data['menu_items'],
+        $sidebar_data['peut_ajouter_enigme'],
+        $sidebar_data['total_enigmes'],
+        $sidebar_data['has_incomplete_enigme']
+    );
+    echo '<header class="enigme-mobile-header">';
+    echo '<div aria-hidden="true"></div>';
+    echo '<div class="enigme-mobile-actions">';
+    echo '<button type="button" class="enigme-mobile-panel-toggle" aria-controls="enigme-mobile-panel" aria-expanded="false" aria-label="'
+        . esc_attr__('Menu de navigation', 'chassesautresor-com') . '">';
+    echo '<span class="screen-reader-text">' . esc_html__('Menu de navigation', 'chassesautresor-com') . '</span>';
+    echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
+    echo '</button>';
+    echo '</div>';
+    echo '</header>';
 
-<?php
-echo '<header class="enigme-mobile-header">';
-echo '<div aria-hidden="true"></div>';
-echo '<div class="enigme-mobile-actions">';
-echo '<button type="button" class="enigme-mobile-panel-toggle" aria-controls="enigme-mobile-panel" aria-expanded="false" aria-label="'
-    . esc_attr__('Menu de navigation', 'chassesautresor-com') . '">';
-echo '<span class="screen-reader-text">' . esc_html__('Menu de navigation', 'chassesautresor-com') . '</span>';
-echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
-echo '</button>';
-echo '</div>';
-echo '</header>';
-
-echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
-echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';
-echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true" aria-labelledby="enigme-mobile-panel-title">';
-echo '<h2 id="enigme-mobile-panel-title" class="screen-reader-text">' . esc_html__('Navigation de la chasse', 'chassesautresor-com') . '</h2>';
-echo '<div class="enigme-mobile-panel__content">' . ($sidebar_sections['navigation'] ?? '') . '</div>';
-echo '</div>';
-echo '</div>';
+    echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
+    echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';
+    echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true" aria-labelledby="enigme-mobile-panel-title">';
+    echo '<h2 id="enigme-mobile-panel-title" class="screen-reader-text">' . esc_html__('Navigation de la chasse', 'chassesautresor-com') . '</h2>';
+    echo '<div class="enigme-mobile-panel__content">' . ($sidebar_sections['navigation'] ?? '') . '</div>';
+    echo '</div>';
+    echo '</div>';
+}
 ?>
 
 <div id="primary" class="content-area page-chasse-wrapper">


### PR DESCRIPTION
## Résumé
- Harmonisation des classes d’état retournées par `get_cta_enigme()` avec les puces documentées.
- Génération HTML des éléments du menu qui n’ajoute l’attribut `class` qu’en présence d’un état.
- Couverture des états via une batterie de tests garantissant la conformité des classes.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3f8352f28833299fa6ea9917487c8