### PR TITLE
Use wp_date with timezone for message expiry

### DIFF
--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -94,7 +94,7 @@ namespace {
     }
 
     if (!function_exists('wp_date')) {
-        function wp_date($format, $timestamp) { return gmdate($format, $timestamp); }
+        function wp_date($format, $timestamp, $timezone = null) { return gmdate($format, $timestamp); }
     }
 
     if (!function_exists('get_the_title')) {

--- a/tests/EnigmeMenuRenderingTest.php
+++ b/tests/EnigmeMenuRenderingTest.php
@@ -236,7 +236,7 @@ if (!function_exists('remove_accents')) {
 }
 
 if (!function_exists('wp_date')) {
-    function wp_date($format, $timestamp)
+    function wp_date($format, $timestamp, $timezone = null)
     {
         return date($format, $timestamp);
     }

--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -77,7 +77,7 @@ if (!function_exists('remove_accents')) {
 }
 
 if (!function_exists('wp_date')) {
-    function wp_date($format, $timestamp)
+    function wp_date($format, $timestamp, $timezone = null)
     {
         return date($format, $timestamp);
     }

--- a/tests/IndiceEnigmeCreationTest.php
+++ b/tests/IndiceEnigmeCreationTest.php
@@ -118,7 +118,7 @@ if (!function_exists('current_time')) {
 }
 
 if (!function_exists('wp_date')) {
-    function wp_date($format, $timestamp) { return gmdate($format, $timestamp); }
+    function wp_date($format, $timestamp, $timezone = null) { return gmdate($format, $timestamp); }
 }
 
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';

--- a/tests/ModifierIndiceImageRemovalTest.php
+++ b/tests/ModifierIndiceImageRemovalTest.php
@@ -45,7 +45,7 @@ namespace {
         function current_time($type) { return $type === 'timestamp' ? 1704067200 : '2024-01-01 00:00:00'; }
     }
     if (!function_exists('wp_date')) {
-        function wp_date($format, $timestamp) { return gmdate($format, $timestamp); }
+        function wp_date($format, $timestamp, $timezone = null) { return gmdate($format, $timestamp); }
     }
     if (!function_exists('wp_is_post_revision')) {
         function wp_is_post_revision($id) { return false; }

--- a/tests/ModifierIndiceImmediateDateTest.php
+++ b/tests/ModifierIndiceImmediateDateTest.php
@@ -48,7 +48,7 @@ namespace {
         function current_time($type) { return $type === 'timestamp' ? 1704067200 : '2024-01-01 00:00:00'; }
     }
     if (!function_exists('wp_date')) {
-        function wp_date($format, $timestamp) { return gmdate($format, $timestamp); }
+        function wp_date($format, $timestamp, $timezone = null) { return gmdate($format, $timestamp); }
     }
     if (!function_exists('wp_is_post_revision')) {
         function wp_is_post_revision($id) { return false; }

--- a/tests/ZZGetSiteMessagesTest.php
+++ b/tests/ZZGetSiteMessagesTest.php
@@ -13,6 +13,24 @@ if (!function_exists('current_time')) {
     }
 }
 
+if (!function_exists('wp_timezone')) {
+    function wp_timezone(): DateTimeZone
+    {
+        return new DateTimeZone('UTC');
+    }
+}
+
+if (!function_exists('wp_date')) {
+    function wp_date(string $format, int $timestamp, ?DateTimeZone $timezone = null): string
+    {
+        $dt = new DateTime('@' . $timestamp);
+        if ($timezone instanceof DateTimeZone) {
+            $dt->setTimezone($timezone);
+        }
+        return $dt->format($format);
+    }
+}
+
 /**
  * @runTestsInSeparateProcesses
  */

--- a/tests/site_message_dismissal.test.php
+++ b/tests/site_message_dismissal.test.php
@@ -22,6 +22,24 @@ if (!function_exists('current_time')) {
     }
 }
 
+if (!function_exists('wp_timezone')) {
+    function wp_timezone(): DateTimeZone
+    {
+        return new DateTimeZone('UTC');
+    }
+}
+
+if (!function_exists('wp_date')) {
+    function wp_date(string $format, int $timestamp, ?DateTimeZone $timezone = null): string
+    {
+        $dt = new DateTime('@' . $timestamp);
+        if ($timezone instanceof DateTimeZone) {
+            $dt->setTimezone($timezone);
+        }
+        return $dt->format($format);
+    }
+}
+
 if (!function_exists('wp_json_encode')) {
     function wp_json_encode($data, $options = 0, $depth = 512)
     {

--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -49,10 +49,10 @@ function add_site_message(
             $now = (int) current_time('timestamp');
             if ($expires > $now) {
                 $expirationSeconds = $expires - $now;
-                $expiresAt         = gmdate('c', $expires);
+                $expiresAt         = wp_date('Y-m-d H:i:s', $expires, wp_timezone());
             } else {
                 $expirationSeconds = $expires;
-                $expiresAt         = gmdate('c', $now + $expires);
+                $expiresAt         = wp_date('Y-m-d H:i:s', $now + $expires, wp_timezone());
             }
         }
 


### PR DESCRIPTION
## Résumé
- Remplace gmdate par wp_date pour les dates d'expiration des messages
- Adapte les tests unitaires à la nouvelle signature de wp_date

## Changements notables
- Utilisation de wp_date('Y-m-d H:i:s', $timestamp, wp_timezone()) lors de l'enregistrement des messages persistants
- Mise à jour des stubs de tests pour wp_date et wp_timezone

## Testing
- `source ./setup-env.sh && echo 'env setup'`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7fe3e04a08332a9b8da19f49d60b7