### PR TITLE
Fix organizer redirect caching

### DIFF
--- a/wp-content/themes/chassesautresor/templates/page-creer-profil.php
+++ b/wp-content/themes/chassesautresor/templates/page-creer-profil.php
@@ -38,7 +38,8 @@ if (isset($_GET['resend'])) {
         get_user_locale($current_user_id),
         2 * DAY_IN_SECONDS
     );
-    wp_redirect(home_url('/devenir-organisateur/'));
+    $redirect_url = add_query_arg('nocache', (string) time(), home_url('/devenir-organisateur/'));
+    wp_redirect($redirect_url);
     exit;
 }
 
@@ -87,5 +88,6 @@ myaccount_add_persistent_message(
     get_user_locale($current_user_id),
     2 * DAY_IN_SECONDS
 );
-wp_redirect(home_url('/devenir-organisateur/'));
+$redirect_url = add_query_arg('nocache', (string) time(), home_url('/devenir-organisateur/'));
+wp_redirect($redirect_url);
 exit;


### PR DESCRIPTION
## Summary
- ajoute un paramètre de requête pour éviter la mise en cache lors de la redirection après la création de profil organisateur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b85c304da48332b2e515feb80c0f12