### PR TITLE
Supprimer les transients des messages du site

### DIFF
--- a/tests/site_message_dismissal.test.php
+++ b/tests/site_message_dismissal.test.php
@@ -47,33 +47,6 @@ if (!function_exists('wp_json_encode')) {
     }
 }
 
-$cat_test_transients = [];
-if (!function_exists('get_transient')) {
-    function get_transient($key)
-    {
-        global $cat_test_transients;
-        return $cat_test_transients[$key] ?? false;
-    }
-}
-
-if (!function_exists('set_transient')) {
-    function set_transient($key, $value, $expiration = 0)
-    {
-        global $cat_test_transients;
-        $cat_test_transients[$key] = $value;
-        return true;
-    }
-}
-
-if (!function_exists('delete_transient')) {
-    function delete_transient($key)
-    {
-        global $cat_test_transients;
-        unset($cat_test_transients[$key]);
-        return true;
-    }
-}
-
 if (!function_exists('is_user_logged_in')) {
     function is_user_logged_in()
     {
@@ -120,10 +93,9 @@ class SiteMessageDismissalTest extends TestCase
 
     protected function setUp(): void
     {
-        global $wpdb, $cat_test_transients;
+        global $wpdb;
         $this->wpdb = new DummyWpdb();
         $wpdb       = $this->wpdb;
-        $cat_test_transients = [];
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
         }

--- a/wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php
+++ b/wp-content/themes/chassesautresor/inc/cli/class-cat-cli-command.php
@@ -75,25 +75,6 @@ class Cat_CLI_Command
             }
         }
 
-        $siteMessages = get_transient('cat_site_messages');
-        if (is_array($siteMessages)) {
-            $defaultExpiration = gmdate('Y-m-d H:i:s', time() + DAY_IN_SECONDS);
-
-            foreach ($siteMessages as $msg) {
-                if (!is_array($msg)) {
-                    continue;
-                }
-                $status    = isset($msg['status']) ? (string) $msg['status'] : 'site';
-                $expiresAt = isset($msg['expires_at']) ? (string) $msg['expires_at'] : $defaultExpiration;
-
-                $payload = $msg;
-                unset($payload['status'], $payload['expires_at']);
-
-                $repo->insert(0, wp_json_encode($payload), $status, $expiresAt);
-            }
-            delete_transient('cat_site_messages');
-        }
-
         \WP_CLI::success(__('Migration des messages terminée.', 'chassesautresor-com'));
     }
 }


### PR DESCRIPTION
## Résumé
- Retrait de l'utilisation des transients pour les messages du site
- Mise à jour de la commande WP-CLI de migration des messages
- Adaptation des tests aux nouveaux mécanismes de stockage

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b8002badd48332b32db8297008532a