### PR TITLE
feat: add tablet hunt image max height

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -128,6 +128,12 @@
   }
 }
 
+@media (--bp-tablet) {
+  .chasse-fiche-container {
+    --hunt-img-max-height: 600px;
+  }
+}
+
 @media (--bp-desktop) {
   .chasse-fiche-container {
     flex-direction: row;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -601,6 +601,11 @@
     --hunt-img-max-height: 500px;
   }
 }
+@media (min-width: 768px) {
+  .chasse-fiche-container {
+    --hunt-img-max-height: 600px;
+  }
+}
 @media (min-width: 1024px) {
   .chasse-fiche-container {
     flex-direction: row;


### PR DESCRIPTION
## Résumé
- ajuste la hauteur max des images de chasse sur tablette

## Changements notables
- ajoute une media query `--bp-tablet` limitant `--hunt-img-max-height` à 600px
- reconstruit la feuille de style `dist/style.css`

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b670af6dfc8332b4b7fd0d1b2a4770