### PR TITLE
Supprimer la bordure bleue du bouton d'image de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -743,6 +743,11 @@ body[class*="edition-active"] .champ-modifier:not(.bouton-cta):focus {
   outline-offset: 2px;
 }
 
+body[class*="edition-active"] .champ-img .champ-modifier:focus {
+  outline: none;
+  outline-offset: 0;
+}
+
 
 /* ========== 💾 BOUTONS ÉDITION : ENREGISTRER / ANNULER ========== */
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3233,6 +3233,11 @@ body[class*=edition-active] .champ-modifier:not(.bouton-cta):focus {
   outline-offset: 2px;
 }
 
+body[class*=edition-active] .champ-img .champ-modifier:focus {
+  outline: none;
+  outline-offset: 0;
+}
+
 /* ========== 💾 BOUTONS ÉDITION : ENREGISTRER / ANNULER ========== */
 .champ-organisateur .champ-enregistrer,
 .champ-organisateur .champ-annuler {


### PR DESCRIPTION
Supprime la bordure bleue du bouton de modification de l'image de chasse.

### Changements
- Retire l'outline par défaut du bouton de modification d'image pour éviter un encadré bleu indésirable.

### Testing
- `npm run build:css`
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b8464f0c648332a40ba75ad6d6f627