### PR TITLE
feat: add registration email variant

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -361,6 +361,7 @@ require_once $inc_path . 'PointsRepository.php';
 require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
 require_once $inc_path . 'emails/template.php';
+require_once $inc_path . 'emails/user-registration.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once $inc_path . 'cli/class-cat-cli-command.php';

--- a/wp-content/themes/chassesautresor/inc/emails/user-registration.php
+++ b/wp-content/themes/chassesautresor/inc/emails/user-registration.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Customizes the new user registration email.
+ *
+ * @package chassesautresor-com
+ */
+
+defined('ABSPATH') || exit();
+
+/**
+ * Filters the new user notification email to use the HTML template.
+ *
+ * @param array   $email    Default email arguments.
+ * @param WP_User $user     Registered user object.
+ * @param string  $blogname Site name.
+ *
+ * @return array
+ */
+function cta_new_user_notification_email(array $email, $user, string $blogname): array
+{
+    $subject = sprintf(
+        /* translators: %s: Site name */
+        esc_html__('Bienvenue chez %s', 'chassesautresor-com'),
+        $blogname
+    );
+
+    $key = function_exists('get_password_reset_key') ? get_password_reset_key($user) : '';
+    $reset_url = function_exists('network_site_url')
+        ? network_site_url('wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode($user->user_login), 'login')
+        : '';
+
+    $content  = '<p>' . sprintf(
+        /* translators: %s: User display name */
+        esc_html__('Bonjour %s,', 'chassesautresor-com'),
+        $user->display_name
+    ) . '</p>';
+    $content .= '<p>' . esc_html__(
+        'Merci de votre inscription. Cliquez sur le bouton ci-dessous pour définir votre mot de passe.',
+        'chassesautresor-com'
+    ) . '</p>';
+    $content .= '<p><a href="' . esc_url($reset_url) . '" style="display:inline-block;padding:10px 20px;background:#0B132B;color:#ffffff;text-decoration:none;">' . esc_html__('Configurer mon mot de passe', 'chassesautresor-com') . '</a></p>';
+
+    $email['to']      = $user->user_email;
+    $email['subject'] = $subject;
+    $email['message'] = cta_render_email_template($subject, $content);
+
+    $headers   = $email['headers'] ?? [];
+    $has_type  = false;
+    foreach ($headers as $header) {
+        if (stripos($header, 'Content-Type:') === 0) {
+            $has_type = true;
+            break;
+        }
+    }
+    if (!$has_type) {
+        $headers[] = 'Content-Type: text/html; charset=UTF-8';
+    }
+    $email['headers'] = $headers;
+
+    return $email;
+}
+add_filter('wp_new_user_notification_email', 'cta_new_user_notification_email', 10, 3);

--- a/wp-content/themes/chassesautresor/tests/email_user_registration.test.php
+++ b/wp-content/themes/chassesautresor/tests/email_user_registration.test.php
@@ -1,0 +1,83 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($content) {
+        return $content;
+    }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_url')) {
+    function esc_url($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return $text;
+    }
+}
+if (!function_exists('add_filter')) {
+    function add_filter($tag, $function_to_add, $priority = 10, $accepted_args = 1) {}
+}
+if (!function_exists('get_theme_mod')) {
+    function get_theme_mod($name) {
+        return null;
+    }
+}
+if (!function_exists('wp_get_attachment_image_url')) {
+    function wp_get_attachment_image_url($id, $size = 'full') {
+        return '';
+    }
+}
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri($path) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '', $filter = 'raw') {
+        return 'Site';
+    }
+}
+if (!function_exists('get_password_reset_key')) {
+    function get_password_reset_key($user) {
+        return 'abc123';
+    }
+}
+if (!function_exists('network_site_url')) {
+    function network_site_url($path = '', $scheme = null) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+
+require_once __DIR__ . '/../inc/emails/template.php';
+require_once __DIR__ . '/../inc/emails/user-registration.php';
+
+class EmailUserRegistrationTest extends TestCase
+{
+    public function test_custom_registration_email(): void
+    {
+        $user = (object) [
+            'user_login'   => 'test4',
+            'display_name' => 'test4',
+            'user_email'   => 'test4@example.com',
+        ];
+
+        $email = cta_new_user_notification_email([], $user, 'chassesautresor.com');
+
+        $this->assertStringContainsString('Bienvenue', $email['subject']);
+        $this->assertStringContainsString('Configurer mon mot de passe', $email['message']);
+        $this->assertStringContainsString('abc123', $email['message']);
+        $this->assertContains('Content-Type: text/html; charset=UTF-8', $email['headers']);
+    }
+}


### PR DESCRIPTION
## Résumé
- Personnalisation de l'email d'inscription des utilisateurs avec un message d'accueil et un bouton de configuration de mot de passe.

## Changements notables
- Ajout du module `user-registration.php` pour générer l'email HTML de bienvenue.
- Chargement du module dans `functions.php`.
- Ajout d'un test unitaire garantissant la présence du sujet et du lien de configuration de mot de passe.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7c33ab1508332af7bff29695121b3