### PR TITLE
Log when headers already sent in image handler

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -8,6 +8,11 @@ if (!isset($_GET['id']) || !ctype_digit($_GET['id'])) {
 $image_id = (int) $_GET['id'];
 $taille   = $_GET['taille'] ?? 'full';
 
+headers_sent($file, $line);
+if ($file) {
+    error_log("[voir-image-enigme] headers already sent in $file:$line");
+}
+
 // 🔁 Chargement des fonctions
 if (!function_exists('trouver_chemin_image')) {
     require_once get_stylesheet_directory() . '/inc/enigme-functions.php';


### PR DESCRIPTION
## Résumé
- Journalise l'origine d'un envoi d'en-têtes précoce dans le gestionnaire `voir-image-enigme`.

## Changements notables
- Vérifie si des en-têtes ont déjà été envoyés et écrit un log avec le fichier et la ligne incriminés.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c99e3f88332bb273b4c45ac4c8d