### PR TITLE
Désactivation de l’optimisation des images LiteSpeed pour les énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -123,6 +123,25 @@ function cta_disable_cache_for_sensitive_pages() {
 add_action( 'template_redirect', 'cta_disable_cache_for_sensitive_pages' );
 
 /**
+ * Disables LiteSpeed image optimization and lazy loading for dynamic puzzle images.
+ *
+ * @param bool $enabled Whether the optimization is enabled.
+ *
+ * @return bool
+ */
+function cta_disable_litespeed_imgs_for_enigme( $enabled ) {
+    $uri = $_SERVER['REQUEST_URI'] ?? '';
+
+    if ( false !== strpos( $uri, '/voir-image-enigme' ) ) {
+        return false;
+    }
+
+    return $enabled;
+}
+add_filter( 'litespeed_optm_img_optm', 'cta_disable_litespeed_imgs_for_enigme' );
+add_filter( 'litespeed_optm_img_lazy', 'cta_disable_litespeed_imgs_for_enigme' );
+
+/**
  * Renders the language switcher in the header.
  *
  * @param string $row    Header builder row.


### PR DESCRIPTION
## Résumé
- Désactive l’optimisation et le lazy-load des images LiteSpeed sur les URLs de visualisation d’énigmes.

## Changements notables
- Ajout d’un filtre retournant `false` pour `litespeed_optm_img_optm` et `litespeed_optm_img_lazy` lorsque l’URL contient `/voir-image-enigme`.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `wp litespeed-purge all` *(commande introuvable)*
- `php -r "require 'wp-load.php'; do_action('litespeed_purge_all');"` *(erreur de connexion à la base de données)*
- `php -r '$fn=function($enabled){$uri="/voir-image-enigme/example"; if(false!==strpos($uri,"/voir-image-enigme")) return false; return $enabled;}; var_export($fn(true));'`

------
https://chatgpt.com/codex/tasks/task_e_68ba73d198748332b626f5ae1d4db907