### PR TITLE
Fix puzzle image caching with versioned URLs

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -51,13 +51,14 @@ ob_clean();
 header_remove();
 remove_all_actions('shutdown');
 remove_all_actions('template_redirect');
+do_action('litespeed_control_set_nocache');
 
 // ✅ Envoi du fichier
 // 📅 Cache (compatible CDN)
 $mtime = filemtime($path);
 $etag  = '"' . md5($mtime . filesize($path)) . '"';
 
-header('Cache-Control: public, max-age=604800, immutable');
+header('Cache-Control: public, max-age=3600, immutable');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');
 header('ETag: ' . $etag);
 


### PR DESCRIPTION
## Résumé
- Ajout d'un paramètre de version basé sur `filemtime` pour les visuels d'énigme
- Ajustement des en-têtes de cache et désactivation du cache LiteSpeed sur le proxy d'image

## Changements notables
- Ajout du paramètre `v` aux URLs générées par `filtrer_visuels_enigme_front`
- Réduction de `max-age` et exclusion du cache LiteSpeed pour `/voir-image-enigme`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b915a127388332ac338124f6f8b1b4