### PR TITLE
Empêcher l’enregistrement des images d’indices dans le dossier protégé

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-create.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-create.js
@@ -112,12 +112,19 @@
 
     function openMedia() {
       if (!window.wp || !window.wp.media) return;
+
+      var prevId = window.wp.media.model.settings.post.id;
+      window.wp.media.model.settings.post.id = 0;
+
       var frame = window.wp.media({ title: indicesCreate.texts.mediaTitle, multiple: false });
       frame.on('select', function () {
         var attachment = frame.state().get('selection').first().toJSON();
         overlay.querySelector('input[name="indice_image"]').value = attachment.id;
         var url = attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url;
         renderPreview(url);
+      });
+      frame.on('close', function () {
+        window.wp.media.model.settings.post.id = prevId;
       });
       frame.open();
     }


### PR DESCRIPTION
## Résumé
- évite de stocker les images d’indices dans le dossier `_enigmes` protégé

## Modifications
- réinitialise l'identifiant de post avant l’ouverture de la médiathèque pour les indices

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c38b5976348332adc639c06e54cf49