### PR TITLE
Reset chasses terminées lors du reset des stats

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1408,6 +1408,25 @@ function cta_reset_stats() {
 
     $total_deleted += (int) $wpdb->rows_affected;
 
+    $chasses = get_posts([
+        'post_type'   => 'chasse',
+        'post_status' => 'any',
+        'meta_query'  => [
+            [
+                'key'   => 'chasse_cache_statut',
+                'value' => 'termine',
+            ],
+        ],
+        'fields'   => 'ids',
+        'nopaging' => true,
+    ]);
+
+    foreach ($chasses as $chasse_id) {
+        update_field('chasse_cache_statut', 'en_cours', $chasse_id);
+        delete_field('chasse_cache_gagnants', $chasse_id);
+        delete_field('chasse_cache_date_decouverte', $chasse_id);
+    }
+
     wp_send_json_success(['deleted' => $total_deleted]);
 }
 add_action('wp_ajax_cta_reset_stats', 'cta_reset_stats');

--- a/wp-content/themes/chassesautresor/tests/reset_stats_clears_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/reset_stats_clears_messages.test.php
@@ -37,6 +37,28 @@ if (!function_exists('delete_metadata')) {
     }
 }
 
+if (!function_exists('get_posts')) {
+    function get_posts($args = [])
+    {
+        $GLOBALS['get_posts_args'] = $args;
+        return [10];
+    }
+}
+
+if (!function_exists('update_field')) {
+    function update_field($field, $value, $post_id)
+    {
+        $GLOBALS['updated_fields'][] = [$field, $value, $post_id];
+    }
+}
+
+if (!function_exists('delete_field')) {
+    function delete_field($field, $post_id)
+    {
+        $GLOBALS['deleted_fields'][] = [$field, $post_id];
+    }
+}
+
 global $wpdb;
 $wpdb = new class {
     public $prefix = 'wp_';
@@ -58,6 +80,46 @@ class ResetStatsClearsMessagesTest extends TestCase
         $this->assertSame(
             ['user', 0, '_myaccount_messages', '', true],
             $GLOBALS['delete_metadata_args']
+        );
+    }
+
+    public function test_reset_stats_resets_chasse_fields(): void
+    {
+        $GLOBALS['updated_fields'] = [];
+        $GLOBALS['deleted_fields'] = [];
+        $_POST['nonce']            = 'dummy';
+
+        cta_reset_stats();
+
+        $this->assertSame(
+            [
+                'post_type'   => 'chasse',
+                'post_status' => 'any',
+                'meta_query'  => [
+                    [
+                        'key'   => 'chasse_cache_statut',
+                        'value' => 'termine',
+                    ],
+                ],
+                'fields'   => 'ids',
+                'nopaging' => true,
+            ],
+            $GLOBALS['get_posts_args']
+        );
+
+        $this->assertContains(
+            ['chasse_cache_statut', 'en_cours', 10],
+            $GLOBALS['updated_fields']
+        );
+
+        $this->assertContains(
+            ['chasse_cache_gagnants', 10],
+            $GLOBALS['deleted_fields']
+        );
+
+        $this->assertContains(
+            ['chasse_cache_date_decouverte', 10],
+            $GLOBALS['deleted_fields']
         );
     }
 }


### PR DESCRIPTION
## Résumé
- Réinitialise le statut et les informations de fin pour les chasses terminées lors du nettoyage des statistiques.

## Changements notables
- Changement de `chasse_cache_statut` à `en_cours` pour les chasses terminées
- Suppression des champs de gagnants et date de découverte des chasses terminées
- Tests unitaires couvrant la réinitialisation des chasses

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbc57382448332afef87a4c88335b1