### PR TITLE
Message de vérification pour demande d'organisateur

### DIFF
--- a/tests/organisateur_confirmation_message.test.php
+++ b/tests/organisateur_confirmation_message.test.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ARRAY_A')) {
+    define('ARRAY_A', 'ARRAY_A');
+}
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+if (!function_exists('add_action')) {
+    function add_action(...$args): void {}
+}
+if (!function_exists('add_filter')) {
+    function add_filter(...$args): void {}
+}
+if (!function_exists('current_time')) {
+    function current_time(string $type)
+    {
+        return $type === 'mysql' ? '2023-01-01 00:00:00' : 0;
+    }
+}
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data)
+    {
+        return json_encode($data);
+    }
+}
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str)
+    {
+        return $str;
+    }
+}
+if (!function_exists('get_query_var')) {
+    function get_query_var($key)
+    {
+        return '1';
+    }
+}
+if (!function_exists('is_page')) {
+    function is_page($slug)
+    {
+        return false;
+    }
+}
+if (!function_exists('confirmer_demande_organisateur')) {
+    function confirmer_demande_organisateur($user_id, $token)
+    {
+        return 42;
+    }
+}
+if (!function_exists('remove_site_message')) {
+    function remove_site_message($key): void {}
+}
+if (!function_exists('wp_set_current_user')) {
+    function wp_set_current_user($id): void {}
+}
+if (!function_exists('wp_set_auth_cookie')) {
+    function wp_set_auth_cookie($id): void {}
+}
+if (!function_exists('get_permalink')) {
+    function get_permalink($id)
+    {
+        return 'https://example.com/organisateur';
+    }
+}
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($key, $value, $url)
+    {
+        return $url . '?' . $key . '=' . $value;
+    }
+}
+class RedirectException extends Exception {}
+if (!function_exists('wp_safe_redirect')) {
+    function wp_safe_redirect($url): void
+    {
+        throw new RedirectException($url);
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '')
+    {
+        return 'https://example.com' . $path;
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/user-functions.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/organisateur-functions.php';
+
+class OrganisateurConfirmationMessageTest extends TestCase
+{
+    private DummyWpdb $wpdb;
+
+    protected function setUp(): void
+    {
+        global $wpdb;
+        $this->wpdb = new DummyWpdb();
+        $wpdb       = $this->wpdb;
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+    }
+
+    public function test_confirmation_removes_persistent_message(): void
+    {
+        $expires = time() + 2 * DAY_IN_SECONDS;
+        myaccount_add_persistent_message(
+            1,
+            'profil_verification',
+            'Test',
+            'info',
+            true,
+            0,
+            false,
+            null,
+            null,
+            $expires
+        );
+
+        $repo = new UserMessageRepository($this->wpdb);
+        $this->assertNotEmpty($repo->get(1, 'persistent', false));
+
+        $_GET['user']  = 1;
+        $_GET['token'] = 'abc';
+        try {
+            traiter_confirmation_organisateur();
+        } catch (RedirectException $e) {
+            // Redirect expected.
+        }
+
+        $this->assertSame([], $repo->get(1, 'persistent', false));
+    }
+}
+
+class DummyWpdb
+{
+    public string $prefix = 'wp_';
+    public int $insert_id = 0;
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $data = [];
+
+    public function insert(string $table, array $data, array $format): void
+    {
+        $this->insert_id++;
+        $data['id']             = $this->insert_id;
+        $this->data[$this->insert_id] = $data;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function get_results(string $sql, $output)
+    {
+        return array_values($this->data);
+    }
+
+    public function delete(string $table, array $where, array $whereFormat): void
+    {
+        unset($this->data[$where['id']]);
+    }
+
+    public function query(string $sql): void
+    {
+        $now = current_time('mysql');
+        $this->data = array_filter(
+            $this->data,
+            fn($r) => $r['expires_at'] === null || $r['expires_at'] >= $now
+        );
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -876,6 +876,7 @@ function traiter_confirmation_organisateur() {
         $organisateur_id = confirmer_demande_organisateur($user_id, $token);
     }
 
+    myaccount_remove_persistent_message($user_id, 'profil_verification');
     remove_site_message('profil_verification');
 
     if ($organisateur_id) {

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -261,6 +261,7 @@ add_filter('woocommerce_endpoint_edit-account_title', 'ca_profile_endpoint_title
  * @param bool        $include_enigmes Whether to include enigmas in the scope.
  * @param string|null $message_key   Optional translation key.
  * @param string|null $locale        Optional locale for the message.
+ * @param int|null    $expires       Expiration timestamp or delay in seconds.
  *
  * @return void
  */
@@ -273,7 +274,8 @@ function myaccount_add_persistent_message(
     int $chasse_scope = 0,
     bool $include_enigmes = false,
     ?string $message_key = null,
-    ?string $locale = null
+    ?string $locale = null,
+    ?int $expires = null
 ): void {
     global $wpdb;
 
@@ -307,7 +309,14 @@ function myaccount_add_persistent_message(
         }
     }
 
-    $repo->insert($user_id, wp_json_encode($payload), 'persistent', null, $locale);
+    $expires_at = null;
+    if ($expires !== null) {
+        $expires_at = $expires > time()
+            ? gmdate('c', $expires)
+            : gmdate('c', time() + $expires);
+    }
+
+    $repo->insert($user_id, wp_json_encode($payload), 'persistent', $expires_at, $locale);
 }
 
 /**

--- a/wp-content/themes/chassesautresor/templates/page-creer-profil.php
+++ b/wp-content/themes/chassesautresor/templates/page-creer-profil.php
@@ -21,7 +21,22 @@ $current_user_id = get_current_user_id();
 // 3. Gestion de la demande en cours
 if (isset($_GET['resend'])) {
     renvoyer_email_confirmation_organisateur($current_user_id);
-    wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/devenir-organisateur/')));
+
+    $message = __('✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.', 'chassesautresor-com');
+    myaccount_add_persistent_message(
+        $current_user_id,
+        'profil_verification',
+        $message,
+        'info',
+        true,
+        0,
+        false,
+        null,
+        null,
+        time() + 2 * DAY_IN_SECONDS
+    );
+
+    wp_redirect(home_url('/devenir-organisateur/'));
     exit;
 }
 
@@ -34,5 +49,18 @@ if ($token) {
 
 // 4. Nouvelle demande
 lancer_demande_organisateur($current_user_id);
-wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/devenir-organisateur/')));
+$message = __('✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.', 'chassesautresor-com');
+myaccount_add_persistent_message(
+    $current_user_id,
+    'profil_verification',
+    $message,
+    'info',
+    true,
+    0,
+    false,
+    null,
+    null,
+    time() + 2 * DAY_IN_SECONDS
+);
+wp_redirect(home_url('/devenir-organisateur/'));
 exit;

--- a/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
@@ -39,11 +39,6 @@ if (has_post_thumbnail()) {
 }
 
 get_header(); ?>
-<?php if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') : ?>
-<div class="woocommerce-message" role="alert">
-  ✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.
-</div>
-<?php endif; ?>
 <section class="bandeau-hero">
   <div class="hero-overlay" style="background-image: url('<?php echo esc_url($image_url); ?>');">
     <div class="contenu-hero">

--- a/wp-content/themes/chassesautresor/tests/aaa_manual_response_notifies_organizer.test.php
+++ b/wp-content/themes/chassesautresor/tests/aaa_manual_response_notifies_organizer.test.php
@@ -67,12 +67,23 @@ if (!function_exists('envoyer_mail_reponse_manuelle')) {
     function envoyer_mail_reponse_manuelle(...$args) {}
 }
 if (!function_exists('myaccount_add_persistent_message')) {
-    function myaccount_add_persistent_message($user_id, $key, $message, $type = 'info'): void {
+    function myaccount_add_persistent_message(
+        $user_id,
+        $key,
+        $message,
+        $type = 'info',
+        $dismissible = false,
+        $chasse_scope = 0,
+        $include_enigmes = false,
+        $message_key = null,
+        $locale = null,
+        $expires = null
+    ): void {
         $messages = get_user_meta($user_id, '_myaccount_messages', true);
         if (!is_array($messages)) {
             $messages = [];
         }
-        $messages[$key] = ['text' => $message, 'type' => $type];
+        $messages[$key] = ['text' => $message, 'type' => $type, 'dismissible' => $dismissible];
         update_user_meta($user_id, '_myaccount_messages', $messages);
     }
 }

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/my-account.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/my-account.php
@@ -4,12 +4,6 @@
 
 defined('ABSPATH') || exit;
 
-if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') {
-    echo '<div class="woocommerce-message" role="alert">'
-        . esc_html__('✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.', 'chassesautresor-com')
-        . '</div>';
-}
-
 // S'assure que la variable globale est définie.
 $GLOBALS['myaccount_content_template'] = $GLOBALS['myaccount_content_template'] ?? null;
 


### PR DESCRIPTION
### Résumé
- ajoute un message persistant lors des demandes d'organisateur
- permet de définir une expiration sur les messages utilisateur
- supprime le message après confirmation par lien

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7e4cf6f408332877143c3e923d130