### PR TITLE
feat: handle translatable message keys

### DIFF
--- a/tests/UserMessageRepositoryTest.php
+++ b/tests/UserMessageRepositoryTest.php
@@ -34,10 +34,11 @@ class UserMessageRepositoryTest extends TestCase
 
     public function test_insert_stores_row_and_returns_id(): void
     {
-        $id = $this->repo->insert(1, 'Salut', 'info', null);
+        $id = $this->repo->insert(1, 'Salut', 'info', null, 'fr_FR');
 
         $this->assertSame(1, $id);
         $this->assertSame('Salut', $this->wpdb->data[$id]['message']);
+        $this->assertSame('fr_FR', $this->wpdb->data[$id]['locale']);
     }
 
     public function test_update_modifies_row(): void

--- a/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
+++ b/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
@@ -30,8 +30,13 @@ class UserMessageRepository
     /**
      * Insert a new message and return its identifier.
      */
-    public function insert(int $userId, string $message, string $status, ?string $expiresAt = null): int
-    {
+    public function insert(
+        int $userId,
+        string $message,
+        string $status,
+        ?string $expiresAt = null,
+        ?string $locale = null
+    ): int {
         $this->wpdb->insert(
             $this->table,
             [
@@ -39,8 +44,9 @@ class UserMessageRepository
                 'message'    => $message,
                 'status'     => $status,
                 'expires_at' => $expiresAt,
+                'locale'     => $locale,
             ],
-            ['%d', '%s', '%s', '%s']
+            ['%d', '%s', '%s', '%s', '%s']
         );
 
         return (int) $this->wpdb->insert_id;

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -619,6 +619,28 @@ class MyAccountMessagesTest extends TestCase
         delete_user_meta(1, '_myaccount_messages');
     }
 
+    public function test_message_key_is_translated(): void
+    {
+        global $wpdb;
+        $repo = new UserMessageRepository($wpdb);
+        $repo->insert(
+            1,
+            wp_json_encode([
+                'key'         => 'bar',
+                'text'        => 'Original',
+                'message_key' => 'translated_key',
+                'type'        => 'info',
+            ]),
+            'persistent'
+        );
+
+        $output = myaccount_get_important_messages();
+        $this->assertStringContainsString('translated_key', $output);
+        $this->assertStringNotContainsString('Original', $output);
+
+        delete_user_meta(1, '_myaccount_messages');
+    }
+
     public function test_ajax_section_returns_flash_message(): void
     {
         update_user_meta(


### PR DESCRIPTION
## Résumé
- gestion de `message_key` et `locale` pour les messages utilisateurs et site
- traduction des messages via `__()` côté vue
- ajout de tests pour vérifier la locale et la clé de traduction

## Changements notables
- support de `message_key` et `locale` dans l’ajout des messages persistants et site
- repository mis à jour pour stocker la locale
- affichage des messages traduit à partir de la clé

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b489d9a97883328aa71c73fdbaed92