### PR TITLE
Cache des solutions et indices des chasses

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -1,7 +1,7 @@
 🔹 Groupe : paramètre de la chasse
 🆔 ID : 27
 🔑 Key : group_67b58c51b9a49
-📦 Champs trouvés : 19
+📦 Champs trouvés : 21
 
 — chasse_principale_image —
 Type : image
@@ -148,6 +148,18 @@ Choices :
 — chasse_cache_complet —
 Type : true_false
 Label : chasse_cache_complet
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_cache_has_solutions —
+Type : true_false
+Label : chasse_cache_has_solutions
+Instructions : (vide)
+Requis : non
+----------------------------------------
+— chasse_cache_has_indices —
+Type : true_false
+Label : chasse_cache_has_indices
 Instructions : (vide)
 Requis : non
 ----------------------------------------

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -72,27 +72,8 @@ $total_enigmes    = $progression['total'];
 $nb_resolvables   = $progression['resolvables'];
 $nb_engagees      = $progression['engagees'];
 
-$enigmes_associees = $infos_chasse['enigmes_associees'];
-
-$has_solutions = function_exists('solution_existe_pour_objet')
-    ? solution_existe_pour_objet($chasse_id, 'chasse')
-    : false;
-$has_indices = function_exists('prochain_rang_indice')
-    ? prochain_rang_indice($chasse_id, 'chasse') > 1
-    : false;
-if (!$has_solutions || !$has_indices) {
-    foreach ($enigmes_associees as $eid) {
-        if (!$has_solutions && function_exists('solution_existe_pour_objet') && solution_existe_pour_objet($eid, 'enigme')) {
-            $has_solutions = true;
-        }
-        if (!$has_indices && function_exists('prochain_rang_indice') && prochain_rang_indice($eid, 'enigme') > 1) {
-            $has_indices = true;
-        }
-        if ($has_solutions && $has_indices) {
-            break;
-        }
-    }
-}
+$has_solutions = (bool) get_field('chasse_cache_has_solutions', $chasse_id);
+$has_indices   = (bool) get_field('chasse_cache_has_indices', $chasse_id);
 
 $titre_chasse   = get_the_title($chasse_id);
 $enigmes_intro  = '';


### PR DESCRIPTION
## Résumé
- met en cache la présence de solutions et d'indices lors de l'enregistrement d'une énigme, d'un indice ou d'une solution
- lit ces indicateurs dans `single-chasse.php` pour éviter une boucle
- documente les nouveaux champs ACF

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc989120833299a935ec9eea5f7c