### PR TITLE
Restore wp-login.php and move login branding to theme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/login.css
+++ b/wp-content/themes/chassesautresor/assets/css/login.css
@@ -14,12 +14,41 @@ body.login {
     background-color: var(--color-background);
     font-family: var(--font-main);
     color: var(--color-text-primary);
+    display: flex;
+    min-height: 100vh;
+    align-items: center;
+    justify-content: center;
 }
 
 body.login #login {
     width: 100%;
     max-width: 320px;
     padding: 1rem;
+}
+
+body.login h1.wp-login-logo {
+    display: none;
+}
+
+body.login .wp-login-logo {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 1rem;
+}
+
+body.login .wp-login-logo a {
+    display: block;
+    margin: 0 auto;
+}
+
+body.login .wp-login-logo img {
+    max-width: 80px;
+    height: auto;
+}
+
+body.login .login-title {
+    text-align: center;
+    margin-bottom: 1rem;
 }
 
 body.login #loginform,

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -354,6 +354,35 @@ function cta_enqueue_login_styles(): void
 }
 add_action( 'login_enqueue_scripts', 'cta_enqueue_login_styles' );
 
+/**
+ * Adds custom logo and title on the login page.
+ *
+ * @param string $message Existing login message.
+ * @return string
+ */
+function cta_login_branding( string $message ): string
+{
+    $action = isset( $_REQUEST['action'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) : '';
+
+    if ( 'confirm_admin_email' === $action ) {
+        return $message;
+    }
+
+    $custom_logo_id = get_theme_mod( 'custom_logo' );
+    $logo           = $custom_logo_id
+        ? wp_get_attachment_image( $custom_logo_id, 'full', false, [ 'alt' => get_bloginfo( 'name' ) ] )
+        : '';
+    $title          = get_bloginfo( 'name' );
+
+    $html  = '<div class="wp-login-logo"><a href="' . esc_url( home_url( '/' ) ) . '">';
+    $html .= $logo ? $logo : '<span class="screen-reader-text">' . esc_html( $title ) . '</span>';
+    $html .= '</a></div>';
+    $html .= '<h1 class="login-title">' . esc_html( $title ) . '</h1>';
+
+    return $html . $message;
+}
+add_filter( 'login_message', 'cta_login_branding' );
+
 // ----------------------------------------------------------
 // 📂 Chargement des fichiers fonctionnels organisés
 // ----------------------------------------------------------


### PR DESCRIPTION
## Summary
Restaure la page de connexion et déplace la personnalisation vers le thème.

## Changes
- Restauration du fichier `wp-login.php` sans CSS inline ni balisage custom.
- Ajout de styles pour centrer et styliser le formulaire de connexion.
- Injection du logo et du titre via un hook `login_message`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbcfa23ce8833284d1285c7b696d8c