### PR TITLE
Améliore l'affichage de l'organisateur sur la fiche chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -134,11 +134,39 @@
 .header-chasse {
   font-size: 30px;
 }
-.chasse-details-wrapper .auteur-organisateur a {
-    color:var(--color-text-primary);
-}
-.chasse-details-wrapper .auteur-organisateur a:hover {
-    text-decoration: underline;
+
+.chasse-organisateur {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-xs);
+
+    &__logo {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+
+    &__texte {
+        display: flex;
+        align-items: baseline;
+        gap: 0.25rem;
+    }
+
+    &__nom {
+        font-weight: 700;
+        color: var(--color-text-primary);
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    &__presente {
+        color: var(--color-gris-3);
+        font-style: italic;
+    }
 }
 
 .chasse-details-wrapper .meta-row,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -564,12 +564,34 @@
   font-size: 30px;
 }
 
-.chasse-details-wrapper .auteur-organisateur a {
+.chasse-organisateur {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-xs);
+}
+.chasse-organisateur__logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+.chasse-organisateur__texte {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+.chasse-organisateur__nom {
+  font-weight: 700;
   color: var(--color-text-primary);
 }
-
-.chasse-details-wrapper .auteur-organisateur a:hover {
+.chasse-organisateur__nom:hover {
   text-decoration: underline;
+}
+.chasse-organisateur__presente {
+  color: var(--color-gris-3);
+  font-style: italic;
 }
 
 .chasse-details-wrapper .meta-row,

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -250,18 +250,26 @@ if ($edition_active && !$est_complet) {
         <?php endif; ?>
       </div>
 
+      <?php if ($organisateur_id) :
+          $logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
+          $logo    = wp_get_attachment_image_src($logo_id, 'thumbnail');
+          $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
+      ?>
+        <div class="chasse-organisateur">
+          <img class="chasse-organisateur__logo" src="<?= esc_url($logo_url); ?>" alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>">
+          <span class="chasse-organisateur__texte">
+            <a class="chasse-organisateur__nom" href="<?= esc_url(get_permalink($organisateur_id)); ?>"><?= esc_html($organisateur_nom); ?></a>
+            <span class="chasse-organisateur__presente"><?php esc_html_e('présente', 'chassesautresor-com'); ?></span>
+          </span>
+        </div>
+      <?php endif; ?>
+
       <!-- Titre dynamique -->
       <h1 class="titre-objet header-chasse"
         data-cpt="chasse"
         data-post-id="<?= esc_attr($chasse_id); ?>">
         <?= esc_html($titre); ?>
       </h1>
-
-      <?php if ($organisateur_id): ?>
-        <p class="txt-small auteur-organisateur">
-          <?php esc_html_e('Par', 'chassesautresor-com'); ?> <a href="<?= get_permalink($organisateur_id); ?>"><?= esc_html($organisateur_nom); ?></a>
-        </p>
-      <?php endif; ?>
 
       <div class="meta-row svg-xsmall">
         <div class="meta-regular">


### PR DESCRIPTION
## Résumé
- met en avant l'organisateur au-dessus du titre de la chasse
- supprime l'ancien libellé "Par"
- ajoute les styles associés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0527dc48332b3179d6eec78ca9c