### PR TITLE
Fix enigme card reorder cache order

### DIFF
--- a/wp-content/themes/chassesautresor/inc/relations-functions.php
+++ b/wp-content/themes/chassesautresor/inc/relations-functions.php
@@ -888,24 +888,22 @@ function synchroniser_relations_cache_enigmes(int $chasse_id): bool
         return false;
     }
 
-    // 🧩 Énigmes réellement liées à la chasse
-    $posts = get_posts([
+    // 🧩 Énigmes réellement liées à la chasse, triées par menu_order
+    $ids_detectes = get_posts([
         'post_type'      => 'enigme',
         'post_status'    => ['draft', 'pending', 'publish'],
         'posts_per_page' => -1,
         'fields'         => 'ids',
+        'orderby'        => 'menu_order',
+        'order'          => 'ASC',
+        'meta_query'     => [
+            [
+                'key'     => 'enigme_chasse_associee',
+                'value'   => $chasse_id,
+                'compare' => 'LIKE',
+            ],
+        ],
     ]);
-
-    $ids_detectes = [];
-
-    foreach ($posts as $eid) {
-        $associees = get_field('enigme_chasse_associee', $eid, false);
-        $associees = is_array($associees) ? array_map('intval', $associees) : [(int) $associees];
-
-        if (in_array((int)$chasse_id, $associees, true)) {
-            $ids_detectes[] = $eid;
-        }
-    }
 
     // 🧮 Cache actuel
     $cache_actuel = get_field('chasse_cache_enigmes', $chasse_id, false);


### PR DESCRIPTION
## Résumé
- Assure la synchronisation du champ `chasse_cache_enigmes` selon l'ordre `menu_order`.

## Changements notables
- Tri des énigmes liées à une chasse par `menu_order` lors de la mise à jour du cache.

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b90a685908833282eaa6b99fc74312