### PR TITLE
Use UserMessageRepository for validation notice

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -435,10 +435,16 @@ function myaccount_maybe_add_validation_message(): void
         return;
     }
 
-    $key      = 'correction_info_chasse_' . $chasse_id;
-    $messages = get_user_meta($user_id, '_myaccount_messages', true);
-    if (is_array($messages) && isset($messages[$key])) {
-        return;
+    $key = 'correction_info_chasse_' . $chasse_id;
+
+    global $wpdb;
+    $repo     = new UserMessageRepository($wpdb);
+    $existing = $repo->get($user_id, 'persistent', null);
+    foreach ($existing as $row) {
+        $data = json_decode($row['message'], true);
+        if (is_array($data) && ($data['key'] ?? '') === $key) {
+            return;
+        }
     }
 
     $info_msg = sprintf(


### PR DESCRIPTION
## Summary
- utilise UserMessageRepository pour éviter les doublons du message de validation
- adapte le test afin de vérifier l'insertion dans `wp_user_messages`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b896491ba483328f192931c69083de