### PR TITLE
Corrige les couleurs de bordure des cartes de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -656,11 +656,11 @@
 
 /* ========== ✅ Indicateurs de complétion ========== */
 .carte-complete {
-  border: 2px solid var(--color-editor-success);
+  border: 2px solid var(--color-success);
 }
 
 .carte-incomplete {
-  border: 2px dashed var(--color-editor-error);
+  border: 2px dashed var(--color-error);
   animation: clignoteTitre 1s infinite alternate;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -625,11 +625,11 @@
 
 /* ========== ✅ Indicateurs de complétion ========== */
 .carte-complete {
-  border: 2px solid var(--color-editor-success);
+  border: 2px solid var(--color-success);
 }
 
 .carte-incomplete {
-  border: 2px dashed var(--color-editor-error);
+  border: 2px dashed var(--color-error);
   animation: clignoteTitre 1s infinite alternate;
 }
 


### PR DESCRIPTION
## Résumé
- remplace les variables de couleur d'édition par les couleurs globales pour les cartes de chasse
- recompile les styles SCSS

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c02ec6fac08332bef498fde3384d6d