### PR TITLE
feat: carte chasse mobile sur page organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -125,6 +125,7 @@
 
   .carte-cart__contenu {
     padding: var(--space-md);
+    text-align: center;
   }
 
   .carte-cart__titre {
@@ -134,6 +135,11 @@
   .carte-cart__footer {
     padding: 0 var(--space-md) var(--space-md);
     font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-xs);
+    text-align: center;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -91,6 +91,52 @@
   }
 }
 
+/* ========== 🆕 Carte format CART ========== */
+.carte-cart {
+  width: 100%;
+  max-width: 300px;
+  padding: 0;
+  overflow: hidden;
+  margin: 0 auto;
+
+  .carte-cart__lien {
+    display: flex;
+    flex-direction: column;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .carte-cart__image-wrapper {
+    position: relative;
+  }
+
+  .carte-cart__image {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    display: block;
+  }
+
+  .badge-statut {
+    position: absolute;
+    top: var(--space-xs);
+    left: var(--space-xs);
+  }
+
+  .carte-cart__contenu {
+    padding: var(--space-md);
+  }
+
+  .carte-cart__titre {
+    margin: 0 0 var(--space-xs);
+  }
+
+  .carte-cart__footer {
+    padding: 0 var(--space-md) var(--space-md);
+    font-size: 0.875rem;
+  }
+}
+
 /* ========== 🌟 Carte mise en avant ========== */
 .carte-featured {
   position: relative;

--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -587,3 +587,31 @@ a.bouton-edition-attention {
 .chasses {
   margin-top: var(--space-4xl);
 }
+
+/* Grille responsive pour les chasses (format CART) */
+.organisateur-chasses-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-xl);
+  justify-content: center;
+}
+
+.organisateur-chasse__desktop {
+  display: none;
+}
+
+@media (--bp-desktop) {
+  .organisateur-chasses-grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xl);
+  }
+
+  .organisateur-chasse__desktop {
+    display: block;
+  }
+
+  .organisateur-chasse__mobile {
+    display: none;
+  }
+}

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -114,6 +114,7 @@
 }
 .carte-cart .carte-cart__contenu {
   padding: var(--space-md);
+  text-align: center;
 }
 .carte-cart .carte-cart__titre {
   margin: 0 0 var(--space-xs);
@@ -121,6 +122,11 @@
 .carte-cart .carte-cart__footer {
   padding: 0 var(--space-md) var(--space-md);
   font-size: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  text-align: center;
 }
 
 /* ========== 🌟 Carte mise en avant ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -83,6 +83,46 @@
   font-size: 0.875rem;
 }
 
+/* ========== 🆕 Carte format CART ========== */
+.carte-cart {
+  width: 100%;
+  max-width: 300px;
+  padding: 0;
+  overflow: hidden;
+  margin: 0 auto;
+}
+.carte-cart .carte-cart__lien {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+}
+.carte-cart .carte-cart__image-wrapper {
+  position: relative;
+}
+.carte-cart .carte-cart__image {
+  width: 100%;
+  aspect-ratio: 4/3;
+  -o-object-fit: cover;
+     object-fit: cover;
+  display: block;
+}
+.carte-cart .badge-statut {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+}
+.carte-cart .carte-cart__contenu {
+  padding: var(--space-md);
+}
+.carte-cart .carte-cart__titre {
+  margin: 0 0 var(--space-xs);
+}
+.carte-cart .carte-cart__footer {
+  padding: 0 var(--space-md) var(--space-md);
+  font-size: 0.875rem;
+}
+
 /* ========== 🌟 Carte mise en avant ========== */
 .carte-featured {
   position: relative;
@@ -9455,6 +9495,31 @@ a.bouton-edition-attention {
   margin-top: var(--space-4xl);
 }
 
+/* Grille responsive pour les chasses (format CART) */
+.organisateur-chasses-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-xl);
+  justify-content: center;
+}
+
+.organisateur-chasse__desktop {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .organisateur-chasses-grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xl);
+  }
+  .organisateur-chasse__desktop {
+    display: block;
+  }
+  .organisateur-chasse__mobile {
+    display: none;
+  }
+}
 /* 🎨 Variables globales */
 /* Legacy aliases */
 :root {

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -115,7 +115,7 @@ get_header();
                     get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [
                         'organisateur_id' => $organisateur_id,
                         'show_header'     => false,
-                        'grid_class'      => 'grille-liste',
+                        'grid_class'      => 'organisateur-chasses-grid',
                         'after_items'     => $after_items,
                     ]);
                     ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Compact card format for hunts (CART).
