### PR TITLE
feat: améliorer le responsive du header organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -100,8 +100,7 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo {
-  width: 100%;
-  max-width: 500px;
+  width: 90%;
   aspect-ratio: 1 / 1;
   overflow: hidden;
 }
@@ -275,7 +274,7 @@ a.bouton-edition-attention {
   margin-top: var(--space-lg);
 }
 
-@media (--bp-desktop) {
+@media (--bp-tablet) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
@@ -283,11 +282,33 @@ a.bouton-edition-attention {
   }
 
   .header-organisateur__col--logo {
-    flex: 0 0 600px;
+    flex: 0 0 400px;
+    width: 400px;
   }
 
   .header-organisateur__col--infos {
     flex: 1;
+  }
+}
+
+@media (--bp-desktop) {
+  .header-organisateur__col--logo {
+    flex-basis: 450px;
+    width: 450px;
+  }
+}
+
+@media (--bp-wide) {
+  .header-organisateur__col--logo {
+    flex-basis: 500px;
+    width: 500px;
+  }
+}
+
+@media (--bp-xxl) {
+  .header-organisateur__col--logo {
+    flex-basis: 600px;
+    width: 600px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -282,8 +282,8 @@ a.bouton-edition-attention {
   }
 
   .header-organisateur__col--logo {
-    flex: 0 0 400px;
-    width: 400px;
+    flex: 0 0 350px;
+    width: 350px;
   }
 
   .header-organisateur__col--infos {
@@ -293,8 +293,8 @@ a.bouton-edition-attention {
 
 @media (--bp-desktop) {
   .header-organisateur__col--logo {
-    flex-basis: 450px;
-    width: 450px;
+    flex-basis: 420px;
+    width: 420px;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8984,8 +8984,7 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo {
-  width: 100%;
-  max-width: 500px;
+  width: 90%;
   aspect-ratio: 1/1;
   overflow: hidden;
 }
@@ -9159,17 +9158,36 @@ a.bouton-edition-attention {
   margin-top: var(--space-lg);
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 768px) {
   .conteneur-organisateur {
     flex-direction: row;
     align-items: center;
     gap: var(--space-3xl);
   }
   .header-organisateur__col--logo {
-    flex: 0 0 600px;
+    flex: 0 0 400px;
+    width: 400px;
   }
   .header-organisateur__col--infos {
     flex: 1;
+  }
+}
+@media (min-width: 1024px) {
+  .header-organisateur__col--logo {
+    flex-basis: 450px;
+    width: 450px;
+  }
+}
+@media (min-width: 1280px) {
+  .header-organisateur__col--logo {
+    flex-basis: 500px;
+    width: 500px;
+  }
+}
+@media (min-width: 1440px) {
+  .header-organisateur__col--logo {
+    flex-basis: 600px;
+    width: 600px;
   }
 }
 /* ========== 🧭 MODAL BIENVENUE ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9165,8 +9165,8 @@ a.bouton-edition-attention {
     gap: var(--space-3xl);
   }
   .header-organisateur__col--logo {
-    flex: 0 0 400px;
-    width: 400px;
+    flex: 0 0 350px;
+    width: 350px;
   }
   .header-organisateur__col--infos {
     flex: 1;
@@ -9174,8 +9174,8 @@ a.bouton-edition-attention {
 }
 @media (min-width: 1024px) {
   .header-organisateur__col--logo {
-    flex-basis: 450px;
-    width: 450px;
+    flex-basis: 420px;
+    width: 420px;
   }
 }
 @media (min-width: 1280px) {


### PR DESCRIPTION
Améliore le comportement responsive du header organisateur.

- Bascule du conteneur en mode ligne dès 768px.
- Ajuste la taille du logo: 400px, 450px, 500px puis 600px selon la largeur d’écran, 90% en dessous de 768px.
- Met à jour la feuille de style compilée.

## Tests
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1086b97c483329081dc60250f441e