### PR TITLE
Améliore l'affichage du mode de validation des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/badge-validation-tooltip.js
+++ b/wp-content/themes/chassesautresor/assets/js/badge-validation-tooltip.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.badge-validation[data-tooltip]').forEach(btn => {
+    const msg = btn.dataset.tooltip;
+    if (!msg) return;
+    const tooltip = document.createElement('div');
+    tooltip.className = 'badge-validation__tooltip';
+    tooltip.innerHTML = msg;
+    btn.appendChild(tooltip);
+
+    const hide = () => btn.classList.remove('show-tooltip');
+    const show = () => btn.classList.add('show-tooltip');
+
+    btn.addEventListener('mouseenter', show);
+    btn.addEventListener('mouseleave', hide);
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      btn.classList.toggle('show-tooltip');
+    });
+    btn.addEventListener('blur', hide);
+  });
+
+  document.addEventListener('click', e => {
+    document.querySelectorAll('.badge-validation.show-tooltip').forEach(btn => {
+      if (!btn.contains(e.target)) {
+        btn.classList.remove('show-tooltip');
+      }
+    });
+  });
+});

--- a/wp-content/themes/chassesautresor/assets/js/badge-validation-tooltip.js
+++ b/wp-content/themes/chassesautresor/assets/js/badge-validation-tooltip.js
@@ -12,10 +12,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     btn.addEventListener('mouseenter', show);
     btn.addEventListener('mouseleave', hide);
