### PR TITLE
Utilisation du proxy pour les images d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -176,9 +176,19 @@ function afficher_visuels_enigme(int $enigme_id): void
                 : ($caption ?: __('Visuel énigme', 'chassesautresor-com'));
         }
 
+        $classes = 'enigme-image--limited';
+        if ($index === 0) {
+            $classes .= ' image-active';
+        }
+
         $attrs = [
-            'class' => $index === 0 ? 'image-active' : '',
+            'class' => $classes,
+            'style' => 'width:auto;max-width:100%;',
         ];
+
+        if ($index === 0) {
+            $attrs['id'] = 'image-enigme-active';
+        }
 
         echo '<figure class="image-principale">';
         echo build_picture_enigme($image_id, $alt, ['full'], $attrs);

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-images.php
@@ -7,56 +7,7 @@ if (!$post_id) {
     return;
 }
 
-// Récupération standard des images (format tableau ACF avec clés 'ID', etc.)
-$images = get_field('enigme_visuel_image', $post_id);
-cat_debug('[images] 🔍 Énigme #' . $post_id . ' → images récupérées : ' . print_r($images, true));
-
-// Filtrage des images valides (hors placeholder)
-$valid_images = [];
-if (is_array($images)) {
-    foreach ($images as $img) {
-        $id = (int) ($img['ID'] ?? 0);
-        if ($id && $id !== ID_IMAGE_PLACEHOLDER_ENIGME) {
-            $valid_images[] = $id;
-        }
-    }
-}
-if (!$valid_images) {
-    $valid_images[] = ID_IMAGE_PLACEHOLDER_ENIGME;
-}
-
-if (function_exists('utilisateur_peut_voir_enigme') && !utilisateur_peut_voir_enigme($post_id)) {
-    echo '<div class="visuels-proteges">🔒 Les visuels de cette énigme sont protégés.</div>';
-    return;
-}
-
 cat_debug('[images] ✅ Galerie active pour #' . $post_id);
 
-echo '<div class="galerie-enigme-wrapper">';
-foreach ($valid_images as $index => $image_id) {
-    $attrs = [
-        'loading' => 'lazy',
-        'srcset'  => wp_get_attachment_image_srcset($image_id, 'large'),
-        'sizes'   => wp_get_attachment_image_sizes($image_id, 'large'),
-    ];
-    if ($index === 0) {
-        $attrs['id']    = 'image-enigme-active';
-        $attrs['class'] = 'image-active';
-    }
-    $attrs['class'] = trim(($attrs['class'] ?? '') . ' enigme-image--limited');
-    $attrs['style'] = 'width:auto;max-width:100%;';
-
-    $alt = trim((string) get_post_meta($image_id, '_wp_attachment_image_alt', true));
-    if (!$alt) {
-        $alt = $image_id === ID_IMAGE_PLACEHOLDER_ENIGME
-            ? __('Image par défaut de l’énigme', 'chassesautresor-com')
-            : __('Image de l’énigme', 'chassesautresor-com');
-    }
-    $attrs['alt'] = esc_attr($alt);
-
-    echo '<figure class="image-principale">';
-    echo wp_get_attachment_image($image_id, 'large', false, $attrs);
-    echo '</figure>';
-}
-echo '</div>';
+afficher_visuels_enigme($post_id);
 


### PR DESCRIPTION
## Résumé
- Génère les visuels via `build_picture_enigme` et le proxy `/voir-image-enigme`.
- Simplifie le partial des images d’énigme en délégant l’affichage à `afficher_visuels_enigme`.
- Ajoute les attributs requis (`id` et classes) au premier visuel.

## Testing
- `source ./setup-env.sh && echo 'env loaded'`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b85cb59bb083329a198ca867a91f74