### PR TITLE
Optimize resolvable riddles count

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -601,10 +601,13 @@ function chasse_calculer_progression_utilisateur(int $chasse_id, int $user_id): 
     $total   = count($enigmes);
 
     $resolvables = 0;
-    foreach ($enigmes as $eid) {
-        if (get_field('enigme_mode_validation', $eid) !== 'aucune') {
-            $resolvables++;
-        }
+    if ($total > 0) {
+        global $wpdb;
+        $placeholders = implode(',', array_fill(0, $total, '%d'));
+        $sql = "SELECT COUNT(DISTINCT post_id) FROM {$wpdb->prefix}postmeta WHERE meta_key = %s "
+            . "AND meta_value <> %s AND post_id IN ($placeholders)";
+        $params = array_merge(['enigme_mode_validation', 'aucune'], $enigmes);
+        $resolvables = (int) $wpdb->get_var($wpdb->prepare($sql, $params));
     }
 
     $engagees = 0;


### PR DESCRIPTION
### Résumé
- remplace la boucle PHP par une requête SQL pour compter les énigmes résolvables

### Changements notables
- compte directement les énigmes avec un mode de validation défini dans `wp_postmeta`
- renvoie ce total via la clé `resolvables`

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b5ce4dc19c83329f9df2973c1521a3