### PR TITLE
Ajout de l'alt des images de chasse

### DIFF
--- a/tests/ChasseEnigmesPayantesTest.php
+++ b/tests/ChasseEnigmesPayantesTest.php
@@ -15,6 +15,9 @@ class ChasseEnigmesPayantesTest extends TestCase
         if (!function_exists('get_permalink')) {
             function get_permalink($id) { return 'https://example.com/chasse/' . $id; }
         }
+        if (!function_exists('get_the_title')) {
+            function get_the_title($post_id) { return 'Chasse ' . $post_id; }
+        }
         if (!function_exists('current_user_can')) {
             function current_user_can($capability) { return false; }
         }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1464,6 +1464,8 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     $image_raw = get_field('chasse_principale_image', $chasse_id);
     $image_id  = is_array($image_raw) ? ($image_raw['ID'] ?? null) : $image_raw;
     $image_url = $image_id ? wp_get_attachment_image_src($image_id, 'chasse-fiche')[0] : null;
+    $image_alt = $image_id ? get_post_meta($image_id, '_wp_attachment_image_alt', true) : '';
+    $image_alt = $image_alt !== '' ? $image_alt : get_the_title($chasse_id);
 
     $liens = get_field('chasse_principale_liens', $chasse_id);
     $liens = is_array($liens) ? $liens : [];
@@ -1505,6 +1507,7 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
         'image_raw'           => $image_raw,
         'image_id'            => $image_id,
         'image_url'           => $image_url,
+        'image_alt'           => $image_alt,
         'liens'               => $liens,
         'enigmes_associees'   => $enigmes,
         'total_enigmes'       => count($enigmes),

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -190,20 +190,14 @@ if ($edition_active && !$est_complet) {
                   href="<?= esc_url(wp_get_attachment_image_url($image_id, 'full')); ?>"
                   class="fancybox image"
                 >
-                  <?php
-                  echo wp_get_attachment_image(
-                      $image_id,
-                      'chasse-fiche',
-                      false,
-                      [
-                          'class'       => 'chasse-image visuel-cpt img-h-max',
-                          'data-cpt'    => 'chasse',
-                          'data-post-id' => $chasse_id,
-                          'alt'         => __('Image de la chasse', 'chassesautresor-com'),
-                          'sizes'       => '(max-width: 800px) 100vw, 800px',
-                      ]
-                  );
-                  ?>
+                  <img
+                      class="chasse-image visuel-cpt img-h-max"
+                      data-cpt="chasse"
+                      data-post-id="<?= esc_attr($chasse_id); ?>"
+                      src="<?= esc_url($infos_chasse['image_url']); ?>"
+                      alt="<?= esc_attr($infos_chasse['image_alt']); ?>"
+                      sizes="(max-width: 800px) 100vw, 800px"
+                  />
                 </a>
               <?php endif; ?>
             </div>


### PR DESCRIPTION
## Résumé
- expose l'attribut alt de l'image principale d'une chasse
- affiche cet alt dans le gabarit plein écran

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfb7a75bc883328501433b3ff7466d