### PR TITLE
Corrige l'affichage des solutions après la fin d'une chasse

### DIFF
--- a/tests/ChasseSolutionsRenderTest.php
+++ b/tests/ChasseSolutionsRenderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('WP_Post')) {
+    class WP_Post {
+        public $ID;
+        public function __construct($id)
+        {
+            $this->ID = $id;
+        }
+    }
+}
+
+class ChasseSolutionsRenderTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_details_are_open_by_default(): void
+    {
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return 'chasse'; }
+        }
+        if (!defined('SOLUTION_STATE_EN_COURS')) {
+            define('SOLUTION_STATE_EN_COURS', 'en_cours');
+        }
+        if (!defined('SOLUTION_STATE_A_VENIR')) {
+            define('SOLUTION_STATE_A_VENIR', 'a_venir');
+        }
+        if (!defined('SOLUTION_STATE_FIN_CHASSE')) {
+            define('SOLUTION_STATE_FIN_CHASSE', 'fin_chasse');
+        }
+        if (!defined('SOLUTION_STATE_FIN_CHASSE_DIFFERE')) {
+            define('SOLUTION_STATE_FIN_CHASSE_DIFFERE', 'fin_chasse_differee');
+        }
+        if (!function_exists('utilisateur_peut_voir_solution_chasse')) {
+            function utilisateur_peut_voir_solution_chasse($id, $user) { return true; }
+        }
+        if (!function_exists('recuperer_enigmes_pour_chasse')) {
+            function recuperer_enigmes_pour_chasse($id) { return []; }
+        }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) { return [new WP_Post(10)]; }
+        }
+        if (!function_exists('current_time')) {
+            function current_time($type) { return 0; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($str) { return $str; }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($name, $post_id, $format = true) {
+                $map = [
+                    1 => ['chasse_cache_statut' => 'termine'],
+                    10 => [
+                        'solution_disponibilite' => 'fin_chasse',
+                        'solution_decalage_jours' => 0,
+                        'solution_heure_publication' => '00:00',
+                        'solution_explication' => 'CONTENT',
+                    ],
+                ];
+                return $map[$post_id][$name] ?? null;
+            }
+        }
+        if (!function_exists('esc_html__')) {
+            function esc_html__($text, $domain = null) { return $text; }
+        }
+        if (!function_exists('esc_html')) {
+            function esc_html($text) { return $text; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+        ob_start();
+        render_chasse_solutions(1, 0);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('<details open>', $html);
+        $this->assertStringContainsString('CONTENT', $html);
+    }
+}

--- a/tests/ChasseSolutionsTest.php
+++ b/tests/ChasseSolutionsTest.php
@@ -141,8 +141,8 @@ class ChasseSolutionsTest extends TestCase
             function get_field($key, $post_id)
             {
                 global $captured_fields;
-                if ($key === 'statut_chasse') {
-                    return 'terminée';
+                if ($key === 'chasse_cache_statut') {
+                    return 'termine';
                 }
                 return $captured_fields[$key] ?? null;
             }
@@ -533,7 +533,7 @@ class ChasseSolutionsTest extends TestCase
                 'solution_heure_publication' => '00:00',
             ],
             $chasse_id   => [
-                'statut_chasse' => 'en cours',
+                'chasse_cache_statut' => 'en_cours',
             ],
         ];
 
@@ -587,7 +587,7 @@ class ChasseSolutionsTest extends TestCase
                 'solution_heure_publication' => '00:00',
             ],
             $chasse_id   => [
-                'statut_chasse' => 'terminée',
+                'chasse_cache_statut' => 'termine',
             ],
         ];
 

--- a/tests/SolutionAccessTest.php
+++ b/tests/SolutionAccessTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SolutionAccessTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_anonymous_can_view_solution_when_hunt_finished(): void
+    {
+        if (!function_exists('solution_recuperer_par_objet')) {
+            function solution_recuperer_par_objet(int $id, string $type) {
+                return (object) ['ID' => 99];
+            }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id) {
+                return $key === 'chasse_cache_statut' ? 'termine' : null;
+            }
+        }
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $capability) { return false; }
+        }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) { return false; }
+        }
+        if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+            function utilisateur_est_engage_dans_chasse($user_id, $chasse_id) { return false; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
+
+        $this->assertTrue(utilisateur_peut_voir_solution_chasse(1, 0));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_anonymous_cannot_view_solution_before_end(): void
+    {
+        if (!function_exists('solution_recuperer_par_objet')) {
+            function solution_recuperer_par_objet(int $id, string $type) {
+                return (object) ['ID' => 99];
+            }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id) {
+                return $key === 'chasse_cache_statut' ? 'en_cours' : null;
+            }
+        }
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $capability) { return false; }
+        }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) { return false; }
+        }
+        if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+            function utilisateur_est_engage_dans_chasse($user_id, $chasse_id) { return false; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
+
+        $this->assertFalse(utilisateur_peut_voir_solution_chasse(1, 0));
+    }
+}

