### PR TITLE
Limite la taille du logo organisateur sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -103,9 +103,10 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo {
-  width: 90%;
+  width: auto;
   max-width: 90vw;
   max-height: 300px;
+  margin: 0 auto;
   overflow: hidden;
   position: relative;
   border-radius: 22px;
@@ -129,6 +130,7 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo img {
+  display: block;
   width: auto;
   max-width: 100%;
   height: auto;

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -104,7 +104,8 @@ a.bouton-edition-attention {
 
 .header-organisateur__col--logo {
   width: 90%;
-  aspect-ratio: 1 / 1;
+  max-width: 90vw;
+  max-height: 300px;
   overflow: hidden;
   position: relative;
   border-radius: 22px;
@@ -128,11 +129,12 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo img {
-  width: 100%;
-  height: 100%;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 300px;
   object-fit: cover;
   object-position: center;
-  aspect-ratio: 1 / 1;
 }
 
 .header-organisateur__logo--static {
@@ -321,10 +323,18 @@ a.bouton-edition-attention {
   .header-organisateur__col--logo {
     flex: 0 0 350px;
     width: 350px;
+    aspect-ratio: 1 / 1;
+    max-height: none;
   }
 
   .header-organisateur__col--infos {
     flex: 1;
+  }
+
+  .header-organisateur__col--logo img {
+    width: 100%;
+    height: 100%;
+    max-height: none;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8984,7 +8984,8 @@ a.bouton-edition-attention {
 
 .header-organisateur__col--logo {
   width: 90%;
-  aspect-ratio: 1/1;
+  max-width: 90vw;
+  max-height: 300px;
   overflow: hidden;
   position: relative;
   border-radius: 22px;
@@ -9007,13 +9008,14 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo img {
-  width: 100%;
-  height: 100%;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 300px;
   -o-object-fit: cover;
      object-fit: cover;
   -o-object-position: center;
      object-position: center;
-  aspect-ratio: 1/1;
 }
 
 .header-organisateur__logo--static {
@@ -9197,9 +9199,16 @@ a.bouton-edition-attention {
   .header-organisateur__col--logo {
     flex: 0 0 350px;
     width: 350px;
+    aspect-ratio: 1/1;
+    max-height: none;
   }
   .header-organisateur__col--infos {
     flex: 1;
+  }
+  .header-organisateur__col--logo img {
+    width: 100%;
+    height: 100%;
+    max-height: none;
   }
 }
 @media (min-width: 1024px) {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8983,9 +8983,10 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo {
-  width: 90%;
+  width: auto;
   max-width: 90vw;
   max-height: 300px;
+  margin: 0 auto;
   overflow: hidden;
   position: relative;
   border-radius: 22px;
@@ -9008,6 +9009,7 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo img {
+  display: block;
   width: auto;
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
Rend l'image du header organisateur responsive et adaptée aux petits écrans.

- Limite la hauteur du logo du header organisateur à 300 px et la largeur à 90 % de l'écran sur mobile
- Rétablit l'affichage carré du logo à partir de la résolution tablette
- Régénère le CSS compilé

**Testing**
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c127d75e908332b7662ea6edd8575b