### PR TITLE
Start session at init and refine message header check

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -32,6 +32,15 @@ function cat_install_user_messages_table(): void
 }
 add_action('after_switch_theme', 'cat_install_user_messages_table');
 
+add_action(
+    'init',
+    function (): void {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+    }
+);
+
 /**
  * Store a site-wide message.
  *
@@ -135,13 +144,13 @@ function get_site_messages(): string
         error_log('[get_site_messages] bypass pour requête image');
         return '';
     }
-    if (headers_sent($file, $line)) {
-        error_log("[get_site_messages] headers déjà envoyés ($file:$line)");
-        return '';
-    }
     if (session_status() !== PHP_SESSION_ACTIVE) {
-        session_start();
-        error_log('[get_site_messages] session démarrée');
+        if (headers_sent($file, $line)) {
+            error_log("[get_site_messages] headers déjà envoyés ($file:$line)");
+        } else {
+            session_start();
+            error_log('[get_site_messages] session démarrée');
+        }
     }
 
     if (!empty($_SESSION['cat_site_messages'])) {


### PR DESCRIPTION
## Résumé
- Lancer la session PHP dès l'init du thème
- Adapter get_site_messages pour ne plus quitter en cas d'en-têtes déjà envoyés

## Changements notables
- Démarrage de session anticipé via un hook `init`
- Vérification `headers_sent` limitée à l'ouverture de session, sans retour prématuré

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bffe92ac4c833295093fbfea3974b3