### PR TITLE
Déplace l'alerte du champ Bonne(s) réponse(s) vers le bouton valider

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-edit.js
@@ -866,6 +866,15 @@ function initChampBonnesReponses() {
       btn.className = 'champ-modifier bonne-reponse-valider btn-obligatoire';
       btn.textContent = wp.i18n.__('valider', 'chassesautresor-com');
 
+      const updateBlink = () => {
+        const hasValue = input.value.trim().length > 0;
+        wrapper.classList.toggle('champ-vide-obligatoire', !hasValue);
+        input.classList.toggle('champ-vide-obligatoire', !hasValue);
+        btn.classList.toggle('champ-vide-obligatoire', hasValue);
+      };
+
+      input.addEventListener('input', updateBlink);
+
       btn.addEventListener('click', () => {
         const val = input.value.trim();
         if (!val) return;
@@ -877,6 +886,7 @@ function initChampBonnesReponses() {
 
       wrapper.appendChild(input);
       wrapper.appendChild(btn);
+      updateBlink();
       return;
     }
 

--- a/wp-content/themes/chassesautresor/docs/panneau-enigme-parametres.md
+++ b/wp-content/themes/chassesautresor/docs/panneau-enigme-parametres.md
@@ -37,6 +37,8 @@ Ce comportement est géré par [`champ-init.js`](../assets/js/core/champ-init.js
 
 Lorsqu'un champ obligatoire est vide, la classe `champ-attention` colore son label en rouge et la classe `champ-vide-obligatoire` déclenche une animation clignotante autour de l'input.
 
+Pour la ligne « Bonne(s) réponse(s) », tant qu'aucune réponse n'est enregistrée, le clignotement se déplace sur le bouton « valider » dès qu'une saisie est entamée afin d'inciter l'utilisateur à confirmer l'ajout.
+
 ## Saisie des nombres
 
 Les champs numériques « Coût » et « Nb tentatives » sont limités à six chiffres (`max="999999"`) et leur largeur est fixée à 100px (classe `champ-number`).


### PR DESCRIPTION
Améliore la gestion de l'alerte pour le champ « Bonne(s) réponse(s) » lors de l'ajout de la première réponse.

- Déplace le clignotement du wrapper vers le bouton « valider » dès qu'une valeur est saisie
- Documente le comportement spécifique dans le guide du panneau Paramètres

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b52ae20288833283d2f2db104f2be9