### PR TITLE
Exiger un logo personnalisé pour chaque organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -44,7 +44,6 @@ function initChampImage(bloc) {
       image.src = thumbUrl;
       image.srcset = thumbUrl;
       bloc.classList.remove('champ-vide');
-      bloc.classList.remove('champ-vide-obligatoire');
       input.value = id;
 
       if (typeof window.mettreAJourResumeInfos === 'function') {

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -44,6 +44,7 @@ function initChampImage(bloc) {
       image.src = thumbUrl;
       image.srcset = thumbUrl;
       bloc.classList.remove('champ-vide');
+      bloc.classList.remove('champ-vide-obligatoire');
       input.value = id;
 
       if (typeof window.mettreAJourResumeInfos === 'function') {

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -332,6 +332,7 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
       (type === 'enigme' && ['enigme_visuel_legende', 'enigme_visuel_texte'].includes(champ))
     );
   ligne.classList.toggle('champ-attention', estObligatoire && !estRempli);
+  ligne.classList.toggle('champ-vide-obligatoire', estObligatoire && !estRempli);
 
   const input = ligne.querySelector('input, textarea, select');
   if (input) {

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -234,7 +234,7 @@ window.mettreAJourCarteAjoutChasse = function () {
   // 🔍 Champs JS dynamiques
   const champsJS = [
     '[data-champ="post_title"]',
-    '[data-champ="logo_organisateur"]'
+    '[data-champ="profil_public_logo_organisateur"]'
   ];
 
   // 🔁 Vérifie visuellement ceux qui sont vides

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -310,7 +310,7 @@ body.edition-active .champ-organisateur.champ-vide:hover {
 }
 
 .champ-vide-obligatoire {
-  animation: clignoteTitre 1s infinite alternate;
+  box-shadow: 0 0 8px var(--color-editor-error);
 }
 
 @keyframes clignoteTitre {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2938,7 +2938,7 @@ body.edition-active .champ-organisateur.champ-vide:hover {
 }
 
 .champ-vide-obligatoire {
-  animation: clignoteTitre 1s infinite alternate;
+  box-shadow: 0 0 8px var(--color-editor-error);
 }
 
 @keyframes clignoteTitre {

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -84,11 +84,10 @@ function creer_organisateur_pour_utilisateur($user_id)
   // Liaison utilisateur (champ relation)
   update_field('utilisateurs_associes', [strval($user_id)], $post_id);
 
-  // Préremplissage logo + email
+  // Préremplissage email
   $user_data = get_userdata($user_id);
   $email = $user_data ? $user_data->user_email : '';
 
-  update_field('profil_public_logo_organisateur', 3927, $post_id);
   update_field('profil_public_email_contact', $email, $post_id);
 
   cat_debug("✅ Organisateur créé (pending) pour user $user_id : post ID $post_id");

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -277,7 +277,8 @@ if ($edition_active && !$est_complet) {
       <?php if ($organisateur_id) :
           $logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
           $logo    = wp_get_attachment_image_src($logo_id, 'thumbnail');
-          $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
+          $transparent = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+          $logo_url = $logo ? $logo[0] : $transparent;
       ?>
         <div class="chasse-organisateur">
           <img class="chasse-organisateur__logo" src="<?= esc_url($logo_url); ?>" alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -131,7 +131,7 @@ $is_complete = (
                     null,
                     [
                         'class'      => 'champ-organisateur champ-img champ-logo ligne-logo '
-                            . (empty($logo_id) ? 'champ-vide' : 'champ-rempli')
+                            . (empty($logo_id) ? 'champ-vide champ-vide-obligatoire' : 'champ-rempli')
                             . ($peut_editer ? '' : ' champ-desactive'),
                         'attributes' => [
                             'data-champ'   => 'profil_public_logo_organisateur',

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -6,7 +6,8 @@ $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
 
 $logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
 $logo = wp_get_attachment_image_src($logo_id, 'thumbnail');
-$logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
+$transparent = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+$logo_url = $logo ? $logo[0] : $transparent;
 
 $titre_organisateur = get_post_field('post_title', $organisateur_id);
 
@@ -48,7 +49,7 @@ $classes_header .= ' container container--boxed';
 
       <!-- Colonne gauche : logo -->
       <div class="colonne-logo">
-        <div class="champ-organisateur champ-img champ-logo <?= empty($logo_id) ? 'champ-vide' : ''; ?>"
+        <div class="champ-organisateur champ-img champ-logo <?= empty($logo_id) ? 'champ-vide champ-vide-obligatoire' : ''; ?>"
           data-cpt="organisateur"
           data-champ="profil_public_logo_organisateur"
           data-post-id="<?= esc_attr($organisateur_id); ?>">


### PR DESCRIPTION
## Résumé
- impose l'ajout d'un logo propre à chaque organisateur
- signale visuellement l'absence de logo dans les panneaux et en-têtes
- supprime l'utilisation d'une image par défaut pour les organisateurs

## Modifications notables
- suppression du préremplissage du logo lors de la création d'un organisateur
- ajout de la classe `champ-vide-obligatoire` et gestion dynamique associée
- remplacement des logos de secours par une image transparente

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd36275c088332abf41e43a08c4de2