### PR TITLE
Afficher les indices programmés dans une énigme

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -573,7 +573,7 @@ require_once __DIR__ . '/indices.php';
         $indices = function_exists('get_posts')
             ? get_posts([
                 'post_type'      => 'indice',
-                'post_status'    => ['publish', 'draft'],
+                'post_status'    => ['publish', 'draft', 'future'],
                 'meta_query'     => [
                     [
                         'key'     => 'indice_cible_type',


### PR DESCRIPTION
### Résumé
- inclusion des indices programmés lors du rendu de la participation

### Changements notables
- prise en compte du statut `future` pour les indices liés à une énigme

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68c2511c0af88332971bfc151a6d7fde