### PR TITLE
feat: add organiser header share and settings icons

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -142,9 +142,12 @@ a.bouton-edition-attention {
 
 /* ========== 📌 ICÔNES D'ACTIONS ========== */
 .header-organisateur__actions {
+  position: absolute;
+  top: 1.2rem;
+  right: var(--space-xs);
   display: flex;
+  gap: var(--space-xs);
   align-items: center;
-  gap: var(--space-md);
   color: var(--color-text-primary);
 }
 
@@ -164,6 +167,20 @@ a.bouton-edition-attention {
 .header-organisateur__actions a:hover,
 .header-organisateur__actions button:not(.bouton-edition-toggle):hover {
   color: var(--color-accent);
+}
+
+.header-organisateur__actions .organisateur-share-button {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-primary);
+}
+
+.header-organisateur__actions .organisateur-share-button svg {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */
@@ -203,7 +220,7 @@ a.bouton-edition-attention {
   font-size: 1.6rem;
 }
 
-.header-organisateur__actions .lien-contact {
+.header-organisateur__liens-row .lien-contact {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8995,9 +8995,12 @@ a.bouton-edition-attention {
 
 /* ========== 📌 ICÔNES D'ACTIONS ========== */
 .header-organisateur__actions {
+  position: absolute;
+  top: 1.2rem;
+  right: var(--space-xs);
   display: flex;
+  gap: var(--space-xs);
   align-items: center;
-  gap: var(--space-md);
   color: var(--color-text-primary);
 }
 
@@ -9017,6 +9020,20 @@ a.bouton-edition-attention {
 .header-organisateur__actions a:hover,
 .header-organisateur__actions button:not(.bouton-edition-toggle):hover {
   color: var(--color-accent);
+}
+
+.header-organisateur__actions .organisateur-share-button {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-primary);
+}
+
+.header-organisateur__actions .organisateur-share-button svg {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */
@@ -9054,7 +9071,7 @@ a.bouton-edition-attention {
   font-size: 1.6rem;
 }
 
-.header-organisateur__actions .lien-contact {
+.header-organisateur__liens-row .lien-contact {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -52,6 +52,29 @@ $classes_header .= ' container container--boxed';
     <div class="morse-wrapper" data-morse="<?= esc_attr($titre_organisateur); ?>"></div>
   </div>
   <header class="<?= esc_attr($classes_header); ?>">
+    <div class="header-organisateur__actions">
+      <?php if (function_exists('ADDTOANY_SHARE_SAVE_BUTTON')) : ?>
+        <?php
+        $share_url   = get_permalink($organisateur_id);
+        $share_title = $titre_organisateur;
+        $share_href  = 'https://www.addtoany.com/share#url=' . rawurlencode($share_url) . '&title=' . rawurlencode($share_title);
+        ?>
+        <a
+          class="a2a_dd a2a_counter organisateur-share-button addtoany_share_save addtoany_share"
+          href="<?= esc_url($share_href); ?>"
+          data-a2a-url="<?= esc_url($share_url); ?>"
+          data-a2a-title="<?= esc_attr($share_title); ?>"
+          aria-label="<?= esc_attr__('Partager', 'chassesautresor-com'); ?>"
+        >
+          <?= get_svg_icon('share-icon'); ?>
+        </a>
+      <?php endif; ?>
+      <?php if ($peut_modifier) : ?>
+        <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="<?= esc_attr__('Paramètres organisateur', 'chassesautresor-com'); ?>">
+          <i class="fa-solid fa-gear"></i>
+        </button>
+      <?php endif; ?>
+    </div>
     <div class="conteneur-organisateur">
       <div class="header-organisateur__col header-organisateur__col--logo">
         <div class="champ-organisateur champ-img champ-logo <?= empty($logo_id) ? 'champ-vide' : ''; ?>"
@@ -99,16 +122,9 @@ $classes_header .= ' container container--boxed';
               <?php endforeach; ?>
             </ul>
           <?php endif; ?>
-          <div class="header-organisateur__actions">
-            <a href="<?= esc_url($url_contact); ?>" class="lien-contact" aria-label="<?= esc_attr__('Contact', 'chassesautresor-com'); ?>">
-              <i class="fa-solid fa-envelope"></i>
-            </a>
-            <?php if ($peut_modifier) : ?>
-              <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="Paramètres organisateur">
-                <i class="fa-solid fa-gear"></i>
-              </button>
-            <?php endif; ?>
-          </div>
+          <a href="<?= esc_url($url_contact); ?>" class="lien-contact" aria-label="<?= esc_attr__('Contact', 'chassesautresor-com'); ?>">
+            <i class="fa-solid fa-envelope"></i>
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Résumé
- ajout d’un bouton de partage AddToAny en haut à droite du header organisateur
- déplacement de l’icône de réglages à côté du bouton de partage

## Modifications notables
- intégration des actions de partage et de réglage dans le header organisateur
- positionnement CSS dédié pour les icônes et style du lien de contact

## Testing
- `npm run build:css`
- `source ./setup-env.sh && composer install --no-progress`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08170fd708332a7409642e97d6507