### PR TITLE
Supprimer les max-width du CTA chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -328,7 +328,6 @@
   align-items: center;
   text-align: left;
   width: 100%;
-  max-width: 100%;
 }
 
 .chasse-cta-section .chasse-caracteristiques {
@@ -343,12 +342,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-}
-
-@media (--bp-tablet) {
-  .chasse-cta-section {
-    max-width: 650px;
-  }
 }
 
 .chasse-caracteristiques .caracteristique-label {

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -67,7 +67,6 @@ a.bouton-edition-attention {
   border-left: 4px solid var(--color-secondary);
   padding: 1.2rem;
   margin: var(--space-2xl) auto;
-  max-width: 700px;
   text-align: center;
   border-radius: 6px;
   font-size: 1rem;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -751,7 +751,6 @@
   align-items: center;
   text-align: left;
   width: 100%;
-  max-width: 100%;
 }
 
 .chasse-cta-section .chasse-caracteristiques {
@@ -768,11 +767,6 @@
   justify-content: center;
 }
 
-@media (min-width: 768px) {
-  .chasse-cta-section {
-    max-width: 650px;
-  }
-}
 .chasse-caracteristiques .caracteristique-label {
   flex: 0 0 6rem;
   font-weight: 700;
@@ -8539,7 +8533,6 @@ a.bouton-edition-attention {
   border-left: 4px solid var(--color-secondary);
   padding: 1.2rem;
   margin: var(--space-2xl) auto;
-  max-width: 700px;
   text-align: center;
   border-radius: 6px;
   font-size: 1rem;


### PR DESCRIPTION
## Résumé
- supprime les `max-width` dans la section d'appel à l'action des chasses
- regénère la feuille de style du thème

## Changements notables
- suppression de la contrainte de largeur dans `_chasse.scss`
- suppression de la limite de largeur dans `_organisateurs.scss`
- recompilation de `dist/style.css`

## Testing
- `source ./setup-env.sh`
- `composer install --no-progress --no-interaction`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b5a792d7188332809ba7c4797d9a56