### PR TITLE
Purge LiteSpeed cache after status updates

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1880,6 +1880,7 @@ function traiter_validation_chasse_admin() {
         $cache['chasse_cache_statut_validation'] = 'valide';
         update_field('champs_caches', $cache, $chasse_id);
         update_field('chasse_cache_statut_validation', 'valide', $chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
         mettre_a_jour_statuts_chasse($chasse_id);
 
         foreach ($enigmes as $eid) {
@@ -1918,6 +1919,7 @@ function traiter_validation_chasse_admin() {
         $cache['chasse_cache_statut_validation'] = 'correction';
         update_field('champs_caches', $cache, $chasse_id);
         update_field('chasse_cache_statut_validation', 'correction', $chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
 
         wp_update_post([
             'ID'          => $chasse_id,
@@ -1988,6 +1990,7 @@ function traiter_validation_chasse_admin() {
         $cache['chasse_cache_statut_validation'] = 'banni';
         update_field('champs_caches', $cache, $chasse_id);
         update_field('chasse_cache_statut_validation', 'banni', $chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
 
         foreach ($enigmes as $eid) {
             wp_update_post(['ID' => $eid, 'post_status' => 'draft']);

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -379,6 +379,7 @@ function gerer_chasse_terminee($chasse_id)
         // ✅ Marquer la chasse comme complète et terminée
         update_field('chasse_cache_complet', 1, $chasse_id);
         update_field('chasse_cache_statut', 'termine', $chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
     }
 
     foreach ($toutes_enigmes as $enigme_id) {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -199,6 +199,7 @@ function creer_chasse_et_rediriger_si_appel()
 
   update_field('chasse_cache_statut', 'revision', $post_id);
   update_field('chasse_cache_statut_validation', 'creation', $post_id);
+  function_exists('do_action') && do_action('litespeed_purge_post', $post_id);
   update_field('chasse_cache_organisateur', [$organisateur_id], $post_id);
 
   // 🚀 Redirection vers la prévisualisation frontale
@@ -527,6 +528,7 @@ function modifier_champ_chasse()
   if ($champ === 'champs_caches.chasse_cache_statut' && $valeur === 'termine') {
     $ok = update_field('chasse_cache_statut', 'termine', $post_id);
     if ($ok !== false) {
+      function_exists('do_action') && do_action('litespeed_purge_post', $post_id);
       // ✅ Marque la chasse comme complète sans déclencher de recalcul automatique
       update_field('chasse_cache_complet', 1, $post_id);
       $champ_valide = true;
@@ -590,7 +592,10 @@ function modifier_champ_chasse()
   // 🔹 Validation manuelle (par admin)
   if ($champ === 'champs_caches.chasse_cache_statut_validation' || $champ === 'chasse_cache_statut_validation') {
     $ok = update_field('chasse_cache_statut_validation', sanitize_text_field($valeur), $post_id);
-    if ($ok !== false) $champ_valide = true;
+    if ($ok !== false) {
+      function_exists('do_action') && do_action('litespeed_purge_post', $post_id);
+      $champ_valide = true;
+    }
   }
 
   // 🔹 Cas générique (fallback)

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -811,6 +811,7 @@ function verifier_ou_mettre_a_jour_cache_complet(int $post_id): void
             if ($cache !== $reel) {
                 update_field('chasse_cache_complet', $reel ? 1 : 0, $post_id);
                 chasse_clear_infos_affichage_cache($post_id);
+                function_exists('do_action') && do_action('litespeed_purge_post', $post_id);
             }
             break;
 
@@ -823,6 +824,7 @@ function verifier_ou_mettre_a_jour_cache_complet(int $post_id): void
                     $chasse_id = recuperer_id_chasse_associee($post_id);
                     if ($chasse_id) {
                         chasse_clear_infos_affichage_cache((int) $chasse_id);
+                        function_exists('do_action') && do_action('litespeed_purge_post', (int) $chasse_id);
                     }
                 }
             }
@@ -876,6 +878,7 @@ function verifier_ou_recalculer_statut_chasse($chasse_id): void
     if ($validation !== 'valide' && $statut !== 'revision') {
         mettre_a_jour_statuts_chasse($chasse_id);
         chasse_clear_infos_affichage_cache($chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
         return;
     }
 
@@ -884,6 +887,7 @@ function verifier_ou_recalculer_statut_chasse($chasse_id): void
     if (!in_array($statut, $statuts_valides, true)) {
         mettre_a_jour_statuts_chasse($chasse_id);
         chasse_clear_infos_affichage_cache($chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
         return;
     }
 
@@ -898,6 +902,7 @@ function verifier_ou_recalculer_statut_chasse($chasse_id): void
     if ($statut !== 'termine' && $date_fin && $date_fin < $now) {
         mettre_a_jour_statuts_chasse($chasse_id);
         chasse_clear_infos_affichage_cache($chasse_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
     }
 }
 
@@ -979,6 +984,7 @@ function mettre_a_jour_statuts_chasse($chasse_id)
 
     mettre_a_jour_statuts_enigmes_de_la_chasse($chasse_id, $statut);
     chasse_clear_infos_affichage_cache($chasse_id);
+    function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
 }
 
 
@@ -1111,6 +1117,7 @@ function forcer_statut_apres_acf($post_id, $nouvelle_validation = null)
 
     if ($nouvelle_validation !== null) {
         update_field('chasse_cache_statut_validation', sanitize_text_field($nouvelle_validation), $post_id);
+        function_exists('do_action') && do_action('litespeed_purge_post', $post_id);
         $validation = sanitize_text_field($nouvelle_validation);
     }
 

--- a/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
+++ b/wp-content/themes/chassesautresor/templates/page-traitement-validation-chasse.php
@@ -38,6 +38,7 @@ forcer_statut_apres_acf($chasse_id, 'en_attente');
 
 // Met à jour le statut métier pour refléter l'attente de validation
 update_field('chasse_cache_statut', 'en_attente', $chasse_id);
+function_exists('do_action') && do_action('litespeed_purge_post', $chasse_id);
 
 myaccount_clear_correction_message($chasse_id);
 


### PR DESCRIPTION
## Résumé
- Purge le cache LiteSpeed après les mises à jour de statut des chasses
- Étend la purge aux modules administratifs et d’édition lors des changements de statut ou de validation

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ba73bbdb78833283691030e8c6779c