### PR TITLE
Masque la navigation chasse pour joueurs non engagés

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-engagement.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-engagement.js
@@ -1,0 +1,18 @@
+(function () {
+  document.addEventListener('submit', (e) => {
+    const form = e.target.closest('.cta-chasse-form');
+    if (!form) return;
+    e.preventDefault();
+    const data = new FormData(form);
+    fetch(form.action, {
+      method: 'POST',
+      body: data,
+      credentials: 'same-origin'
+    })
+      .then((res) => {
+        if (res.ok) {
+          window.location.reload();
+        }
+      });
+  });
+})();

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -270,6 +270,16 @@ add_action('wp_enqueue_scripts', function () {
             true
         );
     }
+
+    if (is_singular('chasse')) {
+        wp_enqueue_script(
+            'chasse-engagement',
+            $script_dir . 'chasse-engagement.js',
+            [],
+            filemtime($theme_path . '/assets/js/chasse-engagement.js'),
+            true
+        );
+    }
 });
 
 add_action('wp_enqueue_scripts', function () {

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -20,6 +20,10 @@ verifier_ou_mettre_a_jour_cache_complet($chasse_id);
 $user_id            = get_current_user_id();
 $est_orga_associe   = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
 $points_utilisateur = get_user_points($user_id);
+$est_engage_chasse  = utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
+$peut_voir_aside    = $est_engage_chasse
+    || current_user_can('manage_options')
+    || $est_orga_associe;
 
 // Récupération centralisée des infos
 $infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
@@ -187,38 +191,43 @@ if (!is_user_logged_in()) {
 get_header();
 cat_debug("🧪 test organisateur_associe : " . ($est_orga_associe ? 'OUI' : 'NON'));
 
-$can_validate = peut_valider_chasse($chasse_id, $user_id);
+$can_validate     = peut_valider_chasse($chasse_id, $user_id);
 echo '<div class="container container--xl-full chasse-layout">';
-$sidebar_sections = render_sidebar(
-    'chasse',
-    0,
-    $chasse_id,
-    $sidebar_data['menu_items'],
-    $sidebar_data['peut_ajouter_enigme'],
-    $sidebar_data['total_enigmes'],
-    $sidebar_data['has_incomplete_enigme']
-);
+$sidebar_sections = ['navigation' => '', 'stats' => ''];
+if ($peut_voir_aside) {
+    $sidebar_sections = render_sidebar(
+        'chasse',
+        0,
+        $chasse_id,
+        $sidebar_data['menu_items'],
+        $sidebar_data['peut_ajouter_enigme'],
+        $sidebar_data['total_enigmes'],
+        $sidebar_data['has_incomplete_enigme']
+    );
+}
 ?>
 
 <?php
-echo '<header class="enigme-mobile-header">';
-echo '<div aria-hidden="true"></div>';
-echo '<div class="enigme-mobile-actions">';
-echo '<button type="button" class="enigme-mobile-panel-toggle" aria-controls="enigme-mobile-panel" aria-expanded="false" aria-label="'
-    . esc_attr__('Menu de navigation', 'chassesautresor-com') . '">';
-echo '<span class="screen-reader-text">' . esc_html__('Menu de navigation', 'chassesautresor-com') . '</span>';
-echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
-echo '</button>';
-echo '</div>';
-echo '</header>';
+if ($peut_voir_aside) {
+    echo '<header class="enigme-mobile-header">';
+    echo '<div aria-hidden="true"></div>';
+    echo '<div class="enigme-mobile-actions">';
+    echo '<button type="button" class="enigme-mobile-panel-toggle" aria-controls="enigme-mobile-panel" aria-expanded="false" aria-label="'
+        . esc_attr__('Menu de navigation', 'chassesautresor-com') . '">';
+    echo '<span class="screen-reader-text">' . esc_html__('Menu de navigation', 'chassesautresor-com') . '</span>';
+    echo '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
+    echo '</button>';
+    echo '</div>';
+    echo '</header>';
 
-echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
-echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';
-echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true" aria-labelledby="enigme-mobile-panel-title">';
-echo '<h2 id="enigme-mobile-panel-title" class="screen-reader-text">' . esc_html__('Navigation de la chasse', 'chassesautresor-com') . '</h2>';
-echo '<div class="enigme-mobile-panel__content">' . ($sidebar_sections['navigation'] ?? '') . '</div>';
-echo '</div>';
-echo '</div>';
+    echo '<div id="enigme-mobile-panel" class="enigme-mobile-panel" hidden>';
+    echo '<div class="enigme-mobile-panel__overlay" tabindex="-1"></div>';
+    echo '<div class="enigme-mobile-panel__sheet" role="dialog" aria-modal="true" aria-labelledby="enigme-mobile-panel-title">';
+    echo '<h2 id="enigme-mobile-panel-title" class="screen-reader-text">' . esc_html__('Navigation de la chasse', 'chassesautresor-com') . '</h2>';
+    echo '<div class="enigme-mobile-panel__content">' . ($sidebar_sections['navigation'] ?? '') . '</div>';
+    echo '</div>';
+    echo '</div>';
+}
 ?>
 
 <div id="primary" class="content-area page-chasse-wrapper">


### PR DESCRIPTION
## Résumé
- limite l'accès serveur à la navigation des chasses aux joueurs engagés
- masque l'aside et le panneau mobile quand l'utilisateur n'est pas autorisé
- recharge la page via JS après engagement à une chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5285807a083329721f636b03099f5