### PR TITLE
Désactiver le cache sur les pages sensibles

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -107,6 +107,22 @@ function cta_redirect_account_page_for_guests() {
 add_action( 'init', 'cta_redirect_account_page_for_guests' );
 
 /**
+ * Disables LiteSpeed cache for logged-in users and sensitive pages.
+ *
+ * @return void
+ */
+function cta_disable_cache_for_sensitive_pages() {
+    if ( is_user_logged_in() || is_singular( [ 'chasse', 'enigme', 'organisateur' ] ) ) {
+        if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+            define( 'DONOTCACHEPAGE', true );
+        }
+
+        do_action( 'litespeed_control_set_nocache' );
+    }
+}
+add_action( 'template_redirect', 'cta_disable_cache_for_sensitive_pages' );
+
+/**
  * Renders the language switcher in the header.
  *
  * @param string $row    Header builder row.


### PR DESCRIPTION
## Résumé
- empêcher la mise en cache LiteSpeed pour les utilisateurs connectés et les pages critiques

## Changements notables
- ajout d'un hook `template_redirect` désactivant le cache sur les pages de chasses, énigmes et organisateurs

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c4bbafc8332a1c7d4f3a6af21f8