### PR TITLE
feat: support past start date for hunts

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -23,7 +23,7 @@ const html = `
               <input type="checkbox" id="date-debut-differee">
               <span class="switch-slider"></span>
             </label>
-            <span class="toggle-option">Later</span>
+            <span class="toggle-option">Other date</span>
             <div class="date-debut-actions" style="display:none;">
               <input type="datetime-local" id="chasse-date-debut" value="" class="champ-inline-date champ-date-edit">
               <div id="erreur-date-debut" class="message-erreur" role="alert" aria-live="assertive"></div>

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -7,6 +7,7 @@ let inputDateFin;
 let erreurDebut;
 let erreurFin;
 let toggleDateFin;
+let toggleDateDebut;
 
 function parseDateDMY(value) {
   if (!value) return new Date(NaN);
@@ -173,10 +174,12 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
   inputDateFin = document.getElementById('chasse-date-fin');
   erreurDebut = document.getElementById('erreur-date-debut');
   erreurFin = document.getElementById('erreur-date-fin');
+  toggleDateDebut = document.getElementById('date-debut-differee');
   toggleDateFin = document.getElementById('date-fin-limitee');
   mettreAJourCaracteristiqueDate();
   inputDateDebut?.addEventListener('change', mettreAJourCaracteristiqueDate);
   inputDateFin?.addEventListener('change', mettreAJourCaracteristiqueDate);
+  toggleDateDebut?.addEventListener('change', mettreAJourCaracteristiqueDate);
   toggleDateFin?.addEventListener('change', mettreAJourCaracteristiqueDate);
 
   // ==============================
@@ -1056,7 +1059,7 @@ function initChampNbGagnants() {
 }
 
 // ================================
-// 🕒 Gestion du champ Date de début (Maintenant / Plus tard)
+// 🕒 Gestion du champ Date de début (Maintenant / Autre date)
 // ================================
 function initChampDateDebut() {
   const input = document.getElementById('chasse-date-debut');
@@ -1384,7 +1387,8 @@ function enregistrerDatesChasse() {
     date_debut: inputDateDebut.value.trim(),
     // On conserve toujours la date en base, même si l'affichage est "Illimitée"
     date_fin: inputDateFin.value.trim(),
-    illimitee: toggleDateFin?.checked ? 0 : 1
+    illimitee: toggleDateFin?.checked ? 0 : 1,
+    debut_differee: toggleDateDebut?.checked ? 1 : 0
   });
   console.log('[enregistrerDatesChasse] params=', params.toString());
 

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1545,8 +1545,8 @@ msgid "Now"
 msgstr "Maintenant"
 
 #: template-parts/chasse/chasse-edition-main.php:518
-msgid "Later"
-msgstr "Plus tard"
+msgid "Other date"
+msgstr "Autre date"
 
 #: template-parts/chasse/chasse-edition-main.php:549
 msgid "Date de fin"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -40,8 +40,7 @@ $date_debut_iso = $date_debut_obj ? $date_debut_obj->format('Y-m-d\TH:i') : '';
 
 $date_fin_obj = convertir_en_datetime($date_fin);
 $date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
-$maintenant    = current_datetime();
-$debut_differe = $date_debut_obj && $date_debut_obj > $maintenant;
+$debut_differe = (bool) get_post_meta($chasse_id, 'chasse_infos_date_debut_differee', true);
 $illimitee  = $infos_chasse['champs']['illimitee'];
 $nb_max     = $infos_chasse['champs']['nb_max'] ?? 1;
 $mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'automatique';
@@ -519,7 +518,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                                     >
                                     <span class="switch-slider"></span>
                                 </label>
-                                <span class="toggle-option"><?= esc_html__('Later', 'chassesautresor-com'); ?></span>
+                                <span class="toggle-option"><?= esc_html__('Other date', 'chassesautresor-com'); ?></span>
                                 <div class="date-debut-actions" style="<?= $debut_differe ? '' : 'display:none;'; ?>">
                                     <input type="datetime-local"
                                         id="chasse-date-debut"


### PR DESCRIPTION
## Summary
- maintenir l'option "Autre date" lors de l'édition d'une chasse
- permettre l'enregistrement d'une date de début passée
- ajuster les libellés et traductions pour le commutateur de date de début

## Testing
- `npm test`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c1b649970883329be0af8b57dc8145