### PR TITLE
Ajout de la colonne Chasse au tableau des tentatives

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -738,7 +738,9 @@ body.woocommerce h2 {
 .tentatives-table th:nth-child(2),
 .tentatives-table td:nth-child(2),
 .tentatives-table th:nth-child(3),
-.tentatives-table td:nth-child(3) {
+.tentatives-table td:nth-child(3),
+.tentatives-table th:nth-child(4),
+.tentatives-table td:nth-child(4) {
     text-align: left;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8664,7 +8664,9 @@ body.woocommerce h2 {
 .tentatives-table th:nth-child(2),
 .tentatives-table td:nth-child(2),
 .tentatives-table th:nth-child(3),
-.tentatives-table td:nth-child(3) {
+.tentatives-table td:nth-child(3),
+.tentatives-table th:nth-child(4),
+.tentatives-table td:nth-child(4) {
   text-align: left;
 }
 

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-chasses.php
@@ -122,6 +122,7 @@ $pages = (int) ceil($total / $per_page);
             <thead>
                 <tr>
                     <th><?php esc_html_e('Date', 'chassesautresor-com'); ?></th>
+                    <th><?php esc_html_e('Chasse', 'chassesautresor-com'); ?></th>
                     <th><?php esc_html_e('Énigme', 'chassesautresor-com'); ?></th>
                     <th><?php esc_html_e('Proposition', 'chassesautresor-com'); ?></th>
                     <th><?php esc_html_e('Résultat', 'chassesautresor-com'); ?></th>
@@ -130,7 +131,17 @@ $pages = (int) ceil($total / $per_page);
             <tbody>
                 <?php foreach ($tentatives as $tent) : ?>
                 <tr>
+                    <?php $chasse_id = (int) recuperer_id_chasse_associee($tent->enigme_id); ?>
                     <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
+                    <td>
+                        <?php if ($chasse_id) : ?>
+                        <a href="<?php echo esc_url(get_permalink($chasse_id)); ?>">
+                            <?php echo esc_html(get_the_title($chasse_id)); ?>
+                        </a>
+                        <?php else : ?>
+                        &mdash;
+                        <?php endif; ?>
+                    </td>
                     <td><?php echo esc_html($tent->post_title); ?></td>
                     <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? ''); ?>
                     <?php


### PR DESCRIPTION
## Résumé
- affiche la chasse associée à chaque tentative dans l’onglet Chasses
- aligne les nouvelles colonnes du tableau des tentatives

## Testing
- `npm run build:css`
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bd42e5606c8332aacee003ce4b7cc0