### PR TITLE
Gérer l'état engagé du bloc CTA

### DIFF
--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -3,7 +3,7 @@ use PHPUnit\Framework\TestCase;
 
 if (!function_exists('current_user_can')) {
     function current_user_can($capability) {
-        return $capability === 'administrator';
+        return false;
     }
 }
 
@@ -28,6 +28,18 @@ if (!function_exists('get_permalink')) {
 if (!function_exists('esc_html__')) {
     function esc_html__($text, $domain) {
         return $text;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+
+if (!function_exists('_n')) {
+    function _n($single, $plural, $number, $domain) {
+        return $number === 1 ? $single : $plural;
     }
 }
 
@@ -67,12 +79,27 @@ if (!function_exists('date_i18n')) {
     }
 }
 
+if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+    function utilisateur_est_engage_dans_chasse($user_id, $chasse_id) {
+        return $GLOBALS['is_engage'] ?? false;
+    }
+}
+
+if (!function_exists('chasse_calculer_progression_utilisateur')) {
+    function chasse_calculer_progression_utilisateur($chasse_id, $user_id) {
+        return $GLOBALS['progression'] ?? ['engagees' => 0, 'total' => 0, 'resolues' => 0, 'resolvables' => 0];
+    }
+}
+
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
 
 class GenererCtaChasseTest extends TestCase
 {
     public function test_admin_or_organizer_gets_disabled_button(): void
     {
+        $GLOBALS['force_admin_override'] = true;
+        $GLOBALS['force_engage_override'] = false;
+        $GLOBALS['force_organisateur_override'] = false;
         $cta = generer_cta_chasse(123, 5);
         $this->assertSame(
             [
@@ -86,6 +113,9 @@ class GenererCtaChasseTest extends TestCase
 
     public function test_guest_gets_login_cta_without_message(): void
     {
+        $GLOBALS['force_admin_override'] = false;
+        $GLOBALS['force_engage_override'] = false;
+        $GLOBALS['force_organisateur_override'] = false;
         $cta = generer_cta_chasse(123, 0);
         $this->assertSame(
             [
@@ -96,5 +126,23 @@ class GenererCtaChasseTest extends TestCase
             $cta
         );
     }
+
+    public function test_engaged_without_enigme_shows_prompt(): void
+    {
+        $GLOBALS['force_admin_override'] = false;
+        $GLOBALS['force_engage_override'] = true;
+        $GLOBALS['force_organisateur_override'] = false;
+        $GLOBALS['progression'] = ['engagees' => 0, 'total' => 3, 'resolues' => 0, 'resolvables' => 2];
+        $cta = generer_cta_chasse(123, 1);
+        $this->assertSame(
+            [
+                'cta_html'    => '<a href="#chasse-enigmes-wrapper" class="bouton-secondaire">Voir les énigmes</a>',
+                'cta_message' => '<p>✅ Vous participez à cette chasse</p><p>Commencez par consulter les énigmes disponibles</p>',
+                'type'        => 'engage',
+            ],
+            $cta
+        );
+    }
+
 }
 

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -20,6 +20,36 @@ msgstr ""
 msgid "chassesautresor.com"
 msgstr ""
 
+#: inc/chasse-functions.php:681
+msgid "Vous participez à cette chasse"
+msgstr ""
+
+#: inc/chasse-functions.php:684
+msgid "Commencez par consulter les énigmes disponibles"
+msgstr ""
+
+#: inc/chasse-functions.php:685
+msgid "Voir les énigmes"
+msgstr ""
+
+#: inc/chasse-functions.php:698
+msgid "Voir mes énigmes"
+msgstr ""
+
+#: inc/chasse-functions.php:688
+#, php-format
+msgid "%1$d / %2$d énigme vue"
+msgid_plural "%1$d / %2$d énigmes vues"
+msgstr[0] ""
+msgstr[1] ""
+
+#: inc/chasse-functions.php:693
+#, php-format
+msgid "%1$d / %2$d énigme résolue"
+msgid_plural "%1$d / %2$d énigmes résolues"
+msgstr[0] ""
+msgstr[1] ""
+
 #: templates/myaccount/content-outils.php:24
 msgid "Protection globale"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3208,3 +3208,33 @@ msgstr "manual validation of your attempt by the organizer"
 #: inc/sidebar.php:144
 msgid "pas de système de validation en ligne pour cette énigme"
 msgstr "no online validation system for this enigma"
+
+#: inc/chasse-functions.php:681
+msgid "Vous participez à cette chasse"
+msgstr "You are participating in this hunt"
+
+#: inc/chasse-functions.php:684
+msgid "Commencez par consulter les énigmes disponibles"
+msgstr "Start by viewing the available riddles"
+
+#: inc/chasse-functions.php:685
+msgid "Voir les énigmes"
+msgstr "View riddles"
+
+#: inc/chasse-functions.php:698
+msgid "Voir mes énigmes"
+msgstr "View my riddles"
+
+#: inc/chasse-functions.php:688
+#, php-format
+msgid "%1$d / %2$d énigme vue"
+msgid_plural "%1$d / %2$d énigmes vues"
+msgstr[0] "%1$d / %2$d riddle viewed"
+msgstr[1] "%1$d / %2$d riddles viewed"
+
+#: inc/chasse-functions.php:693
+#, php-format
+msgid "%1$d / %2$d énigme résolue"
+msgid_plural "%1$d / %2$d énigmes résolues"
+msgstr[0] "%1$d / %2$d riddle solved"
+msgstr[1] "%1$d / %2$d riddles solved"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3170,3 +3170,33 @@ msgstr "validation manuelle de votre tentative par l'organisateur"
 #: inc/sidebar.php:144
 msgid "pas de système de validation en ligne pour cette énigme"
 msgstr "pas de système de validation en ligne pour cette énigme"
+
+#: inc/chasse-functions.php:681
+msgid "Vous participez à cette chasse"
+msgstr "Vous participez à cette chasse"
+
+#: inc/chasse-functions.php:684
+msgid "Commencez par consulter les énigmes disponibles"
+msgstr "Commencez par consulter les énigmes disponibles"
+
+#: inc/chasse-functions.php:685
+msgid "Voir les énigmes"
+msgstr "Voir les énigmes"
+
+#: inc/chasse-functions.php:698
+msgid "Voir mes énigmes"
+msgstr "Voir mes énigmes"
+
+#: inc/chasse-functions.php:688
+#, php-format
+msgid "%1$d / %2$d énigme vue"
+msgid_plural "%1$d / %2$d énigmes vues"
+msgstr[0] "%1$d / %2$d énigme vue"
+msgstr[1] "%1$d / %2$d énigmes vues"
+
+#: inc/chasse-functions.php:693
+#, php-format
+msgid "%1$d / %2$d énigme résolue"
+msgid_plural "%1$d / %2$d énigmes résolues"
+msgstr[0] "%1$d / %2$d énigme résolue"
+msgstr[1] "%1$d / %2$d énigmes résolues"

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -66,25 +66,13 @@ $image_id  = $infos_chasse['image_id'];
 $image_url = $infos_chasse['image_url'];
 
 
-$enigmes_resolues = compter_enigmes_resolues($chasse_id, $user_id);
+$progression      = $infos_chasse['progression'];
+$enigmes_resolues = $progression['resolues'];
+$total_enigmes    = $progression['total'];
+$nb_resolvables   = $progression['resolvables'];
+$nb_engagees      = $progression['engagees'];
 
 $enigmes_associees = $infos_chasse['enigmes_associees'];
-$total_enigmes    = count($enigmes_associees);
-$validables       = [];
-foreach ($enigmes_associees as $eid) {
-    if (get_field('enigme_mode_validation', $eid) !== 'aucune') {
-        $validables[] = $eid;
-    }
-}
-$nb_resolvables = count($validables);
-
-$nb_engagees = 0;
-if ($user_id && $total_enigmes > 0) {
-    global $wpdb;
-    $placeholders = implode(',', array_fill(0, $total_enigmes, '%d'));
-    $sql          = "SELECT COUNT(DISTINCT enigme_id) FROM {$wpdb->prefix}engagements WHERE user_id = %d AND enigme_id IN ($placeholders)";
-    $nb_engagees  = (int) $wpdb->get_var($wpdb->prepare($sql, array_merge([$user_id], $enigmes_associees)));
-}
 
 $has_solutions = function_exists('solution_existe_pour_objet')
     ? solution_existe_pour_objet($chasse_id, 'chasse')

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -387,13 +387,14 @@ if ($edition_active && !$est_complet) {
             <?php endif; ?>
           </div>
 
-          <?php if (($cta_data['type'] ?? '') !== 'engage') : ?>
-            <?php $cta_id = ($cta_data['type'] ?? '') === 'validation' ? 'cta-validation-chasse' : ''; ?>
-            <div class="cta-chasse-row"<?php echo $cta_id ? ' id="' . esc_attr($cta_id) . '"' : ''; ?>>
-              <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
-              <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
-            </div>
-          <?php endif; ?>
+          <?php
+          $cta_type = $cta_data['type'] ?? '';
+          $cta_id   = $cta_type === 'validation' ? 'cta-validation-chasse' : '';
+          ?>
+          <div class="cta-chasse-row"<?php echo $cta_id ? ' id="' . esc_attr($cta_id) . '"' : ''; ?>>
+            <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
+            <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
+          </div>
           </div>
 
         <?php


### PR DESCRIPTION
## Summary
- afficher la confirmation et la progression lorsque le joueur est engagé
- centraliser la progression utilisateur dans `preparer_infos_affichage_chasse`
- tests unitaires pour le CTA engagé

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b56eb58798833295129c2a03fecdeb