### PR TITLE
Limite la largeur des cartes énigme dans la grille de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -31,6 +31,12 @@
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: var(--space-4xl);
   justify-content: center;
+
+  .carte-enigme {
+    width: 100%;
+    max-width: 400px;
+    margin: 0 auto;
+  }
 }
 
 /* ========== 🃏 Carte compacte ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -32,6 +32,11 @@
   gap: var(--space-4xl);
   justify-content: center;
 }
+.cards-grid .carte-enigme {
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+}
 
 /* ========== 🃏 Carte compacte ========== */
 .carte-compact {
@@ -67,6 +72,41 @@
 }
 .carte-compact .carte-compact__meta {
   font-size: 0.875rem;
+}
+
+/* ========== 🌟 Carte mise en avant ========== */
+.carte-featured {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.carte-featured .carte-featured__label {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+  background: var(--color-accent);
+  color: var(--color-text-primary);
+  padding: var(--space-xxs) var(--space-xs);
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+.carte-featured .carte-featured__image {
+  width: 100%;
+  aspect-ratio: 16/9;
+  -o-object-fit: cover;
+     object-fit: cover;
+  display: block;
+}
+.carte-featured .carte-featured__content {
+  padding: var(--space-md);
+}
+.carte-featured .carte-featured__title {
+  margin: 0 0 var(--space-xs);
+}
+.carte-featured .carte-featured__excerpt {
+  margin: 0 0 var(--space-md);
 }
 
 /* ========== 🎴 Cartes d\'énigme et de chasse ========== */


### PR DESCRIPTION
## Résumé
- Ajout d'une largeur maximale aux cartes énigme pour éviter l'affichage pleine largeur lorsqu'une seule carte est présente
- Recompilation du CSS du thème

## Changements notables
- Limitation à 400px de la largeur des cartes énigme dans la grille

## Tests
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68bbb95f111c83328a7cda31e5b680c4