### PR TITLE
Fix language switcher current URL using home_url

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -141,7 +141,7 @@ function cta_render_lang_switcher( $row, $column ) {
         ],
     ];
 
-    $current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+    $current_url = home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ) );
     $current_url = remove_query_arg( 'lang', $current_url );
     ?>
     <div class="lang-switcher ast-builder-layout-element site-header-focus-item">


### PR DESCRIPTION
Résumé en français:
Remplace la construction manuelle de l'URL courante du sélecteur de langue par `home_url` pour s'appuyer sur la configuration WordPress.

- Utilisation de `home_url()` pour déterminer l'URL courante sans dépendre du domaine.

### Testing
- `source ./setup-env.sh`
- `composer install --no-interaction --no-progress --no-suggest`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7b664fe948332a2107e1d54b50ad1