### PR TITLE
Clear chasse display cache on ACF save

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1420,5 +1420,18 @@ function chasse_invalidate_infos_affichage_cache(int $post_id, \WP_Post $post, b
         }
     }
 }
+
+function chasse_acf_clear_infos_affichage_cache($post_id): void
+{
+    if (!is_numeric($post_id)) {
+        return;
+    }
+
+    $post_id = (int) $post_id;
+    if (get_post_type($post_id) === 'chasse') {
+        chasse_clear_infos_affichage_cache($post_id);
+    }
+}
+add_action('acf/save_post', 'chasse_acf_clear_infos_affichage_cache', 20);
 add_action('save_post', 'chasse_invalidate_infos_affichage_cache', 10, 3);
 add_action('chasse_engagement_created', 'chasse_clear_infos_affichage_cache');


### PR DESCRIPTION
## Résumé
- assure l'invalidation du cache d'affichage d'une chasse lors de l'enregistrement via ACF

## Changements notables
- ajout d'un hook `acf/save_post` pour supprimer le cache des informations de chasse

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b849bcd0c88332ac2db4d0d6fd3548