### PR TITLE
Affiche toujours le badge de mode de fin de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -61,6 +61,7 @@
   position: absolute;
   top: 10px;
   right: 10px;
+  z-index: 1;
 }
 
 .header-chasse__image .mode-fin-icone {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -493,6 +493,7 @@
   position: absolute;
   top: 10px;
   right: 10px;
+  z-index: 1;
 }
 
 .header-chasse__image .mode-fin-icone {


### PR DESCRIPTION
## Résumé
- empêche la disparition du badge de mode de fin de chasse au survol de la carte

## Changements notables
- ajoute un `z-index` au badge `mode-fin-icone`
- reconstruit la feuille de style compilée

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5286ad9b88332911d78aa62c10ff9