### PR TITLE
feat: add compass rose background for organiser page

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -1,5 +1,26 @@
 /* 👤 Header organisateur */
 
+/* 🧭 Fond page organisateur */
+#organisateur-page {
+  position: relative;
+  z-index: 0;
+}
+
+#organisateur-page::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 75vw;
+  height: 75vw;
+  background: url('../assets/svg/compass-rose.svg') no-repeat top left;
+  background-size: 100% 100%;
+  opacity: 0.15;
+  filter: brightness(0) invert(1);
+  pointer-events: none;
+  z-index: -1;
+}
+
   /* 🧱 Structure du header */
   /* 📐 Classes générales header */
   /* 🔠 Typographie spécifique au header */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8867,6 +8867,27 @@ body.woocommerce h2 {
 }
 
 /* 👤 Header organisateur */
+/* 🧭 Fond page organisateur */
+#organisateur-page {
+  position: relative;
+  z-index: 0;
+}
+
+#organisateur-page::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 75vw;
+  height: 75vw;
+  background: url("../assets/svg/compass-rose.svg") no-repeat top left;
+  background-size: 100% 100%;
+  opacity: 0.15;
+  filter: brightness(0) invert(1);
+  pointer-events: none;
+  z-index: -1;
+}
+
 /* 🧱 Structure du header */
 /* 📐 Classes générales header */
 /* 🔠 Typographie spécifique au header */


### PR DESCRIPTION
## Résumé
- ajoute une rose des vents en fond du contenu principal des pages organisateur
- compile le CSS avec ce nouveau style

## Changes
- ajoute un pseudo-élément sur `#organisateur-page` pour afficher le SVG *compass-rose*
- positionne le visuel en haut à gauche en occupant 75% de la largeur de l’écran avec une opacité légère

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c0fdfd917c8332a4a2f1902f81d187