### PR TITLE
Ajout du mode carte pour l'affichage des chasses

### DIFF
--- a/docs/affichage-chasses.md
+++ b/docs/affichage-chasses.md
@@ -1,0 +1,36 @@
+# Affichage des chasses
+
+Le partiel `template-parts/chasse/boucle-chasses.php` permet d'afficher une liste de chasses.
+
+## Mode « carte »
+
+Passer l'argument `mode` à `carte` génère des cartes compactes disposées dans une grille adaptative (`cards-grid`).
+
+### Exemple basique
+
+```php
+get_template_part(
+    'template-parts/chasse/boucle-chasses',
+    null,
+    [
+        'chasse_ids' => [1, 2, 3],
+        'mode'       => 'carte',
+    ]
+);
+```
+
+### Personnalisation de la grille
+
+La classe de grille par défaut est `cards-grid`. On peut la remplacer ou l'étendre via l'argument `grid_class` :
+
+```php
+get_template_part(
+    'template-parts/chasse/boucle-chasses',
+    null,
+    [
+        'chasse_ids' => [1, 2, 3],
+        'mode'       => 'carte',
+        'grid_class' => 'cards-grid ma-grille-personnalisee',
+    ]
+);
+```

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -25,11 +25,54 @@
   gap: var(--space-xl);
 }
 
+// Grille responsive pour cartes
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: var(--space-4xl);
   justify-content: center;
+}
+
+/* ========== 🃏 Carte compacte ========== */
+.carte-compact {
+  padding: 0;
+  overflow: hidden;
+
+  .carte-compact__lien {
+    display: flex;
+    flex-direction: column;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .carte-compact__image-wrapper {
+    position: relative;
+  }
+
+  .carte-compact__image {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    display: block;
+  }
+
+  .badge-statut {
+    position: absolute;
+    top: var(--space-xs);
+    left: var(--space-xs);
+  }
+
+  .carte-compact__contenu {
+    padding: var(--space-md);
+  }
+
+  .carte-compact__titre {
+    margin: 0 0 var(--space-xs);
+  }
+
+  .carte-compact__meta {
+    font-size: 0.875rem;
+  }
 }
 
 /* ========== 🎴 Cartes d\'énigme et de chasse ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -28,9 +28,45 @@
 
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: var(--space-4xl);
   justify-content: center;
+}
+
+/* ========== 🃏 Carte compacte ========== */
+.carte-compact {
+  padding: 0;
+  overflow: hidden;
+}
+.carte-compact .carte-compact__lien {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+}
+.carte-compact .carte-compact__image-wrapper {
+  position: relative;
+}
+.carte-compact .carte-compact__image {
+  width: 100%;
+  aspect-ratio: 4/3;
+  -o-object-fit: cover;
+     object-fit: cover;
+  display: block;
+}
+.carte-compact .badge-statut {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+}
+.carte-compact .carte-compact__contenu {
+  padding: var(--space-md);
+}
+.carte-compact .carte-compact__titre {
+  margin: 0 0 var(--space-xs);
+}
+.carte-compact .carte-compact__meta {
+  font-size: 0.875rem;
 }
 
 /* ========== 🎴 Cartes d\'énigme et de chasse ========== */

--- a/wp-content/themes/chassesautresor/template-parts/chasse/boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/boucle-chasses.php
@@ -3,7 +3,8 @@ defined('ABSPATH') || exit;
 
 $show_header  = $args['show_header'] ?? true;
 $header_text  = $args['header_text'] ?? __('Chasses', 'chassesautresor-com');
-$grid_class   = $args['grid_class'] ?? 'grille-liste';
+$mode         = $args['mode'] ?? 'liste';
+$grid_class   = $args['grid_class'] ?? ($mode === 'carte' ? 'cards-grid' : 'grille-liste');
 $before_items = $args['before_items'] ?? '';
 $after_items  = $args['after_items'] ?? '';
 $query        = $args['query'] ?? null;
@@ -36,10 +37,18 @@ $chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use (
 <?php echo $before_items; ?>
   <?php foreach ($chasse_ids as $chasse_id) : ?>
     <?php
-    $chasse_id      = (int) $chasse_id;
-    $est_orga       = est_organisateur();
-    $wp_status      = get_post_status($chasse_id);
-    $voir_bordure   = $est_orga &&
+    $chasse_id = (int) $chasse_id;
+
+    if ('carte' === $mode) {
+        get_template_part('template-parts/chasse/chasse-card-compact', null, [
+            'chasse_id' => $chasse_id,
+        ]);
+        continue;
+    }
+
+    $est_orga     = est_organisateur();
+    $wp_status    = get_post_status($chasse_id);
+    $voir_bordure = $est_orga &&
       utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id) &&
       $wp_status !== 'publish';
     $classe_completion = '';

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -1,0 +1,41 @@
+<?php
+defined('ABSPATH') || exit;
+
+if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id = (int) $args['chasse_id'];
+$infos     = preparer_infos_affichage_carte_chasse($chasse_id);
+
+if (empty($infos)) {
+    return;
+}
+?>
+<div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
+    <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-compact__lien">
+        <div class="carte-compact__image-wrapper">
+            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+                <?php echo esc_html($infos['statut_label']); ?>
+            </span>
+            <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-compact__image">
+        </div>
+        <div class="carte-compact__contenu">
+            <h3 class="carte-compact__titre"><?php echo esc_html($infos['titre']); ?></h3>
+            <div class="carte-compact__meta meta-row svg-xsmall">
+                <div class="meta-regular">
+                    <?php echo get_svg_icon('enigme'); ?>
+                    <?php
+                    echo esc_html(
+                        sprintf(
+                            _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                            $infos['total_enigmes']
+                        )
+                    );
+                    ?> —
+                    <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+                </div>
+            </div>
+        </div>
+    </a>
+</div>


### PR DESCRIPTION
## Résumé
- Ajout d'un modèle `chasse-card-compact` pour afficher les chasses en cartes 4/3.
- `boucle-chasses` gère désormais un mode `carte` avec surcharge possible de la classe de grille.
- Styles SCSS et CSS mis à jour pour les nouvelles cartes et la grille.

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68bba25a82a88332a1a4c617f86a9466