### PR TITLE
Afficher les images des cartes de chasse via wp_get_attachment_image

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1258,15 +1258,18 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     $extrait       = wp_trim_words($texte_complet, 60, '...');
 
     $image_data = get_field('chasse_principale_image', $chasse_id);
+    $image_id = 0;
     $image = '';
     if (is_array($image_data) && !empty($image_data['sizes']['medium'])) {
+        $image_id = $image_data['ID'] ?? 0;
         $image = $image_data['sizes']['medium'];
     } elseif ($image_data) {
         $image_id = is_array($image_data) ? ($image_data['ID'] ?? 0) : (int) $image_data;
         $image = $image_id ? wp_get_attachment_image_url($image_id, 'medium') : '';
     }
     if (!$image) {
-        $image = get_the_post_thumbnail_url($chasse_id, 'medium');
+        $image_id = get_post_thumbnail_id($chasse_id);
+        $image = $image_id ? wp_get_attachment_image_url($image_id, 'medium') : '';
     }
 
     $champs = chasse_get_champs($chasse_id);
@@ -1403,6 +1406,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
         'titre'             => $titre,
         'permalink'         => $permalink,
         'image'             => $image,
+        'image_id'          => $image_id,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs_label'  => $nb_joueurs_label,
         'date_debut'        => $date_debut_affichage,

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -1,0 +1,60 @@
+<?php
+defined('ABSPATH') || exit;
+
+if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id = $args['chasse_id'];
+$completion_class = $args['completion_class'] ?? '';
+
+$infos = preparer_infos_affichage_carte_chasse($chasse_id);
+if (empty($infos)) {
+    return;
+}
+?>
+
+<div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
+    <div class="carte-ligne__image">
+        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+            <?php echo esc_html($infos['statut_label']); ?>
+        </span>
+        <?php
+        echo wp_get_attachment_image(
+            $infos['image_id'],
+            'large',
+            false,
+            [ 'sizes' => '(min-width:768px) 100vw, 100vw' ]
+        );
+        ?>
+    </div>
+
+    <div class="carte-ligne__contenu">
+        <h3 class="carte-ligne__titre">
+            <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
+        </h3>
+
+        <div class="meta-row svg-xsmall">
+            <div class="meta-regular">
+                <?php echo get_svg_icon('enigme'); ?>
+                <?php echo esc_html(sprintf(_n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'), $infos['total_enigmes'])); ?> —
+                <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+            </div>
+            <div class="meta-etiquette">
+                <?php echo get_svg_icon('calendar'); ?>
+                <span class="chasse-date-plage">
+                    <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
+                    <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                </span>
+            </div>
+        </div>
+
+        <?php echo $infos['extrait_html']; ?>
+        <?php echo $infos['lot_html']; ?>
+        <div class="flex-row cta-div">
+            <a href="<?php echo esc_url($infos['permalink']); ?>" class="bouton-secondaire"><?= esc_html__('En savoir plus', 'chassesautresor-com'); ?></a>
+        </div>
+        <?php echo $infos['footer_html']; ?>
+    </div>
+</div>
+


### PR DESCRIPTION
## Résumé
- Utilisation de `wp_get_attachment_image` pour afficher les visuels des cartes de chasse.
- Exposition de l'ID d'image dans `preparer_infos_affichage_carte_chasse` pour un rendu plus flexible.

## Changements notables
- Nouveau template `chasse-card-wide` avec images responsive.
- Ajout de `image_id` et gestion des images de secours dans la préparation des données.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfbb64d44c8332a2d90c26674aeb6a