### PR TITLE
Harmonisation des badges des chasses côté organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -245,6 +245,52 @@
   flex-shrink: 0;
 }
 
+/* ========== 🗺️ Carte chasse large ========== */
+.carte-wide__image {
+  position: relative;
+
+  .badge-statut {
+    position: absolute;
+    top: var(--space-xs);
+    left: var(--space-xs);
+  }
+
+  .badge-cout {
+    position: absolute;
+    top: var(--space-xs);
+    right: var(--space-xs);
+    background: var(--color-grey-light);
+    color: var(--color-text-fond-clair);
+  }
+
+  .badge-validation {
+    position: absolute;
+    bottom: var(--space-xs);
+    left: var(--space-xs);
+  }
+
+  .mode-fin-icone {
+    position: absolute;
+    bottom: var(--space-xs);
+    right: var(--space-xs);
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-grey-light);
+    color: var(--color-text-fond-clair);
+    font-size: 0.75rem;
+  }
+
+  .mode-fin-icone svg,
+  .mode-fin-icone i {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+}
+
 .carte-enigme h3 {
   margin: 0;
   padding: 0 var(--space-md);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -223,6 +223,47 @@
   flex-shrink: 0;
 }
 
+/* ========== 🗺️ Carte chasse large ========== */
+.carte-wide__image {
+  position: relative;
+}
+.carte-wide__image .badge-statut {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+}
+.carte-wide__image .badge-cout {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  background: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
+}
+.carte-wide__image .badge-validation {
+  position: absolute;
+  bottom: var(--space-xs);
+  left: var(--space-xs);
+}
+.carte-wide__image .mode-fin-icone {
+  position: absolute;
+  bottom: var(--space-xs);
+  right: var(--space-xs);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
+  font-size: 0.75rem;
+}
+.carte-wide__image .mode-fin-icone svg,
+.carte-wide__image .mode-fin-icone i {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
 .carte-enigme h3 {
   margin: 0;
   padding: 0 var(--space-md);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -5,9 +5,10 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
     return;
 }
 
-$chasse_id = (int) $args['chasse_id'];
+$chasse_id      = (int) $args['chasse_id'];
 $completion_class = $args['completion_class'] ?? '';
 $infos           = preparer_infos_affichage_carte_chasse($chasse_id);
+$mode_fin        = get_field('chasse_mode_fin', $chasse_id) ?: 'automatique';
 
 $orga_id    = get_organisateur_from_chasse($chasse_id);
 $logo_url   = $orga_id ? get_the_post_thumbnail_url($orga_id, 'thumbnail') : '';
@@ -22,6 +23,32 @@ if (empty($infos)) {
     <div class="carte-wide__image">
         <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
             <?php echo esc_html($infos['statut_label']); ?>
+        </span>
+        <?php if ($infos['mode_validation'] === 'manuelle') : ?>
+            <span class="badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation manuelle', 'chassesautresor-com')); ?>">
+                <?php echo get_svg_icon('reply-mail'); ?>
+            </span>
+        <?php elseif ($infos['mode_validation'] === 'automatique') : ?>
+            <span class="badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation automatique', 'chassesautresor-com')); ?>">
+                <?php echo get_svg_icon('reply-auto'); ?>
+            </span>
+        <?php endif; ?>
+        <?php if ((int) $infos['cout_points'] > 0) : ?>
+            <span class="badge-cout" aria-label="<?php echo esc_attr(sprintf(__('Coût de participation : %d points.', 'chassesautresor-com'), $infos['cout_points'])); ?>">
+                <?php echo esc_html($infos['cout_points'] . ' ' . __('pts', 'chassesautresor-com')); ?>
+            </span>
+        <?php endif; ?>
+        <?php
+        $mode_fin_label = $mode_fin === 'automatique'
+            ? __('mode de fin de chasse : automatique', 'chassesautresor-com')
+            : __('mode de fin de chasse : manuelle', 'chassesautresor-com');
+        ?>
+        <span class="mode-fin-icone" title="<?php echo esc_attr($mode_fin_label); ?>" aria-label="<?php echo esc_attr($mode_fin_label); ?>">
+            <?php if ($mode_fin === 'automatique') : ?>
+                <i class="fa-solid fa-bolt"></i>
+            <?php else : ?>
+                <?php echo get_svg_icon('hand'); ?>
+            <?php endif; ?>
         </span>
         <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">
     </div>
@@ -51,27 +78,6 @@ if (empty($infos)) {
                 <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
             </div>
         </div>
-
-        <?php if ((int) $infos['cout_points'] > 0 || $infos['mode_validation'] !== '') : ?>
-        <div class="meta-badges">
-            <?php if ((int) $infos['cout_points'] > 0) : ?>
-            <span class="badge-rond badge-cout" aria-label="<?php echo esc_attr(sprintf(esc_html__('Coût par tentative : %d points.', 'chassesautresor-com'), $infos['cout_points'])); ?>">
-                <?php echo get_svg_icon('coins-points'); ?>
-                <span><?php echo esc_html($infos['cout_points']); ?></span>
-            </span>
-            <?php endif; ?>
-
-            <?php if ($infos['mode_validation'] === 'manuelle') : ?>
-            <span class="badge-rond badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation manuelle', 'chassesautresor-com')); ?>">
-                <?php echo get_svg_icon('reply-mail'); ?>
-            </span>
-            <?php elseif ($infos['mode_validation'] === 'automatique') : ?>
-            <span class="badge-rond badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation automatique', 'chassesautresor-com')); ?>">
-                <?php echo get_svg_icon('reply-auto'); ?>
-            </span>
-            <?php endif; ?>
-        </div>
-        <?php endif; ?>
 
         <?php echo $infos['extrait_html']; ?>
         <?php echo $infos['lot_html']; ?>


### PR DESCRIPTION
## Résumé
- Harmonise l'affichage des badges des chasses côté organisateur avec ceux de la fiche chasse

## Changements notables
- Ajout des badges de statut, validation, coût et mode de fin directement sur l'image des cartes de chasse côté organisateur
- Styling dédié pour positionner les badges sur les cartes larges

## Testing
- `node build-css.js`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfc587940883328b4abe7ec36162a0