### PR TITLE
Affiche la solution de l'énigme avant celle de la chasse

### DIFF
--- a/tests/ChasseSolutionsRenderTest.php
+++ b/tests/ChasseSolutionsRenderTest.php
@@ -82,4 +82,71 @@ class ChasseSolutionsRenderTest extends TestCase
         $this->assertStringContainsString('<details open>', $html);
         $this->assertStringContainsString('CONTENT', $html);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_riddle_solutions_not_displayed(): void
+    {
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return $id === 1 ? 'chasse' : 'enigme'; }
+        }
+        if (!defined('SOLUTION_STATE_EN_COURS')) {
+            define('SOLUTION_STATE_EN_COURS', 'en_cours');
+        }
+        if (!defined('SOLUTION_STATE_A_VENIR')) {
+            define('SOLUTION_STATE_A_VENIR', 'a_venir');
+        }
+        if (!defined('SOLUTION_STATE_FIN_CHASSE')) {
+            define('SOLUTION_STATE_FIN_CHASSE', 'fin_chasse');
+        }
+        if (!defined('SOLUTION_STATE_FIN_CHASSE_DIFFERE')) {
+            define('SOLUTION_STATE_FIN_CHASSE_DIFFERE', 'fin_chasse_differee');
+        }
+        if (!function_exists('utilisateur_peut_voir_solution_chasse')) {
+            function utilisateur_peut_voir_solution_chasse($id, $user) { return true; }
+        }
+        if (!function_exists('get_posts')) {
+            function get_posts($args) { return [new WP_Post(10), new WP_Post(20)]; }
+        }
+        if (!function_exists('current_time')) {
+            function current_time($type) { return 0; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($str) { return $str; }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($name, $post_id, $format = true) {
+                $map = [
+                    1 => ['chasse_cache_statut' => 'termine'],
+                    10 => [
+                        'solution_disponibilite' => 'fin_chasse',
+                        'solution_decalage_jours' => 0,
+                        'solution_heure_publication' => '00:00',
+                        'solution_explication' => 'HUNT',
+                    ],
+                    20 => [
+                        'solution_disponibilite' => 'fin_chasse',
+                        'solution_decalage_jours' => 0,
+                        'solution_heure_publication' => '00:00',
+                        'solution_explication' => 'RIDDLE',
+                    ],
+                ];
+                return $map[$post_id][$name] ?? null;
+            }
+        }
+        if (!function_exists('esc_html__')) {
+            function esc_html__($text, $domain = null) { return $text; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+        ob_start();
+        render_chasse_solutions(1, 0);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('HUNT', $html);
+        $this->assertStringNotContainsString('RIDDLE', $html);
+    }
 }

--- a/tests/SolutionAccessTest.php
+++ b/tests/SolutionAccessTest.php
@@ -67,4 +67,44 @@ final class SolutionAccessTest extends TestCase
 
         $this->assertFalse(utilisateur_peut_voir_solution_chasse(1, 0));
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_player_can_view_enigme_solution_after_hunt_ended(): void
+    {
+        if (!function_exists('solution_recuperer_par_objet')) {
+            function solution_recuperer_par_objet(int $id, string $type) {
+                return (object) ['ID' => 123];
+            }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id) {
+                return $key === 'chasse_cache_statut' ? 'termine' : null;
+            }
+        }
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $capability) { return false; }
+        }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) { return false; }
+        }
+        if (!function_exists('utilisateur_est_engage_dans_enigme')) {
+            function utilisateur_est_engage_dans_enigme($user_id, $enigme_id) { return true; }
+        }
+        if (!function_exists('recuperer_id_chasse_associee')) {
+            function recuperer_id_chasse_associee($enigme_id) { return 10; }
+        }
+        if (!function_exists('get_post_type')) {
+            function get_post_type($id) { return 'enigme'; }
+        }
+        if (!function_exists('get_statut_utilisateur_enigme')) {
+            function get_statut_utilisateur_enigme($user_id, $enigme_id) { return 'en_cours'; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
+
+        $this->assertTrue(utilisateur_peut_voir_solution_enigme(2, 1));
+    }
 }

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1170,6 +1170,14 @@ function utilisateur_peut_voir_solution_enigme(int $post_id, int $user_id): bool
         return false;
     }
 
+    if (
+        get_field('chasse_cache_statut', $chasse_id) === 'termine'
+        && function_exists('utilisateur_est_engage_dans_enigme')
+        && utilisateur_est_engage_dans_enigme($user_id, $post_id)
+    ) {
+        return true;
+    }
+
     if (utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
         return true;
     }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1370,31 +1370,6 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
         }
     }
 
