### PR TITLE
feat: journaliser les blocages de validation de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -525,38 +525,43 @@ function afficher_chasse_associee_callback()
  */
 function peut_valider_chasse(int $chasse_id, int $user_id): bool
 {
+    $debug_enabled = defined('CAT_DEBUG_ENABLED') && CAT_DEBUG_ENABLED;
+    if (function_exists('apply_filters')) {
+        $debug_enabled = apply_filters('cat_debug_enabled', $debug_enabled);
+    }
+
     if (!$chasse_id || !$user_id) {
-        if (function_exists('cat_debug')) {
-            cat_debug('❌ ID de chasse ou utilisateur manquant.');
+        if ($debug_enabled) {
+            error_log('❌ ID de chasse ou utilisateur manquant.');
         }
         return false;
     }
 
     if (get_post_type($chasse_id) !== 'chasse') {
-        if (function_exists('cat_debug')) {
-            cat_debug("❌ Post type différent de 'chasse' pour ID {$chasse_id}.");
+        if ($debug_enabled) {
+            error_log("❌ Post type différent de 'chasse' pour ID {$chasse_id}.");
         }
         return false;
     }
 
     if (!est_organisateur($user_id)) {
-        if (function_exists('cat_debug')) {
-            cat_debug("❌ Utilisateur {$user_id} n'est pas un organisateur.");
+        if ($debug_enabled) {
+            error_log("❌ Utilisateur {$user_id} n'est pas un organisateur.");
         }
         return false;
     }
 
     if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
-        if (function_exists('cat_debug')) {
-            cat_debug("❌ Utilisateur {$user_id} non associé à la chasse {$chasse_id}.");
+        if ($debug_enabled) {
+            error_log("❌ Utilisateur {$user_id} non associé à la chasse {$chasse_id}.");
         }
         return false;
     }
 
     $organisateur_id = get_organisateur_from_chasse($chasse_id);
     if (!$organisateur_id || !get_field('organisateur_cache_complet', $organisateur_id)) {
-        if (function_exists('cat_debug')) {
-            cat_debug(
+        if ($debug_enabled) {
+            error_log(
                 "❌ Organisateur absent ou incomplet pour la chasse {$chasse_id}."
             );
         }
@@ -564,15 +569,15 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
     }
 
     if (!get_field('chasse_cache_complet', $chasse_id)) {
-        if (function_exists('cat_debug')) {
-            cat_debug("❌ Chasse {$chasse_id} incomplète.");
+        if ($debug_enabled) {
+            error_log("❌ Chasse {$chasse_id} incomplète.");
         }
         return false;
     }
 
     if (get_post_status($chasse_id) !== 'pending') {
-        if (function_exists('cat_debug')) {
-            cat_debug(
+        if ($debug_enabled) {
+            error_log(
                 "❌ Statut WP différent de 'pending' pour la chasse {$chasse_id}."
             );
         }
@@ -583,8 +588,8 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
     $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
 
     if (!in_array($statut_validation ?? '', ['creation', 'correction'], true)) {
-        if (function_exists('cat_debug')) {
-            cat_debug(
+        if ($debug_enabled) {
+            error_log(
                 "❌ Statut de validation '{$statut_validation}' invalide pour la chasse {$chasse_id}."
             );
         }
@@ -592,8 +597,8 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
     }
 
     if (($statut_metier ?? '') !== 'revision') {
-        if (function_exists('cat_debug')) {
-            cat_debug(
+        if ($debug_enabled) {
+            error_log(
                 "❌ Statut métier '{$statut_metier}' invalide pour la chasse {$chasse_id}."
             );
         }
@@ -604,8 +609,8 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
     // afin d'éviter toute incohérence liée au cache "chasse_cache_enigmes".
     $enigmes = recuperer_ids_enigmes_pour_chasse($chasse_id);
     if (empty($enigmes)) {
-        if (function_exists('cat_debug')) {
-            cat_debug("❌ Aucune énigme associée à la chasse {$chasse_id}.");
+        if ($debug_enabled) {
+            error_log("❌ Aucune énigme associée à la chasse {$chasse_id}.");
         }
         return false;
     }
@@ -614,8 +619,8 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
         $etat   = get_field('enigme_cache_etat_systeme', $eid);
         $complet = get_field('enigme_cache_complet', $eid);
         if ($etat !== 'bloquee_chasse' || !$complet) {
-            if (function_exists('cat_debug')) {
-                cat_debug(
+            if ($debug_enabled) {
+                error_log(
                     "❌ Énigme {$eid} non bloquée pour la chasse ou incomplète (etat={$etat}, complet={$complet})."
                 );
             }

--- a/wp-content/themes/chassesautresor/inc/constants.php
+++ b/wp-content/themes/chassesautresor/inc/constants.php
@@ -25,3 +25,7 @@ const SOLUTION_STATE_DESACTIVE         = 'DESACTIVE';
 if (!defined('CAT_DEBUG_VERBOSE')) {
     define('CAT_DEBUG_VERBOSE', false);
 }
+
+if (!defined('CAT_DEBUG_ENABLED')) {
+    define('CAT_DEBUG_ENABLED', false);
+}


### PR DESCRIPTION
## Résumé
- ajoute la constante `CAT_DEBUG_ENABLED` pour activer les logs de debug
- journalise chaque critère bloquant dans `peut_valider_chasse`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `rg "❌" /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfffce919083328fcce12668ca1a54