### PR TITLE
Désactive l'envoi de 304 pour les images d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -101,8 +101,10 @@ if (($if_none_match && trim($if_none_match) === $etag) ||
     if (defined('WP_DEBUG') && WP_DEBUG) {
         error_log('[voir-image-enigme] 304 not modified for image ' . $image_id);
     }
-    http_response_code(304);
-    exit;
+    // Les lignes ci-dessous sont désactivées afin de toujours renvoyer le fichier avec un
+    // code 200 et confirmer que le bloc de cache est en cause.
+    // http_response_code(304);
+    // exit;
 }
 
 header('Content-Type: ' . $mime);


### PR DESCRIPTION
## Résumé
- désactivation temporaire de la réponse 304 pour `voir-image-enigme`

## Changements notables
- commente les lignes renvoyant un statut 304 afin de servir systématiquement les images avec un code 200

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf41996204833294d8667d751de304