### PR TITLE
Affichage des indices de chasse sur la page énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -1,12 +1,9 @@
 document.addEventListener('DOMContentLoaded', function () {
-  var container = document.querySelector('.zone-indices .indice-display');
-  if (!container) return;
-
-  function displayContent(html) {
+  function displayContent(container, html) {
     container.innerHTML = html;
   }
 
-  function fetchIndice(id, link) {
+  function fetchIndice(id, link, container) {
     var fd = new FormData();
     fd.append('action', 'debloquer_indice');
     fd.append('indice_id', id);
@@ -14,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(function (r) { return r.json(); })
       .then(function (res) {
         if (res.success) {
-          displayContent(res.data.html);
+          displayContent(container, res.data.html);
           if (link) {
             link.dataset.unlocked = '1';
             link.classList.remove('indice-link--locked');
@@ -34,12 +31,15 @@ document.addEventListener('DOMContentLoaded', function () {
     var link = e.target.closest('.indice-link');
     if (link) {
       e.preventDefault();
+      var zone = link.closest('.zone-indices-group');
+      var container = zone ? zone.querySelector('.indice-display') : null;
+      if (!container) return;
       if (link.dataset.unlocked === '1') {
-        fetchIndice(link.dataset.indiceId, link);
+        fetchIndice(link.dataset.indiceId, link, container);
       } else {
         var cout = link.dataset.cout || '0';
         container.innerHTML = '<p>' + indicesUnlock.texts.unlock + ' - ' + cout + ' ' + indicesUnlock.texts.pts + '</p>'
-          + '<button type="button" class="btn-debloquer-indice" data-indice-id="' + link.dataset.indiceId + '">'
+          + '<button type="button" class="btn-debloquer-indice" data-indice-id="' + link.dataset.indiceId + '">' 
           + indicesUnlock.texts.unlock + '</button>';
       }
       return;
@@ -49,9 +49,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (btn) {
       e.preventDefault();
       btn.disabled = true;
+      var zoneBtn = btn.closest('.zone-indices-group');
+      var containerBtn = zoneBtn ? zoneBtn.querySelector('.indice-display') : null;
       var id = btn.dataset.indiceId;
-      var linkSel = document.querySelector('.indice-link[data-indice-id="' + id + '"]');
-      fetchIndice(id, linkSel);
+      var linkSel = zoneBtn ? zoneBtn.querySelector('.indice-link[data-indice-id="' + id + '"]') : null;
+      if (containerBtn) {
+        fetchIndice(id, linkSel, containerBtn);
+      }
     }
   });
 });

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -65,6 +65,20 @@
     margin-top: var(--space-md);
   }
 
+  .zone-indices-group {
+    margin-top: var(--space-md);
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    h4 {
+      margin: 0 0 var(--space-sm);
+      font-size: 1rem;
+      text-align: center;
+    }
+  }
+
   .indice-contenu {
     display: flex;
     gap: var(--space-md);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5533,6 +5533,17 @@ body.panneau-ouvert::before {
 .zone-indices .indice-display {
   margin-top: var(--space-md);
 }
+.zone-indices .zone-indices-group {
+  margin-top: var(--space-md);
+}
+.zone-indices .zone-indices-group:first-of-type {
+  margin-top: 0;
+}
+.zone-indices .zone-indices-group h4 {
+  margin: 0 0 var(--space-sm);
+  font-size: 1rem;
+  text-align: center;
+}
 .zone-indices .indice-contenu {
   display: flex;
   gap: var(--space-md);

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2994,3 +2994,11 @@ msgstr ""
 #: inc/enigme/indices.php:120
 msgid "Débloquer l'indice"
 msgstr ""
+
+#: inc/enigme/affichage.php:725
+msgid "Pour cette énigme"
+msgstr ""
+
+#: inc/enigme/affichage.php:728
+msgid "Pour toute la chasse"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3278,3 +3278,11 @@ msgstr "Close"
 #: inc/enigme/indices.php:120
 msgid "Débloquer l'indice"
 msgstr "Unlock hint"
+
+#: inc/enigme/affichage.php:725
+msgid "Pour cette énigme"
+msgstr "For this riddle"
+
+#: inc/enigme/affichage.php:728
+msgid "Pour toute la chasse"
+msgstr "For the entire hunt"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3240,3 +3240,11 @@ msgstr "Fermer"
 #: inc/enigme/indices.php:120
 msgid "Débloquer l'indice"
 msgstr "Débloquer l'indice"
+
+#: inc/enigme/affichage.php:725
+msgid "Pour cette énigme"
+msgstr "Pour cette énigme"
+
+#: inc/enigme/affichage.php:728
+msgid "Pour toute la chasse"
+msgstr "Pour toute la chasse"


### PR DESCRIPTION
## Résumé
- affiche aussi les indices de la chasse dans le bloc participation d’une énigme
- permet d’ouvrir simultanément un indice d’énigme et un indice de chasse
- gère plusieurs sections d’indices et ajoute leur style dédié

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test -- --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c2952365108332bdd9b0653c25ce5b