### PR TITLE
Corrige l'affichage des titres d'énigmes dans la modale d'indice

### DIFF
--- a/tests/ChasseListerEnigmesAjaxTest.php
+++ b/tests/ChasseListerEnigmesAjaxTest.php
@@ -64,4 +64,56 @@ class ChasseListerEnigmesAjaxTest extends TestCase
         $ids = array_column($json_success_data['enigmes'], 'id');
         $this->assertSame([2], $ids);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_decodes_html_entities_in_titles(): void
+    {
+        if (!function_exists('is_user_logged_in')) {
+            function is_user_logged_in() { return true; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 10 ? 'chasse' : 'enigme'; }
+        }
+        if (!function_exists('indice_action_autorisee')) {
+            function indice_action_autorisee($a, $b, $c) { return true; }
+        }
+        if (!function_exists('sanitize_key')) {
+            function sanitize_key($key) { return $key; }
+        }
+        if (!function_exists('wp_send_json_error')) {
+            function wp_send_json_error($data = null) { throw new Exception((string) $data); }
+        }
+        if (!function_exists('wp_send_json_success')) {
+            function wp_send_json_success($data = null) { global $json_success_data; $json_success_data = $data; return $data; }
+        }
+        if (!function_exists('recuperer_enigmes_pour_chasse')) {
+            function recuperer_enigmes_pour_chasse($id)
+            {
+                return [(object) ['ID' => 1]];
+            }
+        }
+        if (!function_exists('solution_existe_pour_objet')) {
+            function solution_existe_pour_objet($id, $type) { return false; }
+        }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($post) { return 'Sans &#8211; titre'; }
+        }
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
+
+        $_POST = [
+            'chasse_id' => 10,
+        ];
+
+        ajax_chasse_lister_enigmes();
+
+        global $json_success_data;
+        $this->assertSame('Sans – titre', $json_success_data['enigmes'][0]['title']);
+    }
 }

--- a/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-indice.php
@@ -397,7 +397,7 @@ function ajax_chasse_lister_enigmes(): void
     $enigmes = array_map(
         static fn($p) => [
             'id'          => $p->ID,
-            'title'       => get_the_title($p),
+            'title'       => html_entity_decode(get_the_title($p), ENT_QUOTES, 'UTF-8'),
             'indice_rang' => prochain_rang_indice($chasse_id, 'chasse'),
         ],
         $posts


### PR DESCRIPTION
## Résumé
- Corrige l'affichage des titres d'énigmes chargés dans la modale de création d'indice
- Ajoute un test de couverture pour vérifier le décodage des entités HTML

## Changements notables
- Décodage des entités HTML lors de la liste des énigmes disponibles pour un indice
- Test unitaire garantissant le bon affichage des titres

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b674ef20a88332befab70014ac71ea