### PR TITLE
Affichage inline des solutions PDF

### DIFF
--- a/tests/SolutionPdfDisplayTest.php
+++ b/tests/SolutionPdfDisplayTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('WP_Post')) {
+    class WP_Post
+    {
+        public $ID;
+
+        public function __construct(int $id)
+        {
+            $this->ID = $id;
+        }
+    }
+}
+
+class SolutionPdfDisplayTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_solution_pdf_is_embedded_when_field_returns_id(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__);
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+        }
+        if (!function_exists('add_filter')) {
+            function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {}
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id)
+            {
+                return $key === 'solution_fichier' ? 42 : '';
+            }
+        }
+        if (!function_exists('wp_get_attachment_url')) {
+            function wp_get_attachment_url($id)
+            {
+                return $id === 42 ? 'https://example.com/file.pdf' : '';
+            }
+        }
+        if (!function_exists('esc_url')) {
+            function esc_url($url) { return $url; }
+        }
+        if (!function_exists('esc_attr__')) {
+            function esc_attr__($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($text) { return $text; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+        $solution = new WP_Post(10);
+        $html     = solution_contenu_html($solution);
+
+        $this->assertStringContainsString('<iframe', $html);
+        $this->assertStringContainsString('https://example.com/file.pdf', $html);
+    }
+}

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -552,6 +552,22 @@ li.active .enigme-menu__edit {
   font-weight: 600;
 }
 
+.solution-pdf {
+  margin-block: var(--space-md);
+
+  .solution-embed {
+    width: 100%;
+    height: 60vh;
+    border: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .solution-pdf .solution-embed {
+    height: 80vh;
+  }
+}
+
 /* 📝 Mise en forme du texte d'énigme */
 .enigme-texte {
   max-width: 65ch;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5464,6 +5464,76 @@ body.panneau-ouvert::before {
   height: auto;
 }
 
+.zone-indices {
+  margin-top: var(--space-lg);
+}
+.zone-indices .indice-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+.zone-indices .indice-link {
+  display: inline-block;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+}
+.zone-indices .indice-link--locked {
+  background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.05);
+  color: var(--color-text-primary);
+}
+.zone-indices .indice-link--unlocked {
+  background-color: var(--color-primary);
+  color: var(--color-text-fond-clair);
+}
+.zone-indices .btn-debloquer-indice {
+  display: inline-block;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-primary);
+  color: var(--color-text-fond-clair);
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.zone-indices .indice-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.6);
+}
+.zone-indices .indice-modal[hidden] {
+  display: none;
+}
+.zone-indices .indice-modal .indice-modal-dialog {
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  padding: var(--space-md);
+  border-radius: 4px;
+  max-width: 90%;
+  max-height: 80%;
+  overflow: auto;
+  position: relative;
+}
+.zone-indices .indice-modal .indice-modal-close {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  background: none;
+  border: 0;
+  color: var(--color-text-primary);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
 .menu-lateral .stats-bar-chart .bar-value,
 .menu-lateral .stats-bar-chart .bar-value--outside {
   font-size: 1rem;
@@ -5896,6 +5966,20 @@ li.active .enigme-menu__edit {
   font-weight: 600;
 }
 
+.solution-pdf {
+  margin-block: var(--space-md);
+}
+.solution-pdf .solution-embed {
+  width: 100%;
+  height: 60vh;
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .solution-pdf .solution-embed {
+    height: 80vh;
+  }
+}
 /* 📝 Mise en forme du texte d'énigme */
 .enigme-texte {
   max-width: 65ch;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1298,9 +1298,12 @@ function solution_contenu_html(WP_Post $solution): string
     $texte       = get_field('solution_explication', $solution->ID);
 
     if ($fichier_url) {
-        return '<a href="' . esc_url($fichier_url)
-            . '" class="lien-solution-pdf" target="_blank" rel="noopener">&#128196; '
-            . esc_html($fichier_nom) . '</a>';
+        $html  = '<div class="solution-pdf">';
+        $html .= '<iframe src="' . esc_url($fichier_url) . '" class="solution-embed"';
+        $html .= ' title="' . esc_attr__('Solution PDF', 'chassesautresor-com') . '"></iframe>';
+        $html .= '</div>';
+
+        return $html;
     }
 
     if ($texte) {

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1293,9 +1293,19 @@ function solution_chasse_peut_etre_affichee(int $chasse_id): bool
 function solution_contenu_html(WP_Post $solution): string
 {
     $fichier     = get_field('solution_fichier', $solution->ID);
-    $fichier_url = is_array($fichier) ? ($fichier['url'] ?? '') : '';
-    $fichier_nom = is_array($fichier) ? ($fichier['filename'] ?? basename($fichier_url)) : basename($fichier_url);
-    $texte       = get_field('solution_explication', $solution->ID);
+    $fichier_url = '';
+    $fichier_nom = '';
+
+    if (is_array($fichier)) {
+        $fichier_url = $fichier['url'] ?? '';
+        $fichier_nom = $fichier['filename'] ?? basename($fichier_url);
+    } elseif (!empty($fichier)) {
+        $fichier_id  = (int) $fichier;
+        $fichier_url = wp_get_attachment_url($fichier_id) ?: '';
+        $fichier_nom = basename($fichier_url);
+    }
+
+    $texte = get_field('solution_explication', $solution->ID);
 
     if ($fichier_url) {
         $html  = '<div class="solution-pdf">';


### PR DESCRIPTION
## Résumé
- intègre les fichiers PDF de solution directement dans la page via une balise iframe
- ajoute le style responsive pour les solutions PDF

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c194e447bc83329001592f9114a0cb