### PR TITLE
Tri chronologique des indices

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/edition-animation.php
@@ -289,7 +289,7 @@ if ($objet_type === 'chasse') {
               'post_type'      => 'indice',
               'post_status'    => ['publish', 'pending', 'draft'],
               'orderby'        => 'date',
-              'order'          => 'DESC',
+              'order'          => 'ASC',
               'posts_per_page' => $par_page_indices,
               'paged'          => $page_indices,
               'meta_query'     => $meta,


### PR DESCRIPTION
Affiche les indices du plus ancien au plus récent.

- Inverse l'ordre de tri des indices pour placer les plus récents en dernier.
- Vérifie la cohérence de la numérotation des titres d'indice.

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c239c8590483329c964283431ccd17