### PR TITLE
feat: enlarge organizer header logo to 300px square

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -98,8 +98,8 @@ a.bouton-edition-attention {
 }
 .conteneur-organisateur .colonne-logo {
   flex: 0 0 auto;
-  width: 100px;
-  max-width: 100px;
+  width: 300px;
+  max-width: 300px;
 }
 .conteneur-organisateur .colonne-texte {
   flex: 1 1 0;
@@ -144,10 +144,10 @@ a.bouton-edition-attention {
 
 
 .header-organisateur__logo img {
-    width: 50px;
-    height: 50px;
+    width: 300px;
+    height: 300px;
     object-fit: contain;
-    border-radius: 50%;
+    border-radius: 0;
 }
 
 
@@ -238,7 +238,7 @@ a.bouton-edition-attention {
     font-size: 0.85rem;
 }
 .colonne-logo {
-    max-width: none;
+    max-width: 300px;
     margin: 0 auto;
 }
 
@@ -265,7 +265,7 @@ a.bouton-edition-attention {
         font-size: inherit;
     }
     .colonne-logo {
-        max-width: 100px;
+        max-width: 300px;
         margin: 0;
     }
     .colonne-texte {
@@ -285,8 +285,8 @@ a.bouton-edition-attention {
         gap: var(--space-xl);
     }
     .colonne-logo {
-        width: auto;
-        max-width: 120px;
+        width: 300px;
+        max-width: 300px;
         flex-shrink: 0;
         margin: 0;
     }
@@ -329,7 +329,7 @@ a.bouton-edition-attention {
   /* 🔹 Logo centré & redimensionné */
   .colonne-logo {
     width: 100%;
-    max-width: 120px;
+    max-width: 300px;
     margin: 0 auto;
   }
 
@@ -371,8 +371,9 @@ a.bouton-edition-attention {
   }
     .header-organisateur__logo img {
         box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
-        border-radius: 0.5rem;
-        width: 70px;
+        border-radius: 0;
+        width: 300px;
+        height: 300px;
     }
   /* 🔹 Champs de saisie */
   .champ-edition,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8950,8 +8950,8 @@ a.bouton-edition-attention {
 
 .conteneur-organisateur .colonne-logo {
   flex: 0 0 auto;
-  width: 100px;
-  max-width: 100px;
+  width: 300px;
+  max-width: 300px;
 }
 
 .conteneur-organisateur .colonne-texte {
@@ -8996,11 +8996,11 @@ a.bouton-edition-attention {
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */
 .header-organisateur__logo img {
-  width: 50px;
-  height: 50px;
+  width: 300px;
+  height: 300px;
   -o-object-fit: contain;
      object-fit: contain;
-  border-radius: 50%;
+  border-radius: 0;
 }
 
 /* ========== 🧭 MODAL BIENVENUE ========== */
@@ -9095,7 +9095,7 @@ a.bouton-edition-attention {
 }
 
 .colonne-logo {
-  max-width: none;
+  max-width: 300px;
   margin: 0 auto;
 }
 
@@ -9122,7 +9122,7 @@ a.bouton-edition-attention {
     font-size: inherit;
   }
   .colonne-logo {
-    max-width: 100px;
+    max-width: 300px;
     margin: 0;
   }
   .colonne-texte {
@@ -9139,8 +9139,8 @@ a.bouton-edition-attention {
     gap: var(--space-xl);
   }
   .colonne-logo {
-    width: auto;
-    max-width: 120px;
+    width: 300px;
+    max-width: 300px;
     flex-shrink: 0;
     margin: 0;
   }
@@ -9175,7 +9175,7 @@ a.bouton-edition-attention {
   /* 🔹 Logo centré & redimensionné */
   .colonne-logo {
     width: 100%;
-    max-width: 120px;
+    max-width: 300px;
     margin: 0 auto;
   }
   .header-organisateur__logo {
@@ -9211,8 +9211,9 @@ a.bouton-edition-attention {
   }
   .header-organisateur__logo img {
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
-    border-radius: 0.5rem;
-    width: 70px;
+    border-radius: 0;
+    width: 300px;
+    height: 300px;
   }
   /* 🔹 Champs de saisie */
   .champ-edition,

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -59,6 +59,7 @@ $classes_header .= ' container container--boxed';
                 aria-label="<?= esc_attr__('Voir la page de l\u2019organisateur', 'chassesautresor-com'); ?>">
                 <img src="<?= esc_url($logo_url); ?>"
                   alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
+                  width="300" height="300"
                   class="header-organisateur__logo visuel-cpt"
                   data-cpt="organisateur"
                   data-post-id="<?= esc_attr($organisateur_id); ?>" />


### PR DESCRIPTION
## Résumé
- Agrandit le logo de l’organisateur à 300x300 sans coins arrondis.
- Met à jour les styles responsive et ajoute les attributs HTML nécessaires.

## Modifications
- Ajustement de la largeur des colonnes et du logo dans le SCSS.
- Compilation de la feuille CSS dist.
- Ajout des attributs `width` et `height` dans le template du header.

## Tests
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05bd596908332bcbf95a25c3178a2