### PR TITLE
Affiche la récompense dans le footer des cartes chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -492,6 +492,19 @@
   flex-direction: column;
   flex: 1;
   padding: 0 var(--space-2xl) var(--space-md);
+  height: 100%;
+}
+
+.carte-wide__content {
+  flex: 1;
+  overflow: hidden;
+}
+
+.carte-wide__content .chasse-intro-extrait {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .carte-wide__titre {
@@ -502,15 +515,20 @@
   justify-content: center;
 }
 
+.carte-wide__footer {
+  margin-top: auto;
+}
+
 @media (--bp-desktop) {
   .carte-wide {
     flex-direction: row;
+    height: 320px;
   }
 
   .carte-wide__image {
-    flex: 0 0 200px;
-    width: 200px;
-    height: 200px;
+    flex: 0 0 300px;
+    width: 300px;
+    height: 300px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -232,7 +232,13 @@
 
 .chasse-footer {
     margin-top: var(--space-md);
-    text-align: right;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &__reward {
+        font-weight: 700;
+    }
 
     &__texte {
         color: var(--color-gris-3);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -465,6 +465,19 @@
   flex-direction: column;
   flex: 1;
   padding: 0 var(--space-2xl) var(--space-md);
+  height: 100%;
+}
+
+.carte-wide__content {
+  flex: 1;
+  overflow: hidden;
+}
+
+.carte-wide__content .chasse-intro-extrait {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .carte-wide__titre {
@@ -475,14 +488,19 @@
   justify-content: center;
 }
 
+.carte-wide__footer {
+  margin-top: auto;
+}
+
 @media (min-width: 1024px) {
   .carte-wide {
     flex-direction: row;
+    height: 320px;
   }
   .carte-wide__image {
-    flex: 0 0 200px;
-    width: 200px;
-    height: 200px;
+    flex: 0 0 300px;
+    width: 300px;
+    height: 300px;
   }
 }
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */
@@ -939,7 +957,12 @@
 
 .chasse-footer {
   margin-top: var(--space-md);
-  text-align: right;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.chasse-footer__reward {
+  font-weight: 700;
 }
 .chasse-footer__texte {
   color: var(--color-gris-3);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -100,14 +100,20 @@ if (empty($infos)) {
 
         <?php if ($orga_id) : ?>
             <?php
-            $reward_title = get_field('titre_recompense', $chasse_id);
-            $reward_value = get_field('valeur_recompense', $chasse_id);
+            $reward_title = get_field('chasse_infos_recompense_titre', $chasse_id);
+            $reward_value = get_field('chasse_infos_recompense_valeur', $chasse_id);
             ?>
             <div class="carte-wide__footer">
                 <footer class="chasse-footer">
                     <?php if (!empty($reward_title) && (float) $reward_value > 0) : ?>
                         <span class="chasse-footer__reward">
-                            <?php echo esc_html($reward_title . ' — ' . $reward_value . ' €'); ?>
+                            <?php
+                            printf(
+                                esc_html__('%1$s — %2$s €', 'chassesautresor-com'),
+                                esc_html($reward_title),
+                                esc_html($reward_value)
+                            );
+                            ?>
                         </span>
                     <?php endif; ?>
                     <span class="chasse-footer__texte">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -52,7 +52,7 @@ if (empty($infos)) {
         if ($image_id) {
             $image_html = wp_get_attachment_image(
                 $image_id,
-                [200, 200],
+                [300, 300],
                 false,
                 [
                     'alt'     => $infos['titre'],
@@ -96,16 +96,24 @@ if (empty($infos)) {
             </div>
 
             <?php echo $infos['extrait_html']; ?>
-            <?php echo $infos['lot_html']; ?>
         </div>
 
         <?php if ($orga_id) : ?>
+            <?php
+            $reward_title = get_field('titre_recompense', $chasse_id);
+            $reward_value = get_field('valeur_recompense', $chasse_id);
+            ?>
             <div class="carte-wide__footer">
                 <footer class="chasse-footer">
+                    <?php if (!empty($reward_title) && (float) $reward_value > 0) : ?>
+                        <span class="chasse-footer__reward">
+                            <?php echo esc_html($reward_title . ' — ' . $reward_value . ' €'); ?>
+                        </span>
+                    <?php endif; ?>
                     <span class="chasse-footer__texte">
-                        <?= esc_html__('Proposé par', 'chassesautresor-com'); ?>
-                        <a class="chasse-footer__nom" href="<?= esc_url(get_permalink($orga_id)); ?>">
-                            <?= esc_html(get_the_title($orga_id)); ?>
+                        <?php echo esc_html__('Proposé par', 'chassesautresor-com'); ?>
+                        <a class="chasse-footer__nom" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
+                            <?php echo esc_html(get_the_title($orga_id)); ?>
                         </a>
                     </span>
                 </footer>


### PR DESCRIPTION
## Résumé
- déplace le lot des chasses du contenu vers le pied de carte
- agrandit l’image et fixe la hauteur des cartes larges
- ajuste le footer pour aligner récompense et organisateur

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c013bd75f883328f24643d6497d228