### PR TITLE
fix: refresh enigma menu after completion

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -30,7 +30,7 @@ function modifierChampSimple(champ, valeur, postId, cpt = 'enigme') {
       if (res.success) {
         DEBUG && console.log(`✅ Champ ${champ} enregistré`);
         if (typeof window.onChampSimpleMisAJour === 'function') {
-          window.onChampSimpleMisAJour(champ, postId, valeur, cpt);
+          window.onChampSimpleMisAJour(champ, postId, valeur, cpt, res.data);
         }
         return true; // important : pour pouvoir chaîner dans le .then(...)
       } else {

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -187,7 +187,7 @@ window.mettreAJourResumeInfos = function () {
 // ==============================
 // ✅ Hook unifié – Réagit à toute modification simple de champ pour tous les CPTs
 // ==============================
-window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
+window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt, extra) {
   cpt = cpt?.toLowerCase?.() || cpt;
 
   if (champ === 'post_title') {
@@ -276,6 +276,15 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
 
     if (champsResume.includes(champ) && typeof window.mettreAJourResumeInfos === 'function') {
       window.mettreAJourResumeInfos();
+    }
+    if (
+      extra &&
+      extra.complet_changed &&
+      window.sidebarAside &&
+      typeof window.sidebarAside.reload === 'function'
+    ) {
+      const cid = extra.chasse_id || document.querySelector('.enigme-navigation')?.dataset.chasseId;
+      window.sidebarAside.reload(cid);
     }
   }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -236,8 +236,9 @@ function modifier_champ_enigme()
     wp_send_json_error('⚠️ acces_refuse');
   }
 
-  $champ_valide = false;
-  $reponse = ['champ' => $champ, 'valeur' => $valeur];
+  $champ_valide    = false;
+  $reponse         = ['champ' => $champ, 'valeur' => $valeur];
+  $ancien_complet  = (bool) get_field('enigme_cache_complet', $post_id);
 
   // 🔹 Bloc interdit (pre_requis manuel)
   if ($champ === 'enigme_acces_condition' && $valeur === 'pre_requis') {
@@ -356,6 +357,16 @@ function modifier_champ_enigme()
       wp_send_json_error('⚠️ echec_mise_a_jour_final');
     }
   }
+
+  if (function_exists('verifier_ou_mettre_a_jour_cache_complet')) {
+    verifier_ou_mettre_a_jour_cache_complet($post_id);
+  }
+  $nouveau_complet              = (bool) get_field('enigme_cache_complet', $post_id);
+  $reponse['complet']           = $nouveau_complet;
+  $reponse['complet_changed']   = $ancien_complet !== $nouveau_complet;
+  $reponse['chasse_id']         = function_exists('recuperer_id_chasse_associee')
+    ? (int) recuperer_id_chasse_associee($post_id)
+    : 0;
 
   wp_send_json_success($reponse);
 }


### PR DESCRIPTION
## Résumé
- actualise la pastille du menu des énigmes après la complétion

## Détails
- met à jour le cache de complétion après chaque modification
- relaie la nouvelle complétion au panneau latéral via JavaScript

## Testing
- `source ./setup-env.sh && echo 'env ready'`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test` *(jest introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b88508715c833299a53e09451133bd