### PR TITLE
Log cache headers before 304 response

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -93,11 +93,23 @@ header('Cache-Control: public, max-age=3600, immutable');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');
 header('ETag: ' . $etag);
 
-$if_none_match    = $_SERVER['HTTP_IF_NONE_MATCH'] ?? '';
-$if_modified_since = $_SERVER['HTTP_IF_MODIFIED_SINCE'] ?? '';
+$if_none_match           = $_SERVER['HTTP_IF_NONE_MATCH'] ?? '';
+$if_modified_since       = $_SERVER['HTTP_IF_MODIFIED_SINCE'] ?? '';
+$if_none_match_match     = $if_none_match && trim($if_none_match) === $etag;
+$if_modified_since_match = $if_modified_since && strtotime($if_modified_since) >= $mtime;
 
-if (($if_none_match && trim($if_none_match) === $etag) ||
-    ($if_modified_since && strtotime($if_modified_since) >= $mtime)) {
+if (defined('WP_DEBUG') && WP_DEBUG) {
+    error_log(
+        '[voir-image-enigme] If-None-Match: ' . var_export($if_none_match, true)
+        . ' => ' . ($if_none_match_match ? 'match' : 'no match')
+    );
+    error_log(
+        '[voir-image-enigme] If-Modified-Since: ' . var_export($if_modified_since, true)
+        . ' => ' . ($if_modified_since_match ? 'match' : 'no match')
+    );
+}
+
+if ($if_none_match_match || $if_modified_since_match) {
     if (defined('WP_DEBUG') && WP_DEBUG) {
         error_log('[voir-image-enigme] 304 not modified for image ' . $image_id);
     }


### PR DESCRIPTION
Ajoute un journal des en-têtes de cache pour comprendre quelle condition déclenche la réponse 304.

- Journalise `If-None-Match` et `If-Modified-Since` avec l'indication de correspondance avant la comparaison 304.

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf417cbb5c8332a7a59bb7acb1e71b