### PR TITLE
Refactorisation du template d’e‑mail avec Twig

### DIFF
--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -17,31 +17,30 @@ defined('ABSPATH') || exit();
  */
 function cta_render_email_template(string $title, string $content): string
 {
-    static $twig = null;
-
     $content = function_exists('wp_kses_post') ? wp_kses_post($content) : $content;
 
-    if (null === $twig) {
-        $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
-        $twig   = new \Twig\Environment($loader);
+    $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
+    $twig   = new \Twig\Environment($loader);
 
-        if (function_exists('get_theme_file_uri')) {
-            $twig->addFunction(new \Twig\TwigFunction('get_theme_file_uri', 'get_theme_file_uri'));
-        }
-
-        if (function_exists('home_url')) {
-            $twig->addFunction(new \Twig\TwigFunction('home_url', 'home_url'));
-        }
-
-        if (function_exists('__')) {
-            $twig->addFunction(new \Twig\TwigFunction('__', '__'));
-        }
+    if (function_exists('get_theme_file_uri')) {
+        $twig->addFunction(new \Twig\TwigFunction('get_theme_file_uri', 'get_theme_file_uri'));
     }
 
-    return $twig->render('email.twig', [
-        'title'   => $title,
-        'content' => $content,
-    ]);
+    if (function_exists('home_url')) {
+        $twig->addFunction(new \Twig\TwigFunction('home_url', 'home_url'));
+    }
+
+    if (function_exists('__')) {
+        $twig->addFunction(new \Twig\TwigFunction('__', '__'));
+    }
+
+    return $twig->render(
+        'email.twig',
+        [
+            'title'   => $title,
+            'content' => $content,
+        ]
+    );
 }
 
 /**

--- a/wp-content/themes/chassesautresor/inc/emails/templates/email.twig
+++ b/wp-content/themes/chassesautresor/inc/emails/templates/email.twig
@@ -1,35 +1,23 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-  </head>
-  <body>
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
-      <tr>
-        <td>
-          <header style="background:#0B132B;padding:20px;text-align:center;">
-            <img src="{{ get_theme_file_uri('assets/images/logo-cat_icone-s.png') }}" alt="" style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
-            <h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">{{ title }}</h1>
-          </header>
-        </td>
-      </tr>
-      <tr>
-        <td style="padding:20px;font-family:Arial,sans-serif;">
-          {{ content|raw }}
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <footer style="background:#0B132B;padding:20px;text-align:center;font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">
-            <p style="margin:0;">
-              <a href="{{ home_url('mentions-legales') }}" style="color:#ffffff;text-decoration:none;">{{ __('Mentions légales', 'chassesautresor-com') }}</a>
-            </p>
-            <p style="margin:10px 0 0;">
-              <img src="{{ get_theme_file_uri('assets/images/logo-cat_hz-txt.png') }}" alt="" style="max-width:150px;height:auto;" />
-            </p>
-          </footer>
-        </td>
-      </tr>
-    </table>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+            {% block header %}
+                {% include 'header.twig' %}
+            {% endblock %}
+            {% block content %}
+                <tr>
+                    <td style="padding:20px;font-family:Arial,sans-serif;">
+                        {{ content|raw }}
+                    </td>
+                </tr>
+            {% endblock %}
+            {% block footer %}
+                {% include 'footer.twig' %}
+            {% endblock %}
+        </table>
+    </body>
 </html>

--- a/wp-content/themes/chassesautresor/inc/emails/templates/footer.twig
+++ b/wp-content/themes/chassesautresor/inc/emails/templates/footer.twig
@@ -1,0 +1,12 @@
+<tr>
+    <td>
+        <footer style="background:#0B132B;padding:20px;text-align:center;font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">
+            <p style="margin:0;">
+                <a href="{{ home_url('mentions-legales') }}" style="color:#ffffff;text-decoration:none;">{{ __('Mentions légales', 'chassesautresor-com') }}</a>
+            </p>
+            <p style="margin:10px 0 0;">
+                <img src="{{ get_theme_file_uri('assets/images/logo-cat_hz-txt.png') }}" alt="" style="max-width:150px;height:auto;" />
+            </p>
+        </footer>
+    </td>
+</tr>

--- a/wp-content/themes/chassesautresor/inc/emails/templates/header.twig
+++ b/wp-content/themes/chassesautresor/inc/emails/templates/header.twig
@@ -1,0 +1,8 @@
+<tr>
+    <td>
+        <header style="background:#0B132B;padding:20px;text-align:center;">
+            <img src="{{ get_theme_file_uri('assets/images/logo-cat_icone-s.png') }}" alt="" style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
+            <h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">{{ title }}</h1>
+        </header>
+    </td>
+</tr>


### PR DESCRIPTION
## Résumé
- Ajout d’un gabarit Twig pour les e-mails avec blocs en-tête, contenu et pied
- Rendu des e-mails via `Twig\Environment` et séparation des partials

## Changes
- Création des templates `header.twig` et `footer.twig`
- Refactorisation de `cta_render_email_template` pour utiliser Twig
- Mise à jour du gabarit principal `email.twig`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7fb76daa88332a66a037314e9ef77