### PR TITLE
Améliore présentation des chasses sur page organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -498,14 +498,15 @@
 
 .carte-wide__content {
   flex: 1;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .carte-wide__content .chasse-intro-extrait {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .carte-wide__titre {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -471,14 +471,15 @@
 
 .carte-wide__content {
   flex: 1;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .carte-wide__content .chasse-intro-extrait {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .carte-wide__titre {

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1253,9 +1253,10 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     $titre     = get_the_title($chasse_id);
     $permalink = get_permalink($chasse_id);
 
-    $description   = get_field('chasse_principale_description', $chasse_id);
+    $description = get_field('chasse_principale_description', $chasse_id);
+    $description = preg_replace('/^\s*Présentation\s*2\.1\s*/i', '', (string) $description);
     $texte_complet = wp_strip_all_tags($description);
-    $extrait       = wp_trim_words($texte_complet, 60, '...');
+    $extrait = wp_trim_words($texte_complet, 300, '...');
 
     $image_data = get_field('chasse_principale_image', $chasse_id);
     $image_id = 0;
@@ -1376,7 +1377,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id): array
     }
 
 
-    $extrait_html = $extrait ? '<p class="chasse-intro-extrait liste-elegante"> <strong>Présentation :</strong> ' . esc_html($extrait) . '</p>' : '';
+    $extrait_html = $extrait
+        ? '<p class="chasse-intro-extrait liste-elegante">' . esc_html($extrait) . '</p>'
+        : '';
 
     $cta_html    = $cta_data['cta_html'] ?? '';
     $cta_message = $cta_data['cta_message'] ?? '';


### PR DESCRIPTION
## Résumé
- Ajuste la description des chasses pour retirer le label "Présentation" et allonger l'extrait
- Centre le texte des cartes de chasse et supprime le line clamp

## Changements notables
- Extension de l'extrait des chasses à 300 mots et suppression du préfixe de présentation
- Mise à jour du style pour centrer verticalement et horizontalement l'extrait des cartes

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c02069b1408332a64ffd537b1fb065