### PR TITLE
Log voir_image_enigme query var

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1235,10 +1235,10 @@ add_action('init', function () {
  * Le handler effectue les vérifications d’accès, puis sert le fichier s’il est autorisé.
  */
 add_action('template_redirect', function () {
-    $voir_image_enigme = get_query_var('voir_image_enigme');
-    error_log('voir_image_enigme query var: ' . $voir_image_enigme);
+    $qv = get_query_var('voir_image_enigme');
+    error_log('voir_image_enigme query var: ' . var_export($qv, true) . ' | URI=' . $_SERVER['REQUEST_URI']);
 
-    if ((int) $voir_image_enigme !== 1) {
+    if ((int) $qv !== 1) {
         return;
     }
 


### PR DESCRIPTION
Ajoute un log de debug sur la query var `voir_image_enigme`.

- Journalise la valeur de `voir_image_enigme` avec l'URI associée
- Préserve ce log pour un suivi continu

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf218725e88332a52e9fb65d77f592