### PR TITLE
Log voir_image_enigme query var and compare as integer

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1235,7 +1235,12 @@ add_action('init', function () {
  * Le handler effectue les vérifications d’accès, puis sert le fichier s’il est autorisé.
  */
 add_action('template_redirect', function () {
-    if (get_query_var('voir_image_enigme') !== '1') return;
+    $voir_image_enigme = get_query_var('voir_image_enigme');
+    error_log('voir_image_enigme query var: ' . $voir_image_enigme);
+
+    if ((int) $voir_image_enigme !== 1) {
+        return;
+    }
 
     $handler = get_stylesheet_directory() . '/inc/handlers/voir-image-enigme.php';
 


### PR DESCRIPTION
## Résumé
- Harmonisation du contrôle sur `voir_image_enigme` et ajout d'un journal pour faciliter le diagnostic.

## Changements notables
- Journalisation de la valeur `voir_image_enigme` avant traitement.
- Conversion de la variable de requête en entier pour la comparaison.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf1c97c37083329b5c5c98b6e572b1