### PR TITLE
Fix: badge de mode de fin visible au survol des chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -282,6 +282,7 @@
     background: var(--color-grey-light);
     color: var(--color-text-fond-clair);
     font-size: 0.75rem;
+    z-index: 1;
   }
 
   .mode-fin-icone svg,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -257,6 +257,7 @@
   background: var(--color-grey-light);
   color: var(--color-text-fond-clair);
   font-size: 0.75rem;
+  z-index: 1;
 }
 .carte-wide__image .mode-fin-icone svg,
 .carte-wide__image .mode-fin-icone i {


### PR DESCRIPTION
## Résumé
- assure que le badge de mode de fin reste visible malgré l'effet hover des cartes

## Changements notables
- ajout d'un `z-index` sur `.mode-fin-icone`
- recompilation du style du thème

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npx jest --runInBand --no-color`


------
https://chatgpt.com/codex/tasks/task_e_68c018e10238833281b036be6a2ae81c