### PR TITLE
Alignement des indices dans la participation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -31,7 +31,8 @@
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-sm);
-    justify-content: center;
+    justify-content: flex-start;
+    flex: 1 1 auto;
   }
 
   .indice-link {
@@ -70,7 +71,7 @@
     flex-wrap: wrap;
     align-items: center;
     gap: var(--space-sm);
-    justify-content: center;
+    justify-content: flex-start;
 
     &:not(:first-of-type) {
       margin-top: var(--space-sm);
@@ -78,6 +79,7 @@
 
     &__label {
       font-weight: 600;
+      flex: 0 0 140px;
     }
   }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5506,7 +5506,8 @@ body.panneau-ouvert::before {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
-  justify-content: center;
+  justify-content: flex-start;
+  flex: 1 1 auto;
 }
 .zone-indices .indice-link {
   display: inline-flex;
@@ -5538,13 +5539,14 @@ body.panneau-ouvert::before {
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-sm);
-  justify-content: center;
+  justify-content: flex-start;
 }
 .zone-indices .zone-indices-line:not(:first-of-type) {
   margin-top: var(--space-sm);
 }
 .zone-indices .zone-indices-line__label {
   font-weight: 600;
+  flex: 0 0 140px;
 }
 .zone-indices .indice-contenu {
   display: flex;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -721,10 +721,10 @@ require_once __DIR__ . '/indices.php';
 
             $content .= '<div class="zone-indices">';
             if (!empty($indices_enigme)) {
-                $content .= $build_line($indices_enigme, esc_html__('Pour cette énigme', 'chassesautresor-com'));
+                $content .= $build_line($indices_enigme, esc_html__('Indices énigme', 'chassesautresor-com'));
             }
             if (!empty($indices_chasse)) {
-                $content .= $build_line($indices_chasse, esc_html__('Pour toute la chasse', 'chassesautresor-com'));
+                $content .= $build_line($indices_chasse, esc_html__('Indices chasse', 'chassesautresor-com'));
             }
             $content .= '<div class="indice-display"></div></div>';
         }

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -46,9 +46,14 @@ function debloquer_indice(): void
             ? wp_kses_post($processed)
             : htmlspecialchars($processed, ENT_QUOTES);
         $image_id = get_field('indice_image', $indice_id);
-        $image    = $image_id ? wp_get_attachment_image($image_id, 'thumbnail') : '';
-        $html     = '<div class="indice-contenu">';
-        if ($image) {
+        $image    = '';
+        if ($image_id) {
+            $thumb = wp_get_attachment_image($image_id, 'thumbnail');
+            $full  = wp_get_attachment_image_url($image_id, 'full');
+            $image = $full ? '<a href="' . esc_url($full) . '">' . $thumb . '</a>' : $thumb;
+        }
+        $html = '<div class="indice-contenu">';
+        if ($image !== '') {
             $html .= '<div class="indice-contenu__image">' . $image . '</div>';
         }
         $html .= '<div class="indice-contenu__texte">' . $texte . '</div></div>';
@@ -100,10 +105,15 @@ function debloquer_indice(): void
     $texte           = function_exists('wp_kses_post')
         ? wp_kses_post($processed)
         : htmlspecialchars($processed, ENT_QUOTES);
-    $image_id        = get_field('indice_image', $indice_id);
-    $image           = $image_id ? wp_get_attachment_image($image_id, 'thumbnail') : '';
-    $html            = '<div class="indice-contenu">';
-    if ($image) {
+    $image_id = get_field('indice_image', $indice_id);
+    $image    = '';
+    if ($image_id) {
+        $thumb = wp_get_attachment_image($image_id, 'thumbnail');
+        $full  = wp_get_attachment_image_url($image_id, 'full');
+        $image = $full ? '<a href="' . esc_url($full) . '">' . $thumb . '</a>' : $thumb;
+    }
+    $html = '<div class="indice-contenu">';
+    if ($image !== '') {
         $html .= '<div class="indice-contenu__image">' . $image . '</div>';
     }
     $html .= '<div class="indice-contenu__texte">' . $texte . '</div></div>';

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2996,9 +2996,9 @@ msgid "Débloquer l'indice"
 msgstr ""
 
 #: inc/enigme/affichage.php:725
-msgid "Pour cette énigme"
+msgid "Indices énigme"
 msgstr ""
 
 #: inc/enigme/affichage.php:728
-msgid "Pour toute la chasse"
+msgid "Indices chasse"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3280,9 +3280,9 @@ msgid "Débloquer l'indice"
 msgstr "Unlock hint"
 
 #: inc/enigme/affichage.php:725
-msgid "Pour cette énigme"
-msgstr "For this riddle"
+msgid "Indices énigme"
+msgstr "Riddle hints"
 
 #: inc/enigme/affichage.php:728
-msgid "Pour toute la chasse"
-msgstr "For the entire hunt"
+msgid "Indices chasse"
+msgstr "Hunt hints"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3242,9 +3242,9 @@ msgid "Débloquer l'indice"
 msgstr "Débloquer l'indice"
 
 #: inc/enigme/affichage.php:725
-msgid "Pour cette énigme"
-msgstr "Pour cette énigme"
+msgid "Indices énigme"
+msgstr "Indices énigme"
 
 #: inc/enigme/affichage.php:728
-msgid "Pour toute la chasse"
-msgstr "Pour toute la chasse"
+msgid "Indices chasse"
+msgstr "Indices chasse"


### PR DESCRIPTION
## Résumé
- Aligne à gauche les listes d'indices des énigmes et chasses avec labels homogènes.
- Ajoute l'ouverture des images d'indice via Firelight Lightbox.
- Met à jour les traductions et la feuille de style compilée.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3998246ec833282bdaa29008936f2