### PR TITLE
Fix puzzle cards hidden after hunt completion

### DIFF
--- a/tests/ChasseTermineeEnigmesVisibilityTest.php
+++ b/tests/ChasseTermineeEnigmesVisibilityTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+class ChasseTermineeEnigmesVisibilityTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_affiche_enigmes_pour_chasse_terminee(): void
+    {
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) {
+                return $id === 1 ? 'chasse' : '';
+            }
+        }
+        if (!function_exists('get_current_user_id')) {
+            function get_current_user_id() {
+                return 0;
+            }
+        }
+        if (!function_exists('chasse_est_visible_pour_utilisateur')) {
+            function chasse_est_visible_pour_utilisateur($chasse_id, $user_id) {
+                return true;
+            }
+        }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) {
+                return false;
+            }
+        }
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $capability) {
+                return false;
+            }
+        }
+        if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+            function utilisateur_est_engage_dans_chasse($user_id, $chasse_id) {
+                return false;
+            }
+        }
+        if (!function_exists('preparer_infos_affichage_chasse')) {
+            function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): array {
+                return [
+                    'statut'            => 'termine',
+                    'statut_validation' => 'valide',
+                    'enigmes_associees' => [],
+                ];
+            }
+        }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) {
+                return [];
+            }
+        }
+        if (!function_exists('est_organisateur')) {
+            function est_organisateur() {
+                return false;
+            }
+        }
+        if (!function_exists('get_post_status')) {
+            function get_post_status($id) {
+                return 'publish';
+            }
+        }
+        if (!function_exists('utilisateur_peut_ajouter_enigme')) {
+            function utilisateur_peut_ajouter_enigme($chasse_id, $user_id) {
+                return false;
+            }
+        }
+        if (!function_exists('enigme_compter_joueurs_engages')) {
+            function enigme_compter_joueurs_engages($id) {
+                return 0;
+            }
+        }
+        if (!function_exists('compter_tentatives_du_jour')) {
+            function compter_tentatives_du_jour($user_id, $enigme_id) {
+                return 0;
+            }
+        }
+        if (!function_exists('compter_tentatives_en_attente')) {
+            function compter_tentatives_en_attente($user_id, $enigme_id) {
+                return 0;
+            }
+        }
+        if (!function_exists('get_stylesheet_directory')) {
+            function get_stylesheet_directory() {
+                return __DIR__ . '/../wp-content/themes/chassesautresor';
+            }
+        }
+        if (!function_exists('esc_attr')) {
+            function esc_attr($text) {
+                return $text;
+            }
+        }
+        if (!function_exists('esc_html')) {
+            function esc_html($text) {
+                return $text;
+            }
+        }
+
+        $args = [
+            'chasse_id' => 1,
+        ];
+
+        ob_start();
+        require __DIR__ . '/../wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php';
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('cards-grid', $output);
+    }
+}
+

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -19,13 +19,17 @@ if (!chasse_est_visible_pour_utilisateur($chasse_id, $utilisateur_id)) return;
 
 $est_orga_associe = $args['est_orga_associe'] ?? utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
 $show_help_icon  = $args['show_help_icon'] ?? false;
+$statut_metier   = $infos_chasse['statut'] ?? 'revision';
 
 $autorise_boucle = (
-  user_can($utilisateur_id, 'manage_options') ||
-  $est_orga_associe ||
-  utilisateur_est_engage_dans_chasse($utilisateur_id, $chasse_id)
+    user_can($utilisateur_id, 'manage_options') ||
+    $est_orga_associe ||
+    utilisateur_est_engage_dans_chasse($utilisateur_id, $chasse_id) ||
+    $statut_metier === 'termine'
 );
-if (!$autorise_boucle) return;
+if (!$autorise_boucle) {
+    return;
+}
 
 $est_joueur_engage = utilisateur_est_engage_dans_chasse($utilisateur_id, $chasse_id);
 


### PR DESCRIPTION
## Résumé
- Affiche les cartes d'énigmes même lorsque la chasse est terminée
- Ajoute un test unitaire pour garantir l'accès aux énigmes d'une chasse terminée

## Détails
- Autorise la boucle des énigmes si la chasse a le statut `termine`
- Vérifie que l'affichage des cartes contient bien la grille attendue

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbb5819d9883328b64b86abec6967b