### PR TITLE
style: centrer les étiquettes d'indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -31,6 +31,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-sm);
+    justify-content: center;
   }
 
   .indice-link {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5474,6 +5474,7 @@ body.panneau-ouvert::before {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
+  justify-content: center;
 }
 .zone-indices .indice-link {
   display: inline-flex;


### PR DESCRIPTION
Centrage horizontal des étiquettes d'indices dans le bloc Participation.

- Aligne les étiquettes d'indices au centre de leur conteneur.
- Recompile les styles pour refléter le nouveau centrage.

### Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c26c0485d48332ba432df78b9f0640