### PR TITLE
Purge du cache d'affichage lors du reset des stats

### DIFF
--- a/wp-content/themes/chassesautresor/inc/admin-functions.php
+++ b/wp-content/themes/chassesautresor/inc/admin-functions.php
@@ -1425,6 +1425,7 @@ function cta_reset_stats() {
         update_field('chasse_cache_statut', 'en_cours', $chasse_id);
         delete_field('chasse_cache_gagnants', $chasse_id);
         delete_field('chasse_cache_date_decouverte', $chasse_id);
+        chasse_clear_infos_affichage_cache((int) $chasse_id);
     }
 
     wp_send_json_success(['deleted' => $total_deleted]);


### PR DESCRIPTION
## Résumé
- Invalidation du cache d'affichage des chasses lors de la remise à zéro des statistiques

## Changements notables
- Appel à `chasse_clear_infos_affichage_cache()` pour chaque chasse réinitialisée

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bbd0ebabf88332a5f95e6809236a8d