### PR TITLE
Afficher la réponse avant les indices

### DIFF
--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -26,6 +26,13 @@ if (!function_exists('esc_html__')) {
     }
 }
 
+if (!function_exists('__')) {
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+}
+
 if (!function_exists('get_field')) {
     function get_field($key, $id)
     {
@@ -206,5 +213,32 @@ class EnigmeParticipationInfosTest extends TestCase
 
         $this->assertStringContainsString('indice-link--locked', $html);
         $this->assertStringContainsString('fa-lightbulb', $html);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_reponse_before_indices(): void
+    {
+        global $mocked_posts, $fields, $resolved;
+        $mocked_posts = [301];
+        $fields[301]['indice_cout_points'] = 2;
+        $resolved = true;
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $pos_reponse = strpos($html, 'zone-reponse');
+        $pos_indices = strpos($html, 'zone-indices');
+
+        $this->assertNotFalse($pos_reponse);
+        $this->assertNotFalse($pos_indices);
+        $this->assertLessThan(
+            $pos_indices,
+            $pos_reponse,
+            'La section "Votre réponse" doit précéder les indices.'
+        );
     }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -662,6 +662,10 @@ require_once __DIR__ . '/indices.php';
             ]);
         }
 
+        if ($bloc_reponse !== '') {
+            $content .= '<div class="zone-reponse">' . $bloc_reponse . '</div>';
+        }
+
         if (!empty($indices_enigme) || !empty($indices_chasse)) {
             $build_line = function (array $indices, string $title) use ($user_id) {
                 $html = '<div class="zone-indices-line"><span class="zone-indices-line__label">'
@@ -727,10 +731,6 @@ require_once __DIR__ . '/indices.php';
                 $content .= $build_line($indices_chasse, esc_html__('Indices chasse', 'chassesautresor-com'));
             }
             $content .= '<div class="indice-display"></div></div>';
-        }
-
-        if ($bloc_reponse !== '') {
-            $content .= '<div class="zone-reponse">' . $bloc_reponse . '</div>';
         }
 
         $mode_validation = get_field('enigme_mode_validation', $enigme_id);


### PR DESCRIPTION
## Résumé
- Inversion de l'ordre entre le bloc "Votre réponse" et les indices sur les pages d'énigme
- Ajout d'un test garantissant la présence de la zone réponse avant les indices

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68c3a777cddc83329aac3429c488a485