### PR TITLE
Affiche un message d’attente de validation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -191,6 +191,13 @@ body .wp-block-file .wp-block-file__button:focus,
     outline-offset: 2px;
 }
 
+.bouton-cta--pending {
+    cursor: not-allowed;
+    opacity: 0.6;
+    max-width: 220px;
+    white-space: normal;
+}
+
 /* ========== 🎯 BLOCS RÉPONSE ========== */
 .bloc-reponse {
     position: relative;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1111,6 +1111,13 @@ body .wp-block-file .wp-block-file__button:focus,
   outline-offset: 2px;
 }
 
+.bouton-cta--pending {
+  cursor: not-allowed;
+  opacity: 0.6;
+  max-width: 220px;
+  white-space: normal;
+}
+
 /* ========== 🎯 BLOCS RÉPONSE ========== */
 .bloc-reponse {
   position: relative;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -669,6 +669,16 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         ];
     }
 
+    if ($validation === 'en_attente') {
+        return [
+            'cta_html'    => '<span class="bouton-cta bouton-cta--pending" aria-disabled="true">'
+                . esc_html__( 'Demande de validation en cours', 'chassesautresor-com' )
+                . '</span>',
+            'cta_message' => '',
+            'type'        => 'en_attente',
+        ];
+    }
+
     // 🔐 Admin or organiser: disabled participation button
     $admin_override = $GLOBALS['force_admin_override'] ?? null;
     $is_admin = $admin_override !== null ? (bool) $admin_override : current_user_can('administrator');

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -241,6 +241,10 @@ msgstr ""
 msgid "Tentatives manuelles en attente de réponse"
 msgstr ""
 
+#: inc/chasse-functions.php:675
+msgid "Demande de validation en cours"
+msgstr ""
+
 #: inc/admin-functions.php:1786
 #: template-parts/chasse/chasse-edition-main.php:659
 msgid "Accès refusé."

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -221,6 +221,10 @@ msgstr "%d pending attempt"
 msgid "Tentatives manuelles en attente de réponse"
 msgstr "Configure answer variants"
 
+#: inc/chasse-functions.php:675
+msgid "Demande de validation en cours"
+msgstr "Validation request in progress"
+
 #: inc/admin-functions.php:1786
 #: template-parts/chasse/chasse-edition-main.php:659
 msgid "Accès refusé."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -223,6 +223,10 @@ msgstr ""
 msgid "Tentatives manuelles en attente de réponse"
 msgstr "Configurer les variantes de réponse"
 
+#: inc/chasse-functions.php:675
+msgid "Demande de validation en cours"
+msgstr "Demande de validation en cours"
+
 #: inc/admin-functions.php:1786
 #: template-parts/chasse/chasse-edition-main.php:659
 msgid "Accès refusé."


### PR DESCRIPTION
## Résumé
- affiche "Demande de validation en cours" quand une chasse est en attente
- limite la largeur du message de validation
- ajoute les chaînes de traduction associées

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b91b9367cc833294c095a443332a5c