+ * Image on top, title, and meta footer.
+ *
+ * @package chassesautresor
+ */
+
+defined('ABSPATH') || exit;
+
+if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id       = (int) $args['chasse_id'];
+$completion_class = $args['completion_class'] ?? '';
+$infos           = preparer_infos_affichage_carte_chasse($chasse_id);
+
+if (empty($infos)) {
+    return;
+}
+?>
+<div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
+    <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
+        <div class="carte-cart__image-wrapper">
+            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+                <?php echo esc_html($infos['statut_label']); ?>
+            </span>
+            <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-cart__image">
+        </div>
+        <div class="carte-cart__contenu">
+            <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
+        </div>
+    </a>
+    <div class="carte-cart__footer meta-row svg-xsmall">
+        <div class="meta-regular">
+            <?php echo get_svg_icon('enigme'); ?>
+            <?php
+            echo esc_html(
+                sprintf(
+                    _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                    $infos['total_enigmes']
+                )
+            );
+            ?>
+            —
+            <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+        </div>
+        <div class="meta-etiquette">
+            <?php echo get_svg_icon('calendar'); ?>
+            <span class="chasse-date-plage">
+                <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
+                <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+            </span>
+        </div>
+    </div>
+</div>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -8,7 +8,7 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 }
 
 $show_header  = $args['show_header'] ?? true;
-$grid_class   = $args['grid_class'] ?? 'liste-pleine-largeur';
+$grid_class   = $args['grid_class'] ?? 'organisateur-chasses-grid';
 $before_items = $args['before_items'] ?? '';
 $after_items  = $args['after_items'] ?? '';
 
@@ -39,16 +39,30 @@ $chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use (
       $wp_status !== 'publish';
     $classe_completion = '';
     if ($voir_bordure) {
-      verifier_ou_mettre_a_jour_cache_complet($chasse_id);
-      $complet          = (bool) get_field('chasse_cache_complet', $chasse_id);
-      $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
+        verifier_ou_mettre_a_jour_cache_complet($chasse_id);
+        $complet          = (bool) get_field('chasse_cache_complet', $chasse_id);
+        $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
     }
-    get_template_part('template-parts/chasse/chasse-card-wide', null, [
-      'chasse_id'        => $chasse_id,
-      'completion_class' => $classe_completion,
-      'word_limit'       => 150,
-    ]);
     ?>
+    <div class="organisateur-chasse">
+        <div class="organisateur-chasse__desktop">
+            <?php
+            get_template_part('template-parts/chasse/chasse-card-wide', null, [
+                'chasse_id'        => $chasse_id,
+                'completion_class' => $classe_completion,
+                'word_limit'       => 150,
+            ]);
+            ?>
+        </div>
+        <div class="organisateur-chasse__mobile">
+            <?php
+            get_template_part('template-parts/chasse/chasse-card-cart', null, [
+                'chasse_id'        => $chasse_id,
+                'completion_class' => $classe_completion,
+            ]);
+            ?>
+        </div>
+    </div>
   <?php endforeach; ?>
 <?php echo $after_items; ?>
 </div>


### PR DESCRIPTION
## Résumé
- ajoute une carte de chasse au format CART pour l’affichage mobile des organisateurs

## Changements majeurs
- création du partiel `chasse-card-cart` avec image, titre et métas en pied
- adaptation de la boucle des chasses pour alterner carte mobile et format large sur desktop
- ajout des styles SCSS/CSS correspondants et recompilation du style

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c130bb91a08332a43c0b58cef4c959