### PR TITLE
Aligner le titre des chasses sur l'image

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -468,11 +468,16 @@
   display: block;
 }
 
+
 .carte-wide__contenu {
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: var(--space-md) var(--space-2xl);
+  padding: 0 var(--space-2xl) var(--space-md);
+}
+
+.carte-wide__titre {
+  margin-top: 0;
 }
 
 .carte-wide__footer .cta-div {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -447,7 +447,11 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: var(--space-md) var(--space-2xl);
+  padding: 0 var(--space-2xl) var(--space-md);
+}
+
+.carte-wide__titre {
+  margin-top: 0;
 }
 
 .carte-wide__footer .cta-div {


### PR DESCRIPTION
### Résumé
- ajuste la carte des chasses pour aligner le titre avec le haut de l’image

### Changements notables
- supprime le padding supérieur des cartes `carte-wide`
- annule la marge supérieure du titre de la carte

### Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfd02cd9d4833294cc3b272fe57b04