-    btn.addEventListener('click', e => {
-      e.preventDefault();
+
+    let touched = false;
+
+    btn.addEventListener('touchstart', () => {
+      touched = true;
       btn.classList.toggle('show-tooltip');
     });
+
+    btn.addEventListener('click', () => {
+      if (touched) {
+        touched = false;
+        return;
+      }
+      btn.classList.toggle('show-tooltip');
+    });
+
     btn.addEventListener('blur', hide);
   });
 

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -635,6 +635,12 @@ a.ajout-link:focus-visible {
     cursor: pointer;
     position: relative;
     vertical-align: middle;
+
+    &:hover,
+    &:focus {
+        background: var(--color-grey-light);
+        color: var(--color-text-fond-clair);
+    }
 }
 
 .badge-validation__tooltip {

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -625,11 +625,38 @@ a.ajout-link:focus-visible {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    border: none;
+    padding: 0;
     border-radius: 50%;
     background: var(--color-grey-light);
     color: var(--color-text-fond-clair);
     font-size: 0.75rem;
     box-shadow: 0 0 0 1px var(--color-grey-dark), 0 2px 4px rgba(var(--color-text-fond-clair-rgb), 0.15);
+    cursor: pointer;
+    position: relative;
+    vertical-align: middle;
+}
+
+.badge-validation__tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-grey-light);
+    color: var(--color-text-fond-clair);
+    padding: var(--space-xs);
+    font-size: 0.75rem;
+    line-height: 1.4;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(var(--color-text-fond-clair-rgb), 0.2);
+    width: max-content;
+    max-width: 220px;
+    z-index: 10;
+}
+
+.badge-validation.show-tooltip .badge-validation__tooltip {
+    display: block;
 }
 
 /* ========== 🟢 BADGE ROND ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1836,11 +1836,39 @@ a.ajout-link:focus-visible {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: none;
+  padding: 0;
   border-radius: 50%;
   background: var(--color-grey-light);
   color: var(--color-text-fond-clair);
   font-size: 0.75rem;
   box-shadow: 0 0 0 1px var(--color-grey-dark), 0 2px 4px rgba(var(--color-text-fond-clair-rgb), 0.15);
+  cursor: pointer;
+  position: relative;
+  vertical-align: middle;
+}
+
+.badge-validation__tooltip {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
+  padding: var(--space-xs);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(var(--color-text-fond-clair-rgb), 0.2);
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 220px;
+  z-index: 10;
+}
+
+.badge-validation.show-tooltip .badge-validation__tooltip {
+  display: block;
 }
 
 /* ========== 🟢 BADGE ROND ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1847,6 +1847,10 @@ a.ajout-link:focus-visible {
   position: relative;
   vertical-align: middle;
 }
+.badge-validation:hover, .badge-validation:focus {
+  background: var(--color-grey-light);
+  color: var(--color-text-fond-clair);
+}
 
 .badge-validation__tooltip {
   display: none;

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -62,19 +62,26 @@ function enigme_get_bonnes_reponses(int $enigme_id): array
         $mode_validation = get_field('enigme_mode_validation', $enigme_id);
         $badge_html      = '';
         if ($mode_validation !== 'aucune') {
-            $icon       = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
-            $mode_label = $mode_validation === 'automatique'
-                ? esc_html__('automatique', 'chassesautresor-com')
-                : esc_html__('manuelle', 'chassesautresor-com');
-            $title = sprintf(
-                esc_html__("Mode de validation de l'énigme : %s", 'chassesautresor-com'),
-                $mode_label
-            );
-            $badge_html = '<span class="badge-validation" title="'
-                . esc_attr($title)
+            $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+            if ($mode_validation === 'automatique') {
+                $message = __("Mode de validation de l'énigme automatique. Vous connaîtrez le résultat de votre tentative immédiatement après l'avoir soumise.", 'chassesautresor-com');
+            } else {
+                $chasse_id        = function_exists('recuperer_id_chasse_associee') ? (int) recuperer_id_chasse_associee($enigme_id) : 0;
+                $organisateur_id   = $chasse_id ? get_organisateur_from_chasse($chasse_id) : 0;
+                $organisateur_nom  = $organisateur_id ? get_the_title($organisateur_id) : '';
+                $organisateur_lien = $organisateur_id ? get_permalink($organisateur_id) : '#';
+                $message           = sprintf(
+                    __("Mode de validation de l'énigme manuelle. Vous connaîtrez le résultat de votre tentative après son traitement par %s.", 'chassesautresor-com'),
+                    '<a href="' . esc_url($organisateur_lien) . '">' . esc_html($organisateur_nom) . '</a>'
+                );
+            }
+            $badge_html = '<button type="button" class="badge-validation" data-tooltip="'
+                . esc_attr($message)
+                . '" title="'
+                . esc_attr(wp_strip_all_tags($message))
                 . '"><i class="fa-solid '
                 . esc_attr($icon)
-                . '"></i></span>';
+                . '"></i></button>';
         }
 
         $data  = calculer_contexte_points($user_id, $enigme_id);

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -77,8 +77,6 @@ function enigme_get_bonnes_reponses(int $enigme_id): array
             }
             $badge_html = '<button type="button" class="badge-validation" data-tooltip="'
                 . esc_attr($message)
-                . '" title="'
-                . esc_attr(wp_strip_all_tags($message))
                 . '"><i class="fa-solid '
                 . esc_attr($icon)
                 . '"></i></button>';

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -132,6 +132,13 @@ function charger_scripts_personnalises() {
     wp_enqueue_script('toggle-text', $theme_dir . 'toggle-text.js', ['jquery'], null, true);
     wp_enqueue_script('toggle-tooltip', $theme_dir . 'toggle-tooltip.js', [], null, true);
     wp_enqueue_script(
+        'badge-validation-tooltip',
+        $theme_dir . 'badge-validation-tooltip.js',
+        [],
+        filemtime(get_stylesheet_directory() . '/assets/js/badge-validation-tooltip.js'),
+        true
+    );
+    wp_enqueue_script(
         'chasse-description-toggle',
         $theme_dir . 'chasse-description-toggle.js',
         [],

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -155,18 +155,24 @@ if ($points_manquants <= 0 && !$message_tentatives && $cout > 0) {
 $badge_html = '';
 if ($mode_validation !== 'aucune') {
     $icon       = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
-    $mode_label = $mode_validation === 'automatique'
-        ? esc_html__('automatique', 'chassesautresor-com')
-        : esc_html__('manuelle', 'chassesautresor-com');
-    $title = sprintf(
-        esc_html__("Mode de validation de l'énigme : %s", 'chassesautresor-com'),
-        $mode_label
-    );
-    $badge_html = '<span class="badge-validation" title="'
-        . esc_attr($title)
+    if ($mode_validation === 'automatique') {
+        $message = __("Mode de validation de l'énigme automatique. Vous connaîtrez le résultat de votre tentative immédiatement après l'avoir soumise.", 'chassesautresor-com');
+    } else {
+        $organisateur_id   = get_organisateur_from_chasse($chasse_id);
+        $organisateur_nom  = $organisateur_id ? get_the_title($organisateur_id) : '';
+        $organisateur_lien = $organisateur_id ? get_permalink($organisateur_id) : '#';
+        $message           = sprintf(
+            __("Mode de validation de l'énigme manuelle. Vous connaîtrez le résultat de votre tentative après son traitement par %s.", 'chassesautresor-com'),
+            '<a href="' . esc_url($organisateur_lien) . '">' . esc_html($organisateur_nom) . '</a>'
+        );
+    }
+    $badge_html = '<button type="button" class="badge-validation" data-tooltip="'
+        . esc_attr($message)
+        . '" title="'
+        . esc_attr(wp_strip_all_tags($message))
         . '"><i class="fa-solid '
         . esc_attr($icon)
-        . '"></i></span>';
+        . '"></i></button>';
 }
 
 $nonce = wp_create_nonce('reponse_auto_nonce');

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -168,8 +168,6 @@ if ($mode_validation !== 'aucune') {
     }
     $badge_html = '<button type="button" class="badge-validation" data-tooltip="'
         . esc_attr($message)
-        . '" title="'
-        . esc_attr(wp_strip_all_tags($message))
         . '"><i class="fa-solid '
         . esc_attr($icon)
         . '"></i></button>';


### PR DESCRIPTION
## Résumé
- Aligne l'icône du mode de validation avec le texte « Votre réponse »
- Enrichit le message d'aide du mode de validation (automatique ou manuelle) visible au survol et au clic
- Charge un script dédié pour afficher ces info-bulles sur desktop et mobile

## Testing
- `source ./setup-env.sh`
- `npm install`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3aa2d3f088332aaaf254ad59d5c89