### PR TITLE
Fix dynamic subtitle preview for enigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -110,12 +110,8 @@ function initChampTexte(bloc) {
         }
 
         if (champ === 'enigme_visuel_legende') {
-          const legendeDOM =
-            document.querySelector('.enigme-soustitre') ||
-            document.querySelector('.enigme-legende');
-          if (legendeDOM) {
-            legendeDOM.textContent = brute;
-            legendeDOM.classList.add('modifiee');
+          if (typeof window.mettreAJourLegendeEnigme === 'function') {
+            window.mettreAJourLegendeEnigme(brute);
           }
         }
 
@@ -198,15 +194,8 @@ function initChampTexte(bloc) {
     }
 
     if (champ === 'enigme_visuel_legende') {
-      // Mise à jour dynamique du sous-titre affiché sous le titre de l'énigme.
-      // ​​Supporte à la fois l'ancien sélecteur `.enigme-legende` et
-      // le nouveau `.enigme-soustitre` utilisé dans les templates.
-      const legendeDOM =
-        document.querySelector('.enigme-soustitre') ||
-        document.querySelector('.enigme-legende');
-      if (legendeDOM) {
-        legendeDOM.textContent = valeur;
-        legendeDOM.classList.add('modifiee');
+      if (typeof window.mettreAJourLegendeEnigme === 'function') {
+        window.mettreAJourLegendeEnigme(valeur);
       }
     }
 

--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -114,9 +114,23 @@ window.mettreAJourTitreHeader = function (cpt, valeur) {
  * @param {string} valeur - La nouvelle légende à afficher
  */
 window.mettreAJourLegendeEnigme = function (valeur) {
-  const legende = document.querySelector('.enigme-soustitre');
-  if (legende) {
-    legende.textContent = valeur;
+  const texte = valeur?.trim() || '';
+  let legende =
+    document.querySelector('.enigme-soustitre') ||
+    document.querySelector('.enigme-legende');
+
+  if (texte) {
+    if (!legende) {
+      const header = document.querySelector('.enigme-header');
+      if (!header) return;
+      legende = document.createElement('p');
+      legende.className = 'enigme-soustitre';
+      header.appendChild(legende);
+    }
+    legende.textContent = texte;
+    legende.classList.add('modifiee');
+  } else if (legende) {
+    legende.remove();
   }
 };
 

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -266,8 +266,9 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt, extra) {
     ];
 
     if (champ === 'enigme_visuel_legende') {
-      const legende = document.querySelector('.enigme-soustitre');
-      if (legende) legende.textContent = valeur;
+      if (typeof window.mettreAJourLegendeEnigme === 'function') {
+        window.mettreAJourLegendeEnigme(valeur);
+      }
     }
 
     if (champ === 'enigme_reponse_bonne' && typeof window.forcerRecalculStatutEnigme === 'function') {


### PR DESCRIPTION
Corrige l'affichage dynamique du sous-titre lors de l'édition d'une énigme.

- Centralise la mise à jour du sous-titre dans un helper pouvant créer ou retirer l'élément
- Utilise ce helper lors de l'édition et dans le panneau de résumé

### Testing
- `source ./setup-env.sh && php -v`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd2eccb08332bf782d7ed547530c