### PR TITLE
Ajout d'une commande WP-CLI pour migrer les messages

### DIFF
--- a/tests/MessageMigrationCommandTest.php
+++ b/tests/MessageMigrationCommandTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('WP_CLI')) {
+    class WP_CLI
+    {
+        public static function log($message): void {}
+        public static function success($message): void {}
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('current_time')) {
+    function current_time(string $type)
+    {
+        return $type === 'timestamp'
+            ? strtotime('2023-01-01 00:00:00')
+            : '2023-01-01 00:00:00';
+    }
+}
+
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512)
+    {
+        return json_encode($data, $options);
+    }
+}
+
+// Global storage for meta and transients.
+$cat_test_user_meta = [];
+$cat_test_transients = [];
+
+if (!function_exists('get_users')) {
+    function get_users($args)
+    {
+        return [1];
+    }
+}
+
+if (!function_exists('get_user_meta')) {
+    function get_user_meta($user_id, $key, $single)
+    {
+        global $cat_test_user_meta;
+        return $cat_test_user_meta[$user_id][$key] ?? [];
+    }
+}
+
+if (!function_exists('delete_user_meta')) {
+    function delete_user_meta($user_id, $key)
+    {
+        global $cat_test_user_meta;
+        unset($cat_test_user_meta[$user_id][$key]);
+    }
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient($key)
+    {
+        global $cat_test_transients;
+        return $cat_test_transients[$key] ?? false;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($key)
+    {
+        global $cat_test_transients;
+        unset($cat_test_transients[$key]);
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php';
+
+/**
+ * @covers Cat_CLI_Command
+ */
+class MessageMigrationCommandTest extends TestCase
+{
+    private MigrationDummyWpdb $wpdb;
+
+    protected function setUp(): void
+    {
+        global $cat_test_user_meta, $cat_test_transients, $wpdb;
+        $cat_test_user_meta = [
+            1 => [
+                '_myaccount_messages' => [
+                    'k1' => [
+                        'text'       => 'Persist',
+                        'type'       => 'info',
+                        'expires_at' => '2023-02-01 00:00:00',
+                    ],
+                ],
+                '_myaccount_flash_messages' => [
+                    ['text' => 'Flash', 'type' => 'error'],
+                ],
+            ],
+        ];
+        $cat_test_transients = [
+            'cat_site_messages' => [
+                ['type' => 'warning', 'content' => 'Global'],
+            ],
+        ];
+        $this->wpdb = new MigrationDummyWpdb();
+        $wpdb       = $this->wpdb;
+    }
+
+    public function test_migrate_messages_moves_all_data(): void
+    {
+        $cmd = new Cat_CLI_Command();
+        $cmd->migrate_messages();
+
+        global $cat_test_user_meta, $cat_test_transients;
+
+        $repo = new UserMessageRepository($this->wpdb);
+        $this->assertCount(2, $repo->get(1, null, null));
+        $this->assertCount(1, $repo->get(0, 'site', null));
+
+        $this->assertArrayNotHasKey('_myaccount_messages', $cat_test_user_meta[1] ?? []);
+        $this->assertArrayNotHasKey('_myaccount_flash_messages', $cat_test_user_meta[1] ?? []);
+        $this->assertArrayNotHasKey('cat_site_messages', $cat_test_transients);
+    }
+}
+
+class MigrationDummyWpdb
+{
+    public string $prefix = 'wp_';
+
+    public int $insert_id = 0;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $data = [];
+
+    public function insert(string $table, array $data, array $format): void
+    {
+        $this->insert_id++;
+        $data['id']             = $this->insert_id;
+        $this->data[$this->insert_id] = $data;
+    }
+
+    public function get_results(string $sql, $output): array
+    {
+        $rows = array_values($this->data);
+
+        if (preg_match('/user_id = (\d+)/', $sql, $m)) {
+            $rows = array_filter($rows, fn ($r) => (int) $r['user_id'] === (int) $m[1]);
+        }
+
+        if (preg_match("/status = '([^']+)'/", $sql, $m)) {
+            $rows = array_filter($rows, fn ($r) => $r['status'] === $m[1]);
+        }
+
+        return array_values($rows);
+    }
+
+    public function delete(string $table, array $where, array $whereFormat): void
+    {
+        unset($this->data[$where['id']]);
+    }
+}

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -350,6 +350,10 @@ require_once $inc_path . 'PointsRepository.php';
 require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
 
+if (defined('WP_CLI') && WP_CLI) {
+    require_once $inc_path . 'cli/class-cat-cli-command.php';
+}
+
 add_action('shutdown', function (): void {
     global $wpdb;
 

--- a/wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php
+++ b/wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * WP-CLI commands for chassesautresor.
+ */
+class Cat_CLI_Command
+{
+    /**
+     * Migrate user and site messages to the wp_user_messages table.
+     *
+     * ## EXAMPLES
+     *
+     *     wp cat migrate-messages
+     *
+     * @return void
+     */
+    public function migrate_messages(): void
+    {
+        global $wpdb;
+
+        $repo    = new UserMessageRepository($wpdb);
+        $userIds = get_users(['fields' => 'ids']);
+
+        foreach ($userIds as $userId) {
+            $migrated = 0;
+
+            $persistent = get_user_meta($userId, '_myaccount_messages', true);
+            if (is_array($persistent)) {
+                foreach ($persistent as $key => $msg) {
+                    if (!is_array($msg)) {
+                        continue;
+                    }
+                    $status    = isset($msg['status']) ? (string) $msg['status'] : 'persistent';
+                    $expiresAt = isset($msg['expires_at']) ? (string) $msg['expires_at'] : null;
+
+                    $payload       = $msg;
+                    $payload['key'] = (string) $key;
+                    unset($payload['status'], $payload['expires_at']);
+
+                    $repo->insert($userId, wp_json_encode($payload), $status, $expiresAt);
+                    $migrated++;
+                }
+                delete_user_meta($userId, '_myaccount_messages');
+            }
+
+            $flash = get_user_meta($userId, '_myaccount_flash_messages', true);
+            if (is_array($flash)) {
+                foreach ($flash as $msg) {
+                    if (!is_array($msg)) {
+                        continue;
+                    }
+                    $status    = isset($msg['status']) ? (string) $msg['status'] : 'flash';
+                    $expiresAt = isset($msg['expires_at']) ? (string) $msg['expires_at'] : null;
+
+                    $payload = $msg;
+                    unset($payload['status'], $payload['expires_at']);
+
+                    $repo->insert($userId, wp_json_encode($payload), $status, $expiresAt);
+                    $migrated++;
+                }
+                delete_user_meta($userId, '_myaccount_flash_messages');
+            }
+
+            if ($migrated > 0) {
+                \WP_CLI::log(
+                    sprintf(
+                        /* translators: 1: number of messages, 2: user ID. */
+                        __('%1$d messages migrés pour l\'utilisateur %2$d', 'chassesautresor-com'),
+                        $migrated,
+                        $userId
+                    )
+                );
+            }
+        }
+
+        $siteMessages = get_transient('cat_site_messages');
+        if (is_array($siteMessages)) {
+            $defaultExpiration = gmdate('Y-m-d H:i:s', time() + DAY_IN_SECONDS);
+
+            foreach ($siteMessages as $msg) {
+                if (!is_array($msg)) {
+                    continue;
+                }
+                $status    = isset($msg['status']) ? (string) $msg['status'] : 'site';
+                $expiresAt = isset($msg['expires_at']) ? (string) $msg['expires_at'] : $defaultExpiration;
+
+                $payload = $msg;
+                unset($payload['status'], $payload['expires_at']);
+
+                $repo->insert(0, wp_json_encode($payload), $status, $expiresAt);
+            }
+            delete_transient('cat_site_messages');
+        }
+
+        \WP_CLI::success(__('Migration des messages terminée.', 'chassesautresor-com'));
+    }
+}
+
+if (defined('WP_CLI') && WP_CLI) {
+    \WP_CLI::add_command('cat', Cat_CLI_Command::class);
+}


### PR DESCRIPTION
### Résumé
- ajout d'une commande `wp cat migrate-messages` pour migrer les anciens messages vers `wp_user_messages`

### Changements notables
- migration des metas `_myaccount_messages` et `_myaccount_flash_messages` avec suppression des données d'origine
- import des messages globaux `cat_site_messages` pour `user_id = 0` avec expiration par défaut
- ajout d'un test de migration et chargement conditionnel de la commande CLI

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b48777ea188332ac3bc38b9aa6623d