### PR TITLE
Remove transient storage for site messages

### DIFF
--- a/tests/site_message_dismissal.test.php
+++ b/tests/site_message_dismissal.test.php
@@ -29,32 +29,6 @@ if (!function_exists('wp_json_encode')) {
     }
 }
 
-$cat_test_transients = [];
-if (!function_exists('get_transient')) {
-    function get_transient($key)
-    {
-        global $cat_test_transients;
-        return $cat_test_transients[$key] ?? false;
-    }
-}
-
-if (!function_exists('set_transient')) {
-    function set_transient($key, $value, $expiration = 0)
-    {
-        global $cat_test_transients;
-        $cat_test_transients[$key] = $value;
-        return true;
-    }
-}
-
-if (!function_exists('delete_transient')) {
-    function delete_transient($key)
-    {
-        global $cat_test_transients;
-        unset($cat_test_transients[$key]);
-        return true;
-    }
-}
 
 if (!function_exists('is_user_logged_in')) {
     function is_user_logged_in()
@@ -102,10 +76,9 @@ class SiteMessageDismissalTest extends TestCase
 
     protected function setUp(): void
     {
-        global $wpdb, $cat_test_transients;
+        global $wpdb;
         $this->wpdb = new DummyWpdb();
         $wpdb       = $this->wpdb;
-        $cat_test_transients = [];
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
         }

--- a/wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php
+++ b/wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php
@@ -75,25 +75,6 @@ class Cat_CLI_Command
             }
         }
 
-        $siteMessages = get_transient('cat_site_messages');
-        if (is_array($siteMessages)) {
-            $defaultExpiration = gmdate('Y-m-d H:i:s', time() + DAY_IN_SECONDS);
-
-            foreach ($siteMessages as $msg) {
-                if (!is_array($msg)) {
-                    continue;
-                }
-                $status    = isset($msg['status']) ? (string) $msg['status'] : 'site';
-                $expiresAt = isset($msg['expires_at']) ? (string) $msg['expires_at'] : $defaultExpiration;
-
-                $payload = $msg;
-                unset($payload['status'], $payload['expires_at']);
-
-                $repo->insert(0, wp_json_encode($payload), $status, $expiresAt);
-            }
-            delete_transient('cat_site_messages');
-        }
-
         \WP_CLI::success(__('Migration des messages terminée.', 'chassesautresor-com'));
     }
 }

--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -37,26 +37,15 @@ function add_site_message(
     }
 
     if ($persistent) {
-        $messages = get_transient('cat_site_messages');
-        if (!is_array($messages)) {
-            $messages = [];
-        }
-        $messages[] = $message;
-
-        $expirationSeconds = 0;
-        $expiresAt         = null;
+        $expiresAt = null;
         if ($expires !== null) {
             $now = (int) current_time('timestamp');
             if ($expires > $now) {
-                $expirationSeconds = $expires - $now;
-                $expiresAt         = gmdate('c', $expires);
+                $expiresAt = gmdate('c', $expires);
             } else {
-                $expirationSeconds = $expires;
-                $expiresAt         = gmdate('c', $now + $expires);
+                $expiresAt = gmdate('c', $now + $expires);
             }
         }
-
-        set_transient('cat_site_messages', $messages, $expirationSeconds);
 
         global $wpdb;
         $repo = new UserMessageRepository($wpdb);
@@ -83,22 +72,6 @@ function add_site_message(
  */
 function remove_site_message(string $key): void
 {
-    $messages = get_transient('cat_site_messages');
-    if (is_array($messages)) {
-        $messages = array_values(array_filter(
-            $messages,
-            static function (array $msg) use ($key): bool {
-                return ($msg['message_key'] ?? '') !== $key;
-            }
-        ));
-
-        if (!empty($messages)) {
-            set_transient('cat_site_messages', $messages);
-        } else {
-            delete_transient('cat_site_messages');
-        }
-    }
-
     global $wpdb;
     $repo = new UserMessageRepository($wpdb);
     $rows = $repo->get(0, 'site', null);
@@ -126,11 +99,6 @@ function get_site_messages(): string
     if (!empty($_SESSION['cat_site_messages'])) {
         $messages = array_merge($messages, $_SESSION['cat_site_messages']);
         unset($_SESSION['cat_site_messages']);
-    }
-
-    $transient = get_transient('cat_site_messages');
-    if (is_array($transient) && !empty($transient)) {
-        $messages = array_merge($messages, $transient);
     }
 
     global $wpdb;


### PR DESCRIPTION
## Résumé
Remplace le transient des messages du site par le dépôt `UserMessageRepository`.

## Changements notables
- Persistant des messages via `UserMessageRepository` et suppression des appels à `get/set/delete_transient`.
- Simplification de `add_site_message`, `remove_site_message` et `get_site_messages` pour utiliser uniquement le dépôt et la session.
- Nettoyage de la commande WP-CLI de migration et mise à jour des tests unitaires.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff04a75483328932e2d4565f7acb