### PR TITLE
Organisateur : centrage du titre et espace avant la liste de chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -616,6 +616,11 @@ span.champ-obligatoire {
   gap: var(--space-md);
 }
 
+.titre-chasses-wrapper h2 {
+  flex: 1;
+  text-align: center;
+}
+
 .titre-enigmes-wrapper {
   display: flex;
   flex-direction: column;

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -505,3 +505,8 @@ a.bouton-edition-attention {
   font-size: 1rem;
   resize: vertical;
 }
+
+/* 🗺️ Section chasses de l'organisateur */
+.chasses {
+  margin-top: var(--space-4xl);
+}

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7248,6 +7248,11 @@ span.champ-obligatoire {
   gap: var(--space-md);
 }
 
+.titre-chasses-wrapper h2 {
+  flex: 1;
+  text-align: center;
+}
+
 .titre-enigmes-wrapper {
   display: flex;
   flex-direction: column;
@@ -9350,6 +9355,11 @@ a.bouton-edition-attention {
   padding: var(--space-xs);
   font-size: 1rem;
   resize: vertical;
+}
+
+/* 🗺️ Section chasses de l'organisateur */
+.chasses {
+  margin-top: var(--space-4xl);
 }
 
 /* 🎨 Variables globales */

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1261,7 +1261,7 @@ msgid "Validation en ligne nécessaire"
 msgstr ""
 
 #: single-organisateur.php:84
-msgid "Chasses au Trésor"
+msgid "Ses chasses au trésor"
 msgstr ""
 
 #: single-organisateur.php:132

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1249,8 +1249,8 @@ msgid "Vous n’avez pas assez de points pour engager cette énigme."
 msgstr "❌ You don't have enough points to complete this conversion."
 
 #: single-organisateur.php:84
-msgid "Chasses au Trésor"
-msgstr "Treasure hunts"
+msgid "Ses chasses au trésor"
+msgstr "Their treasure hunts"
 
 #: single-organisateur.php:132
 msgid "C'est parti !"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1253,8 +1253,8 @@ msgid "Vous n’avez pas assez de points pour engager cette énigme."
 msgstr "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
 
 #: single-organisateur.php:84
-msgid "Chasses au Trésor"
-msgstr "Chasses au Trésor"
+msgid "Ses chasses au trésor"
+msgstr "Ses chasses au trésor"
 
 #: single-organisateur.php:132
 msgid "C'est parti !"

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -81,7 +81,7 @@ get_header();
         <section class="chasses">
             <div class="conteneur">
                 <div class="titre-chasses-wrapper">
-                    <h2><?php esc_html_e('Chasses au Trésor', 'chassesautresor-com'); ?></h2>
+                    <h2><?php esc_html_e('Ses chasses au trésor', 'chassesautresor-com'); ?></h2>
                     <?php if ($peut_ajouter && $statut_organisateur === 'publish') :
                         get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
                             'has_chasses'     => $has_chasses,


### PR DESCRIPTION
## Résumé
- centrer le titre des chasses sur la page organisateur
- espacer la section listant les chasses pour améliorer la lisibilité

## Changements notables
- mise à jour du titre en "Ses chasses au trésor"
- ajout de styles pour centrer le titre et créer un marge supérieure généreuse
- mise à jour des fichiers de traduction

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c0fe8ac6408332b38b7035f4c58119