-    $enigmes = recuperer_enigmes_pour_chasse($chasse_id);
-    foreach ($enigmes as $enigme) {
-        $enigme_id = $enigme->ID;
-        if (!solution_peut_etre_affichee($enigme_id)
-            || !utilisateur_peut_voir_solution_enigme($enigme_id, $user_id)) {
-            continue;
-        }
-        $sol = solution_recuperer_par_objet($enigme_id, 'enigme');
-        if (!$sol) {
-            continue;
-        }
-        $content = solution_contenu_html($sol);
-        if ($content === '') {
-            continue;
-        }
-        $label = sprintf(
-            /* translators: %s: riddle title */
-            esc_html__('Solution de %s', 'chassesautresor-com'),
-            esc_html(get_the_title($enigme_id))
-        );
-        $sections .= '<section class="solution">';
-        $sections .= '<details open><summary>' . $label . '</summary>';
-        $sections .= '<div class="solution-content">' . $content . '</div></details></section>';
-    }
-
     if ($sections === '') {
         return;
     }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -57,6 +57,37 @@ require_once __DIR__ . '/indices.php';
     add_action('added_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
     add_action('updated_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
     add_action('deleted_user_meta', 'enigme_bump_permissions_cache_version', 10, 4);
+
+    /**
+     * Clear solution caches when a solution is saved.
+     *
+     * @param int $solution_id Solution identifier.
+     */
+    function enigme_clear_render_cache_on_solution_save(int $solution_id): void
+    {
+        $target = get_field('solution_cible_type', $solution_id);
+
+        if ($target === 'enigme') {
+            $enigme_id = (int) get_field('solution_enigme_linked', $solution_id);
+            if ($enigme_id) {
+                enigme_clear_render_cache($enigme_id);
+            }
+
+            return;
+        }
+
+        if ($target === 'chasse') {
+            $chasse_id = (int) get_field('solution_chasse_linked', $solution_id);
+            if ($chasse_id) {
+                $enigmes = recuperer_enigmes_pour_chasse($chasse_id);
+                foreach ($enigmes as $enigme) {
+                    enigme_clear_render_cache((int) $enigme->ID);
+                }
+            }
+        }
+    }
+
+    add_action('save_post_solution', 'enigme_clear_render_cache_on_solution_save', 20, 1);
     /**
      * Clear sidebar caches for a given hunt and user.
      *

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
@@ -13,7 +13,10 @@ if (
     && solution_peut_etre_affichee($post_id)
     && utilisateur_peut_voir_solution_enigme($post_id, $user_id)
 ) {
+    echo '<section class="solution-enigme">';
+    echo '<h4>' . esc_html__('Solution de l\'énigme', 'chassesautresor-com') . '</h4>';
     echo solution_contenu_html($enigme_solution);
+    echo '</section>';
 }
 
 $chasse_id = (int) recuperer_id_chasse_associee($post_id);
@@ -24,7 +27,10 @@ if (
 ) {
     $chasse_solution = solution_recuperer_par_objet($chasse_id, 'chasse');
     if ($chasse_solution) {
+        echo '<section class="solution-chasse">';
+        echo '<h4>' . esc_html__('Solution de la chasse', 'chassesautresor-com') . '</h4>';
         echo solution_contenu_html($chasse_solution);
+        echo '</section>';
     }
 }
 ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
@@ -7,25 +7,24 @@ if (!$post_id) {
     return;
 }
 
-$solution = solution_recuperer_par_objet($post_id, 'enigme');
-if ($solution && solution_peut_etre_affichee($post_id)
-    && utilisateur_peut_voir_solution_enigme($post_id, $user_id)) {
-    echo solution_contenu_html($solution);
-    return;
+$enigme_solution = solution_recuperer_par_objet($post_id, 'enigme');
+if (
+    $enigme_solution
+    && solution_peut_etre_affichee($post_id)
+    && utilisateur_peut_voir_solution_enigme($post_id, $user_id)
+) {
+    echo solution_contenu_html($enigme_solution);
 }
 
 $chasse_id = (int) recuperer_id_chasse_associee($post_id);
-if (!$chasse_id) {
-    return;
-}
-
-if (!solution_chasse_peut_etre_affichee($chasse_id)
-    || !utilisateur_peut_voir_solution_chasse($chasse_id, $user_id)) {
-    return;
-}
-
-$solution = solution_recuperer_par_objet($chasse_id, 'chasse');
-if ($solution) {
-    echo solution_contenu_html($solution);
+if (
+    $chasse_id
+    && solution_chasse_peut_etre_affichee($chasse_id)
+    && utilisateur_peut_voir_solution_chasse($chasse_id, $user_id)
+) {
+    $chasse_solution = solution_recuperer_par_objet($chasse_id, 'chasse');
+    if ($chasse_solution) {
+        echo solution_contenu_html($chasse_solution);
+    }
 }
 ?>


### PR DESCRIPTION
## Résumé
- Affiche la solution spécifique d'une énigme lorsqu'elle est disponible
- Montre ensuite la solution globale de la chasse associée si elle existe

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c26bce12a08332b0bb3de999393627