### PR TITLE
Corrige la gestion des erreurs lors de l'engagement à une chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -849,11 +849,15 @@ function enregistrer_engagement_chasse(int $user_id, int $chasse_id): bool
         [
             'user_id'         => $user_id,
             'chasse_id'       => $chasse_id,
-            'enigme_id'       => null,
             'date_engagement' => current_time('mysql', 1),
         ],
-        ['%d', '%d', '%s', '%s']
+        ['%d', '%d', '%s']
     );
+
+    if (!empty($wpdb->last_error)) {
+        return false;
+    }
+
     if ($inserted) {
         do_action('chasse_engagement_created', $chasse_id);
     }

--- a/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-engagement.php
@@ -42,7 +42,14 @@ if ($chasse_id) {
         exit;
     }
 
-    enregistrer_engagement_chasse($current_user_id, $chasse_id);
+    $engagement_saved = enregistrer_engagement_chasse($current_user_id, $chasse_id);
+
+    if (!$engagement_saved) {
+        wp_safe_redirect(
+            add_query_arg('erreur', 'engagement', get_permalink($chasse_id))
+        );
+        exit;
+    }
 
     if ($cout_points > 0) {
         $reason = sprintf(


### PR DESCRIPTION
## Résumé
Assure l'insertion d'un engagement sans `enigme_id` et signale les erreurs lors de l'enregistrement.

## Changements notables
- Supprime `enigme_id` de l'insertion et vérifie les erreurs SQL
- Redirige avec un paramètre d'erreur si l'engagement échoue dans le template

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b99312765c83328110f46968604b19