### PR TITLE
Ajoute gabarit de chasse mise en avant

### DIFF
--- a/docs/affichage-chasses.md
+++ b/docs/affichage-chasses.md
@@ -34,3 +34,30 @@ get_template_part(
     ]
 );
 ```
+
+## Mode « à la une »
+
+Ce mode affiche une chasse mise en avant avec une image pleine largeur et un bouton d'appel à l'action.
+
+### Exemple avec `WP_Query`
+
+```php
+$query = new WP_Query([
+    'post_type'      => 'chasse',
+    'posts_per_page' => 1,
+    'meta_key'       => 'chasse_en_avant',
+    'meta_value'     => 1,
+]);
+
+get_template_part(
+    'template-parts/chasse/boucle-chasses',
+    null,
+    [
+        'query'           => $query,
+        'mode'            => 'a_la_une',
+        'highlight_label' => __('À la une', 'chassesautresor-com'),
+    ]
+);
+```
+
+Le `grid_class` par défaut est `grille-liste`, mais on peut le modifier via l'argument `grid_class`.

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -75,6 +75,45 @@
   }
 }
 
+/* ========== 🌟 Carte mise en avant ========== */
+.carte-featured {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+
+  .carte-featured__label {
+    position: absolute;
+    top: var(--space-xs);
+    left: var(--space-xs);
+    background: var(--color-accent);
+    color: var(--color-text-primary);
+    padding: var(--space-xxs) var(--space-xs);
+    border-radius: 4px;
+    font-size: 0.875rem;
+  }
+
+  .carte-featured__image {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    display: block;
+  }
+
+  .carte-featured__content {
+    padding: var(--space-md);
+  }
+
+  .carte-featured__title {
+    margin: 0 0 var(--space-xs);
+  }
+
+  .carte-featured__excerpt {
+    margin: 0 0 var(--space-md);
+  }
+}
+
 /* ========== 🎴 Cartes d\'énigme et de chasse ========== */
 .carte-enigme {
   background: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/boucle-chasses.php
@@ -1,14 +1,15 @@
 <?php
 defined('ABSPATH') || exit;
 
-$show_header  = $args['show_header'] ?? true;
-$header_text  = $args['header_text'] ?? __('Chasses', 'chassesautresor-com');
-$mode         = $args['mode'] ?? 'liste';
-$grid_class   = $args['grid_class'] ?? ($mode === 'carte' ? 'cards-grid' : 'grille-liste');
-$before_items = $args['before_items'] ?? '';
-$after_items  = $args['after_items'] ?? '';
-$query        = $args['query'] ?? null;
-$chasse_ids   = $args['chasse_ids'] ?? null;
+$show_header    = $args['show_header'] ?? true;
+$header_text    = $args['header_text'] ?? __('Chasses', 'chassesautresor-com');
+$mode           = $args['mode'] ?? 'liste';
+$grid_class     = $args['grid_class'] ?? ($mode === 'carte' ? 'cards-grid' : 'grille-liste');
+$before_items   = $args['before_items'] ?? '';
+$after_items    = $args['after_items'] ?? '';
+$query          = $args['query'] ?? null;
+$chasse_ids     = $args['chasse_ids'] ?? null;
+$highlight_label = $args['highlight_label'] ?? '';
 
 if ($query instanceof WP_Query) {
     $chasse_ids = array_map(
@@ -42,6 +43,14 @@ $chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use (
     if ('carte' === $mode) {
         get_template_part('template-parts/chasse/chasse-card-compact', null, [
             'chasse_id' => $chasse_id,
+        ]);
+        continue;
+    }
+
+    if ('a_la_une' === $mode) {
+        get_template_part('template-parts/chasse/chasse-featured', null, [
+            'chasse_id'       => $chasse_id,
+            'highlight_label' => $highlight_label,
         ]);
         continue;
     }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-featured.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-featured.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Template part for displaying a featured chasse card.
+ *
+ * @package ChassesAuTresor
+ */
+
+defined('ABSPATH') || exit;
+
+if (empty($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id       = (int) $args['chasse_id'];
+$highlight_label = $args['highlight_label'] ?? '';
+
+$title     = get_the_title($chasse_id);
+$permalink = get_permalink($chasse_id);
+
+$description = get_field('chasse_principale_description', $chasse_id);
+$excerpt     = wp_trim_words(wp_strip_all_tags($description), 25, '…');
+
+$image = get_the_post_thumbnail_url($chasse_id, 'large');
+if (!$image) {
+    $image = get_the_post_thumbnail_url($chasse_id, 'full');
+}
+?>
+
+<div class="carte carte-featured">
+    <?php if (!empty($highlight_label)) : ?>
+        <span class="carte-featured__label"><?php echo esc_html($highlight_label); ?></span>
+    <?php endif; ?>
+
+    <?php if ($image) : ?>
+        <img class="carte-featured__image" src="<?php echo esc_url($image); ?>" alt="<?php echo esc_attr($title); ?>">
+    <?php endif; ?>
+
+    <div class="carte-featured__content">
+        <h3 class="carte-featured__title">
+            <a href="<?php echo esc_url($permalink); ?>"><?php echo esc_html($title); ?></a>
+        </h3>
+        <p class="carte-featured__excerpt"><?php echo esc_html($excerpt); ?></p>
+        <a href="<?php echo esc_url($permalink); ?>" class="bouton-secondaire carte-featured__cta"><?php echo esc_html__('Découvrir', 'chassesautresor-com'); ?></a>
+    </div>
+</div>


### PR DESCRIPTION
## Résumé
- ajoute le template `chasse-featured` pour afficher une chasse à la une
- permet à `boucle-chasses` de rendre ce template via le mode `a_la_une`
- ajoute les styles et la documentation associés

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bba4208d848332a1778fd3491a5a0f