### PR TITLE
Repositionne les boutons d'action en vue mobile sur la page organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -83,7 +83,9 @@ a.bouton-edition-attention {
   line-height: 1.2;
   margin: 0;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
-  padding-right: var(--space-4xl);
+  flex: 1;
+  min-width: 0;
+  padding-right: 0;
 }
 
 
@@ -142,7 +144,8 @@ a.bouton-edition-attention {
 
 /* ========== 📌 ICÔNES D'ACTIONS ========== */
 .header-organisateur__title-row {
-  position: relative;
+  display: flex;
+  align-items: flex-start;
   width: 100%;
 }
 
@@ -150,6 +153,7 @@ a.bouton-edition-attention {
   display: flex;
   gap: var(--space-xs);
   align-items: center;
+  margin-left: auto;
   color: var(--color-text-primary);
 }
 
@@ -186,10 +190,6 @@ a.bouton-edition-attention {
 }
 
 @media (--bp-tablet) {
-  .header-organisateur__title-row {
-    position: static;
-  }
-
   .header-organisateur__actions {
     position: absolute;
     top: 1.2rem;
@@ -197,7 +197,7 @@ a.bouton-edition-attention {
   }
 
   .header-organisateur__nom {
-    padding-right: 0;
+    padding-right: var(--space-4xl);
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -83,6 +83,7 @@ a.bouton-edition-attention {
   line-height: 1.2;
   margin: 0;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
+  padding-right: var(--space-4xl);
 }
 
 
@@ -140,10 +141,12 @@ a.bouton-edition-attention {
 }
 
 /* ========== 📌 ICÔNES D'ACTIONS ========== */
+.header-organisateur__title-row {
+  position: relative;
+  width: 100%;
+}
+
 .header-organisateur__actions {
-  position: absolute;
-  top: 1.2rem;
-  right: var(--space-xs);
   display: flex;
   gap: var(--space-xs);
   align-items: center;
@@ -180,6 +183,22 @@ a.bouton-edition-attention {
 .header-organisateur__actions .organisateur-share-button svg {
   width: 1.5rem;
   height: 1.5rem;
+}
+
+@media (--bp-tablet) {
+  .header-organisateur__title-row {
+    position: static;
+  }
+
+  .header-organisateur__actions {
+    position: absolute;
+    top: 1.2rem;
+    right: var(--space-xs);
+  }
+
+  .header-organisateur__nom {
+    padding-right: 0;
+  }
 }
 
 /* ========== 🖼 LOGO CLIQUABLE ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8965,7 +8965,9 @@ a.bouton-edition-attention {
   line-height: 1.2;
   margin: 0;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
-  padding-right: var(--space-4xl);
+  flex: 1;
+  min-width: 0;
+  padding-right: 0;
 }
 
 /* ========== 📐 COLONNE LOGO & COLONNE TEXTE ========== */
@@ -9024,7 +9026,8 @@ a.bouton-edition-attention {
 
 /* ========== 📌 ICÔNES D'ACTIONS ========== */
 .header-organisateur__title-row {
-  position: relative;
+  display: flex;
+  align-items: flex-start;
   width: 100%;
 }
 
@@ -9032,6 +9035,7 @@ a.bouton-edition-attention {
   display: flex;
   gap: var(--space-xs);
   align-items: center;
+  margin-left: auto;
   color: var(--color-text-primary);
 }
 
@@ -9068,16 +9072,13 @@ a.bouton-edition-attention {
 }
 
 @media (min-width: 768px) {
-  .header-organisateur__title-row {
-    position: static;
-  }
   .header-organisateur__actions {
     position: absolute;
     top: 1.2rem;
     right: var(--space-xs);
   }
   .header-organisateur__nom {
-    padding-right: 0;
+    padding-right: var(--space-4xl);
   }
 }
 /* ========== 🖼 LOGO CLIQUABLE ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8965,6 +8965,7 @@ a.bouton-edition-attention {
   line-height: 1.2;
   margin: 0;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
+  padding-right: var(--space-4xl);
 }
 
 /* ========== 📐 COLONNE LOGO & COLONNE TEXTE ========== */
@@ -9022,10 +9023,12 @@ a.bouton-edition-attention {
 }
 
 /* ========== 📌 ICÔNES D'ACTIONS ========== */
+.header-organisateur__title-row {
+  position: relative;
+  width: 100%;
+}
+
 .header-organisateur__actions {
-  position: absolute;
-  top: 1.2rem;
-  right: var(--space-xs);
   display: flex;
   gap: var(--space-xs);
   align-items: center;
@@ -9064,6 +9067,19 @@ a.bouton-edition-attention {
   height: 1.5rem;
 }
 
+@media (min-width: 768px) {
+  .header-organisateur__title-row {
+    position: static;
+  }
+  .header-organisateur__actions {
+    position: absolute;
+    top: 1.2rem;
+    right: var(--space-xs);
+  }
+  .header-organisateur__nom {
+    padding-right: 0;
+  }
+}
 /* ========== 🖼 LOGO CLIQUABLE ========== */
 /* Structure du contenu à droite */
 .header-organisateur__description {

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-header.php
@@ -52,29 +52,6 @@ $classes_header .= ' container container--boxed';
     <div class="morse-wrapper" data-morse="<?= esc_attr($titre_organisateur); ?>"></div>
   </div>
   <header class="<?= esc_attr($classes_header); ?>">
-    <div class="header-organisateur__actions">
-      <?php if (function_exists('ADDTOANY_SHARE_SAVE_BUTTON')) : ?>
-        <?php
-        $share_url   = get_permalink($organisateur_id);
-        $share_title = $titre_organisateur;
-        $share_href  = 'https://www.addtoany.com/share#url=' . rawurlencode($share_url) . '&title=' . rawurlencode($share_title);
-        ?>
-        <a
-          class="a2a_dd a2a_counter organisateur-share-button addtoany_share_save addtoany_share"
-          href="<?= esc_url($share_href); ?>"
-          data-a2a-url="<?= esc_url($share_url); ?>"
-          data-a2a-title="<?= esc_attr($share_title); ?>"
-          aria-label="<?= esc_attr__('Partager', 'chassesautresor-com'); ?>"
-        >
-          <?= get_svg_icon('share-icon'); ?>
-        </a>
-      <?php endif; ?>
-      <?php if ($peut_modifier) : ?>
-        <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="<?= esc_attr__('Paramètres organisateur', 'chassesautresor-com'); ?>">
-          <i class="fa-solid fa-gear"></i>
-        </button>
-      <?php endif; ?>
-    </div>
     <div class="conteneur-organisateur">
       <div class="header-organisateur__col header-organisateur__col--logo">
         <div class="champ-organisateur champ-img champ-logo <?= empty($logo_id) ? 'champ-vide' : ''; ?>"
@@ -98,7 +75,32 @@ $classes_header .= ' container container--boxed';
       </div>
 
       <div class="header-organisateur__col header-organisateur__col--infos">
-        <h1 class="header-organisateur__nom"><?= esc_html($titre_organisateur); ?></h1>
+        <div class="header-organisateur__title-row">
+          <h1 class="header-organisateur__nom"><?= esc_html($titre_organisateur); ?></h1>
+          <div class="header-organisateur__actions">
+            <?php if (function_exists('ADDTOANY_SHARE_SAVE_BUTTON')) : ?>
+              <?php
+              $share_url   = get_permalink($organisateur_id);
+              $share_title = $titre_organisateur;
+              $share_href  = 'https://www.addtoany.com/share#url=' . rawurlencode($share_url) . '&title=' . rawurlencode($share_title);
+              ?>
+              <a
+                class="a2a_dd a2a_counter organisateur-share-button addtoany_share_save addtoany_share"
+                href="<?= esc_url($share_href); ?>"
+                data-a2a-url="<?= esc_url($share_url); ?>"
+                data-a2a-title="<?= esc_attr($share_title); ?>"
+                aria-label="<?= esc_attr__('Partager', 'chassesautresor-com'); ?>"
+              >
+                <?= get_svg_icon('share-icon'); ?>
+              </a>
+            <?php endif; ?>
+            <?php if ($peut_modifier) : ?>
+              <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="<?= esc_attr__('Paramètres organisateur', 'chassesautresor-com'); ?>">
+                <i class="fa-solid fa-gear"></i>
+              </button>
+            <?php endif; ?>
+          </div>
+        </div>
         <p class="header-organisateur__description">
           <?= esc_html($description_short); ?>
           <button type="button" class="header-organisateur__voir-plus" aria-label="<?= esc_attr__('Voir plus', 'chassesautresor-com'); ?>">


### PR DESCRIPTION
## Résumé
Repositionne les boutons Partage et Paramètres dans le bloc d'informations de l'organisateur lorsque l'affichage est empilé.

## Changements
- Déplace les actions dans un nouveau conteneur associé au titre.
- Ajoute des styles responsives pour placer les boutons en haut à droite sous l'image et conserve l'affichage original dès la tablette.
- Recompile la feuille de style.

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10e08d6c08332b3dd0e14b72928fb