### PR TITLE
feat: show rediscover CTA for finished hunts

### DIFF
--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -247,7 +247,7 @@ class GenererCtaChasseTest extends TestCase
 
         $this->assertSame(
             [
-                'cta_html'    => '<form method="post" action="/traitement-engagement" class="cta-chasse-form"><input type="hidden" name="chasse_id" value="123"><button type="submit" class="bouton-cta bouton-cta--color">Participer</button></form>',
+                'cta_html'    => '<form method="post" action="/traitement-engagement" class="cta-chasse-form"><input type="hidden" name="chasse_id" value="123"><button type="submit" class="bouton-cta bouton-cta--color">Redécouvrir</button></form>',
                 'cta_message' => 'Cette chasse est terminée',
                 'type'        => 'engager',
             ],

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -815,7 +815,7 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         $html .= wp_nonce_field('engager_chasse_' . $chasse_id, 'engager_chasse_nonce', true, false);
         $html .= sprintf(
             '<button type="submit" class="bouton-cta bouton-cta--color">%s</button>',
-            esc_html__('Participer', 'chassesautresor-com')
+            esc_html__('Redécouvrir', 'chassesautresor-com')
         );
         $html .= '</form>';
         $type = 'engager';

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -3002,3 +3002,7 @@ msgstr ""
 #: inc/enigme/affichage.php:728
 msgid "Indices chasse"
 msgstr ""
+
+#: inc/chasse-functions.php:818
+msgid "Redécouvrir"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3286,3 +3286,7 @@ msgstr "Riddle hints"
 #: inc/enigme/affichage.php:728
 msgid "Indices chasse"
 msgstr "Hunt hints"
+
+#: inc/chasse-functions.php:818
+msgid "Redécouvrir"
+msgstr "Rediscover"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3248,3 +3248,7 @@ msgstr "Indices énigme"
 #: inc/enigme/affichage.php:728
 msgid "Indices chasse"
 msgstr "Indices chasse"
+
+#: inc/chasse-functions.php:818
+msgid "Redécouvrir"
+msgstr "Redécouvrir"


### PR DESCRIPTION
## Résumé
Remplace le libellé du CTA des chasses terminées pour les non-participants par « Redécouvrir ».

## Changements
- affichage « Redécouvrir » quand une chasse terminée n’a pas encore été engagée
- ajout des chaînes de traduction correspondantes
- mise à jour des tests unitaires

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c39e190fd88332a83b2c6cb5cc49bd