### PR TITLE
Discrétise les indices de la participation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -23,6 +23,8 @@
 
 .zone-indices {
   margin-top: var(--space-lg);
+  font-size: 0.9rem;
+  opacity: 0.85;
 
   .indice-list {
     list-style: none;
@@ -39,10 +41,11 @@
     display: inline-flex;
     align-items: center;
     gap: var(--space-xs);
-    padding: var(--space-xs) var(--space-sm);
+    padding: calc(var(--space-xs) / 2) var(--space-sm);
     border-radius: 4px;
     text-decoration: none;
     font-weight: 600;
+    font-size: 0.875rem;
 
     &--locked,
     &--unlocked,
@@ -80,6 +83,8 @@
     &__label {
       font-weight: 600;
       flex: 0 0 140px;
+      line-height: 1.2;
+      font-size: 0.875rem;
     }
   }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5498,6 +5498,8 @@ body.panneau-ouvert::before {
 
 .zone-indices {
   margin-top: var(--space-lg);
+  font-size: 0.9rem;
+  opacity: 0.85;
 }
 .zone-indices .indice-list {
   list-style: none;
@@ -5513,10 +5515,11 @@ body.panneau-ouvert::before {
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-sm);
+  padding: calc(var(--space-xs) / 2) var(--space-sm);
   border-radius: 4px;
   text-decoration: none;
   font-weight: 600;
+  font-size: 0.875rem;
 }
 .zone-indices .indice-link--locked, .zone-indices .indice-link--unlocked, .zone-indices .indice-link--upcoming {
   background-color: var(--color-gris-3);
@@ -5547,6 +5550,8 @@ body.panneau-ouvert::before {
 .zone-indices .zone-indices-line__label {
   font-weight: 600;
   flex: 0 0 140px;
+  line-height: 1.2;
+  font-size: 0.875rem;
 }
 .zone-indices .indice-contenu {
   display: flex;


### PR DESCRIPTION
## Résumé
- rend les indices d'une énigme plus discrets

## Changements
- réduit la taille et l'opacité de la zone d'indices
- diminue la hauteur et la police des étiquettes d'indice

## Testing
- `npm run build:css`
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3a131eb9c83328011cb7ce9edb2af