### PR TITLE
Ciblage des actions template_redirect pour le proxy d'image

### DIFF
--- a/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/handlers/voir-image-enigme.php
@@ -82,7 +82,13 @@ while (ob_get_level()) {
     ob_end_clean();
 }
 nocache_headers();
-remove_all_actions('template_redirect');
+// Supprime les actions susceptibles de rediriger ou d'altérer la sortie.
+// - redirect_canonical : évite la redirection automatique vers une URL canonique.
+// - wp_old_slug_redirect : empêche les redirections basées sur d'anciens slugs.
+// - myaccount_maybe_add_validation_message : supprime l'ajout de messages dans "Mon compte".
+remove_action('template_redirect', 'redirect_canonical');
+remove_action('template_redirect', 'wp_old_slug_redirect');
+remove_action('template_redirect', 'myaccount_maybe_add_validation_message');
 do_action('litespeed_control_set_nocache');
 
 // ✅ Envoi du fichier


### PR DESCRIPTION
## Résumé
Remplacement du `remove_all_actions` par des suppressions ciblées afin d'éviter les redirections et messages indésirables lors de la diffusion des images protégées.

## Modifications
- Retrait ciblé des actions `redirect_canonical`, `wp_old_slug_redirect` et `myaccount_maybe_add_validation_message`.
- Documentation en commentaire des actions volontairement retirées.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c00c1e149c8332a47ad887b69ccc5f