### PR TITLE
Corrige l'indicateur de complétion du logo organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -44,6 +44,7 @@ function initChampImage(bloc) {
       image.src = thumbUrl;
       image.srcset = thumbUrl;
       bloc.classList.remove('champ-vide');
+      bloc.classList.add('champ-rempli');
       input.value = id;
 
       if (typeof window.mettreAJourResumeInfos === 'function') {
@@ -71,6 +72,8 @@ function initChampImage(bloc) {
         .then(r => r.json())
         .then(res => {
           if (res.success) {
+            bloc.classList.add('champ-rempli');
+            bloc.classList.remove('champ-vide');
             if (feedback) {
               feedback.innerHTML = '<i class="fa-solid fa-check" aria-hidden="true"></i>';
               feedback.className = 'champ-feedback champ-success';

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -31,6 +31,11 @@ window.mettreAJourResumeInfos = function () {
         estRempli = (ul && ul.children.length > 0) || aDesLiens;
       }
 
+      if (champ === 'profil_public_logo_organisateur') {
+        const image = bloc?.querySelector('img');
+        estRempli = image && !image.src.includes('logo-cat_icone-s');
+      }
+
 
       // Mise à jour visuelle + marquage obligatoire
       mettreAJourLigneResume(ligne, champ, estRempli, 'organisateur');

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -202,7 +202,7 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt, extra) {
 
   // ✅ ORGANISATEUR : mise à jour image
   if (cpt === 'organisateur') {
-    if (champ === 'logo_organisateur') {
+    if (champ === 'profil_public_logo_organisateur') {
       const bloc = document.querySelector(`.champ-organisateur[data-champ="${champ}"][data-post-id="${postId}"]`);
       if (bloc && typeof bloc.__ouvrirMedia === 'function') bloc.__ouvrirMedia();
     }
@@ -210,7 +210,7 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt, extra) {
       'post_title',
       'description_longue',
       'logo',
-      'logo_organisateur',
+      'profil_public_logo_organisateur',
       'email_contact',
       'coordonnees_bancaires',
       'liens_publics'

--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -234,7 +234,7 @@ window.mettreAJourCarteAjoutChasse = function () {
   // 🔍 Champs JS dynamiques
   const champsJS = [
     '[data-champ="post_title"]',
-    '[data-champ="logo_organisateur"]'
+    '[data-champ="profil_public_logo_organisateur"]'
   ];
 
   // 🔁 Vérifie visuellement ceux qui sont vides

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -278,7 +278,18 @@ function ajax_modifier_champ_organisateur()
   }
 
   // ✅ Autres champs ACF simples
-  $ok = update_field($champ_cible, is_numeric($valeur) ? (int) $valeur : $valeur, $post_id);
+  $valeur_formatee = is_numeric($valeur) ? (int) $valeur : $valeur;
+
+  if ($champ_cible === 'profil_public_logo_organisateur') {
+    $field_obj = function_exists('acf_get_field') ? acf_get_field('profil_public_logo_organisateur') : null;
+    $selector = $field_obj['key'] ?? $champ_cible;
+    $ok = update_field($selector, $valeur_formatee, $post_id);
+    if ($ok !== false && isset($field_obj['key'])) {
+      update_post_meta($post_id, '_' . $champ_cible, $field_obj['key']);
+    }
+  } else {
+    $ok = update_field($champ_cible, $valeur_formatee, $post_id);
+  }
 
   // 🔍 Vérifie via get_post_meta en fallback
   $valeur_meta = get_post_meta($post_id, $champ_cible, true);

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -651,8 +651,8 @@ function organisateur_est_complet(int $organisateur_id): bool
 
     $titre_ok = titre_est_valide($organisateur_id);
 
-    $logo = get_field('profil_public_logo_organisateur', $organisateur_id);
-    $logo_ok = !empty($logo);
+    $logo_id = get_post_meta($organisateur_id, 'profil_public_logo_organisateur', true);
+    $logo_ok = !empty($logo_id);
 
     $description_field = get_field('description_longue', $organisateur_id);
     $description = trim((string) $description_field);

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -651,8 +651,8 @@ function organisateur_est_complet(int $organisateur_id): bool
 
     $titre_ok = titre_est_valide($organisateur_id);
 
-    $logo_id = get_post_meta($organisateur_id, 'profil_public_logo_organisateur', true);
-    $logo_ok = !empty($logo_id);
+    $logo_id = (int) get_post_meta($organisateur_id, 'profil_public_logo_organisateur', true);
+    $logo_ok = !empty($logo_id) && $logo_id !== 3927;
 
     $description_field = get_field('description_longue', $organisateur_id);
     $description = trim((string) $description_field);

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -23,6 +23,7 @@ $logo        = get_field('profil_public_logo_organisateur', $organisateur_id);
 $logo_id     = is_array($logo) ? ($logo['ID'] ?? null) : $logo;
 $logo_src    = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail') : false;
 $logo_url    = is_array($logo_src) ? $logo_src[0] : null;
+$logo_id_db  = get_post_meta($organisateur_id, 'profil_public_logo_organisateur', true);
 $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);
 $site         = get_field('lien_site_web', $organisateur_id);
@@ -131,7 +132,7 @@ $is_complete = (
                     null,
                     [
                         'class'      => 'champ-organisateur champ-img champ-logo ligne-logo '
-                            . (empty($logo_id) ? 'champ-vide' : 'champ-rempli')
+                            . (empty($logo_id_db) ? 'champ-vide' : 'champ-rempli')
                             . ($peut_editer ? '' : ' champ-desactive'),
                         'attributes' => [
                             'data-champ'   => 'profil_public_logo_organisateur',
@@ -178,7 +179,7 @@ $is_complete = (
                                     <?php endif; ?>
                                 <?php endif; ?>
                             </div>
-                            <input type="hidden" class="champ-input" value="<?= esc_attr($logo_id ?? '') ?>">
+                            <input type="hidden" class="champ-input" value="<?= esc_attr($logo_id_db ?: '') ?>">
                             <div class="champ-feedback"></div>
                             <?php
                         },

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -18,12 +18,11 @@ $edition_active = in_array(ROLE_ORGANISATEUR_CREATION, $roles) && !$cache_comple
 $user_points    = function_exists('get_user_points') ? get_user_points((int) $current_user->ID) : 0;
 
 // Post
-$titre       = get_post_field('post_title', $organisateur_id);
-$logo        = get_field('profil_public_logo_organisateur', $organisateur_id);
-$logo_id     = is_array($logo) ? ($logo['ID'] ?? null) : $logo;
-$logo_src    = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail') : false;
-$logo_url    = is_array($logo_src) ? $logo_src[0] : null;
-$logo_id_db  = get_post_meta($organisateur_id, 'profil_public_logo_organisateur', true);
+$titre      = get_post_field('post_title', $organisateur_id);
+$logo_id_db = (int) get_post_meta($organisateur_id, 'profil_public_logo_organisateur', true);
+$placeholder_logo_id = 3927; // ID du logo par défaut
+$logo_id    = $logo_id_db && $logo_id_db !== $placeholder_logo_id ? $logo_id_db : null;
+$logo_url   = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail')[0] : null;
 $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);
 $site         = get_field('lien_site_web', $organisateur_id);
@@ -53,11 +52,11 @@ if (function_exists('charger_script_conversion')) {
 
 $peut_editer_titre = champ_est_editable('post_title', $organisateur_id);
 
-$is_complete = (
-  !empty($titre) &&
-  !empty($logo) &&
-  !empty($description)
-);
+  $is_complete = (
+    !empty($titre) &&
+    !empty($logo_id) &&
+    !empty($description)
+  );
 
 ?>
 
@@ -132,7 +131,7 @@ $is_complete = (
                     null,
                     [
                         'class'      => 'champ-organisateur champ-img champ-logo ligne-logo '
-                            . (empty($logo_id_db) ? 'champ-vide' : 'champ-rempli')
+                            . (empty($logo_id) ? 'champ-vide' : 'champ-rempli')
                             . ($peut_editer ? '' : ' champ-desactive'),
                         'attributes' => [
                             'data-champ'   => 'profil_public_logo_organisateur',
@@ -179,7 +178,7 @@ $is_complete = (
                                     <?php endif; ?>
                                 <?php endif; ?>
                             </div>
-                            <input type="hidden" class="champ-input" value="<?= esc_attr($logo_id_db ?: '') ?>">
+                            <input type="hidden" class="champ-input" value="<?= esc_attr($logo_id ?: '') ?>">
                             <div class="champ-feedback"></div>
                             <?php
                         },

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -4,9 +4,13 @@ $organisateur_id = get_organisateur_id_from_context($args ?? []);
 $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
 
 
-$logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
-$logo = wp_get_attachment_image_src($logo_id, 'thumbnail');
-$logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
+$logo_id = (int) get_field('profil_public_logo_organisateur', $organisateur_id, false);
+$placeholder_logo_id = 3927;
+if ($logo_id === $placeholder_logo_id) {
+    $logo_id = 0;
+}
+$logo = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail') : false;
+$logo_url = $logo ? $logo[0] : wp_get_attachment_image_src($placeholder_logo_id, 'thumbnail')[0];
 
 $titre_organisateur = get_post_field('post_title', $organisateur_id);
 


### PR DESCRIPTION
## Résumé
- corrige la détection de complétion du logo organisateur
- harmonise les scripts JS sur le champ `profil_public_logo_organisateur`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bd3a9e860c8332b8cceb79d8e1b6b8