### PR TITLE
feat: use HTML template for password reset

### DIFF
--- a/tests/EmailForgotPasswordTest.php
+++ b/tests/EmailForgotPasswordTest.php
@@ -1,0 +1,95 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($content) {
+        return $content;
+    }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_url')) {
+    function esc_url($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return $text;
+    }
+}
+if (!function_exists('get_theme_mod')) {
+    function get_theme_mod($name) {
+        return null;
+    }
+}
+if (!function_exists('wp_get_attachment_image_url')) {
+    function wp_get_attachment_image_url($id, $size = 'full') {
+        return '';
+    }
+}
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri($path) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '', $filter = 'raw') {
+        return 'Site';
+    }
+}
+if (!function_exists('network_site_url')) {
+    function network_site_url($path = '', $scheme = null) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+
+require_once dirname(__DIR__) . '/wp-content/themes/chassesautresor/inc/emails/template.php';
+require_once dirname(__DIR__) . '/wp-content/themes/chassesautresor/inc/emails/forgot-password.php';
+
+class EmailForgotPasswordTest extends TestCase
+{
+    public function test_custom_forgot_password_email(): void
+    {
+        $user = (object) [
+            'user_login'   => 'test4',
+            'display_name' => 'test4',
+            'user_email'   => 'test4@example.com',
+        ];
+
+        $email = cta_retrieve_password_notification_email([], 'abc123', 'test4', $user);
+
+        $this->assertSame('Réinitialisation de votre mot de passe', $email['subject']);
+        $this->assertStringContainsString('Réinitialiser mon mot de passe', $email['message']);
+        $this->assertStringContainsString('abc123', $email['message']);
+        $this->assertIsArray($email['headers']);
+        $this->assertContains('Content-Type: text/html; charset=UTF-8', $email['headers']);
+    }
+
+    public function test_forgot_password_email_handles_string_headers(): void
+    {
+        $user = (object) [
+            'display_name' => 'test4',
+            'user_email'   => 'test4@example.com',
+        ];
+
+        $email = [ 'headers' => 'From: admin@example.com' ];
+        $email = cta_retrieve_password_notification_email($email, 'abc123', 'test4', $user);
+
+        $this->assertContains('From: admin@example.com', $email['headers']);
+        $this->assertContains('Content-Type: text/html; charset=UTF-8', $email['headers']);
+    }
+}

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -368,6 +368,7 @@ require_once $inc_path . 'messages.php';
 require_once $inc_path . 'messages/class-user-message-repository.php';
 require_once $inc_path . 'emails/template.php';
 require_once $inc_path . 'emails/user-registration.php';
+require_once $inc_path . 'emails/forgot-password.php';
 require_once $inc_path . 'emails/woocommerce.php';
 
 if (defined('WP_CLI') && WP_CLI) {

--- a/wp-content/themes/chassesautresor/inc/emails/forgot-password.php
+++ b/wp-content/themes/chassesautresor/inc/emails/forgot-password.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Customizes the password reset email.
+ *
+ * @package chassesautresor-com
+ */
+
+defined('ABSPATH') || exit();
+
+/**
+ * Filters the password reset notification email to use the HTML template.
+ *
+ * @param array   $email      Default email arguments.
+ * @param string  $key        The activation key.
+ * @param string  $user_login The username for the user.
+ * @param WP_User $user_data  WP_User object.
+ *
+ * @return array
+ */
+function cta_retrieve_password_notification_email(array $email, string $key, string $user_login, $user_data): array
+{
+    $subject = esc_html__(
+        'Réinitialisation de votre mot de passe',
+        'chassesautresor-com'
+    );
+
+    $reset_url = function_exists('network_site_url')
+        ? network_site_url(
+            'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode($user_login),
+            'login'
+        )
+        : '';
+
+    $content  = '<p>' . sprintf(
+        /* translators: %s: User display name */
+        esc_html__('Bonjour %s,', 'chassesautresor-com'),
+        $user_data->display_name
+    ) . '</p>';
+    $content .= '<p>' . esc_html__(
+        'Vous avez demandé la réinitialisation de votre mot de passe. '
+        . 'Cliquez sur le bouton ci-dessous pour en définir un nouveau.',
+        'chassesautresor-com'
+    ) . '</p>';
+    $content .= '<p style="margin-top:20px;"><a href="' . esc_url($reset_url) . '" '
+        . 'style="display:inline-block;padding:10px 20px;background:#0B132B;color:#ffffff;text-decoration:none;">'
+        . esc_html__('Réinitialiser mon mot de passe', 'chassesautresor-com')
+        . '</a></p>';
+
+    $email['to']      = $user_data->user_email ?? '';
+    $email['subject'] = $subject;
+    $email['message'] = cta_render_email_template($subject, $content);
+
+    $headers = $email['headers'] ?? [];
+    if (!is_array($headers)) {
+        $headers = $headers ? preg_split("/(\r\n|\r|\n)/", (string) $headers) : [];
+    }
+    $has_type = false;
+    foreach ($headers as $header) {
+        if (stripos($header, 'Content-Type:') === 0) {
+            $has_type = true;
+            break;
+        }
+    }
+    if (!$has_type) {
+        $headers[] = 'Content-Type: text/html; charset=UTF-8';
+    }
+    $email['headers'] = $headers;
+
+    return $email;
+}
+add_filter('retrieve_password_notification_email', 'cta_retrieve_password_notification_email', 10, 4);


### PR DESCRIPTION
## Summary
- appliquer le template HTML aux courriels de réinitialisation de mot de passe
- charger le nouveau module d'envoi dans le thème
- tester la génération d'un mail HTML avec en-tête et bouton

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b82a51c6708332b9a16112ca8a4fcf