### PR TITLE
Valider les tailles d'image des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -54,6 +54,16 @@ function build_picture_enigme(int $image_id, string $alt, array $sizes, array $i
     $breakpoints = get_enigme_picture_breakpoints();
     $order = ['thumbnail', 'medium', 'large', 'full'];
 
+    $valid_sizes = function_exists('get_intermediate_image_sizes')
+        ? get_intermediate_image_sizes()
+        : ['thumbnail', 'medium', 'large'];
+    $valid_sizes[] = 'full';
+    $valid_sizes = array_intersect($valid_sizes, $order);
+    $sizes = array_values(array_intersect($sizes, $valid_sizes));
+    if (!$sizes) {
+        $sizes = ['full'];
+    }
+
     $max_index = 0;
     foreach ($sizes as $s) {
         $idx = array_search($s, $order, true);

--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -8,6 +8,16 @@ if (!isset($_GET['id']) || !ctype_digit($_GET['id'])) {
 $image_id = (int) $_GET['id'];
 $taille   = $_GET['taille'] ?? 'full';
 
+$sizes = function_exists('get_intermediate_image_sizes')
+    ? get_intermediate_image_sizes()
+    : ['thumbnail', 'medium', 'large'];
+$sizes[] = 'full';
+
+if (!in_array($taille, $sizes, true)) {
+    http_response_code(400);
+    exit(__('Taille d\'image invalide', 'chassesautresor-com'));
+}
+
 // 🔁 Chargement des fonctions
 if (!function_exists('trouver_chemin_image')) {
     require_once get_stylesheet_directory() . '/inc/enigme-functions.php';


### PR DESCRIPTION
## Résumé
- sécurise le proxy `voir-image-enigme` en ne servant que des tailles WordPress reconnues
- filtre les tailles d’image utilisées par `build_picture_enigme`

## Changements notables
- vérification des paramètres de taille et renvoi d’une erreur 400 en cas de valeur invalide
- nettoyage des tailles utilisées pour générer les balises `<picture>` des énigmes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf9c333ec48332bef03188ba1c8fd9