### PR TITLE
Use current_time for organiser confirmation timing

### DIFF
--- a/tests/OrganisateurConfirmationTest.php
+++ b/tests/OrganisateurConfirmationTest.php
@@ -32,6 +32,13 @@ if (!function_exists('creer_organisateur_pour_utilisateur')) {
     }
 }
 
+if (!function_exists('current_time')) {
+    function current_time(string $type)
+    {
+        return $type === 'mysql' ? gmdate('Y-m-d H:i:s', time()) : time();
+    }
+}
+
 if (!class_exists('WP_User')) {
     class WP_User
     {
@@ -64,9 +71,10 @@ class OrganisateurConfirmationTest extends TestCase
     {
         global $cat_test_user_meta;
         $user_id = 1;
+        $now = strtotime(current_time('mysql'));
         $cat_test_user_meta[$user_id] = [
             'organisateur_demande_token' => 'abc',
-            'organisateur_demande_date' => gmdate('Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS),
+            'organisateur_demande_date' => gmdate('Y-m-d H:i:s', $now - 3 * DAY_IN_SECONDS),
         ];
         $this->assertNull(confirmer_demande_organisateur($user_id, 'abc'));
     }
@@ -75,9 +83,10 @@ class OrganisateurConfirmationTest extends TestCase
     {
         global $cat_test_user_meta;
         $user_id = 2;
+        $now = strtotime(current_time('mysql'));
         $cat_test_user_meta[$user_id] = [
             'organisateur_demande_token' => 'def',
-            'organisateur_demande_date' => gmdate('Y-m-d H:i:s', time() - DAY_IN_SECONDS),
+            'organisateur_demande_date' => gmdate('Y-m-d H:i:s', $now - DAY_IN_SECONDS),
         ];
         $this->assertSame(123, confirmer_demande_organisateur($user_id, 'def'));
     }

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -811,7 +811,8 @@ function renvoyer_email_confirmation_organisateur(int $user_id): bool {
         return lancer_demande_organisateur($user_id);
     }
     $timestamp = strtotime((string) $date);
-    if (!$timestamp || (time() - $timestamp) > 2 * DAY_IN_SECONDS) {
+    $now = strtotime((string) current_time('mysql'));
+    if (!$timestamp || ($now - $timestamp) > 2 * DAY_IN_SECONDS) {
         return lancer_demande_organisateur($user_id);
     }
     return envoyer_email_confirmation_organisateur($user_id, (string) $token);
@@ -825,7 +826,8 @@ function confirmer_demande_organisateur(int $user_id, string $token): ?int {
 
     $date      = get_user_meta($user_id, 'organisateur_demande_date', true);
     $timestamp = $date ? strtotime((string) $date) : false;
-    if (!$timestamp || (time() - $timestamp) > 2 * DAY_IN_SECONDS) {
+    $now = strtotime((string) current_time('mysql'));
+    if (!$timestamp || ($now - $timestamp) > 2 * DAY_IN_SECONDS) {
         return null;
     }
 


### PR DESCRIPTION
## Summary
- utilise `current_time()` pour valider la date de demande d'organisateur
- adapte les tests de confirmation d'organisateur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b7f2eb833c83329e24f145119ac91b