### PR TITLE
Expose hunt card cost and validation mode

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1346,8 +1346,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     if ($cout_points > 0) {
         $footer_icones[] = 'coins-points';
     }
-
-    $modes = [];
+    $mode_validation = '';
+    $modes          = [];
     foreach ($enigmes_associees as $eid) {
         $mode = get_field('enigme_mode_validation', $eid);
         if ($mode) {
@@ -1356,8 +1356,10 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     }
     if (isset($modes['manuelle'])) {
         $footer_icones[] = 'reply-mail';
+        $mode_validation = 'manuelle';
     } elseif (isset($modes['automatique'])) {
         $footer_icones[] = 'reply-auto';
+        $mode_validation = 'automatique';
     }
 
     $lot_html = '';
@@ -1405,6 +1407,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
         'image'             => $image,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs_label'  => $nb_joueurs_label,
+        'cout_points'       => $cout_points,
+        'mode_validation'   => $mode_validation,
         'date_debut'        => $date_debut_affichage,
         'date_fin'          => $date_fin_affichage,
         'badge_class'       => $badge_class,

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -1,0 +1,71 @@
+<?php
+defined('ABSPATH') || exit;
+
+if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id = (int) $args['chasse_id'];
+$infos     = preparer_infos_affichage_carte_chasse($chasse_id);
+
+if (empty($infos)) {
+    return;
+}
+?>
+<div class="carte carte-chasse carte-wide <?php echo esc_attr($infos['classe_statut']); ?>">
+    <div class="carte-wide__image">
+        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+            <?php echo esc_html($infos['statut_label']); ?>
+        </span>
+        <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">
+    </div>
+
+    <div class="carte-wide__contenu">
+        <h3 class="carte-wide__titre">
+            <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
+        </h3>
+
+        <div class="meta-row svg-xsmall">
+            <div class="meta-regular">
+                <?php echo get_svg_icon('enigme'); ?>
+                <?php
+                echo esc_html(
+                    sprintf(
+                        _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                        $infos['total_enigmes']
+                    )
+                );
+                ?> —
+                <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+            </div>
+        </div>
+
+        <?php if ((int) $infos['cout_points'] > 0 || $infos['mode_validation'] !== '') : ?>
+        <div class="meta-badges">
+            <?php if ((int) $infos['cout_points'] > 0) : ?>
+            <span class="badge-rond badge-cout" aria-label="<?php echo esc_attr(sprintf(esc_html__('Coût par tentative : %d points.', 'chassesautresor-com'), $infos['cout_points'])); ?>">
+                <?php echo get_svg_icon('coins-points'); ?>
+                <span><?php echo esc_html($infos['cout_points']); ?></span>
+            </span>
+            <?php endif; ?>
+
+            <?php if ($infos['mode_validation'] === 'manuelle') : ?>
+            <span class="badge-rond badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation manuelle', 'chassesautresor-com')); ?>">
+                <?php echo get_svg_icon('reply-mail'); ?>
+            </span>
+            <?php elseif ($infos['mode_validation'] === 'automatique') : ?>
+            <span class="badge-rond badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation automatique', 'chassesautresor-com')); ?>">
+                <?php echo get_svg_icon('reply-auto'); ?>
+            </span>
+            <?php endif; ?>
+        </div>
+        <?php endif; ?>
+
+        <?php echo $infos['extrait_html']; ?>
+        <?php echo $infos['lot_html']; ?>
+        <div class="flex-row cta-div">
+            <a href="<?php echo esc_url($infos['permalink']); ?>" class="bouton-secondaire"><?php echo esc_html__('En savoir plus', 'chassesautresor-com'); ?></a>
+        </div>
+        <?php echo $infos['footer_html']; ?>
+    </div>
+</div>


### PR DESCRIPTION
## Résumé
- expose les champs `cout_points` et `mode_validation` pour les cartes de chasse
- ajoute le template `chasse-card-wide.php` avec badges accessibles

## Changements notables
- renvoie distinctement le coût en points et le mode de validation des énigmes
- affiche les badges de coût et de validation avec `aria-label` localisés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfbb99db148332a4ef94294a754182