### PR TITLE
Check headers after retrieving image path

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -60,6 +60,9 @@ $info = trouver_chemin_image($image_id, $taille);
 $path = $info['path'] ?? null;
 $mime = $info['mime'] ?? 'application/octet-stream';
 error_log('[voir-image-enigme] path=' . var_export($path, true) . ', mime=' . var_export($mime, true));
+if (headers_sent($file, $line)) {
+    error_log('[voir-image-enigme] headers already sent in ' . $file . ':' . $line);
+}
 
 // 🔁 Fallback automatique vers full si fichier manquant
 if (!$path && $taille !== 'full') {


### PR DESCRIPTION
## Résumé
- Ajoute un log lorsque des en-têtes ont déjà été envoyés après la récupération du chemin d'une image.

## Changements notables
- Journalise l'état des en-têtes juste après la récupération du chemin du fichier image.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf3473f63c8332bb99e3836990fd6f