### PR TITLE
Synchroniser les titres d'indices affichés

### DIFF
--- a/tests/IndiceDatePrefillTest.php
+++ b/tests/IndiceDatePrefillTest.php
@@ -107,7 +107,7 @@ namespace IndiceDatePrefill {
 
             $this->assertStringContainsString('data-indice-date="2024-03-14T18:00"', $output);
             $this->assertStringContainsString('data-indice-rang="1"', $output);
-            $this->assertStringContainsString('Indice #1', $output);
+            $this->assertStringContainsString('Titre', $output);
         }
     }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -624,14 +624,16 @@ require_once __DIR__ . '/indices.php';
                 } elseif ($est_debloque) {
                     $classes   = 'indice-link indice-link--unlocked etiquette';
                     $etat_icon = 'fa-lock-open';
-                    $label = sprintf(
+                    $title     = get_the_title($indice_id);
+                    $label     = $title !== '' ? esc_html($title) : sprintf(
                         esc_html__('Indice #%d', 'chassesautresor-com'),
                         $i + 1
                     );
                 } else {
                     $classes   = 'indice-link indice-link--locked etiquette';
                     $etat_icon = 'fa-lock';
-                    $label = sprintf(
+                    $title     = get_the_title($indice_id);
+                    $label     = $title !== '' ? esc_html($title) : sprintf(
                         esc_html__('Indice #%d', 'chassesautresor-com'),
                         $i + 1
                     );

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -87,8 +87,12 @@ if (empty($indices)) {
                 $img_url = wp_get_attachment_image_url($img_id, 'thumbnail') ?: '';
             }
 
-            $indice_title = sprintf(__('Indice #%d', 'chassesautresor-com'), $indice_rank);
-            $contenu      = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
+            $indice_title_raw = get_the_title($indice->ID);
+            $default_title    = defined('TITRE_DEFAUT_INDICE') ? TITRE_DEFAUT_INDICE : '';
+            $indice_title     = $indice_title_raw !== '' && $indice_title_raw !== $default_title
+                ? $indice_title_raw
+                : sprintf(__('Indice #%d', 'chassesautresor-com'), $indice_rank);
+            $contenu          = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
             $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
 
             $date_raw   = get_field('indice_date_disponibilite', $indice->ID) ?: '';


### PR DESCRIPTION
## Résumé
- afficher les titres des indices dans le bloc de participation
- repli sur `Indice #n` quand aucun titre n'est défini

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c250f6e8988332906bd7b14e72c0c7