### PR TITLE
Affiche le logo de l’organisateur sur la carte large

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -1,0 +1,20 @@
+<?php
+defined('ABSPATH') || exit;
+
+if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id = (int) $args['chasse_id'];
+
+$orga_id = get_organisateur_from_chasse($chasse_id);
+$logo_url = $orga_id ? get_the_post_thumbnail_url($orga_id, 'thumbnail') : '';
+$orga_title = $orga_id ? get_the_title($orga_id) : '';
+$orga_link = $orga_id ? get_permalink($orga_id) : '';
+
+if ($orga_id && $logo_url) {
+    echo '<img src="' . esc_url($logo_url) . '" alt="' . esc_attr($orga_title) . '"> ';
+    echo '<a href="' . esc_url($orga_link) . '">' . esc_html($orga_title) . '</a> ';
+    echo esc_html__('présente', 'chassesautresor-com');
+}
+


### PR DESCRIPTION
## Résumé
- Affiche le logo, le lien et le titre de l’organisateur sur la carte chasse large

## Changements notables
- Ajout d’un nouveau template `chasse-card-wide.php` pour exposer le logo et le nom de l’organisateur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfbba6768883329c27690f61d03a87