### PR TITLE
feat: add email templating module

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,3 +13,7 @@ if (!function_exists('add_action')) {
 if (!function_exists('add_filter')) {
     function add_filter(...$args): void {}
 }
+
+if (!function_exists('remove_filter')) {
+    function remove_filter(...$args): void {}
+}

--- a/tests/email_notifications.test.php
+++ b/tests/email_notifications.test.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('esc_html')) {
+    function esc_html(string $text): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url(string $url): string
+    {
+        return $url;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr(string $text): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('get_template_directory_uri')) {
+    function get_template_directory_uri(): string
+    {
+        return 'https://example.com/wp-content/themes/chassesautresor';
+    }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($data)
+    {
+        return $data;
+    }
+}
+
+if (!function_exists('network_site_url')) {
+    function network_site_url(string $path = '', string $scheme = 'login'): string
+    {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('get_password_reset_key')) {
+    function get_password_reset_key($user): string
+    {
+        return 'key';
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/emails/template.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/emails/user-registration.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/emails/password-reset.php';
+
+class EmailNotificationsTest extends TestCase
+{
+    public function test_user_registration_email_headers_are_string(): void
+    {
+        $user = (object) [
+            'user_login'    => 'test',
+            'user_email'    => 'foo@example.com',
+            'display_name'  => 'Test',
+        ];
+
+        $email = [
+            'to'      => '',
+            'subject' => '',
+            'message' => '',
+            'headers' => '',
+        ];
+
+        $result = cta_new_user_notification_email($email, $user, 'Site');
+
+        $this->assertSame('foo@example.com', $result['to']);
+        $this->assertIsString($result['headers']);
+        $this->assertStringContainsString('Content-Type: text/html', $result['headers']);
+        $this->assertStringContainsString('Configurer mon mot de passe', $result['message']);
+    }
+
+    public function test_password_reset_email_uses_template(): void
+    {
+        $user = (object) [
+            'user_login'    => 'test',
+            'user_email'    => 'foo@example.com',
+            'display_name'  => 'Test',
+        ];
+
+        $email = [
+            'to'      => '',
+            'subject' => '',
+            'message' => '',
+            'headers' => '',
+        ];
+
+        $result = cta_password_reset_notification_email($email, $user, 'Site');
+
+        $this->assertSame('foo@example.com', $result['to']);
+        $this->assertStringContainsString('Réinitialiser mon mot de passe', $result['message']);
+        $this->assertStringContainsString('<header', $result['message']);
+        $this->assertStringContainsString('<footer', $result['message']);
+        $this->assertStringContainsString('Content-Type: text/html', $result['headers']);
+    }
+}

--- a/tests/email_notifications.test.php
+++ b/tests/email_notifications.test.php
@@ -39,10 +39,10 @@ if (!function_exists('esc_attr')) {
     }
 }
 
-if (!function_exists('get_template_directory_uri')) {
-    function get_template_directory_uri(): string
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri(string $path = ''): string
     {
-        return 'https://example.com/wp-content/themes/chassesautresor';
+        return 'https://example.com/wp-content/themes/chassesautresor/' . ltrim($path, '/');
     }
 }
 

--- a/tests/email_notifications.test.php
+++ b/tests/email_notifications.test.php
@@ -60,10 +60,12 @@ if (!function_exists('network_site_url')) {
     }
 }
 
-if (!function_exists('get_password_reset_key')) {
-    function get_password_reset_key($user): string
+if (!class_exists('WP_User')) {
+    class WP_User
     {
-        return 'key';
+        public $user_login;
+        public $user_email;
+        public $display_name;
     }
 }
 
@@ -75,11 +77,10 @@ class EmailNotificationsTest extends TestCase
 {
     public function test_user_registration_email_headers_are_string(): void
     {
-        $user = (object) [
-            'user_login'    => 'test',
-            'user_email'    => 'foo@example.com',
-            'display_name'  => 'Test',
-        ];
+        $user = new WP_User();
+        $user->user_login   = 'test';
+        $user->user_email   = 'foo@example.com';
+        $user->display_name = 'Test';
 
         $email = [
             'to'      => '',
@@ -98,11 +99,10 @@ class EmailNotificationsTest extends TestCase
 
     public function test_password_reset_email_uses_template(): void
     {
-        $user = (object) [
-            'user_login'    => 'test',
-            'user_email'    => 'foo@example.com',
-            'display_name'  => 'Test',
-        ];
+        $user = new WP_User();
+        $user->user_login   = 'test';
+        $user->user_email   = 'foo@example.com';
+        $user->display_name = 'Test';
 
         $email = [
             'to'      => '',
@@ -111,7 +111,7 @@ class EmailNotificationsTest extends TestCase
             'headers' => '',
         ];
 
-        $result = cta_password_reset_notification_email($email, $user, 'Site');
+        $result = cta_password_reset_notification_email($email, 'key', 'test', $user);
 
         $this->assertSame('foo@example.com', $result['to']);
         $this->assertStringContainsString('Réinitialiser mon mot de passe', $result['message']);

--- a/tests/email_notifications.test.php
+++ b/tests/email_notifications.test.php
@@ -115,8 +115,8 @@ class EmailNotificationsTest extends TestCase
 
         $this->assertSame('foo@example.com', $result['to']);
         $this->assertStringContainsString('Réinitialiser mon mot de passe', $result['message']);
-        $this->assertStringContainsString('<header', $result['message']);
-        $this->assertStringContainsString('<footer', $result['message']);
+        $this->assertStringContainsString('cta-email-header', $result['message']);
+        $this->assertStringContainsString('cta-email-footer', $result['message']);
         $this->assertStringContainsString('Content-Type: text/html', $result['headers']);
     }
 }

--- a/tests/email_template.test.php
+++ b/tests/email_template.test.php
@@ -18,6 +18,13 @@ if (!function_exists('esc_html__')) {
     }
 }
 
+if (!function_exists('esc_attr__')) {
+    function esc_attr__(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}
+
 if (!function_exists('esc_url')) {
     function esc_url(string $url): string
     {
@@ -32,31 +39,10 @@ if (!function_exists('esc_attr')) {
     }
 }
 
-if (!function_exists('home_url')) {
-    function home_url(string $path = ''): string
+if (!function_exists('get_template_directory_uri')) {
+    function get_template_directory_uri(): string
     {
-        return 'https://example.com' . $path;
-    }
-}
-
-if (!function_exists('get_theme_mod')) {
-    function get_theme_mod(string $name)
-    {
-        return 0;
-    }
-}
-
-if (!function_exists('wp_get_attachment_image_url')) {
-    function wp_get_attachment_image_url(int $id, string $size): string
-    {
-        return '';
-    }
-}
-
-if (!function_exists('get_bloginfo')) {
-    function get_bloginfo(string $show = ''): string
-    {
-        return 'Example Site';
+        return 'https://example.com/wp-content/themes/chassesautresor';
     }
 }
 
@@ -83,6 +69,11 @@ class EmailTemplateTest extends TestCase
         $this->assertStringContainsString('<header', $html);
         $this->assertStringContainsString('<footer', $html);
         $this->assertSame(2, substr_count($html, '#0B132B'));
+        $this->assertStringContainsString('logo-cat_icone-s.png', $html);
+        $this->assertStringContainsString('http://chassesautresor.local/mentions-legales/', $html);
+        $this->assertStringContainsString('logo-cat_hz-txt.png', $html);
+        $this->assertStringContainsString('https://www.chassesautresor.com', $html);
+        $this->assertStringNotContainsString('Se désabonner', $html);
     }
 }
 

--- a/tests/email_template.test.php
+++ b/tests/email_template.test.php
@@ -39,10 +39,10 @@ if (!function_exists('esc_attr')) {
     }
 }
 
-if (!function_exists('get_template_directory_uri')) {
-    function get_template_directory_uri(): string
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri(string $path = ''): string
     {
-        return 'https://example.com/wp-content/themes/chassesautresor';
+        return 'https://example.com/wp-content/themes/chassesautresor/' . ltrim($path, '/');
     }
 }
 

--- a/tests/email_template.test.php
+++ b/tests/email_template.test.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('esc_html')) {
+    function esc_html(string $text): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url(string $url): string
+    {
+        return $url;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr(string $text): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('home_url')) {
+    function home_url(string $path = ''): string
+    {
+        return 'https://example.com' . $path;
+    }
+}
+
+if (!function_exists('get_theme_mod')) {
+    function get_theme_mod(string $name)
+    {
+        return 0;
+    }
+}
+
+if (!function_exists('wp_get_attachment_image_url')) {
+    function wp_get_attachment_image_url(int $id, string $size): string
+    {
+        return '';
+    }
+}
+
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo(string $show = ''): string
+    {
+        return 'Example Site';
+    }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($data)
+    {
+        return $data;
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/emails/template.php';
+
+class EmailTemplateTest extends TestCase
+{
+    public function test_template_contains_title_content_and_sections(): void
+    {
+        $title   = 'Mon titre';
+        $content = '<p>Mon contenu</p>';
+
+        $html = cta_render_email_template($title, $content);
+
+        $this->assertStringContainsString($title, $html);
+        $this->assertStringContainsString($content, $html);
+        $this->assertStringContainsString('<header', $html);
+        $this->assertStringContainsString('<footer', $html);
+        $this->assertSame(2, substr_count($html, '#0B132B'));
+    }
+}
+

--- a/tests/email_template.test.php
+++ b/tests/email_template.test.php
@@ -66,8 +66,8 @@ class EmailTemplateTest extends TestCase
 
         $this->assertStringContainsString($title, $html);
         $this->assertStringContainsString($content, $html);
-        $this->assertStringContainsString('<header', $html);
-        $this->assertStringContainsString('<footer', $html);
+        $this->assertStringContainsString('cta-email-header', $html);
+        $this->assertStringContainsString('cta-email-footer', $html);
         $this->assertSame(2, substr_count($html, '#0B132B'));
         $this->assertStringContainsString('logo-cat_icone-s.png', $html);
         $this->assertStringContainsString('http://chassesautresor.local/mentions-legales/', $html);

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -360,7 +360,6 @@ require_once $inc_path . 'utils.php';
 require_once $inc_path . 'PointsRepository.php';
 require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
-require_once $inc_path . 'emails/template.php';
 require_once $inc_path . 'emails/user-registration.php';
 
 if (defined('WP_CLI') && WP_CLI) {
@@ -401,6 +400,8 @@ require_once $inc_path . 'edition/edition-enigme.php';
 require_once $inc_path . 'edition/edition-indice.php';
 require_once $inc_path . 'edition/edition-solution.php';
 require_once $inc_path . 'edition/edition-securite.php';
+
+require_once get_template_directory() . '/inc/emails/template.php';
 
 
 

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -401,7 +401,7 @@ require_once $inc_path . 'edition/edition-indice.php';
 require_once $inc_path . 'edition/edition-solution.php';
 require_once $inc_path . 'edition/edition-securite.php';
 
-require_once get_template_directory() . '/inc/emails/template.php';
+require_once get_theme_file_path( 'inc/emails/template.php' );
 
 
 

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -361,6 +361,7 @@ require_once $inc_path . 'PointsRepository.php';
 require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
 require_once $inc_path . 'emails/user-registration.php';
+require_once $inc_path . 'emails/password-reset.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once $inc_path . 'cli/class-cat-cli-command.php';

--- a/wp-content/themes/chassesautresor/inc/emails/password-reset.php
+++ b/wp-content/themes/chassesautresor/inc/emails/password-reset.php
@@ -11,19 +11,18 @@ defined('ABSPATH') || exit();
  * Filters the password reset email to use the HTML template.
  *
  * @param array   $email      Default email arguments.
+ * @param string  $key        Activation key for the reset link.
+ * @param string  $user_login Username of the account.
  * @param WP_User $user       User object requesting reset.
- * @param string  $site_title Site name.
  *
  * @return array
  */
-function cta_password_reset_notification_email(array $email, $user, string $site_title): array
+function cta_password_reset_notification_email(array $email, string $key, string $user_login, WP_User $user): array
 {
-    $subject = esc_html__('Réinitialisation du mot de passe', 'chassesautresor-com');
-
-    $key = function_exists('get_password_reset_key') ? get_password_reset_key($user) : '';
+    $subject   = esc_html__('Réinitialisation du mot de passe', 'chassesautresor-com');
     $reset_url = function_exists('network_site_url')
         ? network_site_url(
-            'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode($user->user_login),
+            'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode($user_login),
             'login'
         )
         : '';
@@ -70,4 +69,4 @@ function cta_password_reset_notification_email(array $email, $user, string $site
 
     return $email;
 }
-add_filter('retrieve_password_notification_email', 'cta_password_reset_notification_email', 10, 3);
+add_filter('retrieve_password_notification_email', 'cta_password_reset_notification_email', 10, 4);

--- a/wp-content/themes/chassesautresor/inc/emails/password-reset.php
+++ b/wp-content/themes/chassesautresor/inc/emails/password-reset.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Customizes the password reset email.
+ *
+ * @package chassesautresor-com
+ */
+
+defined('ABSPATH') || exit();
+
+/**
+ * Filters the password reset email to use the HTML template.
+ *
+ * @param array   $email      Default email arguments.
+ * @param WP_User $user       User object requesting reset.
+ * @param string  $site_title Site name.
+ *
+ * @return array
+ */
+function cta_password_reset_notification_email(array $email, $user, string $site_title): array
+{
+    $subject = esc_html__('Réinitialisation du mot de passe', 'chassesautresor-com');
+
+    $key = function_exists('get_password_reset_key') ? get_password_reset_key($user) : '';
+    $reset_url = function_exists('network_site_url')
+        ? network_site_url(
+            'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode($user->user_login),
+            'login'
+        )
+        : '';
+
+    $content  = '<p>' . sprintf(
+        esc_html__('Bonjour %s,', 'chassesautresor-com'),
+        $user->display_name
+    ) . '</p>';
+    $content .= '<p>' . esc_html__(
+        'Vous avez demandé la réinitialisation de votre mot de passe. Cliquez sur le bouton ci-dessous '
+        . 'pour en créer un nouveau.',
+        'chassesautresor-com'
+    ) . '</p>';
+    $content .= '<p style="margin-top:20px;">';
+    $content .= '<a href="' . esc_url($reset_url) . '" ';
+    $content .= 'style="display:inline-block;padding:10px 20px;';
+    $content .= 'background:#0B132B;color:#ffffff;text-decoration:none;">';
+    $content .= esc_html__('Réinitialiser mon mot de passe', 'chassesautresor-com') . '</a></p>';
+    $content .= '<p>' . esc_html__(
+        "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail.",
+        'chassesautresor-com'
+    ) . '</p>';
+
+    $email['to']      = $user->user_email;
+    $email['subject'] = $subject;
+    $email['message'] = cta_render_email_template($subject, $content);
+
+    $headers = $email['headers'] ?? '';
+    if (!is_array($headers)) {
+        $headers = $headers ? preg_split("/(\r\n|\r|\n)/", (string) $headers) : [];
+    }
+
+    $has_type = false;
+    foreach ($headers as $header) {
+        if (stripos($header, 'Content-Type:') === 0) {
+            $has_type = true;
+            break;
+        }
+    }
+    if (!$has_type) {
+        $headers[] = 'Content-Type: text/html; charset=UTF-8';
+    }
+    $email['headers'] = implode("\r\n", $headers);
+
+    return $email;
+}
+add_filter('retrieve_password_notification_email', 'cta_password_reset_notification_email', 10, 3);

--- a/wp-content/themes/chassesautresor/inc/emails/password-reset.php
+++ b/wp-content/themes/chassesautresor/inc/emails/password-reset.php
@@ -67,6 +67,8 @@ function cta_password_reset_notification_email(array $email, string $key, string
     }
     $email['headers'] = implode("\r\n", $headers);
 
+    add_filter('wp_mail_content_type', 'cta_set_html_content_type');
+
     return $email;
 }
 add_filter('retrieve_password_notification_email', 'cta_password_reset_notification_email', 10, 4);

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -20,8 +20,8 @@ function cta_render_email_template(string $title, string $content): string
     $header_bg = '#0B132B';
     $icon_url  = '';
 
-    if (function_exists('get_template_directory_uri')) {
-        $icon_url = get_template_directory_uri() . '/assets/images/logo-cat_icone-s.png';
+    if (function_exists('get_theme_file_uri')) {
+        $icon_url = get_theme_file_uri('assets/images/logo-cat_icone-s.png');
     }
 
     $html  = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head>';
@@ -56,10 +56,8 @@ function cta_render_email_template(string $title, string $content): string
         esc_html__('Mentions légales', 'chassesautresor-com') . '</a>';
     $html .= '<a href="' . esc_url('https://www.chassesautresor.com') . '" ' .
         'style="display:block;margin:10px auto 0;">';
-    $html .= '<img src="' . esc_url(
-        (function_exists('get_template_directory_uri') ? get_template_directory_uri() : '') .
-        '/assets/images/logo-cat_hz-txt.png'
-    ) . '" alt="' . esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" ' .
+    $logo_url = function_exists('get_theme_file_uri') ? get_theme_file_uri('assets/images/logo-cat_hz-txt.png') : '';
+    $html    .= '<img src="' . esc_url($logo_url) . '" alt="' . esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" ' .
         'style="max-width:100%;height:auto;display:block;margin:0 auto;" />';
     $html .= '</a>';
     $html .= '</footer>';
@@ -115,8 +113,26 @@ function cta_send_email(array|string $to, string $subject, string $body, array $
         $headers[] = 'From: ' . $from;
     }
 
-    $html = cta_render_email_template($subject, $body);
+    add_filter('wp_mail_content_type', 'cta_set_html_content_type');
+    $html   = cta_render_email_template($subject, $body);
+    $result = function_exists('wp_mail') ? wp_mail($to, $subject, $html, $headers) : false;
 
-    return function_exists('wp_mail') ? wp_mail($to, $subject, $html, $headers) : false;
+    return $result;
+}
+
+/**
+ * Forces HTML content type for outgoing emails.
+ *
+ * @param string $content_type Current content type.
+ *
+ * @return string
+ */
+function cta_set_html_content_type(string $content_type = ''): string
+{
+    if (function_exists('remove_filter')) {
+        remove_filter('wp_mail_content_type', 'cta_set_html_content_type');
+    }
+
+    return 'text/html; charset=UTF-8';
 }
 

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -18,22 +18,10 @@ defined('ABSPATH') || exit();
 function cta_render_email_template(string $title, string $content): string
 {
     $header_bg = '#0B132B';
-    $logo_html = '';
+    $icon_url  = '';
 
-    if (function_exists('get_theme_mod')) {
-        $logo_id = get_theme_mod('custom_logo');
-
-        if ($logo_id && function_exists('wp_get_attachment_image_url')) {
-            $src = wp_get_attachment_image_url($logo_id, 'full');
-
-            if ($src) {
-                $logo_html = sprintf(
-                    '<img src="%s" alt="%s" style="max-height:60px;height:auto;display:block;margin:0 auto;" />',
-                    esc_url($src),
-                    esc_attr(function_exists('get_bloginfo') ? get_bloginfo('name') : '')
-                );
-            }
-        }
+    if (function_exists('get_template_directory_uri')) {
+        $icon_url = get_template_directory_uri() . '/assets/images/logo-cat_icone-s.png';
     }
 
     $html  = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head>';
@@ -43,11 +31,13 @@ function cta_render_email_template(string $title, string $content): string
 
     $html .= '<tr><td>';
     $html .= '<header style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;">';
-    if ($logo_html) {
-        $html .= $logo_html;
+    $html .= '<h1 style="margin:0;color:#ffffff;font-family:Arial,sans-serif;font-size:24px;">';
+    if ($icon_url) {
+        $html .= '<img src="' . esc_url($icon_url) . '" alt="' .
+            esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" ' .
+            'style="width:50px;height:50px;vertical-align:middle;margin-right:10px;" />';
     }
-    $html .= '<h1 style="margin:0;color:#ffffff;font-family:Arial,sans-serif;font-size:24px;">' .
-        esc_html($title) . '</h1>';
+    $html .= esc_html($title) . '</h1>';
     $html .= '</header>';
     $html .= '</td></tr>';
 
@@ -62,10 +52,16 @@ function cta_render_email_template(string $title, string $content): string
     $html .= '<tr><td>';
     $html .= '<footer style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;';
     $html .= 'font-family:Arial,sans-serif;font-size:12px;color:#ffffff;">';
-    $html .= '<a href="' . esc_url(home_url('/mentions-legales/')) . '" style="color:#ffffff;">' .
-        esc_html__('Mentions légales', 'chassesautresor-com') . '</a> | ';
-    $html .= '<a href="' . esc_url(home_url('/?unsubscribe=1')) . '" style="color:#ffffff;">' .
-        esc_html__('Se désabonner', 'chassesautresor-com') . '</a>';
+    $html .= '<a href="' . esc_url('http://chassesautresor.local/mentions-legales/') . '" style="color:#ffffff;">' .
+        esc_html__('Mentions légales', 'chassesautresor-com') . '</a>';
+    $html .= '<a href="' . esc_url('https://www.chassesautresor.com') . '" ' .
+        'style="display:block;margin:10px auto 0;">';
+    $html .= '<img src="' . esc_url(
+        (function_exists('get_template_directory_uri') ? get_template_directory_uri() : '') .
+        '/assets/images/logo-cat_hz-txt.png'
+    ) . '" alt="' . esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" ' .
+        'style="max-width:100%;height:auto;display:block;margin:0 auto;" />';
+    $html .= '</a>';
     $html .= '</footer>';
     $html .= '</td></tr>';
 

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -30,15 +30,17 @@ function cta_render_email_template(string $title, string $content): string
     $html .= 'style="border-collapse:collapse;">';
 
     $html .= '<tr><td>';
-    $html .= '<header style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;">';
-    $html .= '<h1 style="margin:0;color:#ffffff;font-family:Arial,sans-serif;font-size:24px;">';
+    $html .= '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        . 'class="cta-email-header" style="background:' . esc_attr($header_bg) . ';">';
+    $html .= '<tr><td style="padding:20px;text-align:center;">';
+    $html .= '<span style="display:inline-block;font-family:Arial,sans-serif;font-size:24px;color:#ffffff;">';
     if ($icon_url) {
         $html .= '<img src="' . esc_url($icon_url) . '" alt="' .
             esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" ' .
             'style="width:50px;height:50px;vertical-align:middle;margin-right:10px;" />';
     }
-    $html .= esc_html($title) . '</h1>';
-    $html .= '</header>';
+    $html .= esc_html($title) . '</span>';
+    $html .= '</td></tr></table>';
     $html .= '</td></tr>';
 
     $html .= '<tr><td>';
@@ -50,17 +52,20 @@ function cta_render_email_template(string $title, string $content): string
     $html .= '</td></tr>';
 
     $html .= '<tr><td>';
-    $html .= '<footer style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;';
-    $html .= 'font-family:Arial,sans-serif;font-size:12px;color:#ffffff;">';
-    $html .= '<a href="' . esc_url('http://chassesautresor.local/mentions-legales/') . '" style="color:#ffffff;">' .
-        esc_html__('Mentions légales', 'chassesautresor-com') . '</a>';
-    $html .= '<a href="' . esc_url('https://www.chassesautresor.com') . '" ' .
-        'style="display:block;margin:10px auto 0;">';
+    $html .= '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        . 'class="cta-email-footer" style="background:' . esc_attr($header_bg) . ';">';
+    $html .= '<tr><td style="padding:20px;text-align:center;font-family:Arial,sans-serif;'
+        . 'font-size:12px;color:#ffffff;">';
+    $html .= '<a href="' . esc_url('http://chassesautresor.local/mentions-legales/') . '" style="color:#ffffff;">'
+        . esc_html__('Mentions légales', 'chassesautresor-com') . '</a>';
+    $html .= '<a href="' . esc_url('https://www.chassesautresor.com') . '" '
+        . 'style="display:block;margin:10px auto 0;">';
     $logo_url = function_exists('get_theme_file_uri') ? get_theme_file_uri('assets/images/logo-cat_hz-txt.png') : '';
-    $html    .= '<img src="' . esc_url($logo_url) . '" alt="' . esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" ' .
-        'style="max-width:100%;height:auto;display:block;margin:0 auto;" />';
+    $html    .= '<img src="' . esc_url($logo_url) . '" alt="'
+        . esc_attr__('Chasses au Trésor', 'chassesautresor-com') . '" '
+        . 'style="max-width:100%;height:auto;display:block;margin:0 auto;" />';
     $html .= '</a>';
-    $html .= '</footer>';
+    $html .= '</td></tr></table>';
     $html .= '</td></tr>';
 
     $html .= '</table>';

--- a/wp-content/themes/chassesautresor/inc/emails/user-registration.php
+++ b/wp-content/themes/chassesautresor/inc/emails/user-registration.php
@@ -54,7 +54,7 @@ function cta_new_user_notification_email(array $email, $user, string $blogname):
     if (!$has_type) {
         $headers[] = 'Content-Type: text/html; charset=UTF-8';
     }
-    $email['headers'] = $headers;
+    $email['headers'] = implode("\r\n", $headers);
 
     return $email;
 }

--- a/wp-content/themes/chassesautresor/inc/emails/user-registration.php
+++ b/wp-content/themes/chassesautresor/inc/emails/user-registration.php
@@ -56,6 +56,8 @@ function cta_new_user_notification_email(array $email, $user, string $blogname):
     }
     $email['headers'] = implode("\r\n", $headers);
 
+    add_filter('wp_mail_content_type', 'cta_set_html_content_type');
+
     return $email;
 }
 add_filter('wp_new_user_notification_email', 'cta_new_user_notification_email', 10, 3);


### PR DESCRIPTION
## Résumé
Ajout d'un template HTML centralisé pour l'envoi d'e-mails.

## Changements notables
- Génération d'un gabarit d'e-mail avec en-tête, contenu et pied de page.
- Centralisation de l'envoi via `cta_send_email` et inclusion du module.
- Couverture de rendu par un test PHPUnit dédié.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7e1b124108332a43bb92b6ef3ff40