### PR TITLE
Log insert errors in user message repository

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
+++ b/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
@@ -37,7 +37,7 @@ class UserMessageRepository
         ?string $expiresAt = null,
         ?string $locale = null
     ): int {
-        $this->wpdb->insert(
+        $result = $this->wpdb->insert(
             $this->table,
             [
                 'user_id'    => $userId,
@@ -48,6 +48,14 @@ class UserMessageRepository
             ],
             ['%d', '%s', '%s', '%s', '%s']
         );
+
+        if (false === $result) {
+            error_log('Failed to insert user message: ' . $this->wpdb->last_error);
+
+            throw new \RuntimeException(
+                __('Unable to insert user message.', 'chassesautresor-com')
+            );
+        }
 
         return (int) $this->wpdb->insert_id;
     }


### PR DESCRIPTION
Ajoute une vérification du retour de `$wpdb->insert` pour consigner l'erreur et lever une exception en cas d'échec.

- Journalise l'erreur de base de données lorsque l'insertion échoue
- Lève une exception traduite pour signaler l'échec

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7f4d4ae508332b444af5a22ca581f