### PR TITLE
feat: store account messages in repository

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -25,6 +25,10 @@ function add_site_message(string $type, string $content, bool $persistent = fals
         }
         $messages[] = $message;
         set_transient('cat_site_messages', $messages, 0);
+
+        global $wpdb;
+        $repo = new UserMessageRepository($wpdb);
+        $repo->insert(0, wp_json_encode($message), 'site');
         return;
     }
 
@@ -59,6 +63,16 @@ function get_site_messages(): string
     $transient = get_transient('cat_site_messages');
     if (is_array($transient) && !empty($transient)) {
         $messages = array_merge($messages, $transient);
+    }
+
+    global $wpdb;
+    $repo = new UserMessageRepository($wpdb);
+    $rows = $repo->get(0, 'site', false);
+    foreach ($rows as $row) {
+        $data = json_decode($row['message'], true);
+        if (is_array($data)) {
+            $messages[] = $data;
+        }
     }
 
     if (empty($messages)) {


### PR DESCRIPTION
## Résumé
- utilise `UserMessageRepository` pour enregistrer les messages persistants et flash de l'espace Mon Compte
- lit également les messages site-wide depuis `wp_user_messages`
- adapte les tests à ce nouveau mécanisme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b4834d2c888332b161176b8bda82d4