### PR TITLE
Serve WebP images for enigme visuals

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,19 @@
 # BEGIN NON_LSCACHE
 # END NON_LSCACHE
 
+# BEGIN WebP
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteCond %{HTTP_ACCEPT} "image/webp"
+RewriteCond %{REQUEST_FILENAME} (.+)\.(jpe?g|png)$
+RewriteCond %{REQUEST_FILENAME}.webp -f
+RewriteRule ^ %1.webp [T=image/webp,E=accept:1,L]
+</IfModule>
+<IfModule mod_headers.c>
+Header append Vary Accept env=REDIRECT_accept
+</IfModule>
+# END WebP
+
 # BEGIN WordPress
 # The directives (lines) between "BEGIN WordPress" and "END WordPress" are
 # dynamically generated, and should only be modified via WordPress filters.


### PR DESCRIPTION
## Résumé
- Support des images WebP pour les visuels d’énigmes
- Ajout d’une réécriture .htaccess pour servir les WebP lorsque disponibles

## Changements notables
- Génération d’une balise `<source type="image/webp">` avec détection de compatibilité
- Repli automatique vers les formats JPEG/PNG

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3ad7e9e308332a1df4ee09afccbe6