### PR TITLE
Optimise la vérification du cache complet des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -56,12 +56,13 @@ $attr_draggable = $peut_reordonner ? ' draggable="true"' : '';
 
 // 📌 Vérifie si une énigme est incomplète
 $has_incomplete = false;
+$completion_statuses = [];
 if ($peut_reordonner || user_can($utilisateur_id, 'manage_options')) {
     foreach ($posts as $p) {
         verifier_ou_mettre_a_jour_cache_complet($p->ID);
-        if (!get_field('enigme_cache_complet', $p->ID)) {
+        $completion_statuses[$p->ID] = (bool) get_field('enigme_cache_complet', $p->ID);
+        if (!$completion_statuses[$p->ID]) {
             $has_incomplete = true;
-            break;
         }
     }
 }
@@ -108,8 +109,7 @@ if (!function_exists('compter_tentatives_du_jour') || !function_exists('compter_
         $voir_bordure
         && ($peut_reordonner || user_can($utilisateur_id, 'manage_options'))
       ) {
-        verifier_ou_mettre_a_jour_cache_complet($enigme_id);
-        $complet = (bool) get_field('enigme_cache_complet', $enigme_id);
+        $complet = $completion_statuses[$enigme_id] ?? false;
         $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
       }
 


### PR DESCRIPTION
## Résumé
- évite de recalculer le statut `enigme_cache_complet` pour chaque carte
- utilise le statut mis en cache lors du premier parcours

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b6085f1b2083328ee62c46cfee5ea6