### PR TITLE
Empêcher le cache sur la création d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -176,6 +176,8 @@ function creer_enigme_et_rediriger_si_appel()
     return;
   }
 
+  nocache_headers();
+
   // Vérification de l’utilisateur
   if (!is_user_logged_in()) {
     wp_redirect(wp_login_url());


### PR DESCRIPTION
## Résumé
- empêche la mise en cache du point d'entrée `/creer-enigme`

## Changements notables
- ajoute `nocache_headers()` lors de la création d'une énigme

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b885d0a1d48332839a49af369c4df6