### PR TITLE
Invalidate chasse display cache after status updates

### DIFF
--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -810,6 +810,7 @@ function verifier_ou_mettre_a_jour_cache_complet(int $post_id): void
             $reel  = chasse_est_complet($post_id);
             if ($cache !== $reel) {
                 update_field('chasse_cache_complet', $reel ? 1 : 0, $post_id);
+                chasse_clear_infos_affichage_cache($post_id);
             }
             break;
 
@@ -818,6 +819,12 @@ function verifier_ou_mettre_a_jour_cache_complet(int $post_id): void
             $reel  = enigme_est_complet($post_id);
             if ($cache !== $reel) {
                 update_field('enigme_cache_complet', $reel ? 1 : 0, $post_id);
+                if (function_exists('recuperer_id_chasse_associee')) {
+                    $chasse_id = recuperer_id_chasse_associee($post_id);
+                    if ($chasse_id) {
+                        chasse_clear_infos_affichage_cache((int) $chasse_id);
+                    }
+                }
             }
             break;
     }
@@ -868,6 +875,7 @@ function verifier_ou_recalculer_statut_chasse($chasse_id): void
     $statuts_valides = ['revision', 'a_venir', 'en_cours', 'payante', 'termine'];
     if (!in_array($statut, $statuts_valides, true)) {
         mettre_a_jour_statuts_chasse($chasse_id);
+        chasse_clear_infos_affichage_cache($chasse_id);
         return;
     }
 
@@ -881,6 +889,7 @@ function verifier_ou_recalculer_statut_chasse($chasse_id): void
 
     if ($statut !== 'termine' && $date_fin && $date_fin < $now) {
         mettre_a_jour_statuts_chasse($chasse_id);
+        chasse_clear_infos_affichage_cache($chasse_id);
     }
 }
 
@@ -961,6 +970,7 @@ function mettre_a_jour_statuts_chasse($chasse_id)
     }
 
     mettre_a_jour_statuts_enigmes_de_la_chasse($chasse_id, $statut);
+    chasse_clear_infos_affichage_cache($chasse_id);
 }
 
 

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -22,6 +22,7 @@ if (current_user_can('manage_options') || $est_orga_associe) {
     verifier_ou_recalculer_statut_chasse($chasse_id);
     verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
     verifier_ou_mettre_a_jour_cache_complet($chasse_id);
+    chasse_clear_infos_affichage_cache($chasse_id);
 }
 
 $points_utilisateur = get_user_points($user_id);


### PR DESCRIPTION
## Résumé
- Invalidation du cache d'affichage après recalcul des statuts et vérification de complétude.
- Nettoyage du cache lors des recalculs internes des statuts ou de la complétude des chasses et énigmes.

## Changements
- Appel de `chasse_clear_infos_affichage_cache` sur la page chasse pour refléter immédiatement les mises à jour.
- Ajout d'invalidations similaires dans les fonctions de statut et de cache pour chasses et énigmes.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b84eda1bf48332ab5802be2f99b98c