--- a/tests/SolutionCacheUpdateTest.php
+++ b/tests/SolutionCacheUpdateTest.php
@@ -97,8 +97,8 @@ class SolutionCacheUpdateTest extends TestCase
             function get_field($key, $post_id)
             {
                 global $captured_fields;
-                if ($key === 'statut_chasse') {
-                    return 'terminée';
+                if ($key === 'chasse_cache_statut') {
+                    return 'termine';
                 }
                 return $captured_fields[$key] ?? null;
             }

--- a/tests/SolutionContentHtmlTest.php
+++ b/tests/SolutionContentHtmlTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('WP_Post')) {
+    class WP_Post
+    {
+        public $ID;
+
+        public function __construct(int $id)
+        {
+            $this->ID = $id;
+        }
+    }
+}
+
+final class SolutionContentHtmlTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_returns_link_when_file_id_provided(): void
+    {
+        $solution = new WP_Post(10);
+
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id, $format = true) {
+                return $key === 'solution_fichier' ? 55 : '';
+            }
+        }
+        if (!function_exists('wp_get_attachment_url')) {
+            function wp_get_attachment_url($id) {
+                return $id === 55 ? 'https://example.com/solution.pdf' : '';
+            }
+        }
+        if (!function_exists('get_attached_file')) {
+            function get_attached_file($id) {
+                return $id === 55 ? '/tmp/solution.pdf' : '';
+            }
+        }
+        if (!function_exists('esc_url')) {
+            function esc_url($url) { return $url; }
+        }
+        if (!function_exists('esc_html')) {
+            function esc_html($text) { return $text; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($text) { return $text; }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callback, $priority = 10, $args = 1) {}
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+        $html = solution_contenu_html($solution);
+        $this->assertStringContainsString('solution.pdf', $html);
+    }
+}

