### PR TITLE
Réduit la largeur de l'image de chasse et ajoute respiration au texte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -136,7 +136,7 @@
   .chasse-visuel-wrapper {
     position: sticky;
     top: 0;
-    max-width: 40%;
+    max-width: 35%;
     margin: 0;
   }
   .champ-chasse.champ-img {
@@ -151,6 +151,10 @@
   }
   .chasse-visuel-wrapper .lien-public .texte-lien {
     display: inline;
+  }
+  .chasse-details-wrapper {
+    margin-left: 2.5%;
+    padding-left: 2.5%;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -609,7 +609,7 @@
   .chasse-visuel-wrapper {
     position: sticky;
     top: 0;
-    max-width: 40%;
+    max-width: 35%;
     margin: 0;
   }
   .champ-chasse.champ-img {
@@ -624,6 +624,10 @@
   }
   .chasse-visuel-wrapper .lien-public .texte-lien {
     display: inline;
+  }
+  .chasse-details-wrapper {
+    margin-left: 2.5%;
+    padding-left: 2.5%;
   }
 }
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */


### PR DESCRIPTION
## Résumé
- ajuste la grille de la fiche chasse tablette+ pour limiter l’image à 35%
- ajoute marge et padding pour offrir 5% d’espace respiratoire au texte

## Modifications notables
- largeur de la colonne visuel ramenée de 40% à 35%
- marge et padding horizontaux de 2,5% sur la colonne texte

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5aca3b12c83328abe444e548be2b8