### PR TITLE
Log 304 responses in image handler

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -95,6 +95,9 @@ $if_modified_since = $_SERVER['HTTP_IF_MODIFIED_SINCE'] ?? '';
 
 if (($if_none_match && trim($if_none_match) === $etag) ||
     ($if_modified_since && strtotime($if_modified_since) >= $mtime)) {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('[voir-image-enigme] 304 not modified for image ' . $image_id);
+    }
     http_response_code(304);
     exit;
 }


### PR DESCRIPTION
## Résumé
- ajoute un log lorsque l'image d'énigme renvoie 304

## Changements notables
- journalisation conditionnelle sous WP_DEBUG pour les réponses 304 du handler `voir-image-enigme`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf34590f74833296844c54125b80dd