### PR TITLE
CTA de réponse en rouge

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -188,7 +188,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
         <?= esc_html__('Ajouter des points', 'chassesautresor-com'); ?>
       </a>
     <?php else : ?>
-      <button type="submit" class="bouton-cta" <?= $disabled; ?>><?= $label_btn; ?></button>
+      <button type="submit" class="bouton-cta bouton-cta--color" <?= $disabled; ?>><?= $label_btn; ?></button>
     <?php endif; ?>
   </div>
   <?php if ($points_manquants <= 0 && $cout > 0) : ?>


### PR DESCRIPTION
## Résumé
Affiche le bouton de soumission de réponse des énigmes en rouge pour le rendre plus incitatif.

## Changements
- Ajout de la classe visuelle `bouton-cta--color` au bouton de validation des réponses

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbc76200fc833288c741cf7dc0f7cb