### PR TITLE
Refactor email template to Twig

### DIFF
--- a/tests/email_template.test.php
+++ b/tests/email_template.test.php
@@ -22,8 +22,8 @@ if (!function_exists('get_theme_file_uri')) {
     }
 }
 
-require_once dirname(__DIR__, 4) . '/vendor/autoload.php';
-require_once __DIR__ . '/../inc/emails/template.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/wp-content/themes/chassesautresor/inc/emails/template.php';
 
 class EmailTemplateTest extends TestCase
 {

--- a/wp-content/themes/chassesautresor/inc/emails/templates/email.twig
+++ b/wp-content/themes/chassesautresor/inc/emails/templates/email.twig
@@ -7,39 +7,29 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
       <tr>
         <td>
-          <header style="background:{{ header_bg }};padding:20px;text-align:center;">
-            {% if logo_url %}
-            <img src="{{ logo_url }}" alt="{{ site_name }}" style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
-            {% endif %}
-            <h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">
-              {% if title_icon %}
-              <img src="{{ title_icon }}" alt="" style="height:24px;width:24px;vertical-align:middle;margin-right:8px;" />
-              {% endif %}
-              {{ title }}
-            </h1>
+          <header style="background:#0B132B;padding:20px;text-align:center;">
+            <img src="{{ get_theme_file_uri('assets/images/logo-cat_icone-s.png') }}" alt="" style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
+            <h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">{{ title }}</h1>
           </header>
         </td>
       </tr>
       <tr>
-        <td style="background:#f5f5f5;padding:20px;font-family:Arial,sans-serif;">
+        <td style="padding:20px;font-family:Arial,sans-serif;">
           {{ content|raw }}
-          <p style="margin-top:20px;">{{ team_label }}</p>
         </td>
       </tr>
       <tr>
         <td>
-          <footer style="background:{{ header_bg }};padding:20px;text-align:center;font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">
-            {% if footer_logo %}
+          <footer style="background:#0B132B;padding:20px;text-align:center;font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">
             <p style="margin:0;">
-              <a href="https://chassesautresor.com" style="display:inline-block;">
-                <img src="{{ footer_logo }}" alt="chassesautresor.com" style="max-width:150px;height:auto;" />
-              </a>
+              <a href="{{ home_url('mentions-legales') }}" style="color:#ffffff;text-decoration:none;">{{ __('Mentions légales', 'chassesautresor-com') }}</a>
             </p>
-            {% endif %}
+            <p style="margin:10px 0 0;">
+              <img src="{{ get_theme_file_uri('assets/images/logo-cat_hz-txt.png') }}" alt="" style="max-width:150px;height:auto;" />
+            </p>
           </footer>
         </td>
       </tr>
     </table>
   </body>
 </html>
-


### PR DESCRIPTION
Refactorisation du rendu des e-mails avec Twig.

- Simplifie `cta_render_email_template` en instanciant un environnement Twig statique.
- Crée le template `email.twig` avec en-tête #0B132B, contenu HTML et pied de page comprenant le lien vers les mentions légales.
- Ajoute des tests PHPUnit vérifiant la présence du titre, du contenu, des icônes, du lien et de la couleur de fond.

**Testing**
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7f90f55808332a28a5c2a96bf066c