### PR TITLE
Nettoyage du titre des emails

### DIFF
--- a/tests/EmailSendTitleTest.php
+++ b/tests/EmailSendTitleTest.php
@@ -1,0 +1,77 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($content) {
+        return $content;
+    }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_url')) {
+    function esc_url($text) {
+        return $text;
+    }
+}
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return $text;
+    }
+}
+if (!function_exists('esc_attr__')) {
+    function esc_attr__($text, $domain = null) {
+        return $text;
+    }
+}
+if (!function_exists('get_theme_file_uri')) {
+    function get_theme_file_uri($path) {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        return 'https://example.com/' . ltrim($path, '/');
+    }
+}
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) {
+        return $value;
+    }
+}
+if (!function_exists('wp_encode_mime_header')) {
+    function wp_encode_mime_header($str) {
+        return $str;
+    }
+}
+if (!function_exists('wp_mail')) {
+    function wp_mail($to, $subject, $message, $headers = []) {
+        $GLOBALS['cta_last_email'] = [
+            'to'      => $to,
+            'subject' => $subject,
+            'message' => $message,
+            'headers' => $headers,
+        ];
+        return true;
+    }
+}
+
+require_once __DIR__ . '/bootstrap.php';
+require_once dirname(__DIR__) . '/wp-content/themes/chassesautresor/inc/emails/template.php';
+
+class EmailSendTitleTest extends TestCase
+{
+    public function test_header_title_excludes_bracket_prefix(): void
+    {
+        $subject = '[Chasses au Trésor] Confirmez votre inscription organisateur';
+        $body    = '<p>Content</p>';
+
+        cta_send_email('test@example.com', $subject, $body);
+
+        $html = $GLOBALS['cta_last_email']['message'] ?? '';
+        $this->assertStringContainsString('Confirmez votre inscription organisateur', $html);
+        $this->assertStringNotContainsString('[Chasses au Trésor]', $html);
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/emails/template.php
+++ b/wp-content/themes/chassesautresor/inc/emails/template.php
@@ -111,7 +111,8 @@ function cta_send_email($to, string $subject_raw, string $body, array $headers =
         $headers[] = 'From: ' . $from;
     }
 
-    $html = cta_render_email_template($subject_raw, $body);
+    $title = (string) preg_replace('/^\[[^\]]+\]\s*/', '', $subject_raw);
+    $html  = cta_render_email_template($title, $body);
 
     $subject = function_exists('wp_encode_mime_header')
         ? wp_encode_mime_header($subject_raw)


### PR DESCRIPTION
## Résumé
- Retire le préfixe du nom du site dans le titre affiché en en-tête des emails
- Ajoute un test unitaire garantissant la suppression de ce préfixe

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bd33709ec88332a225213e47d5d40f