### PR TITLE
Encode email subjects on send

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -2064,9 +2064,6 @@ function envoyer_mail_demande_correction(int $organisateur_id, int $chasse_id, s
     $url_chasse   = get_permalink($chasse_id);
 
     $subject_raw = '[Chasses au Trésor] Corrections requises pour votre chasse';
-    $subject = function_exists('wp_encode_mime_header')
-        ? wp_encode_mime_header($subject_raw)
-        : mb_encode_mimeheader($subject_raw, 'UTF-8', 'B', "\r\n");
 
     $body  = '<div style="font-family:Arial,sans-serif;font-size:14px;">';
     $body .= '<p>Bonjour,</p>';
@@ -2086,8 +2083,8 @@ function envoyer_mail_demande_correction(int $organisateur_id, int $chasse_id, s
     };
     add_filter('wp_mail_from_name', $from_filter, 10, 1);
 
-    cta_send_email($emails, $subject, $body, $headers);
-    cta_send_email($admin_email, $subject, $body, $headers);
+    cta_send_email($emails, $subject_raw, $body, $headers);
+    cta_send_email($admin_email, $subject_raw, $body, $headers);
     remove_filter('wp_mail_from_name', $from_filter, 10);
 
 }
@@ -2119,9 +2116,6 @@ function envoyer_mail_chasse_bannie(int $organisateur_id, int $chasse_id)
     $titre_chasse = get_the_title($chasse_id);
 
     $subject_raw = '[Chasses au Trésor] Chasse bannie';
-    $subject = function_exists('wp_encode_mime_header')
-        ? wp_encode_mime_header($subject_raw)
-        : mb_encode_mimeheader($subject_raw, 'UTF-8', 'B', "\r\n");
 
     $body  = '<p>' . esc_html__('Bonjour,', 'chassesautresor-com') . '</p>';
     $body .= '<p>' . sprintf(esc_html__('Votre chasse "%s" a été bannie par l\'administrateur.', 'chassesautresor-com'), esc_html($titre_chasse)) . '</p>';
@@ -2136,7 +2130,7 @@ function envoyer_mail_chasse_bannie(int $organisateur_id, int $chasse_id)
     };
     add_filter('wp_mail_from_name', $from_filter, 10, 1);
 
-    cta_send_email($email, $subject, $body, $headers);
+    cta_send_email($email, $subject_raw, $body, $headers);
     remove_filter('wp_mail_from_name', $from_filter, 10);
 }
 
@@ -2167,9 +2161,6 @@ function envoyer_mail_chasse_supprimee(int $organisateur_id, int $chasse_id)
     $titre_chasse = get_the_title($chasse_id);
 
     $subject_raw = '[Chasses au Trésor] Chasse supprimée';
-    $subject = function_exists('wp_encode_mime_header')
-        ? wp_encode_mime_header($subject_raw)
-        : mb_encode_mimeheader($subject_raw, 'UTF-8', 'B', "\r\n");
 
     $body  = '<p>' . esc_html__('Bonjour,', 'chassesautresor-com') . '</p>';
     $body .= '<p>' . sprintf(esc_html__('Votre chasse "%s" a été supprimée par l\'administrateur.', 'chassesautresor-com'), esc_html($titre_chasse)) . '</p>';
@@ -2184,7 +2175,7 @@ function envoyer_mail_chasse_supprimee(int $organisateur_id, int $chasse_id)
     };
     add_filter('wp_mail_from_name', $from_filter, 10, 1);
 
-    cta_send_email($email, $subject, $body, $headers);
+    cta_send_email($email, $subject_raw, $body, $headers);
     remove_filter('wp_mail_from_name', $from_filter, 10);
 }
 
@@ -2235,9 +2226,6 @@ function envoyer_mail_chasse_validee(int $organisateur_id, int $chasse_id)
     $url_qr_code  = 'https://api.qrserver.com/v1/create-qr-code/?size=400x400&data=' . rawurlencode($url_chasse);
 
     $subject_raw = '✅ Votre chasse est maintenant validée !';
-    $subject = function_exists('wp_encode_mime_header')
-        ? wp_encode_mime_header($subject_raw)
-        : mb_encode_mimeheader($subject_raw, 'UTF-8', 'B', "\r\n");
 
     $body  = '<p>Bonjour,</p>';
     $body .= '<p>Votre chasse <strong>&laquo;' . esc_html($titre_chasse) . '&raquo;</strong> a été <strong>validée avec succès</strong> par notre équipe 🎉<br>';
@@ -2262,7 +2250,7 @@ function envoyer_mail_chasse_validee(int $organisateur_id, int $chasse_id)
     };
     add_filter('wp_mail_from_name', $from_filter, 10, 1);
 
