### PR TITLE
Utilise le proxy pour l'image des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -209,14 +209,17 @@ function afficher_visuels_enigme(int $enigme_id): void
  */
 function get_image_enigme(int $post_id, string $size = 'medium'): ?string
 {
-    $images = get_field('enigme_visuel_image', $post_id);
+    $images   = get_field('enigme_visuel_image', $post_id);
+    $image_id = ID_IMAGE_PLACEHOLDER_ENIGME;
 
     if (is_array($images) && !empty($images[0]['ID'])) {
-        return wp_get_attachment_image_url($images[0]['ID'], $size);
+        $image_id = (int) $images[0]['ID'];
     }
 
-    // 🧩 Placeholder image : image statique ou ID définie par toi
-    return wp_get_attachment_image_url(ID_IMAGE_PLACEHOLDER_ENIGME, $size);
+    return esc_url(add_query_arg([
+        'id'     => $image_id,
+        'taille' => $size,
+    ], site_url('/voir-image-enigme')));
 }
 
 


### PR DESCRIPTION
### Résumé
- Utilise l'endpoint `/voir-image-enigme` pour récupérer les visuels d'énigme.

### Changements notables
- remplace `wp_get_attachment_image_url` par `add_query_arg` dans `get_image_enigme`.

### Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `curl -I https://example.com/voir-image-enigme?id=123&taille=medium` *(⚠️ test exécuté hors environnement Apache, la protection `.htaccess` n'a pas pu être vérifiée)*

------
https://chatgpt.com/codex/tasks/task_e_68be95a51528833294017da3babcbab8