### PR TITLE
Supprime le CTA sur la liste des chasses de l'organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -79,13 +79,8 @@ if (empty($infos)) {
             <?php echo $infos['lot_html']; ?>
         </div>
 
-        <div class="carte-wide__footer">
-            <div class="flex-row cta-div">
-                <a href="<?php echo esc_url($infos['permalink']); ?>" class="bouton-secondaire">
-                    <?php echo esc_html__('En savoir plus', 'chassesautresor-com'); ?>
-                </a>
-            </div>
-            <?php if ($orga_id) : ?>
+        <?php if ($orga_id) : ?>
+            <div class="carte-wide__footer">
                 <footer class="chasse-footer">
                     <span class="chasse-footer__texte">
                         <?= esc_html__('Proposé par', 'chassesautresor-com'); ?>
@@ -94,7 +89,7 @@ if (empty($infos)) {
                         </a>
                     </span>
                 </footer>
-            <?php endif; ?>
-        </div>
+            </div>
+        <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
## Résumé
Supprime le bouton d'appel à l'action dans la liste des chasses d'un organisateur.

## Changements notables
- retrait du lien "En savoir plus" des cartes de chasse en mode large
- affichage du pied de carte uniquement lorsqu'un organisateur est associé

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bfff313b3083328c6e6e43f207b315