### PR TITLE
Supprime le footer sur la page chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -497,19 +497,6 @@ if ($edition_active && !$est_complet) {
 
       </div>
   </div>
-  <footer class="chasse-footer">
-    <?php
-    $footer_organisateur_id = get_organisateur_from_chasse($chasse_id);
-    if ($footer_organisateur_id) :
-    ?>
-        <span class="chasse-footer__texte">
-            <?= esc_html__('Proposé par', 'chassesautresor-com'); ?>
-            <a class="chasse-footer__nom" href="<?= esc_url(get_permalink($footer_organisateur_id)); ?>">
-                <?= esc_html(get_the_title($footer_organisateur_id)); ?>
-            </a>
-        </span>
-    <?php endif; ?>
-  </footer>
 </section>
 
 <?php if ($edition_active) : ?>


### PR DESCRIPTION
## Résumé
- retire le footer non désiré du modèle d'affichage complet d'une chasse

## Changelog
- suppression du bloc `<footer>` ajouté par erreur dans `chasse-affichage-complet.php`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c00e99dd408332bf0f35f00d39b710