### PR TITLE
Affichage du bandeau gagnant pour les chasses terminées

### DIFF
--- a/tests/js/validation-chasse.test.js
+++ b/tests/js/validation-chasse.test.js
@@ -8,6 +8,8 @@ const html = `
 </form>
 `;
 
+global.wp = { i18n: { __: (s) => s } };
+
 describe('validation chasse', () => {
   beforeEach(() => {
     jest.resetModules();

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse-gagnant.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse-gagnant.scss
@@ -1,0 +1,8 @@
+.chasse-gagnant-info {
+    background-color: #f6f9fd;
+    padding: 1rem;
+    border-left: 4px solid #3498db;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    font-weight: 600;
+}

--- a/wp-content/themes/chassesautresor/assets/scss/main.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/main.scss
@@ -1,5 +1,6 @@
 @import "cartes";
 @import "chasse";
+@import "chasse-gagnant";
 @import "commerce";
 @import "components";
 @import "skeleton";

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1017,6 +1017,15 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
     display: none;
   }
 }
+.chasse-gagnant-info {
+  background-color: #f6f9fd;
+  padding: 1rem;
+  border-left: 4px solid #3498db;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
 /* ========== 🛒 AJOUT AU PANIER ========== */
 .woocommerce a.button.add_to_cart_button {
   font-weight: 500;

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1510,6 +1510,11 @@ msgstr ""
 msgid "Nb gagnants"
 msgstr ""
 
+#: template-parts/chasse/chasse-affichage-complet.php:298
+#, php-format
+msgid "Chasse gagnée le %1$s par %2$s"
+msgstr ""
+
 #: template-parts/chasse/chasse-edition-main.php:449
 msgid "Illimité"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1505,6 +1505,11 @@ msgstr "Hunting won on %s by %s"
 msgid "Nb gagnants"
 msgstr "Number of winners"
 
+#: template-parts/chasse/chasse-affichage-complet.php:298
+#, php-format
+msgid "Chasse gagnée le %1$s par %2$s"
+msgstr "Hunt won on %1$s by %2$s"
+
 #: template-parts/chasse/chasse-edition-main.php:449
 msgid "Illimité"
 msgstr "Unlimited"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1523,6 +1523,11 @@ msgstr "Chasse gagnée le %s par %s"
 msgid "Nb gagnants"
 msgstr "Gagnants"
 
+#: template-parts/chasse/chasse-affichage-complet.php:298
+#, php-format
+msgid "Chasse gagnée le %1$s par %2$s"
+msgstr "Chasse gagnée le %1$s par %2$s"
+
 #: template-parts/chasse/chasse-edition-main.php:449
 msgid "Illimité"
 msgstr "Illimité"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -27,6 +27,7 @@ $cout_points       = (int) ($champs['cout_points'] ?? 0);
 
 // Champs cachés
 $date_decouverte      = $champs['date_decouverte'];
+$gagnants             = $champs['gagnants'];
 $current_stored_statut = $champs['current_stored_statut'];
 
 
@@ -47,10 +48,11 @@ $title_mode          = $mode_fin === 'automatique'
     : __('mode de fin de chasse : manuelle', 'chassesautresor-com');
 
 // Dates
-$date_debut_formatee = formater_date($date_debut);
-$date_fin_formatee   = $illimitee
+$date_debut_formatee        = formater_date($date_debut);
+$date_fin_formatee          = $illimitee
     ? __('Illimitée', 'chassesautresor-com')
     : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
+$date_decouverte_formatee   = $date_decouverte ? formater_date($date_decouverte) : '';
 
 $now        = current_time('timestamp');
 $date_label = '';
@@ -292,6 +294,12 @@ if ($edition_active && !$est_complet) {
         data-post-id="<?= esc_attr($chasse_id); ?>">
         <?= esc_html($titre); ?>
       </h1>
+
+      <?php if ($statut === 'termine' && !empty($date_decouverte) && !empty($gagnants)) : ?>
+        <div class="chasse-gagnant-info">
+          <?= sprintf(__('Chasse gagnée le %1$s par %2$s', 'chassesautresor-com'), esc_html($date_decouverte_formatee), esc_html($gagnants)); ?>
+        </div>
+      <?php endif; ?>
 
       <div class="meta-row svg-xsmall">
         <div class="meta-regular">

--- a/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
+++ b/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
@@ -1,0 +1,151 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ChasseGagnantInfoTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_displays_info_for_finished_chasse(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__);
+        }
+        if (!defined('DAY_IN_SECONDS')) {
+            define('DAY_IN_SECONDS', 86400);
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return 'chasse'; }
+        }
+        if (!function_exists('get_permalink')) {
+            function get_permalink($id) { return 'https://example.com/chasse/' . $id; }
+        }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($id) { return 'Ma Chasse'; }
+        }
+        if (!function_exists('formater_date')) {
+            function formater_date($date) { return $date; }
+        }
+        if (!function_exists('current_time')) {
+            function current_time($type) { return 0; }
+        }
+        if (!function_exists('utilisateur_peut_modifier_post')) {
+            function utilisateur_peut_modifier_post($id) { return false; }
+        }
+        if (!function_exists('chasse_est_complet')) {
+            function chasse_est_complet($id) { return false; }
+        }
+        if (!function_exists('get_organisateur_from_chasse')) {
+            function get_organisateur_from_chasse($id) { return null; }
+        }
+        if (!function_exists('get_the_author')) {
+            function get_the_author() { return 'Auteur'; }
+        }
+        if (!function_exists('current_user_can')) {
+            function current_user_can($cap) { return false; }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($field, $post_id) {
+                global $fields;
+                return $fields[$post_id][$field] ?? null;
+            }
+        }
+        if (!function_exists('render_liens_publics')) {
+            function render_liens_publics($liens, $type, $opts = []) { return ''; }
+        }
+        if (!function_exists('get_svg_icon')) {
+            function get_svg_icon($name) { return ''; }
+        }
+        if (!function_exists('esc_html__')) {
+            function esc_html__($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('__')) {
+            function __($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('_n')) {
+            function _n($single, $plural, $number, $domain = null) {
+                return $number === 1 ? $single : $plural;
+            }
+        }
+        if (!function_exists('esc_html')) {
+            function esc_html($text) { return $text; }
+        }
+        if (!function_exists('esc_attr')) {
+            function esc_attr($text) { return $text; }
+        }
+        if (!function_exists('esc_url')) {
+            function esc_url($text) { return $text; }
+        }
+        if (!function_exists('esc_html_e')) {
+            function esc_html_e($text, $domain = null) { echo $text; }
+        }
+        if (!function_exists('esc_attr__')) {
+            function esc_attr__($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('sanitize_text_field')) {
+            function sanitize_text_field($text) { return $text; }
+        }
+        if (!function_exists('esc_url_raw')) {
+            function esc_url_raw($url) { return $url; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($content) { return $content; }
+        }
+        if (!function_exists('get_template_part')) {
+            function get_template_part($slug, $name = null, $args = []) { return ''; }
+        }
+        if (!function_exists('wp_get_attachment_image_url')) {
+            function wp_get_attachment_image_url($id, $size) { return ''; }
+        }
+        if (!function_exists('wp_get_attachment_image_src')) {
+            function wp_get_attachment_image_src($id, $size) { return ['']; }
+        }
+
+        global $fields;
+        $fields = [
+            123 => [],
+        ];
+
+        $infos_chasse = [
+            'champs' => [
+                'lot' => '',
+                'titre_recompense' => '',
+                'valeur_recompense' => '',
+                'date_debut' => '',
+                'date_fin' => '',
+                'illimitee' => false,
+                'nb_max' => 0,
+                'cout_points' => 0,
+                'date_decouverte' => '2024-01-01',
+                'gagnants' => 'John Doe',
+                'mode_fin' => 'automatique',
+                'current_stored_statut' => '',
+            ],
+            'image_raw' => '',
+            'image_id' => null,
+            'image_url' => '',
+            'liens' => [],
+            'enigmes_associees' => [],
+            'total_enigmes' => 0,
+            'nb_joueurs' => 0,
+            'nb_enigmes_payantes' => 0,
+            'top_avances' => ['nb' => 0, 'enigmes' => 0],
+            'statut' => 'termine',
+            'statut_validation' => 'valide',
+            'cta_data' => ['cta_message' => '', 'cta_html' => '', 'type' => ''],
+            'description' => '',
+        ];
+
+        $args = [
+            'chasse_id' => 123,
+            'infos_chasse' => $infos_chasse,
+        ];
+
+        ob_start();
+        include __DIR__ . '/../template-parts/chasse/chasse-affichage-complet.php';
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('Chasse gagnée le 2024-01-01 par John Doe', $html);
+    }
+}


### PR DESCRIPTION
## Résumé
- affiche un bandeau "Chasse gagnée" lorsque la chasse est terminée
- ajoute le style SCSS associé et met à jour les traductions
- ajoute des tests pour vérifier l'affichage et ajuste les tests JS

## Tests
- `npm run build:css`
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfd39069483328036ce1ea9f5eba3