### PR TITLE
Supprimer le sélecteur de langue sur la page de connexion

### DIFF
--- a/wp-content/themes/chassesautresor/assets/css/login.css
+++ b/wp-content/themes/chassesautresor/assets/css/login.css
@@ -15,6 +15,7 @@ body.login {
     font-family: var(--font-main);
     color: var(--color-text-primary);
     display: flex;
+    flex-direction: column;
     min-height: 100vh;
     align-items: center;
     justify-content: center;

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -300,6 +300,17 @@ add_action('wp_enqueue_scripts', function () {
 }, 20);
 
 /**
+ * Disables the language dropdown on the login page.
+ *
+ * @return bool
+ */
+function cta_disable_login_language_dropdown(): bool
+{
+    return false;
+}
+add_filter('login_display_language_dropdown', 'cta_disable_login_language_dropdown');
+
+/**
  * Enqueues custom styles for the login page.
  *
  * @return void


### PR DESCRIPTION
## Résumé
- Masque le sélecteur de langue sur l'écran de connexion
- Centre le formulaire de connexion via le thème

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68bbd34963f88332a342ae7dd9034a38