### PR TITLE
Affichage direct des PDF de solutions

### DIFF
--- a/tests/SolutionContentHtmlTest.php
+++ b/tests/SolutionContentHtmlTest.php
@@ -47,6 +47,9 @@ final class SolutionContentHtmlTest extends TestCase
         if (!function_exists('esc_html')) {
             function esc_html($text) { return $text; }
         }
+        if (!function_exists('esc_html__')) {
+            function esc_html__($text, $domain = '') { return $text; }
+        }
         if (!function_exists('wp_kses_post')) {
             function wp_kses_post($text) { return $text; }
         }
@@ -57,6 +60,7 @@ final class SolutionContentHtmlTest extends TestCase
         require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
 
         $html = solution_contenu_html($solution);
+        $this->assertStringContainsString('<object', $html);
         $this->assertStringContainsString('solution.pdf', $html);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1328,9 +1328,17 @@ function solution_contenu_html(WP_Post $solution): string
         }
 
         if ($fichier_url) {
-            return '<a href="' . esc_url($fichier_url)
-                . '" class="lien-solution-pdf" target="_blank" rel="noopener">&#128196; '
-                . esc_html($fichier_nom) . '</a>';
+            return '<object data="' . esc_url($fichier_url)
+                . '" type="application/pdf" width="100%" height="800">'
+                . '<p>'
+                . esc_html__(
+                    'Votre navigateur ne peut pas afficher le PDF.',
+                    'chassesautresor-com'
+                )
+                . ' <a href="' . esc_url($fichier_url)
+                . '" class="lien-solution-pdf" target="_blank" rel="noopener">'
+                . esc_html__('Télécharger', 'chassesautresor-com')
+                . '</a></p></object>';
         }
     }
 


### PR DESCRIPTION
## Résumé
- affiche les fichiers PDF de solution directement dans la page
- met à jour le test unitaire associé

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c39aa1d8408332a1e9f9aca18e3cb1