### PR TITLE
Log early header output in voir-image-enigme handler

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -5,13 +5,12 @@ if (!isset($_GET['id']) || !ctype_digit($_GET['id'])) {
     exit(__('ID manquant ou invalide', 'chassesautresor-com'));
 }
 
-$image_id = (int) $_GET['id'];
-$taille   = $_GET['taille'] ?? 'full';
-
-headers_sent($file, $line);
-if ($file) {
+if (headers_sent($file, $line)) {
     error_log("[voir-image-enigme] headers already sent in $file:$line");
 }
+
+$image_id = (int) $_GET['id'];
+$taille   = $_GET['taille'] ?? 'full';
 
 // 🔁 Chargement des fonctions
 if (!function_exists('trouver_chemin_image')) {


### PR DESCRIPTION
## Résumé
- Log la provenance d'un éventuel envoi prématuré des en-têtes dans le handler `voir-image-enigme`

## Changements notables
- Ajout d'une vérification `headers_sent` au début du script pour journaliser le fichier et la ligne d'origine

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf175ffe708332af233f582257636e