### PR TITLE
Fix AJAX pager after deletions

### DIFF
--- a/tests/IndicesListerTableChasseTest.php
+++ b/tests/IndicesListerTableChasseTest.php
@@ -34,10 +34,11 @@ if (!class_exists('WP_Query')) {
         public $posts = [];
         public $max_num_pages = 1;
         public function __construct($args) {
-            global $captured_query_args;
-            $captured_query_args = $args;
-            $this->posts = [];
-            $this->max_num_pages = 1;
+            global $captured_query_args, $captured_query_args_list;
+            $captured_query_args      = $args;
+            $captured_query_args_list[] = $args;
+            $this->max_num_pages      = 1;
+            $this->posts              = ($args['paged'] ?? 1) > 1 ? [] : ['p'];
         }
     }
 }
@@ -50,9 +51,10 @@ require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/editio
 class IndicesListerTableChasseTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
-        global $captured_query_args, $json_success_data;
-        $captured_query_args = [];
-        $json_success_data   = null;
+        global $captured_query_args, $captured_query_args_list, $json_success_data;
+        $captured_query_args      = [];
+        $captured_query_args_list = [];
+        $json_success_data        = null;
         $_POST = [];
     }
 
@@ -82,5 +84,27 @@ class IndicesListerTableChasseTest extends TestCase {
         $this->assertSame([5,6], $meta[1][1]['value']);
         $this->assertSame('IN', $meta[1][1]['compare']);
         $this->assertIsArray($json_success_data);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_resets_to_last_page_when_page_exceeds_total(): void {
+        global $captured_query_args_list, $json_success_data;
+
+        $_POST = [
+            'objet_id'   => 3,
+            'objet_type' => 'chasse',
+            'page'       => 2,
+        ];
+
+        ajax_indices_lister_table();
+
+        $this->assertCount(2, $captured_query_args_list);
+        $this->assertSame(2, $captured_query_args_list[0]['paged']);
+        $this->assertSame(1, $captured_query_args_list[1]['paged']);
+        $this->assertSame(1, $json_success_data['page']);
+        $this->assertSame(1, $json_success_data['pages']);
     }
 }

--- a/tests/IndicesListerTableChasseTest.php
+++ b/tests/IndicesListerTableChasseTest.php
@@ -29,6 +29,9 @@ if (!function_exists('sanitize_key')) {
 if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
     function recuperer_ids_enigmes_pour_chasse($id) { return [5,6]; }
 }
+if (!function_exists('get_posts')) {
+    function get_posts($args) { return [1, 2, 3, 4, 5]; }
+}
 if (!class_exists('WP_Query')) {
     class WP_Query {
         public $posts = [];
@@ -101,9 +104,8 @@ class IndicesListerTableChasseTest extends TestCase {
 
         ajax_indices_lister_table();
 
-        $this->assertCount(2, $captured_query_args_list);
-        $this->assertSame(2, $captured_query_args_list[0]['paged']);
-        $this->assertSame(1, $captured_query_args_list[1]['paged']);
+        $this->assertCount(1, $captured_query_args_list);
+        $this->assertSame(1, $captured_query_args_list[0]['paged']);
         $this->assertSame(1, $json_success_data['page']);
         $this->assertSame(1, $json_success_data['pages']);
     }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -523,24 +523,7 @@ function ajax_indices_lister_table(): void
         ];
     }
 
-    $page       = max(1, $page);
-    $query_args = [
-        'post_type'      => 'indice',
-        'post_status'    => ['publish', 'pending', 'draft'],
-        'orderby'        => 'date',
-        'order'          => 'DESC',
-        'posts_per_page' => $per_page,
-        'paged'          => $page,
-        'meta_query'     => $meta,
-    ];
-    $query      = new WP_Query($query_args);
-    $total_pages = (int) $query->max_num_pages;
-    if ($page > $total_pages && $total_pages > 0) {
-        $page                  = $total_pages;
-        $query_args['paged']   = $page;
-        $query                 = new WP_Query($query_args);
-        $total_pages           = (int) $query->max_num_pages;
-    }
+    $page = max(1, $page);
 
     $ids = [];
     if (function_exists('get_posts')) {
@@ -553,6 +536,23 @@ function ajax_indices_lister_table(): void
         ]);
     }
 
+    $count_total = is_countable($ids) ? count($ids) : 0;
+    $total_pages = (int) ceil($count_total / $per_page);
+    if ($total_pages > 0 && $page > $total_pages) {
+        $page = $total_pages;
+    }
+
+    $query_args = [
+        'post_type'      => 'indice',
+        'post_status'    => ['publish', 'pending', 'draft'],
+        'orderby'        => 'date',
+        'order'          => 'DESC',
+        'posts_per_page' => $per_page,
+        'paged'          => $page,
+        'meta_query'     => $meta,
+    ];
+    $query      = new WP_Query($query_args);
+
     $count_chasse = 0;
     $count_enigme = 0;
     if (function_exists('get_post_meta')) {
@@ -564,8 +564,8 @@ function ajax_indices_lister_table(): void
                 ++$count_enigme;
             }
         }
+        $count_total = $count_chasse + $count_enigme;
     }
-    $count_total = $count_chasse + $count_enigme;
 
     $has_enigme_indices = false;
     if ($enigme_id) {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -485,21 +485,30 @@ function ajax_solutions_lister_table(): void
         ];
     }
 
-    $query = new WP_Query([
+    $page       = max(1, $page);
+    $query_args = [
         'post_type'      => 'solution',
         'post_status'    => ['publish', 'pending', 'draft'],
         'orderby'        => 'date',
         'order'          => 'DESC',
         'posts_per_page' => $per_page,
-        'paged'          => max(1, $page),
+        'paged'          => $page,
         'meta_query'     => $meta,
-    ]);
+    ];
+    $query      = new WP_Query($query_args);
+    $total_pages = (int) $query->max_num_pages;
+    if ($page > $total_pages && $total_pages > 0) {
+        $page                  = $total_pages;
+        $query_args['paged']   = $page;
+        $query                 = new WP_Query($query_args);
+        $total_pages           = (int) $query->max_num_pages;
+    }
 
     ob_start();
     get_template_part('template-parts/common/solutions-table', null, [
         'solutions'  => $query->posts,
-        'page'       => max(1, $page),
-        'pages'      => (int) $query->max_num_pages,
+        'page'       => $page,
+        'pages'      => $total_pages,
         'objet_type' => $objet_type,
         'objet_id'   => $objet_id,
     ]);
@@ -507,8 +516,8 @@ function ajax_solutions_lister_table(): void
 
     wp_send_json_success([
         'html'  => $html,
-        'page'  => max(1, $page),
-        'pages' => (int) $query->max_num_pages,
+        'page'  => $page,
+        'pages' => $total_pages,
     ]);
 }
 add_action('wp_ajax_solutions_lister_table', 'ajax_solutions_lister_table');


### PR DESCRIPTION
## Summary
- Corrige la pagination AJAX des tableaux pour revenir à la dernière page existante après suppression d'un élément
- Ajoute des tests pour garantir le recalcul de la page courante

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b6745ae5688332ade259c83f560b65