-    cta_send_email($emails, $subject, $body, $headers);
+    cta_send_email($emails, $subject_raw, $body, $headers);
     remove_filter('wp_mail_from_name', $from_filter, 10);
 }
 

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -80,14 +80,14 @@ function cta_render_email_template(string $title, string $content): string
 /**
  * Sends an HTML email using the template.
  *
- * @param array|string $to      Recipient or list of recipients.
- * @param string       $subject Email subject.
- * @param string       $body    Email body content.
- * @param array        $headers Additional headers.
+ * @param array|string $to          Recipient or list of recipients.
+ * @param string       $subject_raw Email subject.
+ * @param string       $body        Email body content.
+ * @param array        $headers     Additional headers.
  *
  * @return bool
  */
-function cta_send_email($to, string $subject, string $body, array $headers = []): bool
+function cta_send_email($to, string $subject_raw, string $body, array $headers = []): bool
 {
     $has_content_type = false;
     foreach ($headers as $header) {
@@ -111,7 +111,11 @@ function cta_send_email($to, string $subject, string $body, array $headers = [])
         $headers[] = 'From: ' . $from;
     }
 
-    $html = cta_render_email_template($subject, $body);
+    $html = cta_render_email_template($subject_raw, $body);
+
+    $subject = function_exists('wp_encode_mime_header')
+        ? wp_encode_mime_header($subject_raw)
+        : mb_encode_mimeheader($subject_raw, 'UTF-8', 'B', "\r\n");
 
     return function_exists('wp_mail') ? wp_mail($to, $subject, $html, $headers) : false;
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -386,10 +386,6 @@ add_action('wp_ajax_nopriv_soumettre_reponse_automatique', 'soumettre_reponse_au
         $user = get_userdata($user_id);
         $subject_raw = '[Réponse Énigme] ' . $titre_enigme;
 
-        $subject = function_exists('wp_encode_mime_header')
-            ? wp_encode_mime_header($subject_raw)
-            : mb_encode_mimeheader($subject_raw, 'UTF-8', 'B', "\r\n");
-
         $date        = date_i18n('j F Y à H:i', current_time('timestamp'));
         $url_enigme  = get_permalink($enigme_id);
         $profil_url  = get_author_posts_url($user_id);
@@ -422,7 +418,7 @@ add_action('wp_ajax_nopriv_soumettre_reponse_automatique', 'soumettre_reponse_au
         };
         add_filter('wp_mail_from_name', $from_filter, 10, 1);
 
-        cta_send_email($email_organisateur, $subject, $message, $headers);
+        cta_send_email($email_organisateur, $subject_raw, $message, $headers);
         remove_filter('wp_mail_from_name', $from_filter, 10);
     }
 
@@ -464,7 +460,7 @@ add_action('wp_ajax_nopriv_soumettre_reponse_automatique', 'soumettre_reponse_au
         $tentatives_utilisees = compter_tentatives_du_jour($user_id, $enigme_id);
         $tentatives_max = (int) get_field('enigme_tentative_max', $enigme_id);
 
-        $subject = sprintf(
+        $subject_raw = sprintf(
             __('[Chasses au Trésor] %1$s — %2$s', 'chassesautresor-com'),
             $enigme_title,
             $result_label
@@ -527,7 +523,7 @@ add_action('wp_ajax_nopriv_soumettre_reponse_automatique', 'soumettre_reponse_au
         };
         add_filter('wp_mail_from_name', $from_filter, 10, 1);
 
-        cta_send_email($user->user_email, $subject, $message, $headers);
+        cta_send_email($user->user_email, $subject_raw, $message, $headers);
         remove_filter('wp_mail_from_name', $from_filter, 10);
     }
 

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -778,7 +778,7 @@ function envoyer_email_confirmation_organisateur(int $user_id, string $token): b
         'token' => $token,
     ], site_url('/confirmation-organisateur/'));
 
-    $subject = esc_html__(
+    $subject_raw = __(
         '[Chasses au Trésor] Confirmez votre inscription organisateur',
         'chassesautresor-com'
     );
@@ -814,7 +814,7 @@ function envoyer_email_confirmation_organisateur(int $user_id, string $token): b
     $headers = [];
 
     add_filter('wp_mail_from_name', $from_filter, 10, 1);
-    cta_send_email($user->user_email, $subject, $body, $headers);
+    cta_send_email($user->user_email, $subject_raw, $body, $headers);
     remove_filter('wp_mail_from_name', $from_filter, 10);
 
     return true;


### PR DESCRIPTION
## Résumé
- Encode le sujet des e-mails seulement lors de l'envoi, tout en affichant la version brute dans le template HTML
- Adapte les fonctions d'envoi pour transmettre `$subject_raw`

## Changements notables
- Encodage MIME du sujet dans `cta_send_email`
- Mise à jour des notifications administrateur et joueur pour utiliser le sujet non encodé
- Sujet brut utilisé pour l'e-mail de confirmation organisateur

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b91f1e70c48332acf321beada447b3