### PR TITLE
Masquer les stats des cartes d'énigmes hors survol

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -183,6 +183,15 @@
   gap: var(--space-sm);
 }
 
+.carte-enigme-footer .footer-icons-right {
+  display: none;
+}
+
+.carte-enigme:hover .footer-icons-right,
+.carte-enigme:focus-within .footer-icons-right {
+  display: flex;
+}
+
 .carte-enigme-footer .footer-item {
   display: flex;
   align-items: center;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -173,6 +173,15 @@
   gap: var(--space-sm);
 }
 
+.carte-enigme-footer .footer-icons-right {
+  display: none;
+}
+
+.carte-enigme:hover .footer-icons-right,
+.carte-enigme:focus-within .footer-icons-right {
+  display: flex;
+}
+
 .carte-enigme-footer .footer-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Résumé
- masque les icônes de participation et de résolution tant que la carte n’est pas survolée
- compile les styles CSS

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b913fdf0a88332b30eb63d00965494