### PR TITLE
Centrer l'image des chasses pour l'organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -524,6 +524,7 @@
   .carte-wide {
     flex-direction: row;
     height: 320px;
+    align-items: center;
   }
 
   .carte-wide__image {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -497,6 +497,7 @@
   .carte-wide {
     flex-direction: row;
     height: 320px;
+    align-items: center;
   }
   .carte-wide__image {
     flex: 0 0 300px;


### PR DESCRIPTION
## Résumé
- Aligne verticalement l'image des cartes de chasse dans la boucle organisateur
- Recompile la feuille de style du thème

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c033db056083329fe7e56b3bba7bc2