### PR TITLE
Sécurise le recalcul des statuts de chasse et ajoute un cron de mise à jour

### DIFF
--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -1184,6 +1184,39 @@ function forcer_statut_selon_validation_chasse($post_id, $post, $update)
     }
 }
 
+/**
+ * Planifie une tâche récurrente pour vérifier le statut des chasses.
+ *
+ * @return void
+ */
+function schedule_cat_recalculate_chasse_statuses(): void
+{
+    if (!wp_next_scheduled('cat_recalculate_chasse_statuses')) {
+        wp_schedule_event(time(), 'hourly', 'cat_recalculate_chasse_statuses');
+    }
+}
+add_action('after_switch_theme', 'schedule_cat_recalculate_chasse_statuses');
+
+/**
+ * Vérifie périodiquement les statuts des chasses afin de les maintenir à jour.
+ *
+ * @return void
+ */
+function cat_recalculate_chasse_statuses(): void
+{
+    $chasses = get_posts([
+        'post_type'      => 'chasse',
+        'post_status'    => 'any',
+        'fields'         => 'ids',
+        'posts_per_page' => -1,
+    ]);
+
+    foreach ($chasses as $chasse_id) {
+        verifier_ou_recalculer_statut_chasse((int) $chasse_id);
+    }
+}
+add_action('cat_recalculate_chasse_statuses', 'cat_recalculate_chasse_statuses');
+
 
 // ==================================================
 // 🧑‍💻 GESTION DES STATUTS DES JOUEURS (UTILISATEUR ↔ ÉNIGME)

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -10,15 +10,20 @@ defined('ABSPATH') || exit;
 // 🧠 LOGIQUE MÉTIER
 $chasse_id = get_the_ID();
 if (!$chasse_id) {
-  wp_die(__('Chasse introuvable.', 'chassesautresor-com'));
+    wp_die(__('Chasse introuvable.', 'chassesautresor-com'));
 }
 
-verifier_ou_recalculer_statut_chasse($chasse_id);
-verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
-verifier_ou_mettre_a_jour_cache_complet($chasse_id);
+// Utilisateur courant et rôle organisateur
+$user_id          = get_current_user_id();
+$est_orga_associe = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
 
-$user_id            = get_current_user_id();
-$est_orga_associe   = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
+// Mise à jour des statuts réservée aux administrateurs ou organisateurs
+if (current_user_can('manage_options') || $est_orga_associe) {
+    verifier_ou_recalculer_statut_chasse($chasse_id);
+    verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
+    verifier_ou_mettre_a_jour_cache_complet($chasse_id);
+}
+
 $points_utilisateur = get_user_points($user_id);
 $est_engage_chasse  = utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
 $peut_voir_aside    = $est_engage_chasse


### PR DESCRIPTION
## Résumé
- Encadrement du recalcul des statuts de chasse aux seuls administrateurs et organisateurs
- Planification d'une tâche cron pour recalculer régulièrement les statuts des chasses

## Détails
- Protection des opérations de recalcul et de synchronisation dans `single-chasse.php`
- Création d'une tâche programmée `cat_recalculate_chasse_statuses` pour maintenir les statuts

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b602d8b4a88332b34bac57ee1d0004