### PR TITLE
refactor: describe email template as HTML

### DIFF
--- a/wp-content/themes/chassesautresor/inc/emails/woocommerce.php
+++ b/wp-content/themes/chassesautresor/inc/emails/woocommerce.php
@@ -38,7 +38,7 @@ function cta_wc_store_email_heading(string $email_heading): void
 add_action('woocommerce_email_header', 'cta_wc_store_email_heading');
 
 /**
- * Injects the Twig template around WooCommerce email content.
+ * Injects the HTML template around WooCommerce email content.
  *
  * @param string $message Email body content.
  *


### PR DESCRIPTION
Résumé : Remplace la mention de Twig par un modèle HTML dans les e-mails WooCommerce.

- Remplace la mention de Twig dans le commentaire de `cta_wc_render_email_content`

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b84f2c41d48332af123258fd22f712