### PR TITLE
Add border around hint display area

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -66,11 +66,16 @@
   }
 
   .indice-display {
-    margin-top: var(--space-md);
-    position: relative;
-    padding: var(--space-sm);
-    border: 1px solid var(--color-gris-3);
-    border-radius: 4px;
+    display: none;
+
+    &:not(:empty) {
+      display: block;
+      margin-top: var(--space-md);
+      position: relative;
+      padding: var(--space-sm);
+      border: 1px solid var(--color-gris-3);
+      border-radius: 4px;
+    }
 
     .indice-close {
       position: absolute;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -68,6 +68,9 @@
   .indice-display {
     margin-top: var(--space-md);
     position: relative;
+    padding: var(--space-sm);
+    border: 1px solid var(--color-gris-3);
+    border-radius: 4px;
 
     .indice-close {
       position: absolute;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5537,6 +5537,9 @@ body.panneau-ouvert::before {
 .zone-indices .indice-display {
   margin-top: var(--space-md);
   position: relative;
+  padding: var(--space-sm);
+  border: 1px solid var(--color-gris-3);
+  border-radius: 4px;
 }
 .zone-indices .indice-display .indice-close {
   position: absolute;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5535,6 +5535,10 @@ body.panneau-ouvert::before {
   cursor: pointer;
 }
 .zone-indices .indice-display {
+  display: none;
+}
+.zone-indices .indice-display:not(:empty) {
+  display: block;
   margin-top: var(--space-md);
   position: relative;
   padding: var(--space-sm);


### PR DESCRIPTION
## Résumé
- Délimite visuellement la zone d'affichage des indices sur la page d'énigme.

## Changements notables
- Ajout d'une bordure et d'un padding à `.indice-display` pour encadrer les indices.

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a2be31088332b2acf5082c138b3d