### PR TITLE
Lien et hover sur l'image des chasses d'un organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -289,6 +289,20 @@
     width: 0.75rem;
     height: 0.75rem;
   }
+
+  .carte-wide__image-link {
+    display: block;
+    overflow: hidden;
+
+    img {
+      display: block;
+      transition: transform var(--transition-medium);
+    }
+
+    &:hover img {
+      transform: scale(1.05);
+    }
+  }
 }
 
 .carte-enigme h3 {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -292,10 +292,15 @@
 
   .carte-wide__image-link {
     display: block;
+    height: 100%;
     overflow: hidden;
 
     img {
       display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
       transition: transform var(--transition-medium);
     }
 
@@ -503,8 +508,9 @@
   }
 
   .carte-wide__image {
-    flex: 0 0 400px;
-    width: 400px;
+    flex: 0 0 200px;
+    width: 200px;
+    height: 200px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -265,10 +265,17 @@
 }
 .carte-wide__image .carte-wide__image-link {
   display: block;
+  height: 100%;
   overflow: hidden;
 }
 .carte-wide__image .carte-wide__image-link img {
   display: block;
+  width: 100%;
+  height: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  -o-object-position: center;
+     object-position: center;
   transition: transform var(--transition-medium);
 }
 .carte-wide__image .carte-wide__image-link:hover img {
@@ -473,8 +480,9 @@
     flex-direction: row;
   }
   .carte-wide__image {
-    flex: 0 0 400px;
-    width: 400px;
+    flex: 0 0 200px;
+    width: 200px;
+    height: 200px;
   }
 }
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -263,6 +263,17 @@
   width: 0.75rem;
   height: 0.75rem;
 }
+.carte-wide__image .carte-wide__image-link {
+  display: block;
+  overflow: hidden;
+}
+.carte-wide__image .carte-wide__image-link img {
+  display: block;
+  transition: transform var(--transition-medium);
+}
+.carte-wide__image .carte-wide__image-link:hover img {
+  transform: scale(1.05);
+}
 
 .carte-enigme h3 {
   margin: 0;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -48,9 +48,9 @@ if (empty($infos)) {
             <?php endif; ?>
         </span>
         <?php
-        $image_id = $infos['image_id'] ?? 0;
-        if ($image_id) :
-            echo wp_get_attachment_image(
+        $image_id   = $infos['image_id'] ?? 0;
+        if ($image_id) {
+            $image_html = wp_get_attachment_image(
                 $image_id,
                 [400, 400],
                 false,
@@ -59,13 +59,18 @@ if (empty($infos)) {
                     'loading' => 'lazy',
                 ]
             );
-        else :
-            ?>
-            <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" loading="lazy">
-            <?php
-        endif;
+        } else {
+            $image_html = sprintf(
+                '<img src="%s" alt="%s" loading="lazy">',
+                esc_url($infos['image']),
+                esc_attr($infos['titre'])
+            );
+        }
         ?>
-    </div>
+        <a class="carte-wide__image-link" href="<?php echo esc_url($infos['permalink']); ?>">
+            <?php echo $image_html; ?>
+        </a>
+        </div>
 
     <div class="carte-wide__contenu">
         <div class="carte-wide__header">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -52,7 +52,7 @@ if (empty($infos)) {
         if ($image_id) {
             $image_html = wp_get_attachment_image(
                 $image_id,
-                [400, 400],
+                [200, 200],
                 false,
                 [
                     'alt'     => $infos['titre'],


### PR DESCRIPTION
## Résumé
- Ajout d'un lien cliquable sur l'image de chaque chasse listée chez un organisateur
- Effet de survol léger sur ces images
- Compilation des styles mis à jour

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test -- --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c00faac1888332b1ced5bfaddd3efc