### PR TITLE
Ajuste l'affichage des intitulés des liens publics

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -43,6 +43,12 @@ function renderLiensPublics(liens = []) {
   const liste = document.createElement('ul');
   liste.className = 'liste-liens-publics';
 
+  const showLabels = liens.length <= 2;
+
+  if (!showLabels) {
+    liste.classList.add('liens-sans-intitule');
+  }
+
   liens.forEach(({ type_de_lien, url_lien }) => {
     const type = Array.isArray(type_de_lien) ? type_de_lien[0] : type_de_lien;
     const icone = icones[type] || 'fa-link';
@@ -62,10 +68,12 @@ function renderLiensPublics(liens = []) {
     icon.className = `fa ${icone}`;
     a.appendChild(icon);
 
-    const span = document.createElement('span');
-    span.className = 'texte-lien';
-    span.textContent = label;
-    a.appendChild(span);
+    if (showLabels) {
+      const span = document.createElement('span');
+      span.className = 'texte-lien';
+      span.textContent = label;
+      a.appendChild(span);
+    }
 
     li.appendChild(a);
     liste.appendChild(li);

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -277,8 +277,14 @@
   gap: var(--space-xs);
 }
 
-.carte-ligne__footer .texte-lien {
+.carte-ligne__footer .liste-liens-publics.liens-sans-intitule .texte-lien {
   display: none;
+}
+
+.carte-ligne__footer .liste-liens-publics.liens-sans-intitule .lien-public {
+  padding: 0.3em;
+  gap: 0;
+  border-radius: 50%;
 }
 
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -102,14 +102,13 @@
 }
 
 .chasse-visuel-wrapper .lien-public {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--color-grey-light) !important;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  gap: var(--space-xxs);
+  padding: 0 var(--space-xs);
+  border-radius: 1rem;
+  background: var(--color-grey-light) !important;
   color: var(--color-text-fond-clair) !important;
 }
 
@@ -118,7 +117,14 @@
   font-size: 0.75rem;
 }
 
-.chasse-visuel-wrapper .lien-public .texte-lien {
+.chasse-visuel-wrapper .liste-liens-publics.liens-sans-intitule .lien-public {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.chasse-visuel-wrapper .liste-liens-publics.liens-sans-intitule .lien-public .texte-lien {
   display: none;
 }
 
@@ -142,16 +148,7 @@
   .champ-chasse.champ-img {
     margin: 0;
   }
-  .chasse-visuel-wrapper .lien-public {
-    width: auto;
-    height: auto;
-    padding: 0 var(--space-xs);
-    gap: var(--space-xxs);
-    border-radius: 1rem;
-  }
-  .chasse-visuel-wrapper .lien-public .texte-lien {
-    display: inline;
-  }
+  /* Styles spécifiques au layout desktop conservés */
 }
 
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -467,6 +467,16 @@ body:not(.edition-active) #presentation .champ-liens.champ-vide {
     white-space: nowrap;
 }
 
+.liste-liens-publics.liens-sans-intitule .lien-public {
+  padding: 0.3em;
+  gap: 0;
+  border-radius: 50%;
+}
+
+.liste-liens-publics.liens-sans-intitule .lien-public .texte-lien {
+  display: none;
+}
+
 .lien-public.lien-facebook i {
   color: #1877f2;
 }
@@ -522,9 +532,6 @@ section#presentation .presentation-fermer {
 
 /* ========== 📱 RESPONSIVE ========== */
 @media not all and (--bp-small) {
-    .lien-public .texte-lien {
-        display: none;
-    }
     section#presentation .titre-presentation {
         justify-content: center;
     }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -268,8 +268,14 @@
   gap: var(--space-xs);
 }
 
-.carte-ligne__footer .texte-lien {
+.carte-ligne__footer .liste-liens-publics.liens-sans-intitule .texte-lien {
   display: none;
+}
+
+.carte-ligne__footer .liste-liens-publics.liens-sans-intitule .lien-public {
+  padding: 0.3em;
+  gap: 0;
+  border-radius: 50%;
 }
 
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */
@@ -576,14 +582,13 @@
 }
 
 .chasse-visuel-wrapper .lien-public {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--color-grey-light) !important;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  gap: var(--space-xxs);
+  padding: 0 var(--space-xs);
+  border-radius: 1rem;
+  background: var(--color-grey-light) !important;
   color: var(--color-text-fond-clair) !important;
 }
 
@@ -592,7 +597,14 @@
   font-size: 0.75rem;
 }
 
