### PR TITLE
Improve debug logging for voir-image-enigme handler

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -101,7 +101,9 @@ if (($if_none_match && trim($if_none_match) === $etag) ||
 
 header('Content-Type: ' . $mime);
 header('Content-Length: ' . filesize($path));
-$res = readfile($path);
-error_log('[voir-image-enigme] readfile(' . $path . ') → ' . var_export($res, true));
+$bytes = readfile($path);
+if (defined('WP_DEBUG') && WP_DEBUG) {
+    error_log('[voir-image-enigme] readfile(' . $path . ') => ' . var_export($bytes, true));
+}
 exit;
 


### PR DESCRIPTION
### Résumé
- Améliore le log de lecture d'image en mode débogage.

### Changements notables
- Journalise les octets lus par `readfile()` uniquement lorsque `WP_DEBUG` est activé.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf346cf2e88332995389e1c9fbd8e5