### PR TITLE
Handle persistent message insertion failures

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
+++ b/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
@@ -28,7 +28,7 @@ class UserMessageRepository
     }
 
     /**
-     * Insert a new message and return its identifier.
+     * Insert a new message and return its identifier or 0 on failure.
      */
     public function insert(
         int $userId,
@@ -52,9 +52,7 @@ class UserMessageRepository
         if (false === $result) {
             error_log('Failed to insert user message: ' . $this->wpdb->last_error);
 
-            throw new \RuntimeException(
-                __('Unable to insert user message.', 'chassesautresor-com')
-            );
+            return 0;
         }
 
         return (int) $this->wpdb->insert_id;

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -262,7 +262,7 @@ add_filter('woocommerce_endpoint_edit-account_title', 'ca_profile_endpoint_title
  * @param string|null $message_key   Optional translation key.
  * @param string|null $locale        Optional locale for the message.
  *
- * @return void
+ * @return int Message identifier or 0 on failure.
  */
 function myaccount_add_persistent_message(
     int $user_id,
@@ -274,7 +274,7 @@ function myaccount_add_persistent_message(
     bool $include_enigmes = false,
     ?string $message_key = null,
     ?string $locale = null
-): void {
+): int {
     global $wpdb;
 
     $repo   = new UserMessageRepository($wpdb);
@@ -307,7 +307,20 @@ function myaccount_add_persistent_message(
         }
     }
 
-    $repo->insert($user_id, wp_json_encode($payload), 'persistent', null, $locale);
+    $message_id = $repo->insert($user_id, wp_json_encode($payload), 'persistent', null, $locale);
+
+    if (0 === $message_id) {
+        error_log(
+            sprintf(
+                'myaccount_add_persistent_message failed for user %d and key %s: %s',
+                $user_id,
+                $key,
+                $wpdb->last_error
+            )
+        );
+    }
+
+    return $message_id;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Journalise les erreurs de `wpdb->insert` lors de la création d'un message utilisateur.
- Retourne l'identifiant du message ou 0 en cas d'échec dans `myaccount_add_persistent_message`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b7fe2fcc8883328e119d17410b929e