### PR TITLE
Ajout d’un bouton de fermeture pour les indices

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
   function displayContent(container, html) {
-    container.innerHTML = html;
+    container.innerHTML = '<button type="button" class="indice-close" aria-label="' + indicesUnlock.texts.close + '">&times;</button>' + html;
   }
 
   function fetchIndice(id, link, container) {
@@ -38,9 +38,20 @@ document.addEventListener('DOMContentLoaded', function () {
         fetchIndice(link.dataset.indiceId, link, container);
       } else {
         var cout = link.dataset.cout || '0';
-        container.innerHTML = '<p>' + indicesUnlock.texts.unlock + ' - ' + cout + ' ' + indicesUnlock.texts.pts + '</p>'
-          + '<button type="button" class="btn-debloquer-indice" data-indice-id="' + link.dataset.indiceId + '">' 
+        var html = '<p>' + indicesUnlock.texts.unlock + ' - ' + cout + ' ' + indicesUnlock.texts.pts + '</p>'
+          + '<button type="button" class="btn-debloquer-indice" data-indice-id="' + link.dataset.indiceId + '">'
           + indicesUnlock.texts.unlock + '</button>';
+        displayContent(container, html);
+      }
+      return;
+    }
+
+    var closeBtn = e.target.closest('.indice-close');
+    if (closeBtn) {
+      e.preventDefault();
+      var closeContainer = closeBtn.closest('.indice-display');
+      if (closeContainer) {
+        closeContainer.innerHTML = '';
       }
       return;
     }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -64,6 +64,16 @@
 
   .indice-display {
     margin-top: var(--space-md);
+    position: relative;
+
+    .indice-close {
+      position: absolute;
+      top: var(--space-xs);
+      right: var(--space-xs);
+      background: none;
+      border: 0;
+      cursor: pointer;
+    }
   }
 
   .zone-indices-line {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5533,6 +5533,15 @@ body.panneau-ouvert::before {
 }
 .zone-indices .indice-display {
   margin-top: var(--space-md);
+  position: relative;
+}
+.zone-indices .indice-display .indice-close {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  background: none;
+  border: 0;
+  cursor: pointer;
 }
 .zone-indices .zone-indices-line {
   display: flex;

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -151,6 +151,7 @@ function charger_script_deblocage_indice(): void
             'solde' => __('Solde', 'chassesautresor-com'),
             'pts'   => __('pts', 'chassesautresor-com'),
             'unlock'=> __('Débloquer l\'indice', 'chassesautresor-com'),
+            'close' => __('Fermer', 'chassesautresor-com'),
         ],
     ]);
 }


### PR DESCRIPTION
## Résumé
Ajoute un bouton permettant de fermer l’indice affiché dans la section de participation.

## Changements
- Ajout d’un bouton de fermeture dans le script de déblocage d’indice.
- Localisation de la chaîne de traduction « Fermer » et ajout des styles associés.
- Compilation du CSS.

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c39d3158d4833285c716db764d522f