### PR TITLE
Pass footer URLs as Twig variables

### DIFF
--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -34,11 +34,16 @@ function cta_render_email_template(string $title, string $content): string
         $twig->addFunction(new \Twig\TwigFunction('__', '__'));
     }
 
+    $mentions_url = function_exists('home_url') ? home_url('/mentions-legales/') : '';
+    $home_url     = function_exists('home_url') ? home_url('/') : '';
+
     return $twig->render(
         'email.twig',
         [
-            'title'   => $title,
-            'content' => $content,
+            'title'        => $title,
+            'content'      => $content,
+            'mentions_url' => $mentions_url,
+            'home_url'     => $home_url,
         ]
     );
 }

--- a/wp-content/themes/chassesautresor/inc/emails/templates/footer.twig
+++ b/wp-content/themes/chassesautresor/inc/emails/templates/footer.twig
@@ -2,10 +2,12 @@
     <td>
         <footer style="background:#0B132B;padding:20px;text-align:center;font-family:Arial,sans-serif;color:#ffffff;font-size:12px;">
             <p style="margin:0;">
-                <a href="{{ home_url('mentions-legales') }}" style="color:#ffffff;text-decoration:none;">{{ __('Mentions légales', 'chassesautresor-com') }}</a>
+                <a href="{{ mentions_url }}" style="color:#ffffff;text-decoration:none;">{{ __('Mentions légales', 'chassesautresor-com') }}</a>
             </p>
             <p style="margin:10px 0 0;">
-                <img src="{{ get_theme_file_uri('assets/images/logo-cat_hz-txt.png') }}" alt="" style="max-width:150px;height:auto;" />
+                <a href="{{ home_url }}" style="display:inline-block;">
+                    <img src="{{ get_theme_file_uri('assets/images/logo-cat_hz-txt.png') }}" alt="" style="max-width:150px;height:auto;" />
+                </a>
             </p>
         </footer>
     </td>


### PR DESCRIPTION
## Résumé
- externalisation des URLs du pied de page des emails
- passage des liens d'accueil et de mentions légales en variables Twig

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7fd4c8f948332ae670ab31e99c507