### PR TITLE
feat: mise en page responsive des cartes chasse larges

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -401,6 +401,49 @@
   border-radius: 50%;
 }
 
+/* ========== 🧿 Carte wide ========== */
+.carte-wide {
+  display: flex;
+  flex-direction: column;
+}
+
+.carte-wide__image {
+  width: 100%;
+  height: 250px;
+  max-height: 250px;
+  overflow: hidden;
+}
+
+.carte-wide__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.carte-wide__contenu {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: var(--space-md) var(--space-2xl);
+}
+
+.carte-wide__footer .cta-div {
+  justify-content: center;
+}
+
+@media (--bp-tablet) {
+  .carte-wide {
+    flex-direction: row;
+  }
+
+  .carte-wide__image {
+    flex: 0 0 30%;
+    max-width: 30%;
+  }
+}
+
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */
 .carte-ajout-chasse {
   display: flex;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -379,6 +379,49 @@
   border-radius: 50%;
 }
 
+/* ========== 🧿 Carte wide ========== */
+.carte-wide {
+  display: flex;
+  flex-direction: column;
+}
+
+.carte-wide__image {
+  width: 100%;
+  height: 250px;
+  max-height: 250px;
+  overflow: hidden;
+}
+
+.carte-wide__image img {
+  width: 100%;
+  height: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  -o-object-position: center;
+     object-position: center;
+  display: block;
+}
+
+.carte-wide__contenu {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: var(--space-md) var(--space-2xl);
+}
+
+.carte-wide__footer .cta-div {
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  .carte-wide {
+    flex-direction: row;
+  }
+  .carte-wide__image {
+    flex: 0 0 30%;
+    max-width: 30%;
+  }
+}
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */
 .carte-ajout-chasse {
   display: flex;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -20,64 +20,82 @@ if (empty($infos)) {
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
-        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>"
+            data-post-id="<?php echo esc_attr($chasse_id); ?>">
             <?php echo esc_html($infos['statut_label']); ?>
         </span>
         <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">
     </div>
 
     <div class="carte-wide__contenu">
-        <?php if ($orga_id && $logo_url) : ?>
-            <img src="<?php echo esc_url($logo_url); ?>" alt="<?php echo esc_attr($orga_title); ?>">
-            <a href="<?php echo esc_url($orga_link); ?>"><?php echo esc_html($orga_title); ?></a>
-            <?php echo esc_html__('présente', 'chassesautresor-com'); ?>
-        <?php endif; ?>
+        <div class="carte-wide__header">
+            <?php if ($orga_id && $logo_url) : ?>
+                <img src="<?php echo esc_url($logo_url); ?>" alt="<?php echo esc_attr($orga_title); ?>">
+                <a href="<?php echo esc_url($orga_link); ?>"><?php echo esc_html($orga_title); ?></a>
+                <?php echo esc_html__('présente', 'chassesautresor-com'); ?>
+            <?php endif; ?>
 
-        <h3 class="carte-wide__titre">
-            <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
-        </h3>
+            <h3 class="carte-wide__titre">
+                <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
+            </h3>
+        </div>
 
-        <div class="meta-row svg-xsmall">
-            <div class="meta-regular">
-                <?php echo get_svg_icon('enigme'); ?>
-                <?php
-                echo esc_html(
-                    sprintf(
-                        _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
-                        $infos['total_enigmes']
-                    )
-                );
-                ?> —
-                <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+        <div class="carte-wide__content">
+            <div class="meta-row svg-xsmall">
+                <div class="meta-regular">
+                    <?php echo get_svg_icon('enigme'); ?>
+                    <?php
+                    echo esc_html(
+                        sprintf(
+                            _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                            $infos['total_enigmes']
+                        )
+                    );
+                    ?> —
+                    <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+                </div>
             </div>
-        </div>
 
-        <?php if ((int) $infos['cout_points'] > 0 || $infos['mode_validation'] !== '') : ?>
-        <div class="meta-badges">
-            <?php if ((int) $infos['cout_points'] > 0) : ?>
-            <span class="badge-rond badge-cout" aria-label="<?php echo esc_attr(sprintf(esc_html__('Coût par tentative : %d points.', 'chassesautresor-com'), $infos['cout_points'])); ?>">
-                <?php echo get_svg_icon('coins-points'); ?>
-                <span><?php echo esc_html($infos['cout_points']); ?></span>
-            </span>
+            <?php if ((int) $infos['cout_points'] > 0 || $infos['mode_validation'] !== '') : ?>
+            <div class="meta-badges">
+                <?php if ((int) $infos['cout_points'] > 0) : ?>
+                <span class="badge-rond badge-cout"
+                    aria-label="<?php echo esc_attr(
+                        sprintf(
+                            esc_html__('Coût par tentative : %d points.', 'chassesautresor-com'),
+                            $infos['cout_points']
+                        )
+                    ); ?>">
+                    <?php echo get_svg_icon('coins-points'); ?>
+                    <span><?php echo esc_html($infos['cout_points']); ?></span>
+                </span>
+                <?php endif; ?>
+
+                <?php if ($infos['mode_validation'] === 'manuelle') : ?>
+                <span class="badge-rond badge-validation"
+                    aria-label="<?php echo esc_attr(esc_html__('Validation manuelle', 'chassesautresor-com')); ?>">
+                    <?php echo get_svg_icon('reply-mail'); ?>
+                </span>
+                <?php elseif ($infos['mode_validation'] === 'automatique') : ?>
+                <span class="badge-rond badge-validation"
+                    aria-label="<?php echo esc_attr(esc_html__('Validation automatique', 'chassesautresor-com')); ?>">
+                    <?php echo get_svg_icon('reply-auto'); ?>
+                </span>
+                <?php endif; ?>
+            </div>
             <?php endif; ?>
 
-            <?php if ($infos['mode_validation'] === 'manuelle') : ?>
-            <span class="badge-rond badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation manuelle', 'chassesautresor-com')); ?>">
-                <?php echo get_svg_icon('reply-mail'); ?>
-            </span>
-            <?php elseif ($infos['mode_validation'] === 'automatique') : ?>
-            <span class="badge-rond badge-validation" aria-label="<?php echo esc_attr(esc_html__('Validation automatique', 'chassesautresor-com')); ?>">
-                <?php echo get_svg_icon('reply-auto'); ?>
-            </span>
-            <?php endif; ?>
+            <?php echo $infos['extrait_html']; ?>
+            <?php echo $infos['lot_html']; ?>
         </div>
-        <?php endif; ?>
 
-        <?php echo $infos['extrait_html']; ?>
-        <?php echo $infos['lot_html']; ?>
-        <div class="flex-row cta-div">
-            <a href="<?php echo esc_url($infos['permalink']); ?>" class="bouton-secondaire"><?php echo esc_html__('En savoir plus', 'chassesautresor-com'); ?></a>
+        <div class="carte-wide__footer">
+            <div class="flex-row cta-div">
+                <a href="<?php echo esc_url($infos['permalink']); ?>" class="bouton-secondaire">
+                    <?php echo esc_html__('En savoir plus', 'chassesautresor-com'); ?>
+                </a>
+            </div>
+            <?php echo $infos['footer_html']; ?>
         </div>
-        <?php echo $infos['footer_html']; ?>
     </div>
 </div>


### PR DESCRIPTION
## Résumé
- carte chasse pleine largeur responsive avec image à gauche et contenu structuré
- compilation des styles SCSS

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc5ef4d5883328ac65b9a84006f59