### PR TITLE
Log des entêtes de cache pour les images d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -88,6 +88,7 @@ do_action('litespeed_control_set_nocache');
 // 📅 Cache (compatible CDN)
 $mtime = filemtime($path);
 $etag  = '"' . md5($mtime . filesize($path)) . '"';
+error_log('[voir-image-enigme] cache headers mtime=' . $mtime . ', etag=' . $etag);
 
 header('Cache-Control: public, max-age=3600, immutable');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');


### PR DESCRIPTION
## Résumé
- journaliser les valeurs mtime et ETag pour les images d’énigme afin de vérifier la stabilité du cache

## Changements notables
- ajout d’un `error_log` avec mtime et ETag dans `voir-image-enigme`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf419cfae08332a3c7bbcec3268d8d