### PR TITLE
Use full-width layout for organiser hunts

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -25,6 +25,16 @@
   gap: var(--space-xl);
 }
 
+.liste-pleine-largeur {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+
+  > * {
+    width: 100%;
+  }
+}
+
 // Grille responsive pour cartes
 .cards-grid {
   display: grid;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -26,6 +26,15 @@
   gap: var(--space-xl);
 }
 
+.liste-pleine-largeur {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+.liste-pleine-largeur > * {
+  width: 100%;
+}
+
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -8,7 +8,7 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 }
 
 $show_header  = $args['show_header'] ?? true;
-$grid_class   = $args['grid_class'] ?? 'grille-liste';
+$grid_class   = $args['grid_class'] ?? 'liste-pleine-largeur';
 $before_items = $args['before_items'] ?? '';
 $after_items  = $args['after_items'] ?? '';
 
@@ -43,7 +43,7 @@ $chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use (
       $complet          = (bool) get_field('chasse_cache_complet', $chasse_id);
       $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
     }
-    get_template_part('template-parts/chasse/chasse-card', null, [
+    get_template_part('template-parts/chasse/chasse-card-wide', null, [
       'chasse_id'        => $chasse_id,
       'completion_class' => $classe_completion,
     ]);


### PR DESCRIPTION
## Summary
- permettre un affichage pleine largeur des chasses d'un organisateur
- ajouter les styles nécessaires pour la nouvelle classe de grille

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68bfc30afe9c8332872889b648889c09