### PR TITLE
Fix reset stats activation form

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -865,8 +865,9 @@ function ajouter_bouton_reinitialisation_stats() {
         <h2>Réinitialisation des Statistiques</h2>
         <p>⚠️ <strong>Attention :</strong> Cette action est irréversible. Toutes les statistiques des joueurs, énigmes et chasses seront supprimées.</p>
 
-        <form method="post">
-            <?php wp_nonce_field('reset_stats_action', 'reset_stats_nonce'); ?>
+        <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
+            <?php wp_nonce_field('toggle_reinit_stats_action', 'toggle_reinit_stats_nonce'); ?>
+            <input type="hidden" name="action" value="toggle_reinit_stats_action">
 
             <label>
                 <input type="checkbox" name="activer_reinit" value="1" <?php checked($reinit_active, true); ?>>


### PR DESCRIPTION
## Résumé
- Formulaire de bascule de réinitialisation envoyé via `admin-post.php` avec nonce dédié.

## Changements notables
- Ajout d’un champ caché `action` et d’un nonce `toggle_reinit_stats_action` pour sécuriser l’activation de la réinitialisation.
- Vérification de la lecture de `$_POST['activer_reinit']` pour mettre à jour l’option correspondante.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbc25349f883329f5cfdd2e2311f9e