-.chasse-visuel-wrapper .lien-public .texte-lien {
+.chasse-visuel-wrapper .liste-liens-publics.liens-sans-intitule .lien-public {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.chasse-visuel-wrapper .liste-liens-publics.liens-sans-intitule .lien-public .texte-lien {
   display: none;
 }
 
@@ -615,16 +627,7 @@
   .champ-chasse.champ-img {
     margin: 0;
   }
-  .chasse-visuel-wrapper .lien-public {
-    width: auto;
-    height: auto;
-    padding: 0 var(--space-xs);
-    gap: var(--space-xxs);
-    border-radius: 1rem;
-  }
-  .chasse-visuel-wrapper .lien-public .texte-lien {
-    display: inline;
-  }
+  /* Styles spécifiques au layout desktop conservés */
 }
 /* ========== 📝 COLONNE INFOS DE LA CHASSE ========== */
 .chasse-details-wrapper {
@@ -8988,6 +8991,16 @@ body:not(.edition-active) #presentation .champ-liens.champ-vide {
   white-space: nowrap;
 }
 
+.liste-liens-publics.liens-sans-intitule .lien-public {
+  padding: 0.3em;
+  gap: 0;
+  border-radius: 50%;
+}
+
+.liste-liens-publics.liens-sans-intitule .lien-public .texte-lien {
+  display: none;
+}
+
 .lien-public.lien-facebook i {
   color: #1877f2;
 }
@@ -9044,9 +9057,6 @@ section#presentation .presentation-fermer {
 
 /* ========== 📱 RESPONSIVE ========== */
 @media not all and (min-width: 480px) {
-  .lien-public .texte-lien {
-    display: none;
-  }
   section#presentation .titre-presentation {
     justify-content: center;
   }

--- a/wp-content/themes/chassesautresor/inc/utils/liens.php
+++ b/wp-content/themes/chassesautresor/inc/utils/liens.php
@@ -107,17 +107,28 @@ function render_liens_publics(array $liens, string $contexte = 'organisateur', a
         }
     }
 
-    if (!empty($liens_actifs)) {
-        $out = '<ul class="liste-liens-publics">';
+    if (! empty($liens_actifs)) {
+        $show_labels = count($liens_actifs) <= 2;
+        $classes = 'liste-liens-publics';
+        if (! $show_labels) {
+            $classes .= ' liens-sans-intitule';
+        }
+
+        $out = '<ul class="' . esc_attr($classes) . '">';
         foreach ($liens_actifs as $type => $url) {
             $label = $types[$type]['label'] ?? ucfirst($type);
             $icone = $types[$type]['icone'] ?? 'fa-solid fa-link';
-            $out .= '<li class="item-lien-public">
-                      <a href="' . esc_url($url) . '" class="lien-public lien-' . esc_attr($type) . '" target="_blank" rel="noopener">
-                        <i class="fa ' . esc_attr($icone) . '"></i>
-                        <span class="texte-lien">' . esc_html($label) . '</span>
-                      </a>
-                    </li>';
+
+            $out .= '<li class="item-lien-public">'
+                . '<a href="' . esc_url($url) . '" class="lien-public lien-' . esc_attr($type) . '" target="_blank" rel="noopener">'
+                . '<i class="fa ' . esc_attr($icone) . '"></i>';
+
+            if ($show_labels) {
+                $out .= '<span class="texte-lien">' . esc_html($label) . '</span>';
+            }
+
+            $out .= '</a>'
+                . '</li>';
         }
         $out .= '</ul>';
         return $out;

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-presentation.php
@@ -33,17 +33,18 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
 <section id="presentation" class="bloc-presentation-organisateur bloc-toggle masque bloc-discret">
     <button type="button" class="panneau-fermer presentation-fermer" aria-label="Fermer les informations">✖</button>
     <!-- Liens publics -->
-    <?php $champ_vide_liens = count($liens_actifs) === 0;    ?>
-    <?php $classe_liens = count($liens_actifs) >= 3 ? 'liens-compacts' : ''; ?>
-    <div class="champ-organisateur champ-liens <?= empty($liens_actifs) ? 'champ-vide' : ''; ?>"
+    <?php $nb_liens = count($liens_actifs); ?>
+    <div class="champ-organisateur champ-liens <?= $nb_liens === 0 ? 'champ-vide' : ''; ?>"
              data-champ="liens_publics"
              data-cpt="organisateur"
              data-post-id="<?= esc_attr($organisateur_id); ?>">
-        
-            <div class="champ-affichage champ-affichage-liens bloc-liens-publics header-organisateur__liens <?= count($liens_actifs) >= 3 ? 'liens-compacts' : ''; ?>" data-no-edit="1">
-        
-            <?php if (!empty($liens_actifs)) : ?>
-              <ul class="liste-liens-publics">
+
+            <div class="champ-affichage champ-affichage-liens bloc-liens-publics header-organisateur__liens" data-no-edit="1">
+
+            <?php if ($nb_liens > 0) : ?>
+              <?php $ul_classes = 'liste-liens-publics'; ?>
+              <?php if ($nb_liens > 2) { $ul_classes .= ' liens-sans-intitule'; } ?>
+              <ul class="<?= esc_attr($ul_classes); ?>">
                 <?php foreach ($liens_actifs as $type => $url) :
                   $infos = organisateur_get_lien_public_infos($type);
                 ?>
@@ -53,7 +54,9 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
                        target="_blank" rel="noopener"
                        aria-label="<?= esc_attr($infos['label']); ?>">
                       <i class="fa <?= esc_attr($infos['icone']); ?>" aria-hidden="true"></i>
-                      <span class="texte-lien"><?= esc_html($infos['label']); ?></span>
+                      <?php if ($nb_liens <= 2) : ?>
+                        <span class="texte-lien"><?= esc_html($infos['label']); ?></span>
+                      <?php endif; ?>
                     </a>
                   </li>
                 <?php endforeach; ?>


### PR DESCRIPTION
## Résumé
- Affiche ou masque les intitulés des liens publics selon le nombre d’icônes.

## Changements notables
- Ajustement de `renderLiensPublics` côté JS et PHP pour gérer jusqu’à deux liens avec libellé.
- Mise à jour des styles SCSS et du template organisateur pour la classe `liens-sans-intitule`.
- Regénération de la feuille de style compilée.

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6652250fc8332a31e25897ccc27a9