### PR TITLE
Add Secure and HttpOnly flags to language cookie

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -58,7 +58,7 @@ function cta_handle_language() {
         $locale = 'fr' === $lang ? 'fr_FR' : ( 'en' === $lang ? 'en_US' : '' );
 
         if ( $locale ) {
-            setcookie( 'cta_lang', $locale, time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+            setcookie( 'cta_lang', $locale, time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
         }
     } else {
         $locale = cta_get_locale_from_cookie();
@@ -69,7 +69,7 @@ function cta_handle_language() {
             $locale       = 'fr' === $browser_lang ? 'fr_FR' : ( 'en' === $browser_lang ? 'en_US' : '' );
 
             if ( $locale ) {
-                setcookie( 'cta_lang', $locale, time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+                setcookie( 'cta_lang', $locale, time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
             }
         }
     }


### PR DESCRIPTION
## Résumé
- Active les drapeaux Secure et HttpOnly pour le cookie de langue

## Changements notables
- Ajout de `is_ssl()` et `true` aux appels `setcookie` pour `cta_lang`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7b629e55c83329f1c8ef1f86624bc