### PR TITLE
feat: add breadcrumb to chasse page

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -1113,3 +1113,33 @@ a.addtoany_share span {
     font-weight: 600;
 }
 
+/* ========== 🧭 FIL D'ARIANE ========== */
+
+.breadcrumb {
+  margin: var(--space-sm) 0;
+}
+
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.breadcrumb li + li::before {
+  content: '›';
+  margin: 0 var(--space-xs);
+  color: var(--color-text-secondary);
+}
+
+.breadcrumb a {
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover,
+.breadcrumb a:focus {
+  text-decoration: underline;
+}
+

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1842,6 +1842,35 @@ a.addtoany_share span {
   font-weight: 600;
 }
 
+/* ========== 🧭 FIL D'ARIANE ========== */
+.breadcrumb {
+  margin: var(--space-sm) 0;
+}
+
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.breadcrumb li + li::before {
+  content: "›";
+  margin: 0 var(--space-xs);
+  color: var(--color-text-secondary);
+}
+
+.breadcrumb a {
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover,
+.breadcrumb a:focus {
+  text-decoration: underline;
+}
+
 /* Skeleton card styles */
 .carte-skeleton {
   position: relative;

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -233,8 +233,9 @@ if ($peut_voir_aside) {
     // 🧭 Fil d'Ariane
     $breadcrumb_items = [
       [
-        'label' => esc_html__('Accueil', 'chassesautresor-com'),
-        'url'   => home_url('/'),
+        'label'      => esc_html__('Accueil', 'chassesautresor-com'),
+        'label_html' => '<i class="fa-solid fa-house" aria-hidden="true"></i><span class="screen-reader-text">' . esc_html__('Accueil', 'chassesautresor-com') . '</span>',
+        'url'        => home_url('/'),
       ],
     ];
     if ($organisateur_id) {

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -230,12 +230,24 @@ if ($peut_voir_aside) {
   <main id="main" class="site-main">
 
     <?php
-    // 🧭 Header organisateur (dans le flux visible)
+    // 🧭 Fil d'Ariane
+    $breadcrumb_items = [
+      [
+        'label' => esc_html__('Accueil', 'chassesautresor-com'),
+        'url'   => home_url('/'),
+      ],
+    ];
     if ($organisateur_id) {
-      get_template_part('template-parts/organisateur/organisateur-header', null, [
-        'organisateur_id' => $organisateur_id
-      ]);
+      $breadcrumb_items[] = [
+        'label' => get_the_title($organisateur_id),
+        'url'   => get_permalink($organisateur_id),
+      ];
     }
+    $breadcrumb_items[] = [
+      'label'   => get_the_title($chasse_id),
+      'current' => true,
+    ];
+    get_template_part('template-parts/common/breadcrumb', null, ['items' => $breadcrumb_items]);
     ?>
 
     <?php

--- a/wp-content/themes/chassesautresor/template-parts/common/breadcrumb.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/breadcrumb.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Template part: Breadcrumb navigation.
+ *
+ * Expected $args['items'] as array of ['label' => string, 'url' => string|null, 'current' => bool].
+ */
+
+defined('ABSPATH') || exit;
+
+$items = isset($args['items']) && is_array($args['items']) ? $args['items'] : [];
+
+if (empty($items)) {
+    return;
+}
+?>
+<nav class="breadcrumb" aria-label="<?php echo esc_attr__('Fil d\'Ariane', 'chassesautresor-com'); ?>">
+    <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+        <?php foreach ($items as $index => $item) : ?>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <?php if (!empty($item['url']) && empty($item['current'])) : ?>
+                    <a itemprop="item" href="<?= esc_url($item['url']); ?>">
+                        <span itemprop="name"><?= esc_html($item['label']); ?></span>
+                    </a>
+                <?php else : ?>
+                    <span itemprop="name"><?= esc_html($item['label']); ?></span>
+                <?php endif; ?>
+                <meta itemprop="position" content="<?= (int) ($index + 1); ?>" />
+            </li>
+        <?php endforeach; ?>
+    </ol>
+</nav>

--- a/wp-content/themes/chassesautresor/template-parts/common/breadcrumb.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/breadcrumb.php
@@ -2,7 +2,13 @@
 /**
  * Template part: Breadcrumb navigation.
  *
- * Expected $args['items'] as array of ['label' => string, 'url' => string|null, 'current' => bool].
+ * Expected $args['items'] as array of:
+ * [
+ *   'label'      => string,
+ *   'url'        => string|null,
+ *   'current'    => bool,
+ *   'label_html' => string Optional raw HTML for the label.
+ * ].
  */
 
 defined('ABSPATH') || exit;
@@ -15,14 +21,27 @@ if (empty($items)) {
 ?>
 <nav class="breadcrumb" aria-label="<?php echo esc_attr__('Fil d\'Ariane', 'chassesautresor-com'); ?>">
     <ol itemscope itemtype="https://schema.org/BreadcrumbList">
-        <?php foreach ($items as $index => $item) : ?>
+        <?php foreach ($items as $index => $item) :
+            $label      = isset($item['label']) ? $item['label'] : '';
+            $label_html = isset($item['label_html']) ? $item['label_html'] : '';
+            $allowed    = [
+                'i'    => [
+                    'class'       => [],
+                    'aria-hidden' => [],
+                ],
+                'span' => [
+                    'class' => [],
+                ],
+            ];
+            $label_output = $label_html ? wp_kses($label_html, $allowed) : esc_html($label);
+            ?>
             <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
                 <?php if (!empty($item['url']) && empty($item['current'])) : ?>
                     <a itemprop="item" href="<?= esc_url($item['url']); ?>">
-                        <span itemprop="name"><?= esc_html($item['label']); ?></span>
+                        <span itemprop="name"><?= $label_output; ?></span>
                     </a>
                 <?php else : ?>
-                    <span itemprop="name"><?= esc_html($item['label']); ?></span>
+                    <span itemprop="name"><?= $label_output; ?></span>
                 <?php endif; ?>
                 <meta itemprop="position" content="<?= (int) ($index + 1); ?>" />
             </li>


### PR DESCRIPTION
## Summary
- ajout d'un fil d'Ariane accessible sur la page d'une chasse
- suppression de l'en-tête organisateur au profit du fil d'Ariane
- styles SCSS/CSS pour le composant de fil d'Ariane

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59119fdec833283439e1c4bf9f1dd