### PR TITLE
Ajout des métadonnées des chasses avec dates

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -35,6 +35,13 @@ if (empty($infos)) {
                     ?> —
                     <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
                 </div>
+                <div class="meta-etiquette">
+                    <?php echo get_svg_icon('calendar'); ?>
+                    <span class="chasse-date-plage">
+                        <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
+                        <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                    </span>
+                </div>
             </div>
         </div>
     </a>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -93,6 +93,13 @@ if (empty($infos)) {
                     ?> —
                     <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
                 </div>
+                <div class="meta-etiquette">
+                    <?php echo get_svg_icon('calendar'); ?>
+                    <span class="chasse-date-plage">
+                        <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
+                        <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                    </span>
+                </div>
             </div>
 
             <?php echo $infos['extrait_html']; ?>


### PR DESCRIPTION
## Résumé
- Affiche les dates de début et fin dans les cartes de chasse larges et compactes

## Changements notables
- Ajout du bloc `meta-etiquette` avec icône calendrier et plage de dates
- Harmonisation des métadonnées des chasses sur les pages organisateur et chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c018f5fd0483329bfb6cad1f34a169