### PR TITLE
Limiter la boucle des énigmes aux IDs pré-calculés

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -28,18 +28,19 @@ $autorise_boucle = (
 if (!$autorise_boucle) return;
 
 // 🔁 Récupération des énigmes associées
-$posts = get_posts([
-  'post_type'      => 'enigme',
-  'posts_per_page' => -1,
-  'orderby'        => 'menu_order',
-  'order'          => 'ASC',
-  'post_status'    => ['publish', 'pending', 'draft'],
-  'meta_query'     => [[
-    'key'     => 'enigme_chasse_associee',
-    'value'   => $chasse_id,     // 👈 pas de guillemets !
-    'compare' => 'LIKE',
-  ]]
-]);
+$ids_enigmes = $infos_chasse['enigmes_associees'] ?? [];
+
+if (!empty($ids_enigmes)) {
+    $posts = get_posts([
+        'post_type'      => 'enigme',
+        'post_status'    => ['publish', 'pending', 'draft'],
+        'posts_per_page' => count($ids_enigmes),
+        'post__in'       => array_map('intval', $ids_enigmes),
+        'orderby'        => 'post__in',
+    ]);
+} else {
+    $posts = [];
+}
 
 $posts_visibles = $posts;
 $has_enigmes = !empty($posts_visibles);


### PR DESCRIPTION
## Résumé
- utilise la liste `enigmes_associees` pour charger les énigmes d'une chasse
- interroge uniquement les IDs concernés via `post__in`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5c430ccf4833291431288fd2208d4