### PR TITLE
Ajout des attributs alt aux logos des e-mails

### DIFF
--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -37,7 +37,9 @@ function cta_render_email_template(string $title, string $content): string
                 <tr>
                     <td>
                         <header style="background:#0B132B;padding:20px;text-align:center;">
-                            <img src="<?php echo esc_url($logo_header); ?>" alt="" style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
+                            <img src="<?php echo esc_url($logo_header); ?>"
+                                alt="<?php echo esc_attr__('Chasses au Trésor', 'chassesautresor-com'); ?>"
+                                style="max-width:150px;height:auto;display:block;margin:0 auto 10px;" />
                             <h1 style="color:#ffffff;font-family:Arial,sans-serif;font-size:24px;margin:0;">
                                 <?php echo $title_html; ?>
                             </h1>
@@ -59,7 +61,9 @@ function cta_render_email_template(string $title, string $content): string
                             </p>
                             <p style="margin:10px 0 0;">
                                 <a href="<?php echo esc_url($home_url); ?>" style="display:inline-block;">
-                                    <img src="<?php echo esc_url($logo_footer); ?>" alt="" style="max-width:150px;height:auto;" />
+                                    <img src="<?php echo esc_url($logo_footer); ?>"
+                                        alt="<?php echo esc_attr__('Chasses au Trésor', 'chassesautresor-com'); ?>"
+                                        style="max-width:150px;height:auto;" />
                                 </a>
                             </p>
                         </footer>


### PR DESCRIPTION
## Résumé
Ajout des textes alternatifs `Chasses au Trésor` sur les logos d'en-tête et de pied de page du modèle d'e-mail.

## Changements
- Ajout de l'attribut `alt` pour le logo d'en-tête
- Ajout de l'attribut `alt` pour le logo de pied de page

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b85275f5a88332ad28cdd2ef5ed039