### PR TITLE
Redirection vers la chasse après connexion

### DIFF
--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -21,7 +21,7 @@ if (!function_exists('get_field')) {
 
 if (!function_exists('get_permalink')) {
     function get_permalink($id) {
-        return '';
+        return "https://example.com/chasse/{$id}";
     }
 }
 
@@ -67,6 +67,16 @@ if (!function_exists('site_url')) {
     }
 }
 
+if (!function_exists('wp_login_url')) {
+    function wp_login_url($redirect = '', $force_reauth = false) {
+        $base = 'https://example.com/wp-login.php';
+
+        return $redirect
+            ? $base . '?redirect_to=' . rawurlencode($redirect)
+            : $base;
+    }
+}
+
 if (!function_exists('date_i18n')) {
     function date_i18n($format, $timestamp) {
         return '';
@@ -108,7 +118,7 @@ class GenererCtaChasseTest extends TestCase
         $cta = generer_cta_chasse(123, 0);
         $this->assertSame(
             [
-                'cta_html'    => '<a href="https://example.com/mon-compte" class="bouton-cta bouton-cta--color">S\'identifier</a>',
+                'cta_html'    => '<a href="https://example.com/wp-login.php?redirect_to=http%3A%2F%2Fexample.com%2F123" class="bouton-cta bouton-cta--color">S\'identifier</a>',
                 'cta_message' => '',
                 'type'        => 'connexion',
             ],

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -649,11 +649,13 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     $date_fin   = get_field('chasse_infos_date_fin', $chasse_id);
 
     // 🧑‍💻 Utilisateur non connecté
-    if (!$user_id) {
+    if (! $user_id) {
+        $login_url = wp_login_url($permalink);
+
         return [
             'cta_html'    => sprintf(
                 '<a href="%s" class="bouton-cta bouton-cta--color">%s</a>',
-                esc_url(site_url('/mon-compte')),
+                esc_url($login_url),
                 esc_html__('S\'identifier', 'chassesautresor-com')
             ),
             'cta_message' => '',


### PR DESCRIPTION
## Résumé
- assure la redirection vers la chasse après identification depuis le CTA
- met à jour le test unitaire correspondant

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b99137dfb08332aecca95e52ba9b9e