### PR TITLE
Afficher les chasses valides sur la page d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -1,29 +1,56 @@
 <?php
 /**
- * Template Name: Accueil Plein Ecran
- * Description: Page d\'accueil minimaliste avec image plein écran.
+ * Homepage displaying all valid hunts.
  */
 
 defined('ABSPATH') || exit;
 
-$image_url = wp_get_attachment_image_url(8810, 'full');
-if (function_exists('imagify_get_webp_url')) {
-    $image_url = imagify_get_webp_url($image_url);
-}
-?><!DOCTYPE html>
-<html <?php language_attributes(); ?>>
-<head>
-<meta charset="<?php bloginfo('charset'); ?>">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<?php wp_head(); ?>
-</head>
-<body <?php body_class('accueil-fullscreen'); ?>>
-<?php wp_body_open(); ?>
-<div class="accueil-bg" style="background-image:url('<?php echo esc_url($image_url); ?>');">
-    <a class="login-icon" href="<?php echo esc_url(home_url('/mon-compte/')); ?>">
-        <i class="fas fa-user-circle" aria-hidden="true"></i>
-    </a>
+get_header();
+
+$query = new WP_Query([
+    'post_type'      => 'chasse',
+    'post_status'    => 'publish',
+    'meta_query'     => [
+        [
+            'key'   => 'chasse_cache_statut_validation',
+            'value' => 'valide',
+        ],
+    ],
+    'fields'         => 'ids',
+    'posts_per_page' => -1,
+]);
+
+$chasse_ids = $query->posts;
+?>
+
+<div id="primary" class="content-area">
+    <main id="home-page">
+        <section class="chasses">
+            <div class="conteneur">
+                <div class="titre-chasses-wrapper">
+                    <div class="titre-chasses">
+                        <span class="decor decor-gauche">
+                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-right.svg')); ?>
+                        </span>
+                        <h2><?php esc_html_e('Chasses au trésor', 'chassesautresor-com'); ?></h2>
+                        <span class="decor decor-droite">
+                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
+                        </span>
+                    </div>
+                </div>
+                <div class="ligne-chasses"></div>
+                <div class="liste-chasses">
+                    <?php
+                    get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [
+                        'chasse_ids' => $chasse_ids,
+                        'show_header' => false,
+                        'grid_class' => 'organisateur-chasses-grid',
+                    ]);
+                    ?>
+                </div>
+            </div>
+        </section>
+    </main>
 </div>
-<?php wp_footer(); ?>
-</body>
-</html>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -2,18 +2,21 @@
 defined('ABSPATH') || exit;
 
 
+$chasse_ids      = $args['chasse_ids'] ?? null;
 $organisateur_id = $args['organisateur_id'] ?? null;
-if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
-  return;
+
+if (!$chasse_ids) {
+    if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
+        return;
+    }
+    $query      = get_chasses_de_organisateur($organisateur_id);
+    $chasse_ids = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
 }
 
 $show_header  = $args['show_header'] ?? true;
 $grid_class   = $args['grid_class'] ?? 'organisateur-chasses-grid';
 $before_items = $args['before_items'] ?? '';
 $after_items  = $args['after_items'] ?? '';
-
-$query      = get_chasses_de_organisateur($organisateur_id);
-$chasse_ids = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
 
 // 🔒 Filtrer les chasses visibles selon leur statut et l'utilisateur courant
 $user_id    = get_current_user_id();


### PR DESCRIPTION
## Résumé
- affiche sur la page d'accueil la liste des chasses validées
- réutilise le format d'affichage des chasses des pages organisateur
- ajoute la topbar en utilisant le header du thème

## Changelog
- mise à jour du template d'accueil pour requêter les chasses valides et les afficher
- généralisation de la boucle d'affichage des chasses pour accepter une liste d'IDs

## Testing
- `source ./setup-env.sh && composer install --no-progress --no-interaction && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c1b030d008833289c0400a945c00ab