### PR TITLE
Colorise le CTA Devenir organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
+++ b/wp-content/themes/chassesautresor/templates/page-devenir-organisateur.php
@@ -44,8 +44,14 @@ get_header(); ?>
     <div class="contenu-hero">
       <h1 class="hero-title"><?php the_title(); ?></h1>
       <p class="hero-subtitle">Créez, publiez et partagez vos aventures interactives.</p>
-      <?php $cta = get_cta_devenir_organisateur(); ?>
-      <a href="<?php echo $cta['url'] ? esc_url($cta['url']) : '#'; ?>" class="bouton-cta" id="creer-profil-btn" data-event="clic_creer_profil" <?php echo $cta['disabled'] ? 'style="pointer-events:none;opacity:0.6"' : ''; ?>>
+      <?php
+      $cta = get_cta_devenir_organisateur();
+      $cta_class = 'bouton-cta';
+      if (!$cta['disabled']) {
+          $cta_class .= ' bouton-cta--color';
+      }
+      ?>
+      <a href="<?php echo $cta['url'] ? esc_url($cta['url']) : '#'; ?>" class="<?php echo esc_attr($cta_class); ?>" id="creer-profil-btn" data-event="clic_creer_profil" <?php echo $cta['disabled'] ? 'style="pointer-events:none;opacity:0.6"' : ''; ?>>
         <?php echo esc_html($cta['label']); ?>
       </a>
     </div>
@@ -77,6 +83,9 @@ get_header(); ?>
          $cta     = get_cta_devenir_organisateur();
          $content = str_replace('/creer-mon-profil/', $cta['url'], $content);
          $content = str_replace('Créer mon profil', $cta['label'], $content);
+         if (!$cta['disabled']) {
+             $content = str_replace('bouton-cta"', 'bouton-cta bouton-cta--color"', $content);
+         }
          echo $content;
       }
     ?>


### PR DESCRIPTION
### Résumé
- Le bouton Devenir organisateur devient rouge quand il est cliquable

### Changements notables
- Ajout de la classe `bouton-cta--color` au CTA principal lorsque l’utilisateur est éligible
- Application de cette classe au CTA final dynamique lorsqu’il est actif

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b85abb2a7083328a59ae8fbe4af2fa