### PR TITLE
Retirer le message de vérification de profil après confirmation

### DIFF
--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -876,6 +876,8 @@ function traiter_confirmation_organisateur() {
         $organisateur_id = confirmer_demande_organisateur($user_id, $token);
     }
 
+    remove_site_message('profil_verification');
+
     if ($organisateur_id) {
         wp_set_current_user($user_id);
         wp_set_auth_cookie($user_id);


### PR DESCRIPTION
## Résumé
- Nettoie le message de vérification de profil après utilisation du lien d’activation

## Changements notables
- Appel à `remove_site_message('profil_verification')` après traitement de la confirmation

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `php /tmp/test_activation.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7ce6d04488332a6d1407a2ec1a2ec