### PR TITLE
Fix unreadable text on password reset page

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/login.css
+++ b/wp-content/themes/chassesautresor/assets/css/login.css
@@ -23,7 +23,9 @@ body.login #login {
 }
 
 body.login #loginform,
-body.login #registerform {
+body.login #registerform,
+body.login #lostpasswordform,
+body.login #resetpassform {
     background-color: var(--color-background-dark);
     border: 1px solid var(--color-primary);
 }
@@ -74,13 +76,17 @@ body.login #wp-submit:focus {
     border-color: var(--color-primary);
 }
 
-body.login .notice {
+body.login .notice,
+body.login .message,
+body.login .success {
     background-color: var(--color-background-dark);
     border-left: 4px solid var(--color-primary);
     color: var(--color-text-primary);
 }
 
-body.login .notice p {
+body.login .notice p,
+body.login .message p,
+body.login .success p {
     color: inherit;
 }
 


### PR DESCRIPTION
## Résumé
- uniformise le style des formulaires de connexion et de réinitialisation
- améliore le contraste des messages d'information et de succès

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b753459bec833285f04f9f58754949