### PR TITLE
Déplace l'icône de validation vers le formulaire

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -208,6 +208,10 @@ body .wp-block-file .wp-block-file__button:focus,
     font-weight: normal;
 }
 
+.bloc-reponse h3 .badge-validation {
+    margin-right: var(--space-xs);
+}
+
 .badge-cout {
     display: inline-block;
     padding: var(--space-xxs) var(--space-xs);
@@ -618,7 +622,7 @@ a.ajout-link:focus-visible {
 .badge-validation {
     width: 24px;
     height: 24px;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     border-radius: 50%;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1437,6 +1437,10 @@ body .wp-block-file .wp-block-file__button:focus,
   font-weight: normal;
 }
 
+.bloc-reponse h3 .badge-validation {
+  margin-right: var(--space-xs);
+}
+
 .badge-cout {
   display: inline-block;
   padding: var(--space-xxs) var(--space-xs);
@@ -1829,7 +1833,7 @@ a.ajout-link:focus-visible {
 .badge-validation {
   width: 24px;
   height: 24px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -744,28 +744,6 @@ require_once __DIR__ . '/indices.php';
             ? get_user_points($user_id)
             : 0;
 
-        $badge_html = '';
-        if ($mode_validation !== 'aucune') {
-            $chasse_id = recuperer_id_chasse_associee($enigme_id);
-            if (!current_user_can('manage_options')
-                && !utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
-            ) {
-                $icon       = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
-                $mode_label = $mode_validation === 'automatique'
-                    ? esc_html__('automatique', 'chassesautresor-com')
-                    : esc_html__('manuelle', 'chassesautresor-com');
-                $title = sprintf(
-                    esc_html__("Mode de validation de l'énigme : %s", 'chassesautresor-com'),
-                    $mode_label
-                );
-                $badge_html = '<span class="badge-validation" title="'
-                    . esc_attr($title)
-                    . '"><i class="fa-solid '
-                    . esc_attr($icon)
-                    . '"></i></span>';
-            }
-        }
-
         $afficher_tentatives = $mode_validation === 'automatique' && !$deja_resolue;
         $afficher_infos      = $mode_validation !== 'aucune'
             && !$deja_resolue
@@ -820,7 +798,7 @@ require_once __DIR__ . '/indices.php';
         }
 
         $header = '<div class="participation-header">'
-            . ($badge_html !== '' ? $badge_html : '<span></span>')
+            . '<span></span>'
             . $cout_badge
             . '</div>';
 

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -59,7 +59,25 @@ function enigme_get_bonnes_reponses(int $enigme_id): array
             return '<p>Vous ne pouvez plus répondre à cette énigme.</p>';
         }
 
-        $data = calculer_contexte_points($user_id, $enigme_id);
+        $mode_validation = get_field('enigme_mode_validation', $enigme_id);
+        $badge_html      = '';
+        if ($mode_validation !== 'aucune') {
+            $icon       = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+            $mode_label = $mode_validation === 'automatique'
+                ? esc_html__('automatique', 'chassesautresor-com')
+                : esc_html__('manuelle', 'chassesautresor-com');
+            $title = sprintf(
+                esc_html__("Mode de validation de l'énigme : %s", 'chassesautresor-com'),
+                $mode_label
+            );
+            $badge_html = '<span class="badge-validation" title="'
+                . esc_attr($title)
+                . '"><i class="fa-solid '
+                . esc_attr($icon)
+                . '"></i></span>';
+        }
+
+        $data  = calculer_contexte_points($user_id, $enigme_id);
         $nonce = wp_create_nonce('reponse_manuelle_nonce');
         ob_start();
     ?>
@@ -71,7 +89,7 @@ function enigme_get_bonnes_reponses(int $enigme_id): array
         data-solde-apres="<?php echo esc_attr($data['solde_apres']); ?>"
         data-seuil="<?php echo esc_attr($data['seuil']); ?>"
     >
-        <h3><?php echo esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
+        <h3><?php echo $badge_html . esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
         <?php if ($data['points_manquants'] > 0) : ?>
             <p class="message-limite" data-points="manquants">
                 <?php echo esc_html(sprintf(__('Il vous manque %d points pour soumettre votre réponse.', 'chassesautresor-com'), $data['points_manquants'])); ?>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -152,6 +152,23 @@ if ($points_manquants <= 0 && !$message_tentatives && $cout > 0) {
     );
 }
 
+$badge_html = '';
+if ($mode_validation !== 'aucune') {
+    $icon       = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+    $mode_label = $mode_validation === 'automatique'
+        ? esc_html__('automatique', 'chassesautresor-com')
+        : esc_html__('manuelle', 'chassesautresor-com');
+    $title = sprintf(
+        esc_html__("Mode de validation de l'énigme : %s", 'chassesautresor-com'),
+        $mode_label
+    );
+    $badge_html = '<span class="badge-validation" title="'
+        . esc_attr($title)
+        . '"><i class="fa-solid '
+        . esc_attr($icon)
+        . '"></i></span>';
+}
+
 $nonce = wp_create_nonce('reponse_auto_nonce');
 ?>
 
@@ -162,7 +179,7 @@ $nonce = wp_create_nonce('reponse_auto_nonce');
     data-solde-apres="<?= esc_attr($solde_apres); ?>"
     data-seuil="<?= esc_attr($seuil_cout_eleve); ?>"
 >
-    <h3><?= esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
+    <h3><?= $badge_html . esc_html__('Votre réponse', 'chassesautresor-com'); ?></h3>
 
     <div class="reponse-feedback" style="display:none"></div>
   <?php if ($message_tentatives) : ?>


### PR DESCRIPTION
## Résumé
- repositionne le badge d'indication du mode de validation devant le libellé "Votre réponse"

## Changements notables
- retire l'icône de l'en-tête de participation
- affiche le badge avant "Votre réponse" dans les formulaires auto et manuels

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3a33b86308332acdf3a6f935605df