### PR TITLE
Renomme le champ logo organisateur

### DIFF
--- a/tests/js/image-utils.test.js
+++ b/tests/js/image-utils.test.js
@@ -3,7 +3,7 @@ const flush = () => new Promise(resolve => setTimeout(resolve, 0));
 describe('initChampImage', () => {
   beforeEach(() => {
     document.body.innerHTML = `
-      <div class="champ-organisateur champ-img" data-champ="profil_public_logo_organisateur" data-cpt="organisateur" data-post-id="123">
+      <div class="champ-organisateur champ-img" data-champ="logo_organisateur" data-cpt="organisateur" data-post-id="123">
         <img src="" />
         <input class="champ-input" type="hidden" />
         <div class="champ-feedback"></div>

--- a/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-organisateur.php
@@ -88,7 +88,7 @@ function creer_organisateur_pour_utilisateur($user_id)
   $user_data = get_userdata($user_id);
   $email = $user_data ? $user_data->user_email : '';
 
-  update_field('profil_public_logo_organisateur', 3927, $post_id);
+  update_field('logo_organisateur', 3927, $post_id);
   update_field('profil_public_email_contact', $email, $post_id);
 
   cat_debug("✅ Organisateur créé (pending) pour user $user_id : post ID $post_id");
@@ -184,12 +184,13 @@ function ajax_modifier_champ_organisateur()
   $champ_correspondances = [
     'email_contact'                     => 'profil_public_email_contact',
     'parlez_de_vous_presentation'       => 'description_longue',
+    'logo_organisateur'                 => 'logo_organisateur',
   ];
 
   // 🔁 Corrige le nom du champ si groupé
   $champ_cible = $champ_correspondances[$champ] ?? $champ;
 
-  if ($champ_cible === 'profil_public_logo_organisateur') {
+  if ($champ_cible === 'logo_organisateur') {
     $valeur = absint($valeur);
   }
 

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -651,7 +651,7 @@ function organisateur_est_complet(int $organisateur_id): bool
 
     $titre_ok = titre_est_valide($organisateur_id);
 
-    $logo = get_field('profil_public_logo_organisateur', $organisateur_id);
+    $logo = get_field('logo_organisateur', $organisateur_id);
     $logo_ok = !empty($logo);
 
     $description_field = get_field('description_longue', $organisateur_id);

--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -398,6 +398,7 @@ Requis : non
 — logo_organisateur —
 Type : image
 Label : Votre Logo
+Ancien nom : profil_public_logo_organisateur
 Instructions : (vide)
 Requis : non
 ----------------------------------------

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -338,7 +338,7 @@ CPT : organisateur
 Groupe : Paramètres organisateur
 
 * email_contact (email)
-* logo_organisateur (image)
+* logo_organisateur (image) — anciennement `profil_public_logo_organisateur`
 * liens_publics (repeater)
   * type_de_lien (select)
   * url_lien (url)

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -275,7 +275,7 @@ if ($edition_active && !$est_complet) {
       </div>
 
       <?php if ($organisateur_id) :
-          $logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
+          $logo_id = get_field('logo_organisateur', $organisateur_id, false);
           $logo    = wp_get_attachment_image_src($logo_id, 'thumbnail');
           $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
       ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -19,7 +19,7 @@ $user_points    = function_exists('get_user_points') ? get_user_points((int) $cu
 
 // Post
 $titre       = get_post_field('post_title', $organisateur_id);
-$logo        = get_field('profil_public_logo_organisateur', $organisateur_id);
+$logo        = get_field('logo_organisateur', $organisateur_id);
 $logo_id     = is_array($logo) ? ($logo['ID'] ?? null) : $logo;
 $logo_src    = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail') : false;
 $logo_url    = is_array($logo_src) ? $logo_src[0] : null;
@@ -134,7 +134,7 @@ $is_complete = (
                             . (empty($logo_id) ? 'champ-vide' : 'champ-rempli')
                             . ($peut_editer ? '' : ' champ-desactive'),
                         'attributes' => [
-                            'data-champ'   => 'profil_public_logo_organisateur',
+                            'data-champ'   => 'logo_organisateur',
                             'data-cpt'     => 'organisateur',
                             'data-post-id' => $organisateur_id,
                         ],
@@ -153,7 +153,7 @@ $is_complete = (
                                 <?php if ($peut_editer) : ?>
                                     <button type="button"
                                         class="champ-modifier"
-                                        data-champ="profil_public_logo_organisateur"
+                                        data-champ="logo_organisateur"
                                         data-cpt="organisateur"
                                         data-post-id="<?= esc_attr($organisateur_id); ?>"
                                         aria-label="<?= esc_attr__('Modifier le logo de l\'organisateur', 'chassesautresor-com'); ?>">

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -4,7 +4,7 @@ $organisateur_id = get_organisateur_id_from_context($args ?? []);
 $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
 
 
-$logo_id = get_field('profil_public_logo_organisateur', $organisateur_id, false);
+$logo_id = get_field('logo_organisateur', $organisateur_id, false);
 $logo = wp_get_attachment_image_src($logo_id, 'thumbnail');
 $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
 
@@ -50,7 +50,7 @@ $classes_header .= ' container container--boxed';
       <div class="colonne-logo">
         <div class="champ-organisateur champ-img champ-logo <?= empty($logo_id) ? 'champ-vide' : ''; ?>"
           data-cpt="organisateur"
-          data-champ="profil_public_logo_organisateur"
+          data-champ="logo_organisateur"
           data-post-id="<?= esc_attr($organisateur_id); ?>">
 
           <div class="champ-affichage">


### PR DESCRIPTION
## Résumé
- harmonise le champ de logo organisateur dans l’édition et les templates
- ajuste la correspondance ACF et met à jour la documentation

## Changements notables
- remplacement de `profil_public_logo_organisateur` par `logo_organisateur`
- ajout de l’entrée `logo_organisateur` dans la table de correspondance
- mise à jour des notices et tests associés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be63288150833298e2057bf446c7c5