### PR TITLE
Réduit la hauteur de la décoration des titres de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -637,7 +637,7 @@ span.champ-obligatoire {
 
 .titre-chasses-wrapper .titre-chasses .decor {
   flex: 1;
-  height: 6px;
+  height: 4px;
   color: var(--color-titre-enigme);
   display: flex;
   align-items: center;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7265,7 +7265,7 @@ span.champ-obligatoire {
 
 .titre-chasses-wrapper .titre-chasses .decor {
   flex: 1;
-  height: 6px;
+  height: 4px;
   color: var(--color-titre-enigme);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Résumé
- Ajuste la hauteur des éléments décoratifs des titres de chasses à 4 px
- Recompile la feuille de style

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10bd45ef88332b0bbdaafd78edf53