### PR TITLE
Fermer l’accordéon des solutions de chasse par défaut

### DIFF
--- a/tests/ChasseSolutionsRenderTest.php
+++ b/tests/ChasseSolutionsRenderTest.php
@@ -20,7 +20,7 @@ class ChasseSolutionsRenderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_details_are_open_by_default(): void
+    public function test_details_are_closed_by_default(): void
     {
         if (!function_exists('get_post_type')) {
             function get_post_type($id) { return 'chasse'; }
@@ -79,7 +79,8 @@ class ChasseSolutionsRenderTest extends TestCase
         render_chasse_solutions(1, 0);
         $html = ob_get_clean();
 
-        $this->assertStringContainsString('<details open>', $html);
+        $this->assertStringContainsString('<details>', $html);
+        $this->assertStringNotContainsString('<details open>', $html);
         $this->assertStringContainsString('CONTENT', $html);
     }
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1370,7 +1370,7 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
             $content = solution_contenu_html($solution);
             if ($content !== '') {
                 $sections .= '<section class="solution">';
-                $sections .= '<details open><summary>'
+                $sections .= '<details><summary>'
                     . esc_html__('Solution de la chasse', 'chassesautresor-com')
                     . '</summary>';
                 $sections .= '<div class="solution-content">' . $content . '</div></details></section>';


### PR DESCRIPTION
## Summary
- Ferme par défaut la section des solutions d’une chasse
- Met à jour le test unitaire correspondant

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c39f03d6588332940ff3eff4398b9a