### PR TITLE
Gestion de l’ID de logo organisateur et mise à jour des aperçus

### DIFF
--- a/tests/js/image-utils.test.js
+++ b/tests/js/image-utils.test.js
@@ -1,0 +1,64 @@
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('initChampImage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="champ-organisateur champ-img" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="123">
+        <img src="" />
+        <input class="champ-input" type="hidden" />
+        <div class="champ-feedback"></div>
+      </div>`;
+
+    global.ajaxurl = '/ajax';
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ success: true }) }));
+    global.mettreAJourResumeInfos = jest.fn();
+    global.mettreAJourVisuelCPT = jest.fn();
+
+    const handlers = {};
+    const frame = {
+      open: jest.fn(),
+      on: (event, cb) => { handlers[event] = cb; },
+      state: () => ({
+        get: () => ({
+          first: () => ({
+            id: 42,
+            attributes: {
+              url: 'full.png',
+              sizes: {
+                thumbnail: { url: 'thumb.png' },
+                medium: { url: 'med.png' },
+                'chasse-fiche': { url: 'fiche.png' }
+              }
+            }
+          })
+        })
+      }),
+      __handlers: handlers
+    };
+    const mediaFn = jest.fn(() => frame);
+    mediaFn.view = { settings: { post: {} } };
+    global.wp = { media: mediaFn };
+
+    const fs = require('fs');
+    const path = require('path');
+    const script = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../wp-content/themes/chassesautresor/assets/js/core/image-utils.js'
+      ),
+      'utf8'
+    );
+    eval(script);
+    global.initChampImage = initChampImage;
+  });
+
+  it('envoie modifier_champ_organisateur', async () => {
+    const bloc = document.querySelector('.champ-organisateur');
+    initChampImage(bloc);
+    bloc.__ouvrirMedia();
+    bloc.__mediaFrame.__handlers.select();
+    await flush();
+    const params = fetch.mock.calls[0][1].body;
+    expect(params.get('action')).toBe('modifier_champ_organisateur');
+  });
+});

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -189,6 +189,10 @@ function ajax_modifier_champ_organisateur()
   // 🔁 Corrige le nom du champ si groupé
   $champ_cible = $champ_correspondances[$champ] ?? $champ;
 
+  if ($champ_cible === 'profil_public_logo_organisateur') {
+    $valeur = absint($valeur);
+  }
+
   // 🛑 Validation métier : texte de présentation minimal
   if ($champ_cible === 'description_longue') {
     $texte = wp_strip_all_tags($valeur);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -280,7 +280,13 @@ if ($edition_active && !$est_complet) {
           $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
       ?>
         <div class="chasse-organisateur">
-          <img class="chasse-organisateur__logo" src="<?= esc_url($logo_url); ?>" alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>">
+          <img
+            class="chasse-organisateur__logo visuel-cpt"
+            src="<?= esc_url($logo_url); ?>"
+            alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
+            data-cpt="organisateur"
+            data-post-id="<?= esc_attr($organisateur_id); ?>"
+          />
           <span class="chasse-organisateur__texte">
             <a class="chasse-organisateur__nom" href="<?= esc_url(get_permalink($organisateur_id)); ?>"><?= esc_html($organisateur_nom); ?></a>
             <span class="chasse-organisateur__presente"><?php esc_html_e('présente', 'chassesautresor-com'); ?></span>


### PR DESCRIPTION
## Résumé
- Accepte l’ID du fichier pour le logo d’organisateur
- Actualise le logo d’organisateur sur toutes les vues
- Ajoute un test vérifiant l’action `modifier_champ_organisateur`

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd49fe76d48332b8567be2f32f18c4