### PR TITLE
Activer le buffering de sortie pour éviter les avertissements d'en-têtes

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -1,7 +1,5 @@
 <?php
-
-
-
+ob_start();
 
 /**
  * The base configuration for WordPress


### PR DESCRIPTION
## Résumé
- Active un tampon de sortie global pour prévenir les avertissements "headers already sent"

## Changements notables
- Démarrage du buffering via `ob_start()` dès l'initialisation de WordPress

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c2ed07a56c83329e24956fad291ade