### PR TITLE
Add handler start logging in voir-image-enigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -5,12 +5,13 @@ if (!isset($_GET['id']) || !ctype_digit($_GET['id'])) {
     exit(__('ID manquant ou invalide', 'chassesautresor-com'));
 }
 
-if (headers_sent($file, $line)) {
-    error_log("[voir-image-enigme] headers already sent in $file:$line");
-}
-
 $image_id = (int) $_GET['id'];
 $taille   = $_GET['taille'] ?? 'full';
+
+error_log('[voir-image-enigme] handler start for image ' . $image_id);
+if (headers_sent($file, $line)) {
+    error_log('[voir-image-enigme] headers already sent in ' . $file . ':' . $line);
+}
 
 // 🔁 Chargement des fonctions
 if (!function_exists('trouver_chemin_image')) {


### PR DESCRIPTION
## Résumé
Ajout de journaux pour suivre l'exécution de `voir-image-enigme`.

## Changements
- Journalise le démarrage du handler avec l'identifiant de l'image.
- Signale si des en-têtes HTTP ont déjà été envoyés.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf2ad4647c833298711552c4d20c44