### PR TITLE
Log query var for voir_image_enigme proxy

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1235,10 +1235,9 @@ add_action('init', function () {
  * Le handler effectue les vérifications d’accès, puis sert le fichier s’il est autorisé.
  */
 add_action('template_redirect', function () {
-    $qv = get_query_var('voir_image_enigme');
-    error_log('voir_image_enigme query var: ' . var_export($qv, true) . ' | URI=' . $_SERVER['REQUEST_URI']);
-
-    if ((int) get_query_var('voir_image_enigme') !== 1) {
+    $flag = (int) get_query_var('voir_image_enigme');
+    error_log('voir_image_enigme query var: ' . $flag . ' | URI=' . $_SERVER['REQUEST_URI']);
+    if ($flag !== 1) {
         return;
     }
 


### PR DESCRIPTION
## Résumé
Ajout d'un log pour tracer les appels au proxy d'image d'énigme.

## Changements notables
- Journalise `voir_image_enigme` et valide la requête avant de servir l'image

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf29f0788c83328bedf94791757f21