### PR TITLE
Affiche les messages après le héros sur la page organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -99,4 +99,6 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
         <div id="content" class="site-content">
                 <div class="ast-container<?php echo ( is_singular('enigme') || is_singular('chasse') ) ? '' : ' ast-container--boxed'; ?>">
                 <?php astra_content_top(); ?>
+                <?php if (!is_page_template('templates/page-devenir-organisateur.php')) : ?>
                 <section class="msg-important"><?php print_site_messages(); ?></section>
+                <?php endif; ?>

--- a/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
@@ -51,6 +51,7 @@ get_header(); ?>
     </div>
   </div>
 </section>
+<section class="msg-important"><?php print_site_messages(); ?></section>
 <main id="primary" class="site-main conteneur-devenir-organisateur">
     <?php
       while ( have_posts() ) :


### PR DESCRIPTION
## Résumé
- Déplace l'affichage des messages importants après le bandeau héros de la page "Devenir Organisateur".
- Désactive l'affichage global des messages dans l'entête pour ce modèle afin d'éviter les doublons.

## Changements notables
- Ajout d'une section `msg-important` après le bloc héros.
- Conditionnement de `print_site_messages()` dans `header.php`.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b80fa42aac833290fc6d62ca958dd7