### PR TITLE
Check headers before starting session in get_site_messages

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -135,7 +135,7 @@ function get_site_messages(): string
         return '';
     }
 
-    if (session_status() !== PHP_SESSION_ACTIVE) {
+    if (session_status() !== PHP_SESSION_ACTIVE && !headers_sent()) {
         session_start();
     }
 


### PR DESCRIPTION
Ajout d'un contrôle des en-têtes avant le démarrage de la session afin d'éviter les avertissements lorsque du contenu a déjà été envoyé.

## Changements
- Évite l'appel à `session_start()` si les en-têtes ont été envoyés dans `get_site_messages()`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf18d9c96c8332a73b7de1333d1681