--- a/tests/SolutionLookupQueryTest.php
+++ b/tests/SolutionLookupQueryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SolutionLookupQueryTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_query_checks_plain_and_serialized_meta_values(): void
+    {
+        global $captured_args;
+        $captured_args = [];
+
+        if (!function_exists('get_posts')) {
+            function get_posts(array $args) {
+                global $captured_args;
+                $captured_args = $args;
+                return [];
+            }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/constants.php';
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+        solution_recuperer_par_objet(42, 'chasse');
+
+        $meta_query = $captured_args['meta_query'];
+        $this->assertSame('AND', $meta_query['relation']);
+
+        $or_group = $meta_query[2] ?? [];
+        $this->assertSame('OR', $or_group['relation'] ?? '');
+
+        $values = [];
+        foreach ($or_group as $key => $condition) {
+            if (is_int($key) && isset($condition['value'])) {
+                $values[] = $condition['value'];
+            }
+        }
+        $this->assertContains(42, $values);
+        $this->assertContains("\"42\"", $values);
+    }
+}
+

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -545,11 +545,13 @@ li.active .enigme-menu__edit {
   background: var(--bg-solution, var(--ca-color-bg, #f5f5f5));
   padding: var(--space-md);
   border-radius: 6px;
+  color: var(--color-text-fond-clair);
 }
 
 .solution summary {
   cursor: pointer;
   font-weight: 600;
+  color: var(--color-text-fond-clair);
 }
 
 /* 📝 Mise en forme du texte d'énigme */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5889,11 +5889,13 @@ li.active .enigme-menu__edit {
   background: var(--bg-solution, var(--ca-color-bg, #f5f5f5));
   padding: var(--space-md);
   border-radius: 6px;
+  color: var(--color-text-fond-clair);
 }
 
 .solution summary {
   cursor: pointer;
   font-weight: 600;
+  color: var(--color-text-fond-clair);
 }
 
 /* 📝 Mise en forme du texte d'énigme */

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1190,7 +1190,7 @@ function utilisateur_peut_voir_solution_enigme(int $post_id, int $user_id): bool
  */
 function utilisateur_peut_voir_solution_chasse(int $chasse_id, int $user_id): bool
 {
-    if (!$chasse_id || !$user_id) {
+    if (!$chasse_id) {
         return false;
     }
 
@@ -1199,19 +1199,22 @@ function utilisateur_peut_voir_solution_chasse(int $chasse_id, int $user_id): bo
         return false;
     }
 
-    if (user_can($user_id, 'manage_options')) {
-        return true;
+    if ($user_id) {
+        if (user_can($user_id, 'manage_options')) {
+            return true;
+        }
+
+        if (utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
+            return true;
+        }
+
+        if (utilisateur_est_engage_dans_chasse($user_id, $chasse_id)) {
+            return true;
+        }
     }
 
-    if (utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
-        return true;
-    }
-
-    if (utilisateur_est_engage_dans_chasse($user_id, $chasse_id)) {
-        return true;
-    }
-
-    return false;
+    $statut = get_field('chasse_cache_statut', $chasse_id);
+    return $statut === 'termine';
 }
 
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1290,15 +1290,23 @@ function solution_chasse_peut_etre_affichee(int $chasse_id): bool
  */
 function solution_contenu_html(WP_Post $solution): string
 {
-    $fichier     = get_field('solution_fichier', $solution->ID);
-    $fichier_url = is_array($fichier) ? ($fichier['url'] ?? '') : '';
-    $fichier_nom = is_array($fichier) ? ($fichier['filename'] ?? basename($fichier_url)) : basename($fichier_url);
-    $texte       = get_field('solution_explication', $solution->ID);
+    $fichier = get_field('solution_fichier', $solution->ID);
+    $texte   = get_field('solution_explication', $solution->ID);
 
-    if ($fichier_url) {
-        return '<a href="' . esc_url($fichier_url)
-            . '" class="lien-solution-pdf" target="_blank" rel="noopener">&#128196; '
-            . esc_html($fichier_nom) . '</a>';
+    if ($fichier) {
+        if (is_array($fichier)) {
+            $fichier_url = $fichier['url'] ?? '';
+            $fichier_nom = $fichier['filename'] ?? basename($fichier_url);
+        } else {
+            $fichier_url = wp_get_attachment_url($fichier);
+            $fichier_nom = basename(get_attached_file($fichier)) ?: basename($fichier_url);
+        }
+
+        if ($fichier_url) {
+            return '<a href="' . esc_url($fichier_url)
+                . '" class="lien-solution-pdf" target="_blank" rel="noopener">&#128196; '
+                . esc_html($fichier_nom) . '</a>';
+        }
     }
 
     if ($texte) {

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1212,9 +1212,8 @@ function solution_peut_etre_affichee(int $enigme_id): bool
         return false;
     }
 
-    $statut   = get_field('statut_chasse', $chasse_id);
-    $terminee = is_string($statut) && in_array(strtolower($statut), ['terminée', 'termine', 'terminé'], true);
-    if (!$terminee) {
+    $statut   = get_field('chasse_cache_statut', $chasse_id);
+    if ($statut !== 'termine') {
         return false;
     }
 
@@ -1258,9 +1257,8 @@ function solution_chasse_peut_etre_affichee(int $chasse_id): bool
         return false;
     }
 
-    $statut   = get_field('statut_chasse', $chasse_id);
-    $terminee = is_string($statut) && in_array(strtolower($statut), ['terminée', 'termine', 'terminé'], true);
-    if (!$terminee) {
+    $statut   = get_field('chasse_cache_statut', $chasse_id);
+    if ($statut !== 'termine') {
         return false;
     }
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1337,7 +1337,7 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
             $content = solution_contenu_html($solution);
             if ($content !== '') {
                 $sections .= '<section class="solution">';
-                $sections .= '<details><summary>'
+                $sections .= '<details open><summary>'
                     . esc_html__('Solution de la chasse', 'chassesautresor-com')
                     . '</summary>';
                 $sections .= '<div class="solution-content">' . $content . '</div></details></section>';
@@ -1366,7 +1366,7 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
             esc_html(get_the_title($enigme_id))
         );
         $sections .= '<section class="solution">';
-        $sections .= '<details><summary>' . $label . '</summary>';
+        $sections .= '<details open><summary>' . $label . '</summary>';
         $sections .= '<div class="solution-content">' . $content . '</div></details></section>';
     }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-solution.php
@@ -38,8 +38,8 @@ function solution_planifier_publication(int $solution_id): void
         return;
     }
 
-    $statut   = get_field('statut_chasse', $chasse_id);
-    $terminee = is_string($statut) && in_array(strtolower($statut), ['terminée', 'termine', 'terminé'], true);
+    $statut   = get_field('chasse_cache_statut', $chasse_id);
+    $terminee = ($statut === 'termine');
 
     $dispo    = get_field('solution_disponibilite', $solution_id) ?: 'fin_chasse';
     $decalage = (int) get_field('solution_decalage_jours', $solution_id);


### PR DESCRIPTION
Corrige l'affichage des solutions lorsque la chasse est terminée.

- Utilise le statut mis en cache pour déterminer la visibilité des solutions.
- Adapte la planification des publications de solutions.
- Met à jour les tests pour refléter le nouveau champ de statut.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c23fe05328833286a6e21ead976bce