### PR TITLE
feat: style organizer header image

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -106,6 +106,16 @@ a.bouton-edition-attention {
   width: 90%;
   aspect-ratio: 1 / 1;
   overflow: hidden;
+  position: relative;
+  border-radius: 22px;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.12));
+    pointer-events: none;
+  }
 }
 
 .header-organisateur__col--infos {
@@ -122,6 +132,7 @@ a.bouton-edition-attention {
   height: 100%;
   object-fit: cover;
   object-position: center;
+  aspect-ratio: 1 / 1;
 }
 
 .header-organisateur__logo--static {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8986,6 +8986,15 @@ a.bouton-edition-attention {
   width: 90%;
   aspect-ratio: 1/1;
   overflow: hidden;
+  position: relative;
+  border-radius: 22px;
+}
+.header-organisateur__col--logo::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.12));
+  pointer-events: none;
 }
 
 .header-organisateur__col--infos {
@@ -9004,6 +9013,7 @@ a.bouton-edition-attention {
      object-fit: cover;
   -o-object-position: center;
      object-position: center;
+  aspect-ratio: 1/1;
 }
 
 .header-organisateur__logo--static {


### PR DESCRIPTION
## Summary
- ajoute un rayon de 22px et un voile noir léger sur le logo d'organisateur
- maintient `object-fit: cover` et un `aspect-ratio` fixe pour éviter les crops

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c11a8d2cc4833290ad7aedb9e53987