### PR TITLE
Fix mobile header overlay on breadcrumb

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -537,16 +537,14 @@ li.active .enigme-menu__edit {
 
   .enigme-mobile-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     position: fixed;
     top: calc(var(--space-4xl) + env(safe-area-inset-top));
-    left: 0;
-    right: 0;
+    left: auto;
+    right: calc(var(--space-md) + env(safe-area-inset-right));
     padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
     padding-bottom: var(--space-sm);
-    padding-left: calc(var(--space-md) + env(safe-area-inset-left));
-    padding-right: calc(var(--space-md) + env(safe-area-inset-right));
     background-color: transparent;
     z-index: 10;
   }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5606,16 +5606,14 @@ li.active .enigme-menu__edit {
   }
   .enigme-mobile-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     position: fixed;
     top: calc(var(--space-4xl) + env(safe-area-inset-top));
-    left: 0;
-    right: 0;
+    left: auto;
+    right: calc(var(--space-md) + env(safe-area-inset-right));
     padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
     padding-bottom: var(--space-sm);
-    padding-left: calc(var(--space-md) + env(safe-area-inset-left));
-    padding-right: calc(var(--space-md) + env(safe-area-inset-right));
     background-color: transparent;
     z-index: 10;
   }


### PR DESCRIPTION
## Résumé
- Empêche l'en-tête mobile des énigmes de recouvrir toute la largeur
- Recompile le CSS du thème

## Changements notables
- Positionne l'en-tête mobile à droite pour laisser le fil d'Ariane accessible
- Met à jour `style.css` compilé

## Testing
- `source ./setup-env.sh && echo "env setup complete"`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm ci`
- `node build-css.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6661b71c083328b84079d6d3ac074