### PR TITLE
feat: display organiser on wide hunt card

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -7,7 +7,12 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 
 $chasse_id = (int) $args['chasse_id'];
 $completion_class = $args['completion_class'] ?? '';
-$infos     = preparer_infos_affichage_carte_chasse($chasse_id);
+$infos           = preparer_infos_affichage_carte_chasse($chasse_id);
+
+$orga_id    = get_organisateur_from_chasse($chasse_id);
+$logo_url   = $orga_id ? get_the_post_thumbnail_url($orga_id, 'thumbnail') : '';
+$orga_title = $orga_id ? get_the_title($orga_id) : '';
+$orga_link  = $orga_id ? get_permalink($orga_id) : '';
 
 if (empty($infos)) {
     return;
@@ -22,6 +27,12 @@ if (empty($infos)) {
     </div>
 
     <div class="carte-wide__contenu">
+        <?php if ($orga_id && $logo_url) : ?>
+            <img src="<?php echo esc_url($logo_url); ?>" alt="<?php echo esc_attr($orga_title); ?>">
+            <a href="<?php echo esc_url($orga_link); ?>"><?php echo esc_html($orga_title); ?></a>
+            <?php echo esc_html__('présente', 'chassesautresor-com'); ?>
+        <?php endif; ?>
+
         <h3 class="carte-wide__titre">
             <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
         </h3>


### PR DESCRIPTION
## Résumé
- affiche l'organisateur sur la carte large d'une chasse

## Changements notables
- récupère le logo et le nom de l'organisateur
- affiche ces informations avec le texte "présente"

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfbe20d77483328db3a835c421f268