### PR TITLE
Corrige les avertissements de redéfinition des constantes d'organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/inc/constants.php
+++ b/wp-content/themes/chassesautresor/inc/constants.php
@@ -1,8 +1,12 @@
 <?php
 defined( 'ABSPATH' ) || exit;
 
-const ROLE_ORGANISATEUR = 'organisateur';
-const ROLE_ORGANISATEUR_CREATION = 'organisateur_creation';
+if (!defined('ROLE_ORGANISATEUR')) {
+    define('ROLE_ORGANISATEUR', 'organisateur');
+}
+if (!defined('ROLE_ORGANISATEUR_CREATION')) {
+    define('ROLE_ORGANISATEUR_CREATION', 'organisateur_creation');
+}
 
 // --------------------------------------------------
 // 🔢 Solution states


### PR DESCRIPTION
## Résumé
Empêche la redéfinition des constantes des rôles d'organisateur pour éviter les avertissements PHP.

## Changements notables
- Déclare `ROLE_ORGANISATEUR` et `ROLE_ORGANISATEUR_CREATION` uniquement si elles ne sont pas déjà définies.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c3bc5b88332a9a6393a57819bba