### PR TITLE
feat: show estimated reward label

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -350,8 +350,16 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
     if (complet) {
       const valeurSpan = document.createElement('span');
       valeurSpan.className = 'recompense-valeur';
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'recompense-valeur__label';
+      labelSpan.textContent = wp.i18n.__('Valeur estimée', 'chassesautresor-com');
+      valeurSpan.appendChild(labelSpan);
       const arrondi = Math.round(valeur);
-      valeurSpan.textContent = arrondi.toLocaleString('fr-FR') + ' €';
+      valeurSpan.appendChild(document.createTextNode(arrondi.toLocaleString('fr-FR')));
+      const deviseSpan = document.createElement('span');
+      deviseSpan.className = 'recompense-valeur__devise';
+      deviseSpan.textContent = '€';
+      valeurSpan.appendChild(deviseSpan);
 
       const titreSpan = document.createElement('span');
       titreSpan.className = 'recompense-titre';

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -681,6 +681,20 @@ a.ajout-link:focus-visible {
   color: var(--color-text-primary);
 }
 
+.badge-recompense__label,
+.badge-recompense__devise {
+  font-size: 0.75em;
+  opacity: 0.8;
+}
+
+.badge-recompense__label {
+  margin-right: var(--space-xxs);
+}
+
+.badge-recompense__devise {
+  margin-left: 0.15rem;
+}
+
 .badge-recompense.avec-recompense {
   color: var(--color-primary);
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -1216,6 +1216,20 @@ li.ligne-logo .champ-modifier {
   gap: var(--space-xs);
 }
 
+.recompense-valeur__label,
+.recompense-valeur__devise {
+  font-size: 0.75em;
+  opacity: 0.8;
+}
+
+.recompense-valeur__label {
+  margin-right: var(--space-xxs);
+}
+
+.recompense-valeur__devise {
+  margin-left: 0.15rem;
+}
+
 
 .resume-infos li.champ-recompense .champ-texte {
   flex: 1;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1445,6 +1445,20 @@ a.ajout-link:focus-visible {
   color: var(--color-text-primary);
 }
 
+.badge-recompense__label,
+.badge-recompense__devise {
+  font-size: 0.75em;
+  opacity: 0.8;
+}
+
+.badge-recompense__label {
+  margin-right: var(--space-xxs);
+}
+
+.badge-recompense__devise {
+  margin-left: 0.15rem;
+}
+
 .badge-recompense.avec-recompense {
   color: var(--color-primary);
 }
@@ -3514,6 +3528,20 @@ li.ligne-logo .champ-modifier {
   display: flex;
   align-items: baseline;
   gap: var(--space-xs);
+}
+
+.recompense-valeur__label,
+.recompense-valeur__devise {
+  font-size: 0.75em;
+  opacity: 0.8;
+}
+
+.recompense-valeur__label {
+  margin-right: var(--space-xxs);
+}
+
+.recompense-valeur__devise {
+  margin-left: 0.15rem;
 }
 
 .resume-infos li.champ-recompense .champ-texte {

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2931,3 +2931,7 @@ msgstr ""
 #: inc/sidebar.php:144
 msgid "pas de système de validation en ligne pour cette énigme"
 msgstr ""
+
+#: template-parts/chasse/chasse-affichage-complet.php:443 template-parts/chasse/chasse-edition-main.php:284 assets/js/chasse-edit.js:355
+msgid "Valeur estimée"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3216,3 +3216,7 @@ msgstr "You are participating in this hunt"
 #: inc/chasse-functions.php:690
 msgid "Voir mes énigmes"
 msgstr "View my riddles"
+
+#: template-parts/chasse/chasse-affichage-complet.php:443 template-parts/chasse/chasse-edition-main.php:284 assets/js/chasse-edit.js:355
+msgid "Valeur estimée"
+msgstr "Estimated value"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3178,3 +3178,7 @@ msgstr "Vous participez à cette chasse"
 #: inc/chasse-functions.php:690
 msgid "Voir mes énigmes"
 msgstr "Voir mes énigmes"
+
+#: template-parts/chasse/chasse-affichage-complet.php:443 template-parts/chasse/chasse-edition-main.php:284 assets/js/chasse-edit.js:355
+msgid "Valeur estimée"
+msgstr "Valeur estimée"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -437,7 +437,15 @@ if ($edition_active && !$est_complet) {
                     data-post-id="<?= esc_attr($chasse_id); ?>">
                     <div class="champ-affichage">
                         <?php if ((float) $valeur_recompense > 0) : ?>
-                            <p class="lot-valeur"><span class="badge-recompense avec-recompense"><?= esc_html($valeur_recompense); ?> €</span></p>
+                            <p class="lot-valeur">
+                                <span class="badge-recompense avec-recompense">
+                                    <span class="badge-recompense__label">
+                                        <?= esc_html__('Valeur estimée', 'chassesautresor-com'); ?>
+                                    </span>
+                                    <?= esc_html($valeur_recompense); ?>
+                                    <span class="badge-recompense__devise">€</span>
+                                </span>
+                            </p>
                         <?php endif; ?>
                     </div>
                     <div class="champ-feedback"></div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -280,7 +280,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                 <?php if ($recompense_remplie) : ?>
                                     <span class="champ-texte-contenu">
                                         <span class="recompense-valeur">
-                                            <?= esc_html(number_format_i18n(round((float) $valeur), 0)); ?> €
+                                            <span class="recompense-valeur__label">
+                                                <?= esc_html__('Valeur estimée', 'chassesautresor-com'); ?>
+                                            </span>
+                                            <?= esc_html(number_format_i18n(round((float) $valeur), 0)); ?>
+                                            <span class="recompense-valeur__devise">€</span>
                                         </span>
                                         &nbsp;–&nbsp;
                                         <span class="recompense-titre"><?= esc_html($titre_recompense); ?></span>


### PR DESCRIPTION
## Résumé
- affiche une étiquette "Valeur estimée" avant le montant de la récompense
- rend l'étiquette et le symbole € plus discrets
- met à jour les traductions et styles associés

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5a51b25948332a1bbb42bb40dfaa1