### PR TITLE
feat: afficher une icône de validation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -585,8 +585,29 @@
   }
 }
 
+.validation-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--color-editor-success);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+}
+
+@media (--bp-tablet) {
+  .validation-icon {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+}
+
 @media (--bp-desktop) {
-  .settings-icon {
+  .settings-icon,
+  .validation-icon {
     width: 32px;
     height: 32px;
     font-size: 1.125rem;

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -592,7 +592,7 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: var(--color-editor-success);
+  background-color: var(--color-success);
   color: var(--color-text-primary);
   font-size: 0.875rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -568,7 +568,7 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: var(--color-editor-success);
+  background-color: var(--color-success);
   color: var(--color-text-primary);
   font-size: 0.875rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -69,6 +69,41 @@
   font-size: 0.875rem;
 }
 
+/* ========== 🌟 Carte mise en avant ========== */
+.carte-featured {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.carte-featured .carte-featured__label {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+  background: var(--color-accent);
+  color: var(--color-text-primary);
+  padding: var(--space-xxs) var(--space-xs);
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+.carte-featured .carte-featured__image {
+  width: 100%;
+  aspect-ratio: 16/9;
+  -o-object-fit: cover;
+     object-fit: cover;
+  display: block;
+}
+.carte-featured .carte-featured__content {
+  padding: var(--space-md);
+}
+.carte-featured .carte-featured__title {
+  margin: 0 0 var(--space-xs);
+}
+.carte-featured .carte-featured__excerpt {
+  margin: 0 0 var(--space-md);
+}
+
 /* ========== 🎴 Cartes d\'énigme et de chasse ========== */
 .carte-enigme {
   background: var(--color-text-primary);
@@ -526,8 +561,28 @@
     font-size: 1rem;
   }
 }
+.validation-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--color-editor-success);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+}
+
+@media (min-width: 768px) {
+  .validation-icon {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+}
 @media (min-width: 1024px) {
-  .settings-icon {
+  .settings-icon,
+  .validation-icon {
     width: 32px;
     height: 32px;
     font-size: 1.125rem;

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -92,6 +92,11 @@ if (!function_exists('compter_tentatives_du_jour') || !function_exists('compter_
         ? sprintf(__('Ouvrir l\'énigme — %s', 'chassesautresor-com'), $cta['label'])
         : '';
       $statut_utilisateur = $cta['statut_utilisateur'] ?? '';
+      $afficher_validation = in_array(
+        $statut_utilisateur,
+        ['resolue', 'terminee'],
+        true
+      );
       $classes_bouton = in_array(
         $statut_utilisateur,
         ['non_commencee', 'echouee', 'abandonnee', 'soumis'],
@@ -267,8 +272,13 @@ if (!function_exists('compter_tentatives_du_jour') || !function_exists('compter_
               'tab'     => $tab,
             ], get_permalink($enigme_id));
             ?>
-            <?php if ($classe_completion === 'carte-incomplete' || $can_edit) : ?>
+            <?php if ($classe_completion === 'carte-incomplete' || $can_edit || $afficher_validation) : ?>
               <div class="carte-icons">
+                <?php if ($afficher_validation) : ?>
+                  <span class="validation-icon" aria-label="<?= esc_attr__('Énigme résolue', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme résolue', 'chassesautresor-com'); ?>">
+                    <i class="fa-solid fa-check" aria-hidden="true"></i>
+                  </span>
+                <?php endif; ?>
                 <?php if ($classe_completion === 'carte-incomplete') : ?>
                   <span class="warning-icon" aria-label="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>" title="<?= esc_attr__('Énigme incomplète', 'chassesautresor-com'); ?>">
                     <i class="fa-solid fa-exclamation" aria-hidden="true"></i>


### PR DESCRIPTION
## Résumé
Ajout d'une icône de validation pour les énigmes résolues ou terminées.

## Changements
- Détection des statuts `resolue` et `terminee` dans la boucle d'énigmes
- Affichage d'une icône de validation dans la carte correspondante
- Ajout de la classe `.validation-icon` et recompilation des styles

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bba76327bc833283e63a894f1440d7