### PR TITLE
Handle reset stats errors and return deleted rows

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1387,13 +1387,27 @@ function cta_reset_stats() {
         $wpdb->prefix . 'indices_deblocages',
     ];
 
+    $total_deleted = 0;
+
     foreach ($tables as $table) {
-        $wpdb->query("TRUNCATE TABLE {$table}");
+        $wpdb->query("DELETE FROM {$table}");
+
+        if (!empty($wpdb->last_error)) {
+            wp_send_json_error($wpdb->last_error);
+        }
+
+        $total_deleted += (int) $wpdb->rows_affected;
     }
 
     delete_metadata('user', 0, '_myaccount_messages', '', true);
 
-    wp_send_json_success();
+    if (!empty($wpdb->last_error)) {
+        wp_send_json_error($wpdb->last_error);
+    }
+
+    $total_deleted += (int) $wpdb->rows_affected;
+
+    wp_send_json_success(['deleted' => $total_deleted]);
 }
 add_action('wp_ajax_cta_reset_stats', 'cta_reset_stats');
 


### PR DESCRIPTION
## Résumé
- remplace les `TRUNCATE` par `DELETE` lors de la réinitialisation des statistiques
- retourne les erreurs SQL et le nombre total de lignes supprimées

## Changements notables
- utilisation de `DELETE FROM` pour toutes les tables ciblées
- vérification de `$wpdb->last_error` après chaque requête
- réponse JSON contenant le total des lignes supprimées

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b9508712708332a248ab5ccaa3b1dd