### PR TITLE
Affichage de l'icône paramètres sur les cartes énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -460,8 +460,8 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: var(--color-secondary);
-  color: var(--color-text-primary);
+  background-color: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
   font-size: 0.875rem;
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -437,6 +437,50 @@
   }
 }
 
+.carte-icons {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  z-index: 2;
+}
+
+.carte-icons .warning-icon {
+  position: static;
+  top: auto;
+  right: auto;
+}
+
+.settings-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--color-secondary);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+}
+
+@media (--bp-tablet) {
+  .settings-icon {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+}
+
+@media (--bp-desktop) {
+  .settings-icon {
+    width: 32px;
+    height: 32px;
+    font-size: 1.125rem;
+  }
+}
+
 @media (--bp-desktop) {
   .warning-icon {
     width: 32px;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -252,18 +252,35 @@ li.active .enigme-menu__edit {
 
   &-handle {
     position: absolute;
-    top: 0.5rem;
-    left: 0.5rem;
+    top: var(--space-xs);
+    left: var(--space-xs);
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 2rem;
-    height: 2rem;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
-    background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
-    color: var(--color-white);
+    background-color: var(--color-grey-light);
+    color: var(--color-text-fond-clair);
+    font-size: 0.875rem;
     pointer-events: none;
-    z-index: 10;
+    z-index: 2;
+  }
+
+  @media (--bp-tablet) {
+    &-handle {
+      width: 28px;
+      height: 28px;
+      font-size: 1rem;
+    }
+  }
+
+  @media (--bp-desktop) {
+    &-handle {
+      width: 32px;
+      height: 32px;
+      font-size: 1.125rem;
+    }
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -448,8 +448,8 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: var(--color-secondary);
-  color: var(--color-text-primary);
+  background-color: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
   font-size: 0.875rem;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -425,6 +425,48 @@
     font-size: 1rem;
   }
 }
+.carte-icons {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  z-index: 2;
+}
+
+.carte-icons .warning-icon {
+  position: static;
+  top: auto;
+  right: auto;
+}
+
+.settings-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--color-secondary);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+}
+
+@media (min-width: 768px) {
+  .settings-icon {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+}
+@media (min-width: 1024px) {
+  .settings-icon {
+    width: 32px;
+    height: 32px;
+    font-size: 1.125rem;
+  }
+}
 @media (min-width: 1024px) {
   .warning-icon {
     width: 32px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5316,18 +5316,33 @@ li.active .enigme-menu__edit {
 }
 .carte-enigme-handle {
   position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
+  top: var(--space-xs);
+  left: var(--space-xs);
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
-  color: var(--color-white);
+  background-color: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
+  font-size: 0.875rem;
   pointer-events: none;
-  z-index: 10;
+  z-index: 2;
+}
+@media (min-width: 768px) {
+  .carte-enigme-handle {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+}
+@media (min-width: 1024px) {
+  .carte-enigme-handle {
+    width: 32px;
+    height: 32px;
+    font-size: 1.125rem;
+  }
 }
 
 .carte-enigme[draggable=true] {

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -67,7 +67,7 @@ if (!function_exists('enigme_compter_joueurs_engages')) {
   require_once get_stylesheet_directory() . '/inc/enigme/stats.php';
 }
 
-if (!function_exists('compter_tentatives_du_jour')) {
+if (!function_exists('compter_tentatives_du_jour') || !function_exists('compter_tentatives_en_attente')) {
   require_once get_stylesheet_directory() . '/inc/enigme/tentatives.php';
 }
 ?>
@@ -234,11 +234,38 @@ if (!function_exists('compter_tentatives_du_jour')) {
                 </div>
               </footer>
             <?php endif; ?>
-          <?php if ($classe_completion === 'carte-incomplete') : ?>
-            <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
-              <i class="fa-solid fa-exclamation" aria-hidden="true"></i>
-            </span>
-          <?php endif; ?>
+            <?php
+            $can_edit = function_exists('utilisateur_peut_modifier_enigme') && utilisateur_peut_modifier_enigme($enigme_id);
+            $tab = 'param';
+            if (!in_array($infos_chasse['statut_validation'] ?? '', ['creation', 'correction'], true)) {
+              $statut_metier = $infos_chasse['statut'] ?? '';
+              if (in_array($statut_metier, ['en_cours', 'a_venir', 'payante'], true)) {
+                if ($mode_validation === 'manuelle' && compter_tentatives_en_attente($enigme_id) > 0) {
+                  $tab = 'soumission';
+                } else {
+                  $tab = 'stats';
+                }
+              }
+            }
+            $settings_url = add_query_arg([
+              'edition' => 'open',
+              'tab'     => $tab,
+            ], get_permalink($enigme_id));
+            ?>
+            <?php if ($classe_completion === 'carte-incomplete' || $can_edit) : ?>
+              <div class="carte-icons">
+                <?php if ($classe_completion === 'carte-incomplete') : ?>
+                  <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
+                    <i class="fa-solid fa-exclamation" aria-hidden="true"></i>
+                  </span>
+                <?php endif; ?>
+                <?php if ($can_edit) : ?>
+                  <a class="settings-icon" href="<?= esc_url($settings_url); ?>" aria-label="<?= esc_attr__('Paramètres', 'chassesautresor-com'); ?>">
+                    <i class="fa-solid fa-gear" aria-hidden="true"></i>
+                  </a>
+                <?php endif; ?>
+              </div>
+            <?php endif; ?>
         </article>
     <?php endforeach; ?>
 


### PR DESCRIPTION
## Résumé
- affiche l'icône d'édition sur les cartes d'énigme pour les organisateurs et admins
- ouvre le bon onglet du panneau selon l'état de la chasse et les tentatives en attente
- ajoute le style pour l'icône de paramètres

## Testing
- `npm ci`
- `node build-css.js`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5ab33b7ac833285e455e4b575d7a9