### PR TITLE
Visuels accessibles après fin de chasse

### DIFF
--- a/tests/TrouverCheminImageFullTest.php
+++ b/tests/TrouverCheminImageFullTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+class TrouverCheminImageFullTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_full_size_returns_existing_path(): void
+    {
+        global $uploadDir, $capturedSize;
+
+        $uploadDir = sys_get_temp_dir() . '/uploads';
+        if (!is_dir($uploadDir)) {
+            mkdir($uploadDir, 0777, true);
+        }
+        $filePath = $uploadDir . '/image.jpg';
+        file_put_contents($filePath, 'test');
+
+        $capturedSize = null;
+
+        if (!function_exists('wp_get_attachment_image_src')) {
+            function wp_get_attachment_image_src($id, $size)
+            {
+                global $capturedSize;
+                $capturedSize = $size;
+                return ['http://example.com/uploads/image.jpg', 100, 100];
+            }
+        }
+
+        if (!function_exists('wp_get_upload_dir')) {
+            function wp_get_upload_dir()
+            {
+                global $uploadDir;
+                return [
+                    'baseurl' => 'http://example.com/uploads',
+                    'basedir' => $uploadDir,
+                ];
+            }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/visuels.php';
+
+        $result = trouver_chemin_image(1, 'full');
+
+        $this->assertSame($filePath, $result['path']);
+        $this->assertSame('full', $capturedSize);
+    }
+}

--- a/tests/UtilisateurPeutVoirEnigmeChasseTermineeTest.php
+++ b/tests/UtilisateurPeutVoirEnigmeChasseTermineeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+class UtilisateurPeutVoirEnigmeChasseTermineeTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_visuels_accessibles_apres_chasse_terminee(): void
+    {
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id)
+            {
+                return 'enigme';
+            }
+        }
+        if (!function_exists('get_post_status')) {
+            function get_post_status($id)
+            {
+                return 'publish';
+            }
+        }
+        if (!function_exists('get_current_user_id')) {
+            function get_current_user_id()
+            {
+                return 0;
+            }
+        }
+        if (!function_exists('current_user_can')) {
+            function current_user_can($capability)
+            {
+                return false;
+            }
+        }
+        if (!function_exists('recuperer_id_chasse_associee')) {
+            function recuperer_id_chasse_associee($enigme_id)
+            {
+                return 10;
+            }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($field, $post_id = null, $format_value = true)
+            {
+                if ($field === 'chasse_cache_statut' && $post_id === 10) {
+                    return 'termine';
+                }
+                if ($field === 'enigme_cache_etat_systeme') {
+                    return 'terminee';
+                }
+                return null;
+            }
+        }
+        if (!function_exists('cat_debug')) {
+            function cat_debug($message)
+            {
+                // noop for tests
+            }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
+
+        $this->assertTrue(utilisateur_peut_voir_enigme(42, null));
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -500,6 +500,13 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
         return false;
     }
 
+    // 🏁 Chasse terminée : visuels accessibles à tous
+    $chasse_terminee = get_field('chasse_cache_statut', $chasse_id) === 'termine';
+    if ($chasse_terminee && $post_status === 'publish') {
+        cat_debug("🟢 [voir énigme] chasse #$chasse_id terminée → accès public");
+        return true;
+    }
+
     // ✅ Abonné engagé dans la chasse → peut voir l’image si énigme accessible
     if (utilisateur_est_engage_dans_chasse($user_id, $chasse_id)) {
         $autorise = ($post_status === 'publish') && ($etat_systeme === 'accessible');

--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -300,7 +300,7 @@ function afficher_picture_vignette_enigme(int $enigme_id, string $alt = '', arra
  */
 function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
 {
-    $wp_size = $taille === 'full' ? [1920, 1920] : $taille;
+    $wp_size = $taille === 'full' ? 'full' : $taille;
     $src     = wp_get_attachment_image_src($image_id, $wp_size);
     $url = $src[0] ?? null;
     if (!$url) return null;

--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -13,7 +13,7 @@ if (!function_exists('trouver_chemin_image')) {
     require_once get_stylesheet_directory() . '/inc/enigme-functions.php';
 }
 if (!function_exists('utilisateur_peut_voir_enigme')) {
-    require_once get_stylesheet_directory() . '/inc/statut-functions.php';
+    require_once get_stylesheet_directory() . '/inc/access-functions.php';
 }
 
 // 🧩 Récupération de l'énigme associée à cette image


### PR DESCRIPTION
## Résumé
- Autorise l'affichage des visuels d'énigmes lorsque la chasse associée est terminée
- Ajoute un test couvrant l'accès aux visuels après la clôture d'une chasse

## Modifications notables
- Ouverture des images via `utilisateur_peut_voir_enigme` pour les chasses terminées
- Test unitaire garantissant l'accès public aux visuels une fois la chasse achevée

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbb7b924348332a80acc2fbd112282