### PR TITLE
Create user messages table

### DIFF
--- a/tests/UserMessagesTableTest.php
+++ b/tests/UserMessagesTableTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/messages.php';
+
+class UserMessagesTableWpdb
+{
+    public string $prefix = 'wp_';
+
+    public function get_charset_collate(): string
+    {
+        return 'utf8mb4_unicode_ci';
+    }
+}
+
+class UserMessagesTableTest extends TestCase
+{
+    protected $backupGlobals = false;
+
+    public function test_install_creates_table(): void
+    {
+        global $wpdb, $dbDeltaSql;
+        $wpdb       = new UserMessagesTableWpdb();
+        $dbDeltaSql = '';
+        cat_install_user_messages_table();
+        $this->assertStringContainsString('CREATE TABLE wp_user_messages', $dbDeltaSql);
+        $this->assertStringContainsString('locale VARCHAR(10)', $dbDeltaSql);
+        $this->assertStringContainsString('KEY user_id (user_id)', $dbDeltaSql);
+        $this->assertStringContainsString('KEY status (status)', $dbDeltaSql);
+        $this->assertStringContainsString('KEY expires_at (expires_at)', $dbDeltaSql);
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -3,6 +3,36 @@
 defined('ABSPATH') || exit;
 
 /**
+ * Create the table storing user and site messages.
+ *
+ * @return void
+ */
+function cat_install_user_messages_table(): void
+{
+    global $wpdb;
+
+    $table          = $wpdb->prefix . 'user_messages';
+    $charsetCollate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE {$table} (
+        id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        user_id BIGINT UNSIGNED NOT NULL,
+        message LONGTEXT NOT NULL,
+        status VARCHAR(20) NOT NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        expires_at DATETIME NULL,
+        locale VARCHAR(10) NULL,
+        KEY user_id (user_id),
+        KEY status (status),
+        KEY expires_at (expires_at)
+    ) {$charsetCollate};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta($sql);
+}
+add_action('after_switch_theme', 'cat_install_user_messages_table');
+
+/**
  * Store a site-wide message.
  *
  * @param string      $type        Message type used as CSS class.


### PR DESCRIPTION
## Résumé
Création de la table des messages utilisateurs lors de l’activation du thème.

## Changements notables
- ajout du hook d’installation `cat_install_user_messages_table` pour créer la table `wp_user_messages`
- test unitaire vérifiant la génération de la table

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7fe3cc6788332861ad9161328b08e