### PR TITLE
fix: hide organizer attempt warnings

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -215,13 +215,6 @@ function soumettre_reponse_manuelle()
     $link         = '<a href="' . esc_url(get_permalink($enigme_id)) . '">' . esc_html($titre_enigme) . '</a>';
     myaccount_add_persistent_message($user_id, 'tentative_' . $uid, $link, 'info');
 
-    $chasse_id       = recuperer_id_chasse_associee($enigme_id);
-    $organisateur_id = get_organisateur_from_chasse($chasse_id);
-    $orga_users      = (array) get_field('utilisateurs_associes', $organisateur_id);
-    foreach ($orga_users as $orga_user_id) {
-        myaccount_add_persistent_message((int) $orga_user_id, 'tentative_' . $uid, $link, 'info');
-    }
-
     envoyer_mail_reponse_manuelle($user_id, $enigme_id, $reponse, $uid);
 
     $solde = get_user_points($user_id);

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -549,12 +549,7 @@ function myaccount_get_persistent_messages(int $user_id): array
         }
     }
 
-    $is_tentatives_tab = est_organisateur()
-        && isset($_GET['edition'], $_GET['onglet'])
-        && $_GET['edition'] === 'open'
-        && $_GET['onglet'] === 'tentatives';
-
-    if (!empty($tentatives) && !$is_tentatives_tab) {
+    if (!empty($tentatives)) {
         if (count($tentatives) === 1) {
             $output[] = [
                 'text' => sprintf(
@@ -664,11 +659,7 @@ function myaccount_get_important_messages(): string
         myaccount_get_persistent_messages($current_user_id),
         myaccount_get_flash_messages($current_user_id)
     );
-    $flash    = '';
-    $is_tentatives_tab = est_organisateur()
-        && isset($_GET['edition'], $_GET['onglet'])
-        && $_GET['edition'] === 'open'
-        && $_GET['onglet'] === 'tentatives';
+    $flash = '';
 
     if (isset($_GET['points_modifies']) && $_GET['points_modifies'] === '1') {
         $flash = '<p class="flash flash--success">' . __('Points mis à jour avec succès.', 'chassesautresor') . '</p>';
@@ -725,24 +716,6 @@ function myaccount_get_important_messages(): string
     if (est_organisateur()) {
         $current_user_id   = get_current_user_id();
         $organisateur_id   = get_organisateur_from_user($current_user_id);
-        if ($organisateur_id) {
-            $enigmes = recuperer_enigmes_tentatives_en_attente($organisateur_id);
-            if (!empty($enigmes) && !$is_tentatives_tab) {
-                $links = array_map(
-                    function ($id) {
-                        $url   = esc_url(get_permalink($id));
-                        $title = esc_html(get_the_title($id));
-                        return '<a class="enigme-link" href="' . $url . '">' . $title . '</a>';
-                    },
-                    $enigmes
-                );
-
-                $messages[] = [
-                    'text' => '⚠️ ' . __('Important ! Des tentatives attendent votre action :', 'chassesautresor-com') . ' ' . implode('', $links),
-                    'type' => 'warning',
-                ];
-            }
-        }
 
         global $wpdb;
         $repo       = new PointsRepository($wpdb);

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -549,7 +549,12 @@ function myaccount_get_persistent_messages(int $user_id): array
         }
     }
 
-    if (!empty($tentatives)) {
+    $is_tentatives_tab = est_organisateur()
+        && isset($_GET['edition'], $_GET['onglet'])
+        && $_GET['edition'] === 'open'
+        && $_GET['onglet'] === 'tentatives';
+
+    if (!empty($tentatives) && !$is_tentatives_tab) {
         if (count($tentatives) === 1) {
             $output[] = [
                 'text' => sprintf(
@@ -660,6 +665,10 @@ function myaccount_get_important_messages(): string
         myaccount_get_flash_messages($current_user_id)
     );
     $flash    = '';
+    $is_tentatives_tab = est_organisateur()
+        && isset($_GET['edition'], $_GET['onglet'])
+        && $_GET['edition'] === 'open'
+        && $_GET['onglet'] === 'tentatives';
 
     if (isset($_GET['points_modifies']) && $_GET['points_modifies'] === '1') {
         $flash = '<p class="flash flash--success">' . __('Points mis à jour avec succès.', 'chassesautresor') . '</p>';
@@ -718,7 +727,7 @@ function myaccount_get_important_messages(): string
         $organisateur_id   = get_organisateur_from_user($current_user_id);
         if ($organisateur_id) {
             $enigmes = recuperer_enigmes_tentatives_en_attente($organisateur_id);
-            if (!empty($enigmes)) {
+            if (!empty($enigmes) && !$is_tentatives_tab) {
                 $links = array_map(
                     function ($id) {
                         $url   = esc_url(get_permalink($id));

--- a/wp-content/themes/chassesautresor/tests/aaa_manual_response_does_not_notify_organizer.test.php
+++ b/wp-content/themes/chassesautresor/tests/aaa_manual_response_does_not_notify_organizer.test.php
@@ -106,9 +106,9 @@ $wpdb = new WpdbStub();
 
 require_once __DIR__ . '/../inc/enigme/reponses.php';
 
-class ManualResponseNotifiesOrganizerTest extends TestCase
+class ManualResponseDoesNotNotifyOrganizerTest extends TestCase
 {
-    public function test_organizer_receives_persistent_message(): void
+    public function test_organizer_does_not_receive_persistent_message(): void
     {
         $_POST = [
             'enigme_id' => 5,
@@ -116,8 +116,12 @@ class ManualResponseNotifiesOrganizerTest extends TestCase
             'reponse_manuelle_nonce' => 'nonce',
         ];
         soumettre_reponse_manuelle();
-        $messages = get_user_meta(2, '_myaccount_messages', true);
-        $this->assertArrayHasKey('tentative_abc123', $messages);
-        $this->assertSame('<a href="https://example.com/enigme">Énigme</a>', $messages['tentative_abc123']['text']);
+
+        $organizer_messages = get_user_meta(2, '_myaccount_messages', true);
+        $this->assertArrayNotHasKey('tentative_abc123', $organizer_messages);
+
+        $player_messages = get_user_meta(1, '_myaccount_messages', true);
+        $this->assertArrayHasKey('tentative_abc123', $player_messages);
+        $this->assertSame('<a href="https://example.com/enigme">Énigme</a>', $player_messages['tentative_abc123']['text']);
     }
 }

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -464,30 +464,16 @@ class MyAccountMessagesTest extends TestCase
         delete_user_meta(1, '_myaccount_messages');
     }
 
-    public function test_messages_hidden_on_tentatives_tab(): void
+    public function test_no_pending_attempt_messages_for_organizer(): void
     {
-        update_user_meta(
-            1,
-            '_myaccount_messages',
-            [
-                'tentative_123' => [
-                    'text' => '<a href="https://example.com/enigme">Énigme</a>',
-                    'type' => 'info',
-                ],
-            ]
-        );
-
         $GLOBALS['test_enigmes_pending'] = [321];
-        $_GET['edition'] = 'open';
-        $_GET['onglet'] = 'tentatives';
 
         $output = myaccount_get_important_messages();
 
         $this->assertStringNotContainsString('Votre demande de résolution', $output);
         $this->assertStringNotContainsString('Important ! Des tentatives attendent votre action', $output);
 
-        delete_user_meta(1, '_myaccount_messages');
-        unset($GLOBALS['test_enigmes_pending'], $_GET['edition'], $_GET['onglet']);
+        unset($GLOBALS['test_enigmes_pending']);
     }
 
     public function test_flash_message_is_displayed_once(): void

--- a/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
+++ b/wp-content/themes/chassesautresor/tests/myaccount_messages.test.php
@@ -55,7 +55,7 @@ if (!function_exists('get_organisateur_from_user')) {
 if (!function_exists('recuperer_enigmes_tentatives_en_attente')) {
     function recuperer_enigmes_tentatives_en_attente($organisateur_id)
     {
-        return [];
+        return $GLOBALS['test_enigmes_pending'] ?? [];
     }
 }
 
@@ -462,6 +462,32 @@ class MyAccountMessagesTest extends TestCase
         $this->assertStringContainsString('<a href="https://example.com/enigme">Énigme</a>', $output);
 
         delete_user_meta(1, '_myaccount_messages');
+    }
+
+    public function test_messages_hidden_on_tentatives_tab(): void
+    {
+        update_user_meta(
+            1,
+            '_myaccount_messages',
+            [
+                'tentative_123' => [
+                    'text' => '<a href="https://example.com/enigme">Énigme</a>',
+                    'type' => 'info',
+                ],
+            ]
+        );
+
+        $GLOBALS['test_enigmes_pending'] = [321];
+        $_GET['edition'] = 'open';
+        $_GET['onglet'] = 'tentatives';
+
+        $output = myaccount_get_important_messages();
+
+        $this->assertStringNotContainsString('Votre demande de résolution', $output);
+        $this->assertStringNotContainsString('Important ! Des tentatives attendent votre action', $output);
+
+        delete_user_meta(1, '_myaccount_messages');
+        unset($GLOBALS['test_enigmes_pending'], $_GET['edition'], $_GET['onglet']);
     }
 
     public function test_flash_message_is_displayed_once(): void


### PR DESCRIPTION
Résumé : évite l'affichage de messages de tentatives inadaptés sur l'onglet Tentatives de l'édition d'énigme.

- cache les messages destinés au joueur lorsqu'un organisateur consulte l'onglet Tentatives
- supprime l'avertissement obsolète signalant des tentatives à traiter
- ajoute un test couvrant ce comportement

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bd464b5ee083329ecf1978b60bf526