### PR TITLE
Désactive le lien sur l'image de l'organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -121,6 +121,10 @@ a.bouton-edition-attention {
   object-position: center;
 }
 
+.header-organisateur__logo--static {
+  cursor: default;
+}
+
 .description-modal__stats {
   display: flex;
   flex-wrap: wrap;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9003,6 +9003,10 @@ a.bouton-edition-attention {
      object-position: center;
 }
 
+.header-organisateur__logo--static {
+  cursor: default;
+}
+
 .description-modal__stats {
   display: flex;
   flex-wrap: wrap;

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -82,15 +82,28 @@ $classes_header .= ' container container--boxed';
           data-champ="logo_organisateur"
           data-post-id="<?= esc_attr($organisateur_id); ?>">
           <div class="champ-affichage">
-            <a href="<?= esc_url(get_permalink($organisateur_id)); ?>"
-               aria-label="<?= esc_attr__('Voir la page de l\u2019organisateur', 'chassesautresor-com'); ?>">
+            <?php
+            $est_page_organisateur = is_singular('organisateur')
+              && (int) get_queried_object_id() === (int) $organisateur_id;
+            ?>
+            <?php if ($est_page_organisateur) : ?>
               <img src="<?= esc_url($logo_url); ?>"
                    alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
                    width="500" height="500"
-                   class="header-organisateur__logo visuel-cpt"
+                   class="header-organisateur__logo header-organisateur__logo--static visuel-cpt"
                    data-cpt="organisateur"
                    data-post-id="<?= esc_attr($organisateur_id); ?>" />
-            </a>
+            <?php else : ?>
+              <a href="<?= esc_url(get_permalink($organisateur_id)); ?>"
+                 aria-label="<?= esc_attr__('Voir la page de l\u2019organisateur', 'chassesautresor-com'); ?>">
+                <img src="<?= esc_url($logo_url); ?>"
+                     alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
+                     width="500" height="500"
+                     class="header-organisateur__logo visuel-cpt"
+                     data-cpt="organisateur"
+                     data-post-id="<?= esc_attr($organisateur_id); ?>" />
+              </a>
+            <?php endif; ?>
           </div>
           <input type="hidden" class="champ-input" value="<?= esc_attr($logo_id ?? '') ?>">
           <div class="champ-feedback"></div>


### PR DESCRIPTION
## Résumé
- retire le lien de l'image sur la page organisateur
- ajoute un style de curseur neutre pour l'image

## Testing
- `npm test`
- `source ./setup-env.sh && composer install && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c10d9e62648332bb99c0e336d98bff