### PR TITLE
Affiche un lien statistiques pour l’organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -697,6 +697,19 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             'type'        => 'edition',
         ];
     }
+
+    if ($is_orga && $statut === 'en_cours' && $validation === 'valide') {
+        return [
+            'cta_html'    => sprintf(
+                '<a href="%s" class="bouton-secondaire">%s</a>',
+                esc_url(admin_url('post.php?post=' . $chasse_id . '&action=edit&tab=statistiques')),
+                esc_html__('Statistiques', 'chassesautresor-com')
+            ),
+            'cta_message' => '',
+            'type'        => 'statistiques',
+        ];
+    }
+
     if ($is_admin || $is_orga) {
         return [
             'cta_html'    => sprintf(


### PR DESCRIPTION
### Résumé
- Affiche un bouton **Statistiques** pour l'organisateur quand la chasse est en cours et validée

### Changements notables
- Ajout d'une condition ciblant les organisateurs pour accéder aux statistiques de leur chasse

### Tests
- `source ./setup-env.sh && composer install && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bacd6c727083328fae77e4ec43e336