### PR TITLE
Fix organizer image placeholder and completion indicator

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -6,11 +6,9 @@ function initChampImage(bloc) {
   const cpt = bloc.dataset.cpt;
   const postId = bloc.dataset.postId;
 
-  const input = bloc.querySelector('.champ-input');
-  const image = bloc.querySelector('img');
   const feedback = bloc.querySelector('.champ-feedback');
 
-  if (!champ || !cpt || !postId || !input || !image) return;
+  if (!champ || !cpt || !postId) return;
 
   // ✅ Création du frame à la volée quand appelé
   const ouvrirMedia = () => {
@@ -41,10 +39,21 @@ function initChampImage(bloc) {
       const thumbUrl = selection?.attributes?.sizes?.thumbnail?.url || mediumUrl;
       if (!id || !fullUrl) return;
 
-      image.src = thumbUrl;
-      image.srcset = thumbUrl;
-      bloc.classList.remove('champ-vide');
-      input.value = id;
+      document
+        .querySelectorAll(`.champ-${cpt}[data-champ="${champ}"][data-post-id="${postId}"]`)
+        .forEach((el) => {
+          el.classList.remove('champ-vide');
+          el.classList.add('champ-rempli');
+          const imgEl = el.querySelector('img');
+          if (imgEl) {
+            imgEl.src = thumbUrl;
+            imgEl.srcset = thumbUrl;
+          }
+          const hidden = el.querySelector('.champ-input');
+          if (hidden) {
+            hidden.value = id;
+          }
+        });
 
       if (typeof window.mettreAJourResumeInfos === 'function') {
         window.mettreAJourResumeInfos();

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -21,7 +21,9 @@ $user_points    = function_exists('get_user_points') ? get_user_points((int) $cu
 $titre       = get_post_field('post_title', $organisateur_id);
 $logo        = get_field('logo_organisateur', $organisateur_id);
 $logo_id     = is_array($logo) ? ($logo['ID'] ?? null) : $logo;
-$logo_src    = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail') : false;
+$placeholder_id = 3927;
+$logo_src    = $logo_id ? wp_get_attachment_image_src($logo_id, 'thumbnail')
+    : wp_get_attachment_image_src($placeholder_id, 'thumbnail');
 $logo_url    = is_array($logo_src) ? $logo_src[0] : null;
 $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);


### PR DESCRIPTION
## Résumé
- Affiche une image de remplacement pour le logo organisateur
- Met à jour dynamiquement l'indicateur de complétion après sélection d'une image

## Changements
- Utilise le placeholder (id 3927) lorsque le logo organisateur est absent
- Met à jour toutes les occurrences du champ image pour retirer l'état vide et synchroniser le logo

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be6a3cd3588332817cb217606b12ff