### PR TITLE
Avoid session start on enigme image requests

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -128,6 +128,11 @@ function remove_site_message(string $key): void
  */
 function get_site_messages(): string
 {
+    $requestUri = $_SERVER['REQUEST_URI'] ?? '';
+    if (strpos($requestUri, '/voir-image-enigme') === 0) {
+        return '';
+    }
+
     $messages = [];
 
     if (session_status() !== PHP_SESSION_ACTIVE) {


### PR DESCRIPTION
### Résumé
- Évite l'ouverture de session pour les requêtes `/voir-image-enigme`

### Changements notables
- Ignore `get_site_messages()` lors de l'affichage d'une image d'énigme pour ne pas toucher aux sessions ni produire de sortie

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf04e9947083329bc97868a62133e1