### PR TITLE
Corrige l'affichage des indices gratuits non consultés

### DIFF
--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -189,4 +189,22 @@ class EnigmeParticipationInfosTest extends TestCase
 
         $this->assertStringContainsString('Indice #1', $html);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_free_indices_locked_initially(): void
+    {
+        global $mocked_posts, $fields;
+        $mocked_posts = [201];
+        $fields[201]['indice_cout_points'] = 0;
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('indice-link--locked', $html);
+        $this->assertStringContainsString('fa-lock', $html);
+    }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -670,7 +670,7 @@ require_once __DIR__ . '/indices.php';
                 foreach ($indices as $i => $indice_id) {
                     $cout_indice  = (int) get_field('indice_cout_points', $indice_id);
                     $etat_systeme = get_field('indice_cache_etat_systeme', $indice_id) ?: '';
-                    $est_debloque = indice_est_debloque($user_id, $indice_id) || $cout_indice === 0;
+                    $est_debloque = indice_est_debloque($user_id, $indice_id);
 
                     if ($etat_systeme === 'programme') {
                         $classes   = 'indice-link indice-link--upcoming etiquette';


### PR DESCRIPTION
## Résumé
- normalise l'état des indices gratuits jamais affichés
- ajoute un test pour garantir le verrouillage initial des indices gratuits

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c2f98027a48332b2383ed1501287f8