### PR TITLE
Handle missing Twig dependency in email templates

### DIFF
--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -19,8 +19,20 @@ function cta_render_email_template(string $title, string $content): string
 {
     $content = function_exists('wp_kses_post') ? wp_kses_post($content) : $content;
 
-    $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
-    $twig   = new \Twig\Environment($loader);
+    if (!class_exists('\\Twig\\Loader\\FilesystemLoader')) {
+        $autoloader = dirname(__DIR__, 5) . '/vendor/autoload.php';
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+        }
+    }
+
+    if (!class_exists('\\Twig\\Loader\\FilesystemLoader')) {
+        $title_html = function_exists('esc_html') ? esc_html($title) : $title;
+        return '<h1>' . $title_html . '</h1>' . $content;
+    }
+
+    $loader = new \\Twig\\Loader\\FilesystemLoader(__DIR__ . '/templates');
+    $twig   = new \\Twig\\Environment($loader);
 
     if (function_exists('get_theme_file_uri')) {
         $twig->addFunction(new \Twig\TwigFunction('get_theme_file_uri', 'get_theme_file_uri'));


### PR DESCRIPTION
## Résumé
- Corrige l'erreur lors de l'inscription en vérifiant la présence de Twig et en chargeant l'autoloader si nécessaire.

## Changements notables
- Ajout d'un repli HTML simple lorsque Twig n'est pas disponible.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b821bbeb1c8332a6f02461e0f2a472