### PR TITLE
feat: enrichir les puces du menu des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_aside.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_aside.scss
@@ -49,6 +49,9 @@
   font-size: 1.5rem;
   margin: 0;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
 }
 
 .menu-lateral__edition-toggle {

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -205,9 +205,19 @@ li.active .enigme-menu__edit {
 .enigme-menu li.non-engagee {
   --bullet-fill: var(--etat-enigme-menu-non-engagee);
 }
-
-.enigme-menu li.non-engagee::before {
+.enigme-menu li.non-engagee:not(.validation-auto):not(.validation-manuelle):not(.validation-aucune):not(.complete):not(.incomplete):not(.bloquee-date):not(.bloquee-pre-requis)::before {
   content: none;
+}
+
+.enigme-menu li.non-engagee.validation-auto,
+.enigme-menu li.non-engagee.validation-manuelle,
+.enigme-menu li.non-engagee.validation-aucune,
+.enigme-menu li.non-engagee.complete {
+  --bullet-fill: var(--etat-enigme-menu-en-cours);
+}
+
+.enigme-menu li.non-engagee.incomplete {
+  --bullet-fill: var(--etat-enigme-menu-incomplete);
 }
 
 .enigme-menu li.incomplete {

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -228,6 +228,15 @@ li.active .enigme-menu__edit {
   content: "\f111";
   color: var(--etat-enigme-menu-en-attente);
 }
+.menu-lateral.joueur .enigme-menu li > a:not(.enigme-menu__edit) {
+  font-weight: 400;
+}
+
+.menu-lateral.joueur .enigme-menu li.non-engagee > a:not(.enigme-menu__edit),
+.menu-lateral.joueur .enigme-menu li.active > a:not(.enigme-menu__edit) {
+  font-weight: 600;
+}
+
 
 
 .enigme-menu li.active > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -55,20 +55,18 @@
   margin-bottom: var(--space-xxs);
   padding-left: calc(var(--space-md) + 16px);
   --bullet-fill: var(--etat-enigme-menu-en-cours);
-  --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
 .enigme-menu li::before {
-  content: '';
   position: absolute;
   top: 50%;
   left: 16px;
-  width: 8px;
-  height: 8px;
-  background-color: var(--bullet-fill);
-  box-shadow: 0 0 0 1px var(--bullet-outline);
   transform: translateY(-50%);
-  border-radius: 50%;
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  font-size: 0.75rem;
+  color: var(--bullet-fill);
+  content: "\f111";
 }
 
 .enigme-menu li > a:not(.enigme-menu__edit) {
@@ -105,7 +103,6 @@
 
 .enigme-menu li.bloquee {
   --bullet-fill: var(--etat-enigme-menu-bloquee);
-  --bullet-outline: var(--etat-enigme-menu-bloquee);
 }
 
 
@@ -153,10 +150,10 @@ li.active .enigme-menu__edit {
 
 .enigme-menu li.en-attente {
   --bullet-fill: var(--etat-enigme-menu-en-attente);
-  --bullet-outline: var(--etat-enigme-menu-en-attente);
 }
 
 .enigme-menu li.en-attente::before {
+  content: '';
   box-sizing: border-box;
   width: 8px;
   height: 8px;
@@ -164,13 +161,40 @@ li.active .enigme-menu__edit {
   border-top-color: transparent;
   border-radius: 50%;
   background-color: transparent;
-  box-shadow: none;
   animation: enigme-menu-spin 0.6s linear infinite;
 }
 
 .enigme-menu li.succes {
   --bullet-fill: var(--etat-enigme-menu-succes);
-  --bullet-outline: var(--etat-enigme-menu-succes);
+}
+
+.enigme-menu li.succes::before,
+.enigme-menu li.complete::before {
+  content: "\f00c";
+}
+
+.enigme-menu li.incomplete::before {
+  content: "\f044";
+}
+
+.enigme-menu li.bloquee-date::before {
+  content: "\f254";
+}
+
+.enigme-menu li.bloquee-pre-requis::before {
+  content: "\f023";
+}
+
+.enigme-menu li.validation-auto::before {
+  content: "\f0e7";
+}
+
+.enigme-menu li.validation-manuelle::before {
+  content: "\f0e0";
+}
+
+.enigme-menu li.validation-aucune::before {
+  content: "\f06e";
 }
 
 
@@ -182,9 +206,17 @@ li.active .enigme-menu__edit {
   --bullet-fill: var(--etat-enigme-menu-non-engagee);
 }
 
+.enigme-menu li.non-engagee::before {
+  content: none;
+}
+
 .enigme-menu li.incomplete {
   --bullet-fill: var(--etat-enigme-menu-incomplete);
-  --bullet-outline: var(--etat-enigme-menu-incomplete);
+}
+
+.menu-lateral.chasse-en-attente .enigme-menu li::before {
+  content: "\f111";
+  color: var(--etat-enigme-menu-en-attente);
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5116,6 +5116,15 @@ li.active .enigme-menu__edit {
   color: var(--etat-enigme-menu-en-attente);
 }
 
+.menu-lateral.joueur .enigme-menu li > a:not(.enigme-menu__edit) {
+  font-weight: 400;
+}
+
+.menu-lateral.joueur .enigme-menu li.non-engagee > a:not(.enigme-menu__edit),
+.menu-lateral.joueur .enigme-menu li.active > a:not(.enigme-menu__edit) {
+  font-weight: 600;
+}
+
 .enigme-menu li.active > a:not(.enigme-menu__edit) {
   background-color: rgba(255, 215, 0, 0.2);
   font-weight: 600;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1922,6 +1922,9 @@ a.addtoany_share span {
   font-size: 1.5rem;
   margin: 0;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
 }
 
 .menu-lateral__edition-toggle {
@@ -4942,20 +4945,18 @@ body.panneau-ouvert::before {
   margin-bottom: var(--space-xxs);
   padding-left: calc(var(--space-md) + 16px);
   --bullet-fill: var(--etat-enigme-menu-en-cours);
-  --bullet-outline: var(--etat-enigme-menu-en-cours);
 }
 
 .enigme-menu li::before {
-  content: "";
   position: absolute;
   top: 50%;
   left: 16px;
-  width: 8px;
-  height: 8px;
-  background-color: var(--bullet-fill);
-  box-shadow: 0 0 0 1px var(--bullet-outline);
   transform: translateY(-50%);
-  border-radius: 50%;
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  font-size: 0.75rem;
+  color: var(--bullet-fill);
+  content: "\f111";
 }
 
 .enigme-menu li > a:not(.enigme-menu__edit) {
@@ -4991,7 +4992,6 @@ body.panneau-ouvert::before {
 
 .enigme-menu li.bloquee {
   --bullet-fill: var(--etat-enigme-menu-bloquee);
-  --bullet-outline: var(--etat-enigme-menu-bloquee);
 }
 
 .enigme-menu__edit {
@@ -5037,10 +5037,10 @@ li.active .enigme-menu__edit {
 }
 .enigme-menu li.en-attente {
   --bullet-fill: var(--etat-enigme-menu-en-attente);
-  --bullet-outline: var(--etat-enigme-menu-en-attente);
 }
 
 .enigme-menu li.en-attente::before {
+  content: "";
   box-sizing: border-box;
   width: 8px;
   height: 8px;
@@ -5048,13 +5048,40 @@ li.active .enigme-menu__edit {
   border-top-color: transparent;
   border-radius: 50%;
   background-color: transparent;
-  box-shadow: none;
   animation: enigme-menu-spin 0.6s linear infinite;
 }
 
 .enigme-menu li.succes {
   --bullet-fill: var(--etat-enigme-menu-succes);
-  --bullet-outline: var(--etat-enigme-menu-succes);
+}
+
+.enigme-menu li.succes::before,
+.enigme-menu li.complete::before {
+  content: "\f00c";
+}
+
+.enigme-menu li.incomplete::before {
+  content: "\f044";
+}
+
+.enigme-menu li.bloquee-date::before {
+  content: "\f254";
+}
+
+.enigme-menu li.bloquee-pre-requis::before {
+  content: "\f023";
+}
+
+.enigme-menu li.validation-auto::before {
+  content: "\f0e7";
+}
+
+.enigme-menu li.validation-manuelle::before {
+  content: "\f0e0";
+}
+
+.enigme-menu li.validation-aucune::before {
+  content: "\f06e";
 }
 
 .enigme-menu li.non-engagee > a:not(.enigme-menu__edit) {
@@ -5065,9 +5092,17 @@ li.active .enigme-menu__edit {
   --bullet-fill: var(--etat-enigme-menu-non-engagee);
 }
 
+.enigme-menu li.non-engagee::before {
+  content: none;
+}
+
 .enigme-menu li.incomplete {
   --bullet-fill: var(--etat-enigme-menu-incomplete);
-  --bullet-outline: var(--etat-enigme-menu-incomplete);
+}
+
+.menu-lateral.chasse-en-attente .enigme-menu li::before {
+  content: "\f111";
+  color: var(--etat-enigme-menu-en-attente);
 }
 
 .enigme-menu li.active > a:not(.enigme-menu__edit) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5092,8 +5092,19 @@ li.active .enigme-menu__edit {
   --bullet-fill: var(--etat-enigme-menu-non-engagee);
 }
 
-.enigme-menu li.non-engagee::before {
+.enigme-menu li.non-engagee:not(.validation-auto):not(.validation-manuelle):not(.validation-aucune):not(.complete):not(.incomplete):not(.bloquee-date):not(.bloquee-pre-requis)::before {
   content: none;
+}
+
+.enigme-menu li.non-engagee.validation-auto,
+.enigme-menu li.non-engagee.validation-manuelle,
+.enigme-menu li.non-engagee.validation-aucune,
+.enigme-menu li.non-engagee.complete {
+  --bullet-fill: var(--etat-enigme-menu-en-cours);
+}
+
+.enigme-menu li.non-engagee.incomplete {
+  --bullet-fill: var(--etat-enigme-menu-incomplete);
 }
 
 .enigme-menu li.incomplete {

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -274,9 +274,9 @@ if (!function_exists('render_sidebar')) {
         int $total_enigmes = 0,
         bool $has_incomplete_enigme = false
     ): array {
+        $user_id = get_current_user_id();
         if ($context === 'enigme') {
-            $mode    = get_field('enigme_mode_validation', $enigme_id);
-            $user_id = get_current_user_id();
+            $mode = get_field('enigme_mode_validation', $enigme_id);
 
             $stats_html = enigme_sidebar_progression_html($chasse_id, $user_id)
                 . enigme_sidebar_resolution_html($enigme_id);
@@ -337,6 +337,17 @@ if (!function_exists('render_sidebar')) {
 
         $chasse_validation = $chasse_id ? get_field('chasse_cache_statut_validation', $chasse_id) : '';
         $aside_classes     = ['menu-lateral'];
+        $is_player         = !(
+            current_user_can('manage_options')
+            || (
+                $chasse_id
+                && function_exists('utilisateur_est_organisateur_associe_a_chasse')
+                && utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+            )
+        );
+        if ($is_player) {
+            $aside_classes[] = 'joueur';
+        }
         if ($chasse_validation === 'en_attente') {
             $aside_classes[] = 'chasse-en-attente';
         }

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -45,6 +45,7 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
         $total_enigmes         = count($all_enigmes);
         $has_incomplete_enigme = false;
         $chasse_validation     = get_field('chasse_cache_statut_validation', $chasse_id) ?? '';
+        $chasse_statut         = get_field('chasse_cache_statut', $chasse_id) ?? '';
 
         foreach ($all_enigmes as $post_check) {
             if (!get_field('enigme_cache_complet', $post_check->ID)) {
@@ -81,9 +82,25 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                 continue;
             }
 
-            $classes    = [];
-            $complet    = (bool) get_field('enigme_cache_complet', $post->ID);
-            $mode_valid = get_field('enigme_mode_validation', $post->ID);
+            $classes            = [];
+            $complet            = (bool) get_field('enigme_cache_complet', $post->ID);
+            $mode_valid         = get_field('enigme_mode_validation', $post->ID);
+            $display_validation = false;
+
+            if ($complet) {
+                if (
+                    $chasse_validation === 'valide'
+                    && in_array($chasse_statut, ['payante', 'termine', 'en_cours'], true)
+                ) {
+                    $display_validation = true;
+                } elseif (
+                    $is_privileged
+                    && in_array($chasse_validation, ['creation', 'correction', 'en_attente'], true)
+                    && in_array($chasse_statut, ['revision', 'a_venir'], true)
+                ) {
+                    $display_validation = true;
+                }
+            }
 
             if (in_array($cta['etat_systeme'], ['bloquee_date', 'bloquee_pre_requis'], true)) {
                 $classes[] = 'bloquee';
@@ -107,12 +124,14 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                     $classes[] = 'non-engagee';
                 }
 
-                if ($mode_valid === 'automatique') {
-                    $classes[] = 'validation-auto';
-                } elseif ($mode_valid === 'manuelle') {
-                    $classes[] = 'validation-manuelle';
-                } else {
-                    $classes[] = 'validation-aucune';
+                if ($display_validation) {
+                    if ($mode_valid === 'automatique') {
+                        $classes[] = 'validation-auto';
+                    } elseif ($mode_valid === 'manuelle') {
+                        $classes[] = 'validation-manuelle';
+                    } else {
+                        $classes[] = 'validation-aucune';
+                    }
                 }
             }
 

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -86,6 +86,7 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
             $complet            = (bool) get_field('enigme_cache_complet', $post->ID);
             $mode_valid         = get_field('enigme_mode_validation', $post->ID);
             $display_validation = false;
+            $title_validation   = '';
 
             if ($complet) {
                 if (
@@ -126,11 +127,23 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
 
                 if ($display_validation) {
                     if ($mode_valid === 'automatique') {
-                        $classes[] = 'validation-auto';
+                        $classes[]       = 'validation-auto';
+                        $title_validation = esc_attr__(
+                            'validation instantanée en ligne de votre tentative',
+                            'chassesautresor-com'
+                        );
                     } elseif ($mode_valid === 'manuelle') {
-                        $classes[] = 'validation-manuelle';
+                        $classes[]       = 'validation-manuelle';
+                        $title_validation = esc_attr__(
+                            'validation manuelle de votre tentative par l\'organisateur',
+                            'chassesautresor-com'
+                        );
                     } else {
-                        $classes[] = 'validation-aucune';
+                        $classes[]       = 'validation-aucune';
+                        $title_validation = esc_attr__(
+                            'pas de système de validation en ligne pour cette énigme',
+                            'chassesautresor-com'
+                        );
                     }
                 }
             }
@@ -175,9 +188,10 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
             $aria_current = $post->ID === $current_enigme_id ? ' aria-current="page"' : '';
             $link         = '<a href="' . esc_url(get_permalink($post->ID)) . '"' . $aria_current . '>' . $title . '</a>';
             $submenu_items[] = sprintf(
-                '<li class="%s" data-enigme-id="%d">%s%s</li>',
+                '<li class="%s" data-enigme-id="%d"%s>%s%s</li>',
                 esc_attr(implode(' ', $classes)),
                 $post->ID,
+                $title_validation ? ' title="' . $title_validation . '"' : '',
                 $link,
                 $edit
             );

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2911,3 +2911,15 @@ msgstr ""
 #: wp-content/themes/chassesautresor/inc/enigme/cta.php:307
 msgid "Statut inconnu"
 msgstr ""
+
+#: inc/sidebar.php:132
+msgid "validation instantanée en ligne de votre tentative"
+msgstr ""
+
+#: inc/sidebar.php:138
+msgid "validation manuelle de votre tentative par l'organisateur"
+msgstr ""
+
+#: inc/sidebar.php:144
+msgid "pas de système de validation en ligne pour cette énigme"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3187,3 +3187,15 @@ msgstr "Requires %s"
 #: template-parts/enigme/chasse-partial-boucle-enigmes.php:194
 msgid "Parution le %1$s à %2$s"
 msgstr "Published on %1$s at %2$s"
+
+#: inc/sidebar.php:132
+msgid "validation instantanée en ligne de votre tentative"
+msgstr "instant online validation of your attempt"
+
+#: inc/sidebar.php:138
+msgid "validation manuelle de votre tentative par l'organisateur"
+msgstr "manual validation of your attempt by the organizer"
+
+#: inc/sidebar.php:144
+msgid "pas de système de validation en ligne pour cette énigme"
+msgstr "no online validation system for this enigma"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3149,3 +3149,15 @@ msgstr "Nécessite : %s"
 #: template-parts/enigme/chasse-partial-boucle-enigmes.php:194
 msgid "Parution le %1$s à %2$s"
 msgstr "Parution le %1$s à %2$s"
+
+#: inc/sidebar.php:132
+msgid "validation instantanée en ligne de votre tentative"
+msgstr "validation instantanée en ligne de votre tentative"
+
+#: inc/sidebar.php:138
+msgid "validation manuelle de votre tentative par l'organisateur"
+msgstr "validation manuelle de votre tentative par l'organisateur"
+
+#: inc/sidebar.php:144
+msgid "pas de système de validation en ligne pour cette énigme"
+msgstr "pas de système de validation en ligne pour cette énigme"


### PR DESCRIPTION
## Résumé
- enrichit le rendu du menu des énigmes avec des icônes contextuelles
- ajoute une icône de validation en attente dans l'entête de l'aside

## Détails
- icônes pour modes de validation, blocages et état de complétion
- affichage d'un sablier devant le titre lors d'une chasse en attente
- styles SCSS et CSS compilés pour les nouvelles puces

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b537d5a4e08332b190725401e908fd