### PR TITLE
Corrige la couleur de la ligne Morse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -916,8 +916,6 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .ligne-morse {
   position: relative;
   height: 2px;
-  background-color: var(--color-grey-medium);
-  opacity: 0.2;
   overflow: hidden;
 }
 
@@ -931,20 +929,16 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   padding: 0 0.6rem; /* ✅ un peu plus de marge latérale */
   height: 2px;
   align-items: center;
-  background-color: var(--color-background);
-  z-index: 1;
-  box-shadow: 0 0 0 1px var(--color-background); /* ✅ masque 1px de plus autour */
   white-space: nowrap;
   overflow: hidden;
   max-width: 90%;
 }
 
-
 .morse-wrapper .point,
 .morse-wrapper .tiret {
   display: inline-block;
   height: 2px;
-  background-color: var(--color-text-primary);
+  background-color: var(--color-grey-medium);
 }
 
 .morse-wrapper .point {
@@ -954,7 +948,6 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .morse-wrapper .tiret {
   width: 16px;
 }
-
 
 /* ========== 🧩 ACCORDÉON GÉNÉRIQUE – OUVERTURE / FERMETURE DYNAMIQUE ========== */
 

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -916,7 +916,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .ligne-morse {
   position: relative;
   height: 2px;
-  background-color: var(--color-editor-border);
+  background-color: var(--color-grey-medium);
   opacity: 0.2;
   overflow: hidden;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -931,9 +931,9 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   padding: 0 0.6rem; /* ✅ un peu plus de marge latérale */
   height: 2px;
   align-items: center;
-  background-color: var(--color-editor-background);
+  background-color: var(--color-background);
   z-index: 1;
-  box-shadow: 0 0 0 1px var(--color-editor-background); /* ✅ masque 1px de plus autour */
+  box-shadow: 0 0 0 1px var(--color-background); /* ✅ masque 1px de plus autour */
   white-space: nowrap;
   overflow: hidden;
   max-width: 90%;
@@ -944,7 +944,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .morse-wrapper .tiret {
   display: inline-block;
   height: 2px;
-  background-color: var(--color-editor-heading);
+  background-color: var(--color-text-primary);
 }
 
 .morse-wrapper .point {

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -932,6 +932,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   white-space: nowrap;
   overflow: hidden;
   max-width: 90%;
+  opacity: 0.5;
 }
 
 .morse-wrapper .point,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2081,9 +2081,9 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   padding: 0 0.6rem; /* ✅ un peu plus de marge latérale */
   height: 2px;
   align-items: center;
-  background-color: var(--color-editor-background);
+  background-color: var(--color-background);
   z-index: 1;
-  box-shadow: 0 0 0 1px var(--color-editor-background); /* ✅ masque 1px de plus autour */
+  box-shadow: 0 0 0 1px var(--color-background); /* ✅ masque 1px de plus autour */
   white-space: nowrap;
   overflow: hidden;
   max-width: 90%;
@@ -2093,7 +2093,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .morse-wrapper .tiret {
   display: inline-block;
   height: 2px;
-  background-color: var(--color-editor-heading);
+  background-color: var(--color-text-primary);
 }
 
 .morse-wrapper .point {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2066,8 +2066,6 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .ligne-morse {
   position: relative;
   height: 2px;
-  background-color: var(--color-grey-medium);
-  opacity: 0.2;
   overflow: hidden;
 }
 
@@ -2081,9 +2079,6 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   padding: 0 0.6rem; /* ✅ un peu plus de marge latérale */
   height: 2px;
   align-items: center;
-  background-color: var(--color-background);
-  z-index: 1;
-  box-shadow: 0 0 0 1px var(--color-background); /* ✅ masque 1px de plus autour */
   white-space: nowrap;
   overflow: hidden;
   max-width: 90%;
@@ -2093,7 +2088,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .morse-wrapper .tiret {
   display: inline-block;
   height: 2px;
-  background-color: var(--color-text-primary);
+  background-color: var(--color-grey-medium);
 }
 
 .morse-wrapper .point {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2066,7 +2066,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 .ligne-morse {
   position: relative;
   height: 2px;
-  background-color: var(--color-editor-border);
+  background-color: var(--color-grey-medium);
   opacity: 0.2;
   overflow: hidden;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2082,6 +2082,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
   white-space: nowrap;
   overflow: hidden;
   max-width: 90%;
+  opacity: 0.5;
 }
 
 .morse-wrapper .point,


### PR DESCRIPTION
## Résumé
Corrige l'utilisation d'une variable de couleur inexistante pour la ligne Morse.

## Changements notables
- remplace `--color-editor-border` par `--color-grey-medium` pour la barre décorative
- recompile la feuille de style du thème

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c1038e2c7483329c7c449edbac9daf