### PR TITLE
Intégration de Twig pour les emails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
   "name": "chassesautresor/wordpress",
-  "require": {},
+  "require": {
+    "twig/twig": "^3.21"
+  },
   "require-dev": {
     "phpunit/phpunit": "^9.6",
     "yoast/phpunit-polyfills": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,323 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc5104b0fd0d377b3b8c41303aeb4bd8",
-    "packages": [],
+    "content-hash": "7cc0ff7006ca66730b90e7582ea90490",
+    "packages": [
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.21.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "285123877d4dd97dd7c11842ac5fb7e86e60d81d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/285123877d4dd97dd7c11842ac5fb7e86e60d81d",
+                "reference": "285123877d4dd97dd7c11842ac5fb7e86e60d81d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2.0",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.21.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-03T07:21:55+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -8,6 +8,12 @@
  * @since 1.0.0
  */
 defined( 'ABSPATH' ) || exit;
+
+$autoloader = __DIR__ . '/../../../vendor/autoload.php';
+if ( file_exists( $autoloader ) ) {
+    require_once $autoloader;
+}
+
 /**
  * Define Constants
  */

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -15,59 +15,45 @@ defined('ABSPATH') || exit();
  *
  * @return string
  */
-function cta_render_email_template(string $title, string $content): string
-{
+function cta_render_email_template( string $title, string $content ): string {
     $logo_url = '';
-    if (function_exists('get_theme_mod')) {
-        $logo_id = get_theme_mod('custom_logo');
-        if ($logo_id && function_exists('wp_get_attachment_image_url')) {
-            $logo_url = wp_get_attachment_image_url($logo_id, 'full');
+    if ( function_exists( 'get_theme_mod' ) ) {
+        $logo_id = get_theme_mod( 'custom_logo' );
+        if ( $logo_id && function_exists( 'wp_get_attachment_image_url' ) ) {
+            $logo_url = wp_get_attachment_image_url( $logo_id, 'full' );
         }
     }
 
-    if (!$logo_url && function_exists('get_theme_file_uri')) {
-        $logo_url = get_theme_file_uri('assets/images/logo.png');
+    if ( ! $logo_url && function_exists( 'get_theme_file_uri' ) ) {
+        $logo_url = get_theme_file_uri( 'assets/images/logo.png' );
     }
 
-    $title_icon = function_exists('get_theme_file_uri') ? get_theme_file_uri('assets/images/logo-cat_icone-s.png') : '';
-    $footer_logo = function_exists('get_theme_file_uri') ? get_theme_file_uri('assets/images/logo-cat_hz-txt.png') : '';
-    $site_name   = function_exists('get_bloginfo') ? get_bloginfo('name') : '';
+    $title_icon  = function_exists( 'get_theme_file_uri' ) ? get_theme_file_uri( 'assets/images/logo-cat_icone-s.png' ) : '';
+    $footer_logo = function_exists( 'get_theme_file_uri' ) ? get_theme_file_uri( 'assets/images/logo-cat_hz-txt.png' ) : '';
+    $site_name   = function_exists( 'get_bloginfo' ) ? get_bloginfo( 'name' ) : '';
     $header_bg   = '#0B132B';
+    $team_label  = function_exists( 'esc_html__' )
+        ? esc_html__( "L'équipe chassesautresor.com", 'chassesautresor-com' )
+        : "L'équipe chassesautresor.com";
 
-    $html  = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>';
-    $html .= '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" ';
-    $html .= 'style="border-collapse:collapse;">';
-    $html .= '<tr><td>';
-    $html .= '<header style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;">';
-    if ($logo_url) {
-        $html .= '<img src="' . esc_url($logo_url) . '" alt="' . esc_attr($site_name) . '" ';
-        $html .= 'style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />';
-    }
-    $html .= '<h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">';
-    if ($title_icon) {
-        $html .= '<img src="' . esc_url($title_icon) . '" alt="" style="height:24px;width:24px;vertical-align:middle;margin-right:8px;" />';
-    }
-    $html .= esc_html($title) . '</h1>';
-    $html .= '</header>';
-    $html .= '</td></tr>';
-    $html .= '<tr><td style="background:#f5f5f5;padding:20px;font-family:Arial,sans-serif;">';
-    $html .= wp_kses_post($content);
-    $html .= '<p style="margin-top:20px;">' . esc_html__('L\'équipe chassesautresor.com', 'chassesautresor-com') . '</p>';
-    $html .= '</td></tr>';
-    $html .= '<tr><td>';
-    $html .= '<footer style="background:' . esc_attr($header_bg) . ';padding:20px;text-align:center;';
-    $html .= 'font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">';
-    if ($footer_logo) {
-        $html .= '<p style="margin:0;"><a href="https://chassesautresor.com" style="display:inline-block;">';
-        $html .= '<img src="' . esc_url($footer_logo) . '" alt="chassesautresor.com" style="max-width:150px;height:auto;" />';
-        $html .= '</a></p>';
-    }
-    $html .= '</footer>';
-    $html .= '</td></tr>';
-    $html .= '</table>';
-    $html .= '</body></html>';
+    $content = function_exists( 'wp_kses_post' ) ? wp_kses_post( $content ) : $content;
 
-    return $html;
+    $loader = new \Twig\Loader\FilesystemLoader( __DIR__ . '/templates' );
+    $twig   = new \Twig\Environment( $loader );
+
+    return $twig->render(
+        'email.twig',
+        [
+            'title'       => $title,
+            'content'     => $content,
+            'logo_url'    => $logo_url,
+            'title_icon'  => $title_icon,
+            'footer_logo' => $footer_logo,
+            'site_name'   => $site_name,
+            'header_bg'   => $header_bg,
+            'team_label'  => $team_label,
+        ]
+    );
 }
 
 /**

--- a/wp-content/themes/chassesautresor/inc/emails/templates/email.twig
+++ b/wp-content/themes/chassesautresor/inc/emails/templates/email.twig
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+      <tr>
+        <td>
+          <header style="background:{{ header_bg }};padding:20px;text-align:center;">
+            {% if logo_url %}
+            <img src="{{ logo_url }}" alt="{{ site_name }}" style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
+            {% endif %}
+            <h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">
+              {% if title_icon %}
+              <img src="{{ title_icon }}" alt="" style="height:24px;width:24px;vertical-align:middle;margin-right:8px;" />
+              {% endif %}
+              {{ title }}
+            </h1>
+          </header>
+        </td>
+      </tr>
+      <tr>
+        <td style="background:#f5f5f5;padding:20px;font-family:Arial,sans-serif;">
+          {{ content|raw }}
+          <p style="margin-top:20px;">{{ team_label }}</p>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <footer style="background:{{ header_bg }};padding:20px;text-align:center;font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">
+            {% if footer_logo %}
+            <p style="margin:0;">
+              <a href="https://chassesautresor.com" style="display:inline-block;">
+                <img src="{{ footer_logo }}" alt="chassesautresor.com" style="max-width:150px;height:auto;" />
+              </a>
+            </p>
+            {% endif %}
+          </footer>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+

--- a/wp-content/themes/chassesautresor/tests/email_template.test.php
+++ b/wp-content/themes/chassesautresor/tests/email_template.test.php
@@ -52,6 +52,7 @@ if (!function_exists('get_bloginfo')) {
     }
 }
 
+require_once dirname(__DIR__, 4) . '/vendor/autoload.php';
 require_once __DIR__ . '/../inc/emails/template.php';
 
 class EmailTemplateTest extends TestCase


### PR DESCRIPTION
## Résumé
- Intègre Twig pour générer les emails HTML.

## Changements
- Ajout de Twig via Composer et chargement de l'autoloader.
- Conversion du template d'email en fichier Twig et rendu via `Twig\Environment`.
- Mise à jour des tests pour valider le nouveau rendu des emails.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7f5b6cd108332970e6a3e30a57894