### PR TITLE
Rendre les étiquettes d’indice plus discrètes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -42,19 +42,11 @@
     text-decoration: none;
     font-weight: 600;
 
-    &--locked {
-      background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.05);
-      color: var(--color-text-primary);
-    }
-
-    &--unlocked {
-      background-color: var(--color-primary);
-      color: var(--color-text-fond-clair);
-    }
-
+    &--locked,
+    &--unlocked,
     &--upcoming {
-      background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.05);
-      color: var(--color-text-primary);
+      background-color: var(--color-grey-medium);
+      color: var(--color-white);
     }
   }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -45,7 +45,7 @@
     &--locked,
     &--unlocked,
     &--upcoming {
-      background-color: var(--color-grey-medium);
+      background-color: var(--color-gris-3);
       color: var(--color-white);
     }
   }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5485,7 +5485,7 @@ body.panneau-ouvert::before {
   font-weight: 600;
 }
 .zone-indices .indice-link--locked, .zone-indices .indice-link--unlocked, .zone-indices .indice-link--upcoming {
-  background-color: var(--color-grey-medium);
+  background-color: var(--color-gris-3);
   color: var(--color-white);
 }
 .zone-indices .btn-debloquer-indice {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5484,17 +5484,9 @@ body.panneau-ouvert::before {
   text-decoration: none;
   font-weight: 600;
 }
-.zone-indices .indice-link--locked {
-  background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.05);
-  color: var(--color-text-primary);
-}
-.zone-indices .indice-link--unlocked {
-  background-color: var(--color-primary);
-  color: var(--color-text-fond-clair);
-}
-.zone-indices .indice-link--upcoming {
-  background-color: rgba(var(--color-black-rgb, 0, 0, 0), 0.05);
-  color: var(--color-text-primary);
+.zone-indices .indice-link--locked, .zone-indices .indice-link--unlocked, .zone-indices .indice-link--upcoming {
+  background-color: var(--color-grey-medium);
+  color: var(--color-white);
 }
 .zone-indices .btn-debloquer-indice {
   display: inline-block;


### PR DESCRIPTION
## Résumé
- Harmonise les étiquettes d’indice avec un fond gris moyen et une police blanche
- Recompile les styles du thème

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c2519e71208332b040e90da1aeb8b5