### PR TITLE
Lien cliquable sur les images des chasses avec effet hover

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -454,17 +454,31 @@
 }
 
 .carte-wide__image {
-  width: 100%;
-  height: 400px;
-  overflow: hidden;
+    width: 100%;
+    height: 400px;
+    overflow: hidden;
 }
 
 .carte-wide__image img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+}
+
+.carte-wide__image-link {
+    display: block;
+    height: 100%;
+}
+
+.carte-wide__image-link img {
+    transition: transform var(--transition-fast);
+}
+
+.carte-wide__image-link:hover img,
+.carte-wide__image-link:focus img {
+    transform: scale(1.05);
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -442,6 +442,20 @@
      object-position: center;
 }
 
+.carte-wide__image-link {
+  display: block;
+  height: 100%;
+}
+
+.carte-wide__image-link img {
+  transition: transform var(--transition-fast);
+}
+
+.carte-wide__image-link:hover img,
+.carte-wide__image-link:focus img {
+  transform: scale(1.05);
+}
+
 .carte-wide__contenu {
   display: flex;
   flex-direction: column;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -17,28 +17,30 @@ if (empty($infos)) {
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
-        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>"
-            data-post-id="<?php echo esc_attr($chasse_id); ?>">
-            <?php echo esc_html($infos['statut_label']); ?>
-        </span>
-        <?php
-        $image_id = $infos['image_id'] ?? 0;
-        if ($image_id) :
-            echo wp_get_attachment_image(
-                $image_id,
-                [400, 400],
-                false,
-                [
-                    'alt'     => $infos['titre'],
-                    'loading' => 'lazy',
-                ]
-            );
-        else :
-            ?>
-            <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" loading="lazy">
+        <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-wide__image-link">
+            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>"
+                data-post-id="<?php echo esc_attr($chasse_id); ?>">
+                <?php echo esc_html($infos['statut_label']); ?>
+            </span>
             <?php
-        endif;
-        ?>
+            $image_id = $infos['image_id'] ?? 0;
+            if ($image_id) :
+                echo wp_get_attachment_image(
+                    $image_id,
+                    [400, 400],
+                    false,
+                    [
+                        'alt'     => $infos['titre'],
+                        'loading' => 'lazy',
+                    ]
+                );
+            else :
+                ?>
+                <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" loading="lazy">
+                <?php
+            endif;
+            ?>
+        </a>
     </div>
 
     <div class="carte-wide__contenu">


### PR DESCRIPTION
### Résumé
- Rend les images des chasses cliquables vers leur page
- Ajoute un léger zoom au survol des images
- Regénère les styles compilés

### Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c00def92e0833284013e7884dd6d63