### PR TITLE
Journalise le query var voir_image_enigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1235,11 +1235,15 @@ add_action('init', function () {
  * Le handler effectue les vérifications d’accès, puis sert le fichier s’il est autorisé.
  */
 add_action('template_redirect', function () {
-    $flag = (int) get_query_var('voir_image_enigme');
-    error_log('voir_image_enigme query var: ' . $flag . ' | URI=' . $_SERVER['REQUEST_URI']);
-    if ($flag !== 1) {
+    $flag = get_query_var('voir_image_enigme');
+    error_log(
+        'template_redirect voir_image_enigme=' . var_export($flag, true) .
+        ' | URI=' . $_SERVER['REQUEST_URI']
+    );
+    if ((int) $flag !== 1) {
         return;
     }
+    error_log('[template_redirect] inclusion du handler voir-image-enigme');
 
     $handler = get_stylesheet_directory() . '/inc/handlers/voir-image-enigme.php';
 


### PR DESCRIPTION
## Résumé
- Ajout d'un log détaillé pour `voir_image_enigme` dans le callback `template_redirect`
- Message de debug lors de l'inclusion du handler d'image

## Changements notables
- Journalisation de la variable de requête et de l'URI courante
- Log supplémentaire avant l'inclusion du handler `voir-image-enigme.php`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf30e3a01483329478b39cab7b2afd