### PR TITLE
Personnalise les e-mails WooCommerce

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -368,6 +368,7 @@ require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
 require_once $inc_path . 'emails/template.php';
 require_once $inc_path . 'emails/user-registration.php';
+require_once $inc_path . 'emails/woocommerce.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once $inc_path . 'cli/class-cat-cli-command.php';

--- a/wp-content/themes/chassesautresor/inc/emails/woocommerce.php
+++ b/wp-content/themes/chassesautresor/inc/emails/woocommerce.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce email customizations.
+ *
+ * @package chassesautresor-com
+ */
+
+defined('ABSPATH') || exit();
+
+/**
+ * Removes default WooCommerce email header and footer callbacks.
+ *
+ * @return void
+ */
+function cta_wc_override_email_templates(): void
+{
+    if (!function_exists('WC')) {
+        return;
+    }
+
+    $mailer = WC()->mailer();
+    remove_action('woocommerce_email_header', [ $mailer, 'email_header' ]);
+    remove_action('woocommerce_email_footer', [ $mailer, 'email_footer' ]);
+}
+add_action('init', 'cta_wc_override_email_templates');
+
+/**
+ * Stores the WooCommerce email heading for later reuse.
+ *
+ * @param string $email_heading Email heading.
+ *
+ * @return void
+ */
+function cta_wc_store_email_heading(string $email_heading): void
+{
+    $GLOBALS['cta_wc_email_heading'] = $email_heading;
+}
+add_action('woocommerce_email_header', 'cta_wc_store_email_heading');
+
+/**
+ * Injects the Twig template around WooCommerce email content.
+ *
+ * @param string $message Email body content.
+ *
+ * @return string
+ */
+function cta_wc_render_email_content(string $message): string
+{
+    $heading = $GLOBALS['cta_wc_email_heading'] ?? '';
+
+    return cta_render_email_template($heading, $message);
+}
+add_filter('woocommerce_mail_content', 'cta_wc_render_email_content');

--- a/wp-content/themes/chassesautresor/tests/wc_email_template.test.php
+++ b/wp-content/themes/chassesautresor/tests/wc_email_template.test.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($content) {
+        return $content;
+    }
+}
+if (!function_exists('__')) {
+    function __($text, $domain = null) {
+        return $text;
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri($path) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+
+require_once dirname(__DIR__, 4) . '/vendor/autoload.php';
+require_once __DIR__ . '/../inc/emails/template.php';
+require_once __DIR__ . '/../inc/emails/woocommerce.php';
+
+class WooCommerceEmailTemplateTest extends TestCase
+{
+    public function test_wc_email_content_is_wrapped(): void
+    {
+        cta_wc_store_email_heading('Titre');
+        $html = cta_wc_render_email_content('<p>Bonjour</p>');
+
+        $this->assertStringContainsString('Titre', $html);
+        $this->assertStringContainsString('<p>Bonjour</p>', $html);
+        $this->assertStringContainsString('<header', $html);
+        $this->assertStringContainsString('<footer', $html);
+    }
+}


### PR DESCRIPTION
## Résumé
- intègre un gabarit Twig pour les e-mails WooCommerce
- charge le module d’e-mails WooCommerce dans le thème

## Détails
- supprime les callbacks d’en-tête et de pied de page natifs
- stocke l’intitulé du message avant rendu
- enveloppe le contenu avec `cta_render_email_template`
- ajoute un test unitaire pour le rendu des e-mails WooCommerce

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b81e8b4cdc83329d74fef849fdc430