### PR TITLE
Supprimer la journalisation dans la résolution des visuels

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -310,7 +310,6 @@ function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
 
     $upload_dir = wp_get_upload_dir();
     $path = str_replace($upload_dir['baseurl'], $upload_dir['basedir'], $url);
-    error_log("[trouver_chemin_image] chemin résolu $path pour image $image_id ($taille)");
 
     // 🔁 Si une version .webp existe, on la préfère
     $webp_path = preg_replace('/\.(jpe?g|png|gif)$/i', '.webp', $path);
@@ -333,7 +332,6 @@ function trouver_chemin_image(int $image_id, string $taille = 'full'): ?array
     }
 
     if ($taille !== 'full') {
-        error_log("[trouver_chemin_image] fallback vers taille full pour image $image_id");
         return trouver_chemin_image($image_id, 'full');
     }
 


### PR DESCRIPTION
## Résumé
- Retire les `error_log` superflus dans `trouver_chemin_image`
- Retourne `null` sans journaliser en cas d'échec de résolution d'image

## Changements notables
- Nettoyage de la résolution de chemin d'image pour éviter les logs inutiles

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf4650b2788332a20994d7a84b8211