### PR TITLE
Fix organizer logo placeholder and completion updates

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/helpers.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/helpers.js
@@ -145,13 +145,24 @@ window.mettreAJourTitreMenuEnigme = function (valeur) {
 function mettreAJourVisuelCPT(cpt, postId, nouvelleUrl, fullUrl = nouvelleUrl) {
   document
     .querySelectorAll(`img.visuel-cpt[data-cpt="${cpt}"][data-post-id="${postId}"]`)
-    .forEach(img => {
+    .forEach((img) => {
       img.src = nouvelleUrl;
       img.srcset = nouvelleUrl;
 
-      const lien = img.closest('a');
+      const lien = img.closest('a.fancybox');
       if (lien) {
         lien.href = fullUrl;
+      }
+
+      img.removeAttribute('data-placeholder');
+
+      const bloc = img.closest('.champ-img');
+      if (bloc) {
+        bloc.classList.remove('champ-vide');
+        const ajouter = bloc.querySelector('.champ-ajout-image');
+        if (ajouter) {
+          ajouter.style.display = 'none';
+        }
       }
     });
 }

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -9,6 +9,7 @@ function initChampImage(bloc) {
   const input = bloc.querySelector('.champ-input');
   const image = bloc.querySelector('img');
   const feedback = bloc.querySelector('.champ-feedback');
+  const ajouter = bloc.querySelector('.champ-ajout-image');
 
   if (!champ || !cpt || !postId || !input || !image) return;
 
@@ -45,6 +46,9 @@ function initChampImage(bloc) {
       image.srcset = thumbUrl;
       bloc.classList.remove('champ-vide');
       input.value = id;
+      if (ajouter) {
+        ajouter.style.display = 'none';
+      }
 
       if (typeof window.mettreAJourResumeInfos === 'function') {
         window.mettreAJourResumeInfos();

--- a/wp-content/themes/chassesautresor/assets/js/core/resume.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/resume.js
@@ -8,9 +8,9 @@ window.mettreAJourResumeInfos = function () {
   if (panneauOrganisateur) {
     panneauOrganisateur.querySelectorAll('.resume-infos li[data-champ]').forEach((ligne) => {
       const champ = ligne.dataset.champ;
-      const bloc = document.querySelector('.champ-organisateur[data-champ="' + champ + '"]');
+      const bloc = ligne;
 
-      let estRempli = bloc && !bloc.classList.contains('champ-vide');
+      let estRempli = !bloc.classList.contains('champ-vide');
 
       if (champ === 'post_title') {
         const valeurTitre = bloc?.querySelector('.champ-input')?.value.trim().toLowerCase();

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -387,6 +387,10 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   display: none;
 }
 
+.champ-img.champ-vide img[data-placeholder="1"] {
+  display: inline-block;
+}
+
 .champ-img:not(.champ-vide) .champ-ajout-image {
   display: none;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2898,6 +2898,10 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   display: none;
 }
 
+.champ-img.champ-vide img[data-placeholder="1"] {
+  display: inline-block;
+}
+
 .champ-img:not(.champ-vide) .champ-ajout-image {
   display: none;
 }

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -23,6 +23,7 @@ $logo        = get_field('logo_organisateur', $organisateur_id);
 $logo_id     = is_array($logo) ? ($logo['ID'] ?? null) : $logo;
 $logo_src    = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail') : false;
 $logo_url    = is_array($logo_src) ? $logo_src[0] : null;
+$placeholder_url = wp_get_attachment_image_src(3927, 'thumbnail')[0];
 $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);
 $site         = get_field('lien_site_web', $organisateur_id);
@@ -146,8 +147,7 @@ $is_complete = (
                             </label>
                             <?php
                         },
-                        'content' => function () use ($logo_url, $logo_id, $peut_editer, $organisateur_id) {
-                            $transparent = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+                        'content' => function () use ($logo_url, $logo_id, $peut_editer, $organisateur_id, $placeholder_url) {
                             ?>
                             <div class="champ-affichage">
                                 <?php if ($peut_editer) : ?>
@@ -158,7 +158,8 @@ $is_complete = (
                                         data-post-id="<?= esc_attr($organisateur_id); ?>"
                                         aria-label="<?= esc_attr__('Modifier le logo', 'chassesautresor-com'); ?>">
                                         <img
-                                            src="<?= esc_url($logo_url ?: $transparent); ?>"
+                                            src="<?= esc_url($logo_url ?: $placeholder_url); ?>"
+                                            <?php if (!$logo_url) : ?>data-placeholder="1"<?php endif; ?>
                                             alt="<?= esc_attr__('Logo de l’organisateur', 'chassesautresor-com'); ?>"
                                         />
                                         <span class="champ-ajout-image">


### PR DESCRIPTION
## Résumé
- Affiche une image de substitution pour le logo organisateur
- Actualise l'indicateur de complétion et masque le texte d'ajout d'image

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `node build-css.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd5286c3908332b4ea5131598fa503