### PR TITLE
Use prepared SQL for filtering user messages

### DIFF
--- a/tests/MessageMigrationCommandTest.php
+++ b/tests/MessageMigrationCommandTest.php
@@ -168,6 +168,16 @@ class MigrationDummyWpdb
         return array_values($rows);
     }
 
+    public function prepare(string $query, array $params): string
+    {
+        $placeholders = array_map(
+            fn($p) => is_int($p) ? $p : "'{$p}'",
+            $params
+        );
+
+        return vsprintf($query, $placeholders);
+    }
+
     public function delete(string $table, array $where, array $whereFormat): void
     {
         unset($this->data[$where['id']]);

--- a/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
+++ b/wp-content/themes/chassesautresor/inc/messages/class-user-message-repository.php
@@ -98,28 +98,41 @@ class UserMessageRepository
      */
     public function get(?int $userId = null, ?string $status = null, ?bool $expired = null): array
     {
-        $rows = $this->wpdb->get_results("SELECT * FROM {$this->table}", ARRAY_A);
-        $now  = current_time('mysql');
+        $sql    = "SELECT * FROM {$this->table}";
+        $where  = [];
+        $params = [];
 
-        return array_values(array_filter($rows, function ($row) use ($userId, $status, $expired, $now) {
-            if ($userId !== null && (int) $row['user_id'] !== $userId) {
-                return false;
-            }
+        if ($userId !== null) {
+            $where[]  = 'user_id = %d';
+            $params[] = $userId;
+        }
 
-            if ($status !== null && $row['status'] !== $status) {
-                return false;
-            }
+        if ($status !== null) {
+            $where[]  = 'status = %s';
+            $params[] = $status;
+        }
+
+        if ($expired !== null) {
+            $now = current_time('mysql');
 
             if ($expired === true) {
-                return $row['expires_at'] !== null && $row['expires_at'] < $now;
+                $where[]  = 'expires_at IS NOT NULL AND expires_at < %s';
+                $params[] = $now;
+            } else {
+                $where[]  = '(expires_at IS NULL OR expires_at >= %s)';
+                $params[] = $now;
             }
+        }
 
-            if ($expired === false) {
-                return $row['expires_at'] === null || $row['expires_at'] >= $now;
-            }
+        if ($where !== []) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
 
-            return true;
-        }));
+        if ($params !== []) {
+            $sql = $this->wpdb->prepare($sql, $params);
+        }
+
+        return $this->wpdb->get_results($sql, ARRAY_A);
     }
 
     /**


### PR DESCRIPTION
## Résumé
- Utilisation d'une requête SQL préparée pour filtrer les messages utilisateur
- Adaptation des tests aux nouveaux filtres et à l'utilisation de `wpdb->prepare`

## Changements notables
- Construction conditionnelle des clauses `WHERE` dans le dépôt de messages.
- Mise à jour des doublures `wpdb` pour gérer la préparation et le filtrage SQL.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff0b15cc8332bce7a975361ff918