### PR TITLE
Ajout de l'heure à la date de découverte d'une chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -617,7 +617,7 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
       }
       valider.disabled = true;
       const now = new Date();
-      const dateValue = now.toISOString().split('T')[0];
+      const dateValue = now.toISOString().slice(0, 19).replace('T', ' ');
       const dateDisplay = `${String(now.getDate()).padStart(2, '0')}/${String(
         now.getMonth() + 1
       ).padStart(2, '0')}/${now.getFullYear()}`;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -370,9 +370,9 @@ function gerer_chasse_terminee($chasse_id)
 
     $should_close = ($max_winners === 0 || $winner_total >= $max_winners);
     if ($should_close) {
-        $date = current_time('Y-m-d');
-        $date_obj = DateTime::createFromFormat('Y-m-d', $date);
-        if ($date_obj && $date_obj->format('Y-m-d') === $date) {
+        $date = current_time('Y-m-d H:i:s');
+        $date_obj = DateTime::createFromFormat('Y-m-d H:i:s', $date);
+        if ($date_obj && $date_obj->format('Y-m-d H:i:s') === $date) {
             update_field('chasse_cache_date_decouverte', $date, $chasse_id);
         }
 

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -569,9 +569,16 @@ function modifier_champ_chasse()
 
     // 🔹 Date de découverte
     if ($champ === 'champs_caches.chasse_cache_date_decouverte') {
-        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $valeur)) {
+        if (!preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?$/', $valeur)) {
             wp_send_json_error('⚠️ format_date_invalide');
         }
+
+        $date_obj = DateTime::createFromFormat('Y-m-d H:i:s', $valeur) ?: DateTime::createFromFormat('Y-m-d H:i', $valeur);
+        if (!$date_obj) {
+            wp_send_json_error('⚠️ format_date_invalide');
+        }
+
+        $valeur = $date_obj->format('Y-m-d H:i:s');
         $ok = update_field('chasse_cache_date_decouverte', $valeur, $post_id);
         if ($ok !== false) {
             $champ_valide = true;

--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -104,7 +104,7 @@ Instructions : (vide)
 Requis : non
 ----------------------------------------
 — chasse_cache_date_decouverte —
-Type : date_picker
+Type : date_time_picker
 Label : Date de découverte
 Instructions : Permet de terminer manuellement la chasse.
 Requis : non

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -366,7 +366,7 @@ Groupe : paramètre de la chasse
 * chasse_mode_fin (radio)
 * chasse_infos_nb_max_gagants (number)
 * chasse_cache_gagnants (text)
-* chasse_cache_date_decouverte (date_picker)
+* chasse_cache_date_decouverte (date_time_picker)
 * chasse_cache_enigmes (relationship)
 * chasse_cache_organisateur (relationship)
 * chasse_cache_statut_validation (select)

--- a/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
+++ b/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
@@ -117,7 +117,7 @@ class ChasseGagnantInfoTest extends TestCase
                 'illimitee' => false,
                 'nb_max' => 0,
                 'cout_points' => 0,
-                'date_decouverte' => '2024-01-01',
+                'date_decouverte' => '2024-01-01 00:00:00',
                 'gagnants' => 'John Doe',
                 'mode_fin' => 'automatique',
                 'current_stored_statut' => '',
@@ -146,6 +146,6 @@ class ChasseGagnantInfoTest extends TestCase
         include __DIR__ . '/../template-parts/chasse/chasse-affichage-complet.php';
         $html = ob_get_clean();
 
-        $this->assertStringContainsString('Chasse gagnée le 2024-01-01 par John Doe', $html);
+        $this->assertStringContainsString('Chasse gagnée le 2024-01-01 00:00:00 par John Doe', $html);
     }
 }


### PR DESCRIPTION
## Résumé
- Enregistre la date de découverte d'une chasse avec l'heure précise
- Valide et sauvegarde les dates de découverte au format `Y-m-d H:i:s`
- Ajoute l'heure lors de la validation manuelle côté interface

## Changements notables
- Gestion de l'heure pour la date de découverte dans les fonctions de statut
- Mise à jour des validations PHP/JS et des tests associés
- Documentation ACF adaptée au champ `chasse_cache_date_decouverte`

## Testing
- `composer install`
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3ad99adc0833287e62ba4ec7b168e