### PR TITLE
Limit hunt description preview to 120 words

### DIFF
--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -384,7 +384,7 @@ function filtrer_content_sans_titre($content) {
  * @param string $more  Optional string appended after trimming.
  * @return string Trimmed HTML content.
  */
-function cst_trim_html_words($html, $limit = 200, $more = '…') {
+function cst_trim_html_words($html, $limit = 120, $more = '…') {
     $wordCount = 0;
     $output = '';
     $openTags = [];

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-description.php
@@ -6,8 +6,8 @@ $description = $args['description'] ?? '';
 if (!empty($description)) {
     $word_count = str_word_count(wp_strip_all_tags($description));
 
-    if ($word_count > 200) {
-        $short_description = cst_trim_html_words($description, 200);
+    if ($word_count > 120) {
+        $short_description = cst_trim_html_words($description, 120);
         ?>
         <div class="chasse-description" id="chasse-description">
             <div class="description-short"><?= wp_kses_post($short_description); ?></div>


### PR DESCRIPTION
### Résumé
- Limite l'aperçu des descriptions de chasse à 120 mots
- Adapte l'aide `cst_trim_html_words` à cette nouvelle limite

### Changements notables
- Mise à jour du seuil de troncature des descriptions
- Ajustement de la fonction utilitaire de troncature HTML

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b84d9d15e083329be454cb15276bd8