### PR TITLE
Utilise le système de messages global pour devenir organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
@@ -35,15 +35,17 @@ $organisateur_id = get_organisateur_from_user($user_id);
 $image_url = '';
 
 if (has_post_thumbnail()) {
-  $image_url = get_the_post_thumbnail_url(null, 'full'); // ou 'large' si besoin
+    $image_url = get_the_post_thumbnail_url(null, 'full'); // ou 'large' si besoin
+}
+
+if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') {
+    add_site_message(
+        'message-info',
+        __('✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.', 'chassesautresor-com')
+    );
 }
 
 get_header(); ?>
-<?php if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') : ?>
-<div class="woocommerce-message" role="alert">
-  ✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.
-</div>
-<?php endif; ?>
 <section class="bandeau-hero">
   <div class="hero-overlay" style="background-image: url('<?php echo esc_url($image_url); ?>');">
     <div class="contenu-hero">


### PR DESCRIPTION
Affiche désormais le message de vérification via le système unifié de messages.

- Ajout d'une notification `add_site_message` lors de la demande de création de profil organisateur.
- Suppression de l'ancien bloc `woocommerce-message`.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7b5b7db948332b87efcdd73702578