### PR TITLE
Retirer le curseur par défaut sur les liens d’énigme bloquée

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -95,10 +95,6 @@
 }
 
 
-.enigme-menu li.bloquee > a:not(.enigme-menu__edit) {
-  cursor: default;
-}
-
 .enigme-menu li:not(.active):hover > a:not(.enigme-menu__edit) {
   background-color: rgba(255, 215, 0, 0.1);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -4983,10 +4983,6 @@ body.panneau-ouvert::before {
   color: inherit;
 }
 
-.enigme-menu li.bloquee > a:not(.enigme-menu__edit) {
-  cursor: default;
-}
-
 .enigme-menu li:not(.active):hover > a:not(.enigme-menu__edit) {
   background-color: rgba(255, 215, 0, 0.1);
 }


### PR DESCRIPTION
## Résumé
- suppression du curseur par défaut sur les liens d’énigme bloquée
- régénération de la feuille de style compilée

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b53e5f8cf88332b49c4387746de5c8