### PR TITLE
Centrer l'image de chasse sur grands écrans

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -105,8 +105,9 @@
   }
   .chasse-visuel-wrapper {
     position: sticky;
-    top: 50vh;
-    transform: translateY(-50%);
+    top: 0;
+    height: 100vh;
+    justify-content: center;
     max-width: 40%;
     margin: 0;
   }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -536,8 +536,9 @@
   }
   .chasse-visuel-wrapper {
     position: sticky;
-    top: 50vh;
-    transform: translateY(-50%);
+    top: 0;
+    height: 100vh;
+    justify-content: center;
     max-width: 40%;
     margin: 0;
   }


### PR DESCRIPTION
## Résumé
- Centre verticalement le visuel et les liens de la fiche chasse sur les écrans larges
- Recompile la feuille de style du thème

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5a32a418c83328278bab4b29bbab6