### PR TITLE
Encadrement du titre des chasses sur la page Organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -621,9 +621,28 @@ span.champ-obligatoire {
   gap: var(--space-md);
 }
 
-.titre-chasses-wrapper h2 {
+.titre-chasses-wrapper .titre-chasses {
+  display: flex;
+  align-items: center;
   flex: 1;
+  gap: var(--space-md);
+}
+
+.titre-chasses-wrapper .titre-chasses h2 {
+  flex: 0 0 auto;
+  margin: 0;
   text-align: center;
+}
+
+.titre-chasses-wrapper .titre-chasses .decor {
+  flex: 1;
+  height: var(--space-sm);
+  color: var(--color-titre-enigme);
+}
+
+.titre-chasses-wrapper .titre-chasses .decor svg {
+  width: 100%;
+  height: 100%;
 }
 
 .titre-enigmes-wrapper {

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -637,13 +637,16 @@ span.champ-obligatoire {
 
 .titre-chasses-wrapper .titre-chasses .decor {
   flex: 1;
-  height: var(--space-sm);
+  height: 6px;
   color: var(--color-titre-enigme);
+  display: flex;
+  align-items: center;
 }
 
 .titre-chasses-wrapper .titre-chasses .decor svg {
   width: 100%;
   height: 100%;
+  display: block;
 }
 
 .titre-enigmes-wrapper {

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -619,6 +619,7 @@ span.champ-obligatoire {
   display: flex;
   align-items: center;
   gap: var(--space-md);
+  margin-bottom: var(--space-4xl);
 }
 
 .titre-chasses-wrapper .titre-chasses {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7251,6 +7251,7 @@ span.champ-obligatoire {
   display: flex;
   align-items: center;
   gap: var(--space-md);
+  margin-bottom: var(--space-4xl);
 }
 
 .titre-chasses-wrapper .titre-chasses {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7253,9 +7253,28 @@ span.champ-obligatoire {
   gap: var(--space-md);
 }
 
-.titre-chasses-wrapper h2 {
+.titre-chasses-wrapper .titre-chasses {
+  display: flex;
+  align-items: center;
   flex: 1;
+  gap: var(--space-md);
+}
+
+.titre-chasses-wrapper .titre-chasses h2 {
+  flex: 0 0 auto;
+  margin: 0;
   text-align: center;
+}
+
+.titre-chasses-wrapper .titre-chasses .decor {
+  flex: 1;
+  height: var(--space-sm);
+  color: var(--color-titre-enigme);
+}
+
+.titre-chasses-wrapper .titre-chasses .decor svg {
+  width: 100%;
+  height: 100%;
 }
 
 .titre-enigmes-wrapper {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7269,13 +7269,16 @@ span.champ-obligatoire {
 
 .titre-chasses-wrapper .titre-chasses .decor {
   flex: 1;
-  height: var(--space-sm);
+  height: 6px;
   color: var(--color-titre-enigme);
+  display: flex;
+  align-items: center;
 }
 
 .titre-chasses-wrapper .titre-chasses .decor svg {
   width: 100%;
   height: 100%;
+  display: block;
 }
 
 .titre-enigmes-wrapper {

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -1261,7 +1261,7 @@ msgid "Validation en ligne nécessaire"
 msgstr ""
 
 #: single-organisateur.php:84
-msgid "Ses chasses au trésor"
+msgid "Chasses au trésor"
 msgstr ""
 
 #: single-organisateur.php:132

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1249,8 +1249,8 @@ msgid "Vous n’avez pas assez de points pour engager cette énigme."
 msgstr "❌ You don't have enough points to complete this conversion."
 
 #: single-organisateur.php:84
-msgid "Ses chasses au trésor"
-msgstr "Their treasure hunts"
+msgid "Chasses au trésor"
+msgstr "Treasure hunts"
 
 #: single-organisateur.php:132
 msgid "C'est parti !"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1253,8 +1253,8 @@ msgid "Vous n’avez pas assez de points pour engager cette énigme."
 msgstr "❌ Vous n'avez pas assez de points pour effectuer cette conversion."
 
 #: single-organisateur.php:84
-msgid "Ses chasses au trésor"
-msgstr "Ses chasses au trésor"
+msgid "Chasses au trésor"
+msgstr "Chasses au trésor"
 
 #: single-organisateur.php:132
 msgid "C'est parti !"

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -81,7 +81,15 @@ get_header();
         <section class="chasses">
             <div class="conteneur">
                 <div class="titre-chasses-wrapper">
-                    <h2><?php esc_html_e('Ses chasses au trésor', 'chassesautresor-com'); ?></h2>
+                    <div class="titre-chasses">
+                        <span class="decor decor-gauche">
+                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
+                        </span>
+                        <h2><?php esc_html_e('Ses chasses au trésor', 'chassesautresor-com'); ?></h2>
+                        <span class="decor decor-droite">
+                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-right.svg')); ?>
+                        </span>
+                    </div>
                     <?php if ($peut_ajouter && $statut_organisateur === 'publish') :
                         get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
                             'has_chasses'     => $has_chasses,

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -85,7 +85,7 @@ get_header();
                         <span class="decor decor-gauche">
                             <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-right.svg')); ?>
                         </span>
-                        <h2><?php esc_html_e('Ses chasses au trésor', 'chassesautresor-com'); ?></h2>
+                        <h2><?php esc_html_e('Chasses au trésor', 'chassesautresor-com'); ?></h2>
                         <span class="decor decor-droite">
                             <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
                         </span>

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -83,11 +83,11 @@ get_header();
                 <div class="titre-chasses-wrapper">
                     <div class="titre-chasses">
                         <span class="decor decor-gauche">
-                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
+                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-right.svg')); ?>
                         </span>
                         <h2><?php esc_html_e('Ses chasses au trésor', 'chassesautresor-com'); ?></h2>
                         <span class="decor decor-droite">
-                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-right.svg')); ?>
+                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
                         </span>
                     </div>
                     <?php if ($peut_ajouter && $statut_organisateur === 'publish') :


### PR DESCRIPTION
Encadre le titre des chasses sur la page organisateur avec deux motifs étoilés.

- Ajout des SVG décoratifs autour du titre.
- Styles flex pour ajuster la hauteur et la largeur.
- Compilation du CSS.

### Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1026dae8483329f12e8eb3dc1416e