### PR TITLE
feat: add HTML email template and send helper

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -360,6 +360,7 @@ require_once $inc_path . 'utils.php';
 require_once $inc_path . 'PointsRepository.php';
 require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
+require_once $inc_path . 'emails/template.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once $inc_path . 'cli/class-cat-cli-command.php';

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Email template helpers.
+ *
+ * @package chassesautresor-com
+ */
+
+defined('ABSPATH') || exit();
+
+/**
+ * Renders the HTML email template.
+ *
+ * @param string $title   Email title.
+ * @param string $content Email body content.
+ *
+ * @return string
+ */
+function cta_render_email_template(string $title, string $content): string
+{
+    $logo_url = '';
+    if (function_exists('get_theme_mod')) {
+        $logo_id = get_theme_mod('custom_logo');
+        if ($logo_id && function_exists('wp_get_attachment_image_url')) {
+            $logo_url = wp_get_attachment_image_url($logo_id, 'full');
+        }
+    }
+
+    if (!$logo_url && function_exists('get_theme_file_uri')) {
+        $logo_url = get_theme_file_uri('assets/images/logo.png');
+    }
+
+    $site_name = function_exists('get_bloginfo') ? get_bloginfo('name') : '';
+    $header_bg = '#0B132B';
+
+    $html  = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>';
+    $html .= '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" ';
+    $html .= 'style="border-collapse:collapse;">';
+    $html .= '<tr><td>';
+    $html .= '<header style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;">';
+    if ($logo_url) {
+        $html .= '<img src="' . esc_url($logo_url) . '" alt="' . esc_attr($site_name) . '" ';
+        $html .= 'style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />';
+    }
+    $html .= '<h1 style="color:#ffffff;font-family:Arial,sans-serif;margin:0;">';
+    $html .= esc_html($title) . '</h1>';
+    $html .= '</header>';
+    $html .= '</td></tr>';
+    $html .= '<tr><td style="background:#f5f5f5;padding:20px;font-family:Arial,sans-serif;">';
+    $html .= wp_kses_post($content) . '</td></tr>';
+    $html .= '<tr><td>';
+    $html .= '<footer style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;';
+    $html .= 'font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">';
+    $html .= '<p style="margin:0;">' . esc_html__('Mentions légales', 'chassesautresor-com') . ' | ';
+    $html .= '<a href="' . esc_url(home_url('/unsubscribe')) . '" style="color:#ffffff;">';
+    $html .= esc_html__('Se désabonner', 'chassesautresor-com') . '</a></p>';
+    $html .= '</footer>';
+    $html .= '</td></tr>';
+    $html .= '</table>';
+    $html .= '</body></html>';
+
+    return $html;
+}
+
+/**
+ * Sends an HTML email using the template.
+ *
+ * @param array|string $to      Recipient or list of recipients.
+ * @param string       $subject Email subject.
+ * @param string       $body    Email body content.
+ * @param array        $headers Additional headers.
+ *
+ * @return bool
+ */
+function cta_send_email($to, string $subject, string $body, array $headers = []): bool
+{
+    $has_content_type = false;
+    foreach ($headers as $header) {
+        if (0 === stripos($header, 'Content-Type:')) {
+            $has_content_type = true;
+            break;
+        }
+    }
+
+    if (!$has_content_type) {
+        $headers[] = 'Content-Type: text/html; charset=UTF-8';
+    }
+
+    $from = function_exists('apply_filters') ? apply_filters('cta_send_email_from', '') : '';
+    if ($from) {
+        foreach ($headers as $index => $header) {
+            if (0 === stripos($header, 'From:')) {
+                unset($headers[$index]);
+            }
+        }
+        $headers[] = 'From: ' . $from;
+    }
+
+    $html = cta_render_email_template($subject, $body);
+
+    return function_exists('wp_mail') ? wp_mail($to, $subject, $html, $headers) : false;
+}

--- a/wp-content/themes/chassesautresor/tests/email_template.test.php
+++ b/wp-content/themes/chassesautresor/tests/email_template.test.php
@@ -1,0 +1,72 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($content) {
+        return $content;
+    }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_url')) {
+    function esc_url($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return $text;
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('get_theme_mod')) {
+    function get_theme_mod($name) {
+        return null;
+    }
+}
+if (!function_exists('wp_get_attachment_image_url')) {
+    function wp_get_attachment_image_url($id, $size = 'full') {
+        return '';
+    }
+}
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri($path) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '', $filter = 'raw') {
+        return 'Site';
+    }
+}
+
+require_once __DIR__ . '/../inc/emails/template.php';
+
+class EmailTemplateTest extends TestCase
+{
+    public function test_template_contains_title_content_and_sections(): void
+    {
+        $title = 'Titre';
+        $content = '<p>Bonjour</p>';
+
+        $html = cta_render_email_template($title, $content);
+
+        $this->assertStringContainsString($title, $html);
+        $this->assertStringContainsString($content, $html);
+        $this->assertStringContainsString('<header', $html);
+        $this->assertStringContainsString('<footer', $html);
+        $this->assertGreaterThanOrEqual(2, substr_count($html, '#0B132B'));
+    }
+}


### PR DESCRIPTION
Ajout d'un module d'e-mails HTML pour le thème.

- Génère un modèle d'e-mail avec en-tête, contenu sécurisé et pied de page
- Fournit une fonction d'envoi enveloppant `wp_mail`
- Charge le module et ajoute des tests de vérification

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8a7606483328602287b61802635