### PR TITLE
Corrige la taille des images d'énigme sur mobile

### DIFF
--- a/tests/EnigmeImageDimensionsTest.php
+++ b/tests/EnigmeImageDimensionsTest.php
@@ -35,7 +35,7 @@ class EnigmeImageDimensionsTest extends TestCase
     public function test_picture_contains_breakpoint_sources(): void
     {
         ob_start();
-        afficher_picture_vignette_enigme(123, 'Alt', ['full']);
+        afficher_picture_vignette_enigme(123, 'Alt', ['medium', 'large', 'full']);
         $html = ob_get_clean();
 
         $this->assertStringContainsString('<picture>', $html);
@@ -44,20 +44,17 @@ class EnigmeImageDimensionsTest extends TestCase
         $this->assertStringContainsString('taille=large', $html);
         $this->assertStringContainsString('media="(min-width: 769px)"', $html);
         $this->assertStringContainsString('taille=medium', $html);
-        $this->assertStringContainsString('media="(min-width: 481px)"', $html);
-        $this->assertStringContainsString('taille=thumbnail', $html);
-        $this->assertGreaterThan(0, substr_count($html, 'srcset='));
+        $this->assertStringNotContainsString('media="(min-width: 481px)"', $html);
+        $this->assertSame(2, substr_count($html, '<source'));
     }
 
-    public function test_medium_size_includes_thumbnail_fallback(): void
+    public function test_single_size_outputs_only_img(): void
     {
         ob_start();
         afficher_picture_vignette_enigme(321, 'Alt', ['medium']);
         $html = ob_get_clean();
 
         $this->assertStringContainsString('taille=medium', $html);
-        $this->assertStringContainsString('media="(min-width: 481px)"', $html);
-        $this->assertStringContainsString('taille=thumbnail', $html);
-        $this->assertSame(1, substr_count($html, '<source'));
+        $this->assertStringNotContainsString('<source', $html);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/visuels.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/visuels.php
@@ -59,20 +59,17 @@ function build_picture_enigme(int $image_id, string $alt, array $sizes, array $i
         : ['thumbnail', 'medium', 'large'];
     $valid_sizes[] = 'full';
     $valid_sizes = array_intersect($valid_sizes, $order);
-    $sizes = array_values(array_intersect($sizes, $valid_sizes));
+    $sizes       = array_values(array_intersect($sizes, $valid_sizes));
     if (!$sizes) {
         $sizes = ['full'];
     }
 
-    $max_index = 0;
-    foreach ($sizes as $s) {
-        $idx = array_search($s, $order, true);
-        if ($idx !== false && $idx > $max_index) {
-            $max_index = $idx;
-        }
-    }
+    usort(
+        $sizes,
+        static fn (string $a, string $b): int => array_search($a, $order, true) <=> array_search($b, $order, true)
+    );
 
-    $used_sizes = array_slice($order, 0, $max_index + 1);
+    $used_sizes = $sizes;
 
     $html = "<picture>\n";
     $size_2x_map = [
@@ -194,7 +191,7 @@ function afficher_visuels_enigme(int $enigme_id): void
 
         $attrs = [
             'class' => $classes,
-            'style' => 'width:auto;max-width:100%;',
+            'style' => 'max-width:100%;height:auto;',
         ];
 
         if ($index === 0) {
@@ -202,7 +199,7 @@ function afficher_visuels_enigme(int $enigme_id): void
         }
 
         echo '<figure class="image-principale">';
-        echo build_picture_enigme($image_id, $alt, ['full'], $attrs);
+        echo build_picture_enigme($image_id, $alt, ['large', 'full'], $attrs);
         echo '</figure>';
     }
     echo '</div>';


### PR DESCRIPTION
## Résumé
- les visuels d’énigme chargent désormais une version large par défaut
- génération `<picture>` ajustée pour respecter exactement les tailles demandées
- mise à jour des tests des images

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c1b1ddc8888332937d63ecab3b51e5