### PR TITLE
Use placeholder constant for puzzle image

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -215,7 +215,7 @@ function get_image_enigme(int $post_id, string $size = 'medium'): ?string
     }
 
     // 🧩 Placeholder image : image statique ou ID définie par toi
-    return wp_get_attachment_image_url(3925, $size);
+    return wp_get_attachment_image_url(ID_IMAGE_PLACEHOLDER_ENIGME, $size);
 }
 
 


### PR DESCRIPTION
Remplace l'identifiant d'image fixe par la constante dédiée pour le placeholder des énigmes.

- utilise `ID_IMAGE_PLACEHOLDER_ENIGME` dans `get_image_enigme()`

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bba73e2ae0833283d65b1b7523a4e7