### PR TITLE
Harmonize organiser field initialization

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -4,17 +4,23 @@ DEBUG && console.log('✅ organisateur-edit.js chargé');
 document.addEventListener('DOMContentLoaded', () => {
   if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
 
-  // 🟢 Champs inline
-    document.querySelectorAll('.champ-organisateur[data-champ]').forEach((bloc) => {
-      const champ = bloc.dataset.champ;
-      if (bloc.classList.contains('champ-img')) {
-        if (typeof initChampImage === 'function') initChampImage(bloc);
-      } else if (champ === 'liens_publics') {
-        if (typeof initLiensOrganisateur === 'function') initLiensOrganisateur(bloc);
-      } else {
-        if (typeof initChampTexte === 'function') initChampTexte(bloc);
+  // ==============================
+  // 🟢 Initialisation des champs
+  // ==============================
+  document.querySelectorAll('.champ-organisateur[data-champ]').forEach((bloc) => {
+    const champ = bloc.dataset.champ;
+
+    if (bloc.classList.contains('champ-img')) {
+      if (typeof initChampImage === 'function') initChampImage(bloc);
+    } else if (champ === 'liens_publics') {
+      const bouton = bloc.querySelector('.champ-modifier');
+      if (bouton && typeof initLiensOrganisateur === 'function') {
+        initLiensOrganisateur(bloc);
       }
-    });
+    } else {
+      if (typeof initChampTexte === 'function') initChampTexte(bloc);
+    }
+  });
 
     // 🟠 Déclencheurs de résumé
     document.querySelectorAll('.resume-infos .champ-modifier[data-champ]').forEach((btn) => {


### PR DESCRIPTION
## Summary
- harmonise le traitement des champs organisateur avec la chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bd48ec03cc833299af120a7251e330