### PR TITLE
Sanitize array values in enigme edition fallback

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-enigme.php
@@ -369,7 +369,11 @@ function modifier_champ_enigme()
 
   // 🔹 Fallback
   if (!$champ_valide) {
-    $valeur_saine = is_numeric($valeur) ? (int) $valeur : sanitize_text_field($valeur);
+    if (is_array($valeur)) {
+      $valeur_saine = array_map('sanitize_text_field', $valeur);
+    } else {
+      $valeur_saine = is_numeric($valeur) ? (int) $valeur : sanitize_text_field($valeur);
+    }
     $ok = update_field($champ, $valeur_saine, $post_id);
     $valeur_meta = get_post_meta($post_id, $champ, true);
     if ($ok || trim((string) $valeur_meta) === trim((string) $valeur_saine)) {


### PR DESCRIPTION
## Summary
- Gère les valeurs de champ renvoyant un tableau lors de l'édition d'une énigme
- Conserve la validation via comparaison avec la meta existante

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `php -r 'function is_utf8_charset(){return true;} function apply_filters($tag,$value){return $value;} require "wp-includes/formatting.php"; $valeur=["<b>a</b>", "<script>b</script>"]; if (is_array($valeur)) { $valeur_saine = array_map("sanitize_text_field", $valeur); } else { $valeur_saine = is_numeric($valeur) ? (int) $valeur : sanitize_text_field($valeur); } var_dump($valeur_saine);'`


------
https://chatgpt.com/codex/tasks/task_e_68c2ed197c2483329da73bf4208c6354