### PR TITLE
Start output buffering on init

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -19,6 +19,16 @@ if ( file_exists( $autoloader ) ) {
  */
 define( 'CHILD_THEME_CHASSESAUTRESOR_COM_VERSION', '1.0.0' );
 
+add_action(
+    'init',
+    static function () {
+        if ( ! ob_get_level() ) {
+            ob_start();
+        }
+    },
+    0
+);
+
 /**
  * Charge le domaine de traduction du thème enfant.
  */


### PR DESCRIPTION
## Résumé
- Initialise un tampon de sortie à l'init pour éviter les sorties intempestives.

## Modifications
- Ajout d'un hook `init` qui démarre `ob_start()` si aucun tampon n'est actif.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c2f224de548332ab5e19e509cd3801