### PR TITLE
Réduire l'espacement entre cartes d'énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -38,7 +38,7 @@
 // Grille responsive pour cartes
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
   gap: var(--space-4xl);
   justify-content: center;
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -37,7 +37,7 @@
 
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 400px));
   gap: var(--space-4xl);
   justify-content: center;
 }


### PR DESCRIPTION
## Résumé
- resserre l'intervalle entre une carte d'énigme et la carte d'ajout lorsqu'une seule énigme est listée
- met à jour les feuilles de style compilées

## Testing
- `npm ci`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c1971e688332ae96f1737a389207