### PR TITLE
Use WordPress time for message expiration

### DIFF
--- a/tests/ZZGetSiteMessagesTest.php
+++ b/tests/ZZGetSiteMessagesTest.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+if (!function_exists('current_time')) {
+    function current_time(string $type)
+    {
+        return $type === 'timestamp'
+            ? time()
+            : gmdate('Y-m-d H:i:s', time());
+    }
+}
+
 /**
  * @runTestsInSeparateProcesses
  */

--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -46,12 +46,13 @@ function add_site_message(
         $expirationSeconds = 0;
         $expiresAt         = null;
         if ($expires !== null) {
-            if ($expires > time()) {
-                $expirationSeconds = $expires - time();
+            $now = (int) current_time('timestamp');
+            if ($expires > $now) {
+                $expirationSeconds = $expires - $now;
                 $expiresAt         = gmdate('c', $expires);
             } else {
                 $expirationSeconds = $expires;
-                $expiresAt         = gmdate('c', time() + $expires);
+                $expiresAt         = gmdate('c', $now + $expires);
             }
         }
 


### PR DESCRIPTION
## Résumé
- Harmonise l’expiration des messages persistants avec le fuseau horaire WordPress
- Ajoute un stub de `current_time()` dans les tests associés

## Détails
- Remplacement de `time()` par `current_time('timestamp')` lors de la gestion des expirations
- Définition d’une fonction `current_time()` dans `ZZGetSiteMessagesTest.php` pour les tests unitaires

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b7f76996288332968a63b9f48c523c