### PR TITLE
Respect de l'ordre des énigmes dans la navigation de chasse

### DIFF
--- a/tests/EnigmeMenuRenderingTest.php
+++ b/tests/EnigmeMenuRenderingTest.php
@@ -164,6 +164,35 @@ if (!function_exists('wp_cache_set')) {
     }
 }
 
+if (!function_exists('recuperer_enigmes_associees')) {
+    function recuperer_enigmes_associees($chasse_id)
+    {
+        return $GLOBALS['enigma_ids'] ?? array_map(
+            static fn($e) => $e->ID,
+            $GLOBALS['enigma_list'] ?? []
+        );
+    }
+}
+
+if (!function_exists('get_posts')) {
+    function get_posts($args = [])
+    {
+        $ids   = $args['post__in'] ?? [];
+        $posts = $GLOBALS['enigma_list'] ?? [];
+        $map   = [];
+        foreach ($posts as $post) {
+            $map[$post->ID] = $post;
+        }
+        $ordered = [];
+        foreach ($ids as $id) {
+            if (isset($map[$id])) {
+                $ordered[] = $map[$id];
+            }
+        }
+        return $ordered;
+    }
+}
+
 if (!function_exists('recuperer_enigmes_pour_chasse')) {
     function recuperer_enigmes_pour_chasse($chasse_id)
     {
@@ -399,7 +428,7 @@ class EnigmeMenuRenderingTest extends TestCase
         $GLOBALS['post_types'][102]  = 'enigme';
         $GLOBALS['post_status'][102] = 'publish';
         $GLOBALS['titles'][102]      = 'Enigme Bloquee';
-        $GLOBALS['enigma_list']      = [(object) ['ID' => 101], (object) ['ID' => 102]];
+        $GLOBALS['enigma_list']      = [(object) ['ID' => 102], (object) ['ID' => 101]];
 
         ob_start();
         afficher_enigme_stylisee(101);
@@ -428,7 +457,7 @@ class EnigmeMenuRenderingTest extends TestCase
         $GLOBALS['post_types'][102]  = 'enigme';
         $GLOBALS['post_status'][102] = 'publish';
         $GLOBALS['titles'][102]      = 'Enigme Mal Config';
-        $GLOBALS['enigma_list']      = [(object) ['ID' => 101], (object) ['ID' => 102]];
+        $GLOBALS['enigma_list']      = [(object) ['ID' => 102], (object) ['ID' => 101]];
 
         ob_start();
         afficher_enigme_stylisee(101);
@@ -460,7 +489,7 @@ class EnigmeMenuRenderingTest extends TestCase
         $GLOBALS['post_types'][102]  = 'enigme';
         $GLOBALS['post_status'][102] = 'publish';
         $GLOBALS['titles'][102]      = 'Enigme Future';
-        $GLOBALS['enigma_list']      = [(object) ['ID' => 101], (object) ['ID' => 102]];
+        $GLOBALS['enigma_list']      = [(object) ['ID' => 102], (object) ['ID' => 101]];
 
         ob_start();
         afficher_enigme_stylisee(101);

--- a/tests/SidebarPrepareChasseNavTest.php
+++ b/tests/SidebarPrepareChasseNavTest.php
@@ -82,13 +82,28 @@ if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
     }
 }
 
-if (!function_exists('recuperer_enigmes_pour_chasse')) {
-    function recuperer_enigmes_pour_chasse($chasse_id)
+if (!function_exists('recuperer_enigmes_associees')) {
+    function recuperer_enigmes_associees($chasse_id)
     {
-        return [
-            (object) ['ID' => 1],
-            (object) ['ID' => 2],
+        return [2, 1];
+    }
+}
+
+if (!function_exists('get_posts')) {
+    function get_posts($args = [])
+    {
+        $ids   = $args['post__in'] ?? [];
+        $posts = [
+            2 => (object) ['ID' => 2],
+            1 => (object) ['ID' => 1],
         ];
+        $ordered = [];
+        foreach ($ids as $id) {
+            if (isset($posts[$id])) {
+                $ordered[] = $posts[$id];
+            }
+        }
+        return $ordered;
     }
 }
 
@@ -137,7 +152,7 @@ class SidebarPrepareChasseNavTest extends TestCase
 
         $data = sidebar_prepare_chasse_nav(10, 5);
 
-        $this->assertSame([1, 2], $data['visible_ids']);
+        $this->assertSame([2, 1], $data['visible_ids']);
     }
 
     public function test_associated_organizer_sees_all_enigmas(): void
@@ -146,7 +161,7 @@ class SidebarPrepareChasseNavTest extends TestCase
 
         $data = sidebar_prepare_chasse_nav(10, 5);
 
-        $this->assertSame([1, 2], $data['visible_ids']);
+        $this->assertSame([2, 1], $data['visible_ids']);
     }
 }
 

--- a/wp-content/themes/chassesautresor/inc/sidebar.php
+++ b/wp-content/themes/chassesautresor/inc/sidebar.php
@@ -40,7 +40,16 @@ if (!function_exists('sidebar_prepare_chasse_nav')) {
         int $current_enigme_id = 0
     ): array
     {
-        $all_enigmes           = recuperer_enigmes_pour_chasse($chasse_id);
+        $ids                   = recuperer_enigmes_associees($chasse_id);
+        $all_enigmes           = $ids
+            ? get_posts([
+                'post_type'      => 'enigme',
+                'post__in'       => $ids,
+                'orderby'        => 'post__in',
+                'post_status'    => ['publish', 'pending'],
+                'posts_per_page' => -1,
+            ])
+            : [];
         $submenu_items         = [];
         $total_enigmes         = count($all_enigmes);
         $has_incomplete_enigme = false;


### PR DESCRIPTION
### Résumé
Assure que la navigation d'une chasse respecte l'ordre défini dans `chasse_cache_enigmes`.

### Modifications
- Récupération des énigmes via `recuperer_enigmes_associees` et chargement avec `get_posts` en conservant l'ordre.
- Ajustement des tests de navigation pour refléter ce nouvel ordre.

### Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b9055f539483328a4f34c088adef76