### PR TITLE
Style du header organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -211,6 +211,9 @@ a.bouton-edition-attention {
 /* Structure du contenu à droite */
 .header-organisateur__description {
   max-width: 40rem;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--color-blue-grey-light);
 }
 
 .header-organisateur__voir-plus {

--- a/wp-content/themes/chassesautresor/assets/scss/_variables.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_variables.scss
@@ -67,6 +67,7 @@
   --color-text-fond-clair: #1c1c1c;         /* noir clair */
   --color-text-fond-clair-rgb: 28, 28, 28;  /* noir clair en RGB */
   --color-gris-carte: #c2c2c2;              /* 🧩 Fond de carte énigme : gris bleuté doux */
+  --color-blue-grey-light: #C9D1E0;       /* 💠 Bleu-gris clair */
 
   /* Groupe d'état : etat-enigme-menu */
   --etat-enigme-menu-en-cours: currentColor;             /* état par défaut */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9089,6 +9089,9 @@ a.bouton-edition-attention {
 /* Structure du contenu à droite */
 .header-organisateur__description {
   max-width: 40rem;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--color-blue-grey-light);
 }
 
 .header-organisateur__voir-plus {
@@ -9472,6 +9475,7 @@ a.bouton-edition-attention {
   --color-text-fond-clair: #1c1c1c; /* noir clair */
   --color-text-fond-clair-rgb: 28, 28, 28; /* noir clair en RGB */
   --color-gris-carte: #c2c2c2; /* 🧩 Fond de carte énigme : gris bleuté doux */
+  --color-blue-grey-light: #C9D1E0; /* 💠 Bleu-gris clair */
   /* Groupe d'état : etat-enigme-menu */
   --etat-enigme-menu-en-cours: currentColor; /* état par défaut */
   --etat-enigme-menu-bloquee: var(--color-grey-medium);

--- a/wp-content/themes/chassesautresor/dist/variables.css
+++ b/wp-content/themes/chassesautresor/dist/variables.css
@@ -59,6 +59,7 @@
   --color-text-fond-clair: #1c1c1c; /* noir clair */
   --color-text-fond-clair-rgb: 28, 28, 28; /* noir clair en RGB */
   --color-gris-carte: #c2c2c2; /* 🧩 Fond de carte énigme : gris bleuté doux */
+  --color-blue-grey-light: #C9D1E0; /* 💠 Bleu-gris clair */
   /* Groupe d'état : etat-enigme-menu */
   --etat-enigme-menu-en-cours: currentColor; /* état par défaut */
   --etat-enigme-menu-bloquee: var(--color-grey-medium);
@@ -112,13 +113,6 @@
     --transition-medium: 0s;
     --transition-slow: 0s;
   }
-}
-/* 📝 Variables d’édition */
-.mode-edition {
-  --color-editor-button: #1A73E8; /* 🔘 Boutons */
-  --color-editor-button-hover: #1558B0; /*       Hover bouton */
-  --editor-button-hsl: 214 82% 51%; /* = #1A73E8 → var(--color-editor-button) */
-  --editor-button-hover-hsl: 214 79% 39%; /* = #1558B0 → var(--color-editor-button-hover) */
 }
 
 /*# sourceMappingURL=variables.css.map */


### PR DESCRIPTION
Améliore l'apparence du header organisateur.

- Ajout d'une nouvelle couleur bleu-gris au nuancier
- Mise à jour de la description de l'organisateur avec taille et interligne dédiées

### Testing
- `composer install --no-progress`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c11a0fd10883328f76dab80ebc5a86