### PR TITLE
Log get_site_messages session and header checks

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -132,11 +132,16 @@ function get_site_messages(): string
 
     $uri = $_SERVER['REQUEST_URI'] ?? '';
     if (str_starts_with($uri, '/voir-image-enigme')) {
+        error_log('[get_site_messages] bypass pour requête image');
         return '';
     }
-
-    if (session_status() !== PHP_SESSION_ACTIVE && !headers_sent()) {
+    if (headers_sent($file, $line)) {
+        error_log("[get_site_messages] headers déjà envoyés ($file:$line)");
+        return '';
+    }
+    if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
+        error_log('[get_site_messages] session démarrée');
     }
 
     if (!empty($_SESSION['cat_site_messages'])) {


### PR DESCRIPTION
## Résumé
- journalisation de la récupération des messages du site

## Changements notables
- log du bypass pour `/voir-image-enigme`
- arrêt si les en-têtes sont déjà envoyés
- log du démarrage de la session PHP

## Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf304b6cec833296220857edb7d9d4