### PR TITLE
Add cache-busting timestamp to puzzle creation URL

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -21,7 +21,15 @@ $use_button      = $args['use_button'] ?? false;
 
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
-$ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-enigme/')));
+$ajout_url = esc_url(
+    add_query_arg(
+        [
+            'chasse_id' => $chasse_id,
+            'ts'        => time(),
+        ],
+        home_url('/creer-enigme/')
+    )
+);
 
 if ($use_button) : ?>
 <div class="enigme-navigation__ajout">


### PR DESCRIPTION
Ajout d'un timestamp unique à l'URL de création d'énigme afin d'éviter la réutilisation de redirections mises en cache.

- Ajout du paramètre `ts` lors de la génération de `$ajout_url`.

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bad8c2dc488332ae8b18c0864f8465