### PR TITLE
Expiration du lien de confirmation organisateur

### DIFF
--- a/tests/OrganisateurConfirmationTest.php
+++ b/tests/OrganisateurConfirmationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ROLE_ORGANISATEUR_CREATION')) {
+    define('ROLE_ORGANISATEUR_CREATION', 'organisateur_creation');
+}
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+if (!function_exists('get_user_meta')) {
+    function get_user_meta($user_id, $key, $single = false)
+    {
+        global $cat_test_user_meta;
+        return $cat_test_user_meta[$user_id][$key] ?? '';
+    }
+}
+
+if (!function_exists('delete_user_meta')) {
+    function delete_user_meta($user_id, $key): void
+    {
+        global $cat_test_user_meta;
+        unset($cat_test_user_meta[$user_id][$key]);
+    }
+}
+
+if (!function_exists('creer_organisateur_pour_utilisateur')) {
+    function creer_organisateur_pour_utilisateur($user_id)
+    {
+        return 123;
+    }
+}
+
+if (!class_exists('WP_User')) {
+    class WP_User
+    {
+        public int $ID;
+        public array $roles = [];
+
+        public function __construct(int $ID)
+        {
+            $this->ID = $ID;
+        }
+
+        public function add_role($role): void
+        {
+            $this->roles[] = $role;
+        }
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/organisateur-functions.php';
+
+class OrganisateurConfirmationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $cat_test_user_meta;
+        $cat_test_user_meta = [];
+    }
+
+    public function test_confirmer_demande_organisateur_token_expire(): void
+    {
+        global $cat_test_user_meta;
+        $user_id = 1;
+        $cat_test_user_meta[$user_id] = [
+            'organisateur_demande_token' => 'abc',
+            'organisateur_demande_date' => gmdate('Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS),
+        ];
+        $this->assertNull(confirmer_demande_organisateur($user_id, 'abc'));
+    }
+
+    public function test_confirmer_demande_organisateur_token_valide(): void
+    {
+        global $cat_test_user_meta;
+        $user_id = 2;
+        $cat_test_user_meta[$user_id] = [
+            'organisateur_demande_token' => 'def',
+            'organisateur_demande_date' => gmdate('Y-m-d H:i:s', time() - DAY_IN_SECONDS),
+        ];
+        $this->assertSame(123, confirmer_demande_organisateur($user_id, 'def'));
+    }
+}
+


### PR DESCRIPTION
## Résumé
- Lien de confirmation organisateur limité à 48h avec contrôle d'expiration
- Renvoi du mail qui régénère le lien si périmé
- Test unitaire vérifiant la validité du token

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7c05e05688332814ec59b7ba5861a