### PR TITLE
Ajuste le breakpoint de la fiche chasse à 1024px

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -128,7 +128,7 @@
   }
 }
 
-@media (--bp-tablet) {
+@media (--bp-desktop) {
   .chasse-fiche-container {
     flex-direction: row;
     --hunt-img-max-height: 800px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -601,7 +601,7 @@
     --hunt-img-max-height: 500px;
   }
 }
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .chasse-fiche-container {
     flex-direction: row;
     --hunt-img-max-height: 800px;


### PR DESCRIPTION
## Résumé
- Ajuste l'empilement image/texte de la fiche chasse pour s'appliquer jusqu'à 1024px

## Changements notables
- Utilise le breakpoint `--bp-desktop` pour la mise en page de la fiche chasse
- Regénère la feuille de style compilée

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6649780e08332815b7603d49ed8ca