### PR TITLE
Handle failure when saving site messages

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -82,8 +82,13 @@ function add_site_message(
 
         global $wpdb;
         $repo = new UserMessageRepository($wpdb);
-        $repo->insert(0, wp_json_encode($message), 'site', $expiresAt, $locale);
-        return;
+        $inserted = $repo->insert(0, wp_json_encode($message), 'site', $expiresAt, $locale);
+
+        if ($inserted !== 0) {
+            return;
+        }
+
+        error_log('Failed to insert site message, storing in session instead.');
     }
 
     if (session_status() !== PHP_SESSION_ACTIVE) {


### PR DESCRIPTION
Résumé : bascule vers la session quand l'insertion d'un message de site échoue.

- Vérifie le résultat de `UserMessageRepository::insert`.
- En cas d'échec, consigne une erreur et enregistre le message en session.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b80f933a788332a2ba7ec27b133e29