### PR TITLE
Assure un fallback pour la taille 1920 des visuels d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -300,13 +300,34 @@ function afficher_picture_vignette_enigme(int $enigme_id, string $alt = '', arra
  */
 function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
 {
-    $wp_size = $taille === 'full' ? [1920, 1920] : $taille;
-    $src     = wp_get_attachment_image_src($image_id, $wp_size);
-    $url = $src[0] ?? null;
-    if (!$url) return null;
-
     $upload_dir = wp_get_upload_dir();
-    $path = str_replace($upload_dir['baseurl'], $upload_dir['basedir'], $url);
+
+    if ($taille === 'full') {
+        $src = wp_get_attachment_image_src($image_id, [1920, 1920]);
+        $url = $src[0] ?? null;
+        if ($url) {
+            $path = str_replace($upload_dir['baseurl'], $upload_dir['basedir'], $url);
+            if (!file_exists($path)) {
+                $url = null;
+            }
+        }
+
+        if (!$url) {
+            $src = wp_get_attachment_image_src($image_id, 'full');
+            $url = $src[0] ?? wp_get_attachment_url($image_id);
+            if (!$url) {
+                return null;
+            }
+            $path = str_replace($upload_dir['baseurl'], $upload_dir['basedir'], $url);
+        }
+    } else {
+        $src = wp_get_attachment_image_src($image_id, $taille);
+        $url = $src[0] ?? null;
+        if (!$url) {
+            return null;
+        }
+        $path = str_replace($upload_dir['baseurl'], $upload_dir['basedir'], $url);
+    }
 
     // 🔁 Si une version .webp existe, on la préfère
     $webp_path = preg_replace('/\.(jpe?g|png|gif)$/i', '.webp', $path);

--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -315,13 +315,12 @@ function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
         }
 
         if (!$path) {
-            $src = wp_get_attachment_image_src($image_id, 'full');
-            $url = $src[0] ?? wp_get_attachment_url($image_id);
-            if ($url) {
-                $candidate = str_replace($upload_dir['baseurl'], $upload_dir['basedir'], $url);
-                if (file_exists($candidate)) {
-                    $path = $candidate;
-                }
+            $candidate = wp_get_original_image_path($image_id);
+            if (!$candidate) {
+                $candidate = get_attached_file($image_id);
+            }
+            if ($candidate && file_exists($candidate)) {
+                $path = $candidate;
             }
         }
 


### PR DESCRIPTION
## Résumé
- gère l'absence de fichier 1920x1920 dans `trouver_chemin_image`
- conserve la détection de version WebP

## Changements notables
- Tentative de récupération de l'image 1920x1920 puis repli vers `full` ou l'URL de la pièce jointe
- Maintien de la vérification et de la préférence pour les images WebP

## Testing
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`
- `curl -I http://localhost/voir-image-enigme?id=1&taille=full` *(échec : connexion refusée)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc1897a888332afb329518348db2d