### PR TITLE
Skip sessions for image proxy requests

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -128,12 +128,12 @@ function remove_site_message(string $key): void
  */
 function get_site_messages(): string
 {
-    $requestUri = $_SERVER['REQUEST_URI'] ?? '';
-    if (strpos($requestUri, 'voir-image-enigme') !== false) {
+    $messages = [];
+
+    $uri = $_SERVER['REQUEST_URI'] ?? '';
+    if (str_starts_with($uri, '/voir-image-enigme')) {
         return '';
     }
-
-    $messages = [];
 
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();


### PR DESCRIPTION
Empêche l'ouverture de session lors du proxy d'image d'énigme.

- Vérifie l'URI avant `session_start()` pour ignorer `/voir-image-enigme`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf14ae25148332b4d57a30b7fa2484