### PR TITLE
Require engagement for puzzle access after hunt completion

### DIFF
--- a/tests/ChasseTermineeEnigmesVisibilityTest.php
+++ b/tests/ChasseTermineeEnigmesVisibilityTest.php
@@ -14,7 +14,7 @@ class ChasseTermineeEnigmesVisibilityTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_affiche_enigmes_pour_chasse_terminee(): void
+    public function test_masque_enigmes_pour_chasse_terminee_non_engage(): void
     {
         if (!function_exists('get_post_type')) {
             function get_post_type($id) {
@@ -114,7 +114,7 @@ class ChasseTermineeEnigmesVisibilityTest extends TestCase
         require __DIR__ . '/../wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php';
         $output = ob_get_clean();
 
-        $this->assertStringContainsString('cards-grid', $output);
+        $this->assertSame('', $output);
     }
 }
 

--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -57,6 +57,20 @@ if (!function_exists('esc_url')) {
     }
 }
 
+if (!function_exists('__')) {
+    function __($text, $domain)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text)
+    {
+        return $text;
+    }
+}
+
 if (!function_exists('wp_nonce_field')) {
     function wp_nonce_field($action, $name, $referer = true, $echo = false)
     {
@@ -219,4 +233,26 @@ class GenererCtaChasseTest extends TestCase
             $cta
         );
     }
+    public function test_finished_hunt_requires_engagement_cta(): void
+    {
+        $GLOBALS['force_admin_override']        = false;
+        $GLOBALS['force_engage_override']       = false;
+        $GLOBALS['force_organisateur_override'] = false;
+        $GLOBALS['get_field_values']            = [
+            'chasse_cache_statut'            => 'termine',
+            'chasse_cache_statut_validation' => 'valide',
+        ];
+
+        $cta = generer_cta_chasse(123, 5);
+
+        $this->assertSame(
+            [
+                'cta_html'    => '<form method="post" action="/traitement-engagement" class="cta-chasse-form"><input type="hidden" name="chasse_id" value="123"><button type="submit" class="bouton-cta bouton-cta--color">Participer</button></form>',
+                'cta_message' => 'Cette chasse est terminée',
+                'type'        => 'engager',
+            ],
+            $cta,
+        );
+    }
 }
+

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -809,16 +809,16 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             $type    = 'engager';
         }
     } elseif ($statut === 'termine') {
-        // ✅ Chasse terminée : engagement gratuit et automatique
+        // ✅ Chasse terminée : engagement requis pour accéder aux énigmes
         $html  = '<form method="post" action="' . esc_url(site_url('/traitement-engagement')) . '" class="cta-chasse-form">';
         $html .= '<input type="hidden" name="chasse_id" value="' . esc_attr($chasse_id) . '">';
         $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
         $html .= sprintf(
-            '<button type="submit" class="bouton-cta">%s</button>',
-            esc_html__('Voir', 'chassesautresor-com')
+            '<button type="submit" class="bouton-cta bouton-cta--color">%s</button>',
+            esc_html__('Participer', 'chassesautresor-com')
         );
         $html .= '</form>';
-        $type = 'voir';
+        $type = 'engager';
         $message = $date_fin
             ? sprintf(
                 __('Cette chasse est terminée depuis le %s', 'chassesautresor-com'),

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -24,8 +24,7 @@ $statut_metier   = $infos_chasse['statut'] ?? 'revision';
 $autorise_boucle = (
     user_can($utilisateur_id, 'manage_options') ||
     $est_orga_associe ||
-    utilisateur_est_engage_dans_chasse($utilisateur_id, $chasse_id) ||
-    $statut_metier === 'termine'
+    utilisateur_est_engage_dans_chasse($utilisateur_id, $chasse_id)
 );
 if (!$autorise_boucle) {
     return;


### PR DESCRIPTION
## Résumé
- impose l'engagement pour afficher la grille d'énigmes d'une chasse terminée
- adapte le test de visibilité correspondant

## Détails
- retire la visibilité automatique des énigmes après clôture
- vérifie qu'un joueur non engagé ne reçoit aucun rendu de la boucle

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c22e9ee2fc833293f4f1a3acd35d13