### PR TITLE
Add expiration support for site messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Les fonctions utilitaires s'appuient sur `UserMessageRepository` pour manipuler 
 
 - `myaccount_add_persistent_message()` et `myaccount_remove_persistent_message()` pour les messages durables.
 - `myaccount_add_flash_message()` et `myaccount_get_flash_messages()` pour les notifications temporaires.
-- `add_site_message()` et `get_site_messages()` pour les messages globaux.
+- `add_site_message()` (avec expiration optionnelle) et `get_site_messages()` pour les messages globaux.
 - Le repository expose également `insert`, `update`, `delete`, `get` et `purgeExpired()`.
 
 #### Workflow de migration


### PR DESCRIPTION
Résumé : Ajout d'une expiration optionnelle aux messages de site.

- prise en charge d'un paramètre d'expiration pour `add_site_message`
- transmission de la durée au transient et de la date ISO8601 au `UserMessageRepository`
- documentation mise à jour

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7b83457388332b88b4cfc58feb97b