### PR TITLE
Corrige le lien Paramètres du menu des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -125,7 +125,7 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
                     $tab = ($status === 'publish' && get_field('enigme_cache_complet', $post->ID))
                         ? 'stats'
                         : 'param';
-                    $base_url = esc_url(get_permalink($post->ID));
+                    $base_url = get_permalink($post->ID);
                     $edit_url = function_exists('add_query_arg')
                         ? add_query_arg(['edition' => 'open', 'tab' => $tab], $base_url)
                         : $base_url . '?edition=open&tab=' . $tab;


### PR DESCRIPTION
## Résumé
- Correction du lien d'édition des énigmes dans l'aside

## Changements notables
- Ajout des paramètres d'édition à partir de l'URL brute de l'énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b53969d87c8332a2e1d237327b349e