### PR TITLE
feat: add lightbulb icon to indices section

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -600,7 +600,7 @@ require_once __DIR__ . '/indices.php';
             : [];
 
         if (!empty($indices)) {
-            $content .= '<div class="zone-indices"><h3>'
+            $content .= '<div class="zone-indices"><h3><i class="fa-solid fa-lightbulb" aria-hidden="true"></i> '
                 . esc_html__('Indices', 'chassesautresor-com')
                 . '</h3><ul class="indice-list">';
             foreach ($indices as $i => $indice_id) {


### PR DESCRIPTION
## Résumé
Ajoute une icône d'ampoule avant le titre de la section "Indices" dans le bloc de participation des énigmes.

## Changements notables
- Affiche une icône d'ampoule dans la zone des indices lorsque des indices sont disponibles.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c2553485588332a9dfe1f2eb15bcb6