### PR TITLE
Optimiser l'affichage des indices sur la page énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var link = e.target.closest('.indice-link');
     if (link) {
       e.preventDefault();
-      var zone = link.closest('.zone-indices-group');
+      var zone = link.closest('.zone-indices');
       var container = zone ? zone.querySelector('.indice-display') : null;
       if (!container) return;
       if (link.dataset.unlocked === '1') {
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (btn) {
       e.preventDefault();
       btn.disabled = true;
-      var zoneBtn = btn.closest('.zone-indices-group');
+      var zoneBtn = btn.closest('.zone-indices');
       var containerBtn = zoneBtn ? zoneBtn.querySelector('.indice-display') : null;
       var id = btn.dataset.indiceId;
       var linkSel = zoneBtn ? zoneBtn.querySelector('.indice-link[data-indice-id="' + id + '"]') : null;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -65,17 +65,19 @@
     margin-top: var(--space-md);
   }
 
-  .zone-indices-group {
-    margin-top: var(--space-md);
+  .zone-indices-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-sm);
+    justify-content: center;
 
-    &:first-of-type {
-      margin-top: 0;
+    &:not(:first-of-type) {
+      margin-top: var(--space-sm);
     }
 
-    h4 {
-      margin: 0 0 var(--space-sm);
-      font-size: 1rem;
-      text-align: center;
+    &__label {
+      font-weight: 600;
     }
   }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5533,16 +5533,18 @@ body.panneau-ouvert::before {
 .zone-indices .indice-display {
   margin-top: var(--space-md);
 }
-.zone-indices .zone-indices-group {
-  margin-top: var(--space-md);
+.zone-indices .zone-indices-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+  justify-content: center;
 }
-.zone-indices .zone-indices-group:first-of-type {
-  margin-top: 0;
+.zone-indices .zone-indices-line:not(:first-of-type) {
+  margin-top: var(--space-sm);
 }
-.zone-indices .zone-indices-group h4 {
-  margin: 0 0 var(--space-sm);
-  font-size: 1rem;
-  text-align: center;
+.zone-indices .zone-indices-line__label {
+  font-weight: 600;
 }
 .zone-indices .indice-contenu {
   display: flex;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -663,10 +663,10 @@ require_once __DIR__ . '/indices.php';
         }
 
         if (!empty($indices_enigme) || !empty($indices_chasse)) {
-            $build_group = function (array $indices, string $title) use ($user_id) {
-                $html = '<div class="zone-indices-group"><h4>'
+            $build_line = function (array $indices, string $title) use ($user_id) {
+                $html = '<div class="zone-indices-line"><span class="zone-indices-line__label">'
                     . esc_html($title)
-                    . '</h4><ul class="indice-list">';
+                    . '</span><div class="indice-list">';
                 foreach ($indices as $i => $indice_id) {
                     $cout_indice  = (int) get_field('indice_cout_points', $indice_id);
                     $etat_systeme = get_field('indice_cache_etat_systeme', $indice_id) ?: '';
@@ -708,26 +708,25 @@ require_once __DIR__ . '/indices.php';
                             . esc_html__('pts', 'chassesautresor-com') . '</sup>'
                         : '';
 
-                    $html .= '<li><a href="#" class="' . esc_attr($classes) . '"'
+                    $html .= '<a href="#" class="' . esc_attr($classes) . '"'
                         . ' data-indice-id="' . esc_attr($indice_id) . '"'
                         . ' data-cout="' . esc_attr($cout_indice) . '"'
                         . ' data-unlocked="' . ($est_debloque ? '1' : '0') . '">'
                         . '<i class="fa-solid ' . esc_attr($etat_icon) . '" aria-hidden="true"></i> '
-                        . $label . $cout_html . '</a></li>';
+                        . $label . $cout_html . '</a>';
                 }
-                $html .= '</ul><div class="indice-display"></div></div>';
+                $html .= '</div></div>';
                 return $html;
             };
 
-            $content .= '<div class="zone-indices"><h3><i class="fa-solid fa-lightbulb" aria-hidden="true"></i> '
-                . esc_html__('Indices', 'chassesautresor-com') . '</h3>';
+            $content .= '<div class="zone-indices">';
             if (!empty($indices_enigme)) {
-                $content .= $build_group($indices_enigme, esc_html__('Pour cette énigme', 'chassesautresor-com'));
+                $content .= $build_line($indices_enigme, esc_html__('Pour cette énigme', 'chassesautresor-com'));
             }
             if (!empty($indices_chasse)) {
-                $content .= $build_group($indices_chasse, esc_html__('Pour toute la chasse', 'chassesautresor-com'));
+                $content .= $build_line($indices_chasse, esc_html__('Pour toute la chasse', 'chassesautresor-com'));
             }
-            $content .= '</div>';
+            $content .= '<div class="indice-display"></div></div>';
         }
 
         if ($bloc_reponse !== '') {


### PR DESCRIPTION
## Résumé
- refonte de l'affichage des indices en deux lignes sans titre de section
- adaptation du script de déblocage aux nouveaux conteneurs
- styles mis à jour et CSS recompilé

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c395e66e60833280847df20ea3f9a7