### PR TITLE
Synchroniser le panneau latéral lors du tri des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
+++ b/wp-content/themes/chassesautresor/assets/js/enigme-cards-reorder.js
@@ -51,6 +51,18 @@ function initEnigmeCardsReorder() {
     }
   };
 
+  const updateNavOrder = () => {
+    const menu = document.querySelector('.enigme-navigation .enigme-menu');
+    if (!menu) return;
+    const ids = Array.from(
+      grid.querySelectorAll('.carte-enigme[data-enigme-id]')
+    ).map((el) => el.dataset.enigmeId);
+    ids.forEach((id) => {
+      const item = menu.querySelector(`li[data-enigme-id="${id}"]`);
+      if (item) menu.appendChild(item);
+    });
+  };
+
   const saveOrder = () => {
     const order = Array.from(
       grid.querySelectorAll('.carte-enigme[data-enigme-id]')
@@ -70,6 +82,9 @@ function initEnigmeCardsReorder() {
         if (!res.success) {
           alert(wp.i18n.__("Erreur lors de l'enregistrement de l'ordre", 'chassesautresor-com'));
         }
+        if (res.success && window.sidebarAside?.reload) {
+          window.sidebarAside.reload(grid.dataset.chasseId);
+        }
       })
       .catch(() => {
         alert(wp.i18n.__("Erreur lors de l'enregistrement de l'ordre", 'chassesautresor-com'));
@@ -86,6 +101,7 @@ function initEnigmeCardsReorder() {
     e.preventDefault();
     cleanClasses();
     ensureAddLast();
+    updateNavOrder();
     saveOrder();
     dragged = null;
   });
@@ -93,6 +109,7 @@ function initEnigmeCardsReorder() {
   grid.addEventListener('dragend', () => {
     cleanClasses();
     ensureAddLast();
+    updateNavOrder();
     saveOrder();
     dragged = null;
   });


### PR DESCRIPTION
## Résumé
- Mise à jour dynamique de la navigation dans l'aside après réorganisation des cartes d'énigme

## Changements notables
- Réordonne immédiatement le menu latéral selon l'ordre des cartes glissées
- Rafraîchit le contenu de l'aside après sauvegarde de l'ordre des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b9130a71848332bc46bcb90f9a538d