### PR TITLE
Gère les indices programmés dans la participation aux énigmes

### DIFF
--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -304,20 +304,24 @@ class EnigmeParticipationInfosTest extends TestCase
     {
         global $mocked_posts, $fields;
         global $mocked_post_dates;
-        $mocked_posts = [401, 402, 403];
+        $mocked_posts = [401, 402, 403, 404];
 
         $fields[401]['indice_cache_etat_systeme'] = 'programme';
         $fields[401]['indice_cout_points']        = 0;
-        $fields[401]['indice_date_disponibilite'] = '10/11/2023 18:00';
+        $mocked_post_dates[401]                    = '2023-11-10 18:00:00';
 
         $fields[402]['indice_cache_etat_systeme'] = 'programme';
         $fields[402]['indice_cout_points']        = 0;
-        $fields[402]['indice_date_disponibilite'] = '2023-11-12 15:30:00';
+        $mocked_post_dates[402]                    = '2023-11-12 15:30:00';
 
         $fields[403]['indice_cache_etat_systeme'] = 'programme';
         $fields[403]['indice_cout_points']        = 0;
-        // Fallback to the post's publication date when meta is absent.
-        $mocked_post_dates[403] = '2024-11-20 12:00:00';
+        $mocked_post_dates[403]                    = '2024-11-20 12:00:00';
+
+        $fields[404]['indice_cache_etat_systeme'] = 'programme';
+        $fields[404]['indice_cout_points']        = 0;
+        // No post date: rely on the meta field.
+        $fields[404]['indice_date_disponibilite'] = '2023-11-14 09:15';
 
         ob_start();
         render_enigme_participation(10, 'defaut', 1);
@@ -325,6 +329,7 @@ class EnigmeParticipationInfosTest extends TestCase
 
         $this->assertStringContainsString("Aujourd'hui à 18:00", $html);
         $this->assertStringContainsString('12/11/23 à 15:30', $html);
+        $this->assertStringContainsString('14/11/23 à 09:15', $html);
         $this->assertStringContainsString('20/11/24', $html);
     }
 }

--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -302,26 +302,25 @@ class EnigmeParticipationInfosTest extends TestCase
      */
     public function test_programmed_indices_date_format(): void
     {
-        global $mocked_posts, $fields;
-        global $mocked_post_dates;
+        global $mocked_posts, $fields, $mocked_post_dates;
         $mocked_posts = [401, 402, 403, 404];
 
-        $fields[401]['indice_cache_etat_systeme'] = 'programme';
-        $fields[401]['indice_cout_points']        = 0;
-        $mocked_post_dates[401]                    = '2023-11-10 18:00:00';
+        $fields[401]['indice_cache_etat_systeme']       = 'programme';
+        $fields[401]['indice_cout_points']              = 0;
+        $fields[401]['indice_date_disponibilite']       = '2023-11-10 18:00:00';
 
-        $fields[402]['indice_cache_etat_systeme'] = 'programme';
-        $fields[402]['indice_cout_points']        = 0;
-        $mocked_post_dates[402]                    = '2023-11-12 15:30:00';
+        $fields[402]['indice_cache_etat_systeme']       = 'programme';
+        $fields[402]['indice_cout_points']              = 0;
+        $fields[402]['indice_date_disponibilite']       = '2023-11-12 15:30:00';
 
-        $fields[403]['indice_cache_etat_systeme'] = 'programme';
-        $fields[403]['indice_cout_points']        = 0;
-        $mocked_post_dates[403]                    = '2024-11-20 12:00:00';
+        $fields[403]['indice_cache_etat_systeme']       = 'programme';
+        $fields[403]['indice_cout_points']              = 0;
+        // No meta field: rely on the post date.
+        $mocked_post_dates[403]                         = '2024-11-20 12:00:00';
 
-        $fields[404]['indice_cache_etat_systeme'] = 'programme';
-        $fields[404]['indice_cout_points']        = 0;
-        // No post date: rely on the meta field.
-        $fields[404]['indice_date_disponibilite'] = '2023-11-14 09:15';
+        $fields[404]['indice_cache_etat_systeme']       = 'programme';
+        $fields[404]['indice_cout_points']              = 0;
+        $fields[404]['indice_date_disponibilite']       = '2023-11-14 09:15';
 
         ob_start();
         render_enigme_participation(10, 'defaut', 1);

--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -33,6 +33,13 @@ if (!function_exists('__')) {
     }
 }
 
+if (!function_exists('_x')) {
+    function _x($text, $context, $domain = null)
+    {
+        return $text;
+    }
+}
+
 if (!function_exists('get_field')) {
     function get_field($key, $id)
     {
@@ -74,6 +81,25 @@ if (!function_exists('compter_tentatives_du_jour')) {
     {
         return 3;
     }
+}
+
+if (!function_exists('current_time')) {
+    function current_time($type)
+    {
+        if ($type === 'timestamp') {
+            return strtotime('2023-11-10 10:00:00');
+        }
+
+        return '';
+    }
+}
+
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+if (!defined('WEEK_IN_SECONDS')) {
+    define('WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS);
 }
 
 if (!function_exists('remove_accents')) {
@@ -240,5 +266,35 @@ class EnigmeParticipationInfosTest extends TestCase
             $pos_reponse,
             'La section "Votre réponse" doit précéder les indices.'
         );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_programmed_indices_date_format(): void
+    {
+        global $mocked_posts, $fields;
+        $mocked_posts = [401, 402, 403];
+
+        $fields[401]['indice_cache_etat_systeme']   = 'programme';
+        $fields[401]['indice_cout_points']          = 0;
+        $fields[401]['indice_date_disponibilite']   = new DateTime('2023-11-10 18:00:00');
+
+        $fields[402]['indice_cache_etat_systeme']   = 'programme';
+        $fields[402]['indice_cout_points']          = 0;
+        $fields[402]['indice_date_disponibilite']   = new DateTime('2023-11-12 15:30:00');
+
+        $fields[403]['indice_cache_etat_systeme']   = 'programme';
+        $fields[403]['indice_cout_points']          = 0;
+        $fields[403]['indice_date_disponibilite']   = new DateTime('2024-11-20 12:00:00');
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString("Aujourd'hui à 18:00", $html);
+        $this->assertStringContainsString('12/11/23 à 15:30', $html);
+        $this->assertStringContainsString('20/11/24', $html);
     }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -55,6 +55,23 @@
     }
   }
 
+  .indice-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: calc(var(--space-xs) / 2) var(--space-sm);
+    border-radius: 4px;
+    font-weight: 600;
+    font-size: 0.875rem;
+
+    &--locked,
+    &--unlocked,
+    &--upcoming {
+      background-color: var(--color-gris-3);
+      color: var(--color-white);
+    }
+  }
+
   .btn-debloquer-indice {
     display: inline-block;
     padding: var(--space-sm) var(--space-md);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5534,6 +5534,19 @@ body.panneau-ouvert::before {
   background-color: var(--color-gris-3);
   color: var(--color-white);
 }
+.zone-indices .indice-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: calc(var(--space-xs) / 2) var(--space-sm);
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+.zone-indices .indice-label--locked, .zone-indices .indice-label--unlocked, .zone-indices .indice-label--upcoming {
+  background-color: var(--color-gris-3);
+  color: var(--color-white);
+}
 .zone-indices .btn-debloquer-indice {
   display: inline-block;
   padding: var(--space-sm) var(--space-md);

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -681,9 +681,18 @@ require_once __DIR__ . '/indices.php';
                         $etat_icon = 'fa-hourglass';
 
                         $date_raw  = get_field('indice_date_disponibilite', $indice_id);
-                        $timestamp = $date_raw ? strtotime($date_raw) : false;
+                        $timestamp = false;
 
-                        if ($timestamp) {
+                        if ($date_raw instanceof DateTimeInterface) {
+                            $timestamp = $date_raw->getTimestamp();
+                        } elseif (is_numeric($date_raw)) {
+                            $timestamp = (int) $date_raw;
+                        } elseif (is_string($date_raw)) {
+                            $dt = date_create($date_raw, wp_timezone());
+                            $timestamp = $dt ? $dt->getTimestamp() : false;
+                        }
+
+                        if ($timestamp !== false) {
                             $now = current_time('timestamp');
                             /* translators: Date format for scheduled hints, e.g. 10/11/28. */
                             $date_fmt = _x('d/m/y', 'scheduled hint short date', 'chassesautresor-com');

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -680,44 +680,43 @@ require_once __DIR__ . '/indices.php';
                         $classes   = 'indice-label indice-link--upcoming etiquette';
                         $etat_icon = 'fa-hourglass';
 
-                        $date_raw  = get_field('indice_date_disponibilite', $indice_id);
-                        $timestamp = false;
-
-                        if ($date_raw instanceof DateTimeInterface) {
-                            $timestamp = $date_raw->getTimestamp();
-                        } elseif (is_numeric($date_raw)) {
-                            $timestamp = (int) $date_raw;
-                        } elseif (is_string($date_raw) && trim($date_raw) !== '') {
-                            $formats = [
-                                'Y-m-d H:i:s',
-                                'Y-m-d H:i',
-                                'Y-m-d',
-                                'd/m/Y H:i',
-                                'd/m/Y',
-                            ];
-                            foreach ($formats as $format) {
-                                $dt = date_create_from_format($format, $date_raw, wp_timezone());
-                                if ($dt instanceof DateTimeInterface) {
-                                    $timestamp = $dt->getTimestamp();
-                                    break;
-                                }
-                            }
-                            if ($timestamp === false) {
-                                $dt = date_create($date_raw, wp_timezone());
-                                if ($dt instanceof DateTimeInterface) {
-                                    $timestamp = $dt->getTimestamp();
-                                }
-                            }
+                        if (function_exists('get_post_timestamp')) {
+                            $timestamp = get_post_timestamp($indice_id, 'date');
+                        } else {
+                            $post_date = function_exists('get_post_field')
+                                ? get_post_field('post_date', $indice_id)
+                                : '';
+                            $timestamp = $post_date ? strtotime($post_date) : false;
                         }
 
                         if ($timestamp === false) {
-                            if (function_exists('get_post_timestamp')) {
-                                $timestamp = get_post_timestamp($indice_id, 'date');
-                            } else {
-                                $post_date = function_exists('get_post_field')
-                                    ? get_post_field('post_date', $indice_id)
-                                    : '';
-                                $timestamp = $post_date ? strtotime($post_date) : false;
+                            $date_raw = get_field('indice_date_disponibilite', $indice_id);
+
+                            if ($date_raw instanceof DateTimeInterface) {
+                                $timestamp = $date_raw->getTimestamp();
+                            } elseif (is_numeric($date_raw)) {
+                                $timestamp = (int) $date_raw;
+                            } elseif (is_string($date_raw) && trim($date_raw) !== '') {
+                                $formats = [
+                                    'Y-m-d H:i:s',
+                                    'Y-m-d H:i',
+                                    'Y-m-d',
+                                    'd/m/Y H:i',
+                                    'd/m/Y',
+                                ];
+                                foreach ($formats as $format) {
+                                    $dt = date_create_from_format($format, $date_raw, wp_timezone());
+                                    if ($dt instanceof DateTimeInterface) {
+                                        $timestamp = $dt->getTimestamp();
+                                        break;
+                                    }
+                                }
+                                if ($timestamp === false) {
+                                    $dt = date_create($date_raw, wp_timezone());
+                                    if ($dt instanceof DateTimeInterface) {
+                                        $timestamp = $dt->getTimestamp();
+                                    }
+                                }
                             }
                         }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -682,7 +682,13 @@ require_once __DIR__ . '/indices.php';
 
                         $date_raw  = get_field('indice_date_disponibilite', $indice_id);
                         $timestamp = $date_raw ? strtotime($date_raw) : false;
-                        $date_txt  = $timestamp ? wp_date(get_option('date_format'), $timestamp) : '';
+                        $date_txt  = $timestamp
+                            ? wp_date(
+                                /* translators: Date format for a scheduled hint, e.g. 10 novembre 2028. */
+                                _x('j F Y', 'scheduled hint date', 'chassesautresor-com'),
+                                $timestamp
+                            )
+                            : '';
                         $label     = $date_txt !== ''
                             ? sprintf(
                                 esc_html__('Disponible le %s', 'chassesautresor-com'),

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -606,7 +606,7 @@ require_once __DIR__ . '/indices.php';
         $indices_enigme = function_exists('get_posts')
             ? get_posts([
                 'post_type'      => 'indice',
-                'post_status'    => ['publish', 'draft', 'future'],
+                'post_status'    => ['publish', 'draft', 'future', 'pending'],
                 'meta_query'     => [
                     [
                         'key'     => 'indice_cible_type',
@@ -636,7 +636,7 @@ require_once __DIR__ . '/indices.php';
         if ($chasse_id && function_exists('get_posts')) {
             $indices_chasse = get_posts([
                 'post_type'      => 'indice',
-                'post_status'    => ['publish', 'draft', 'future'],
+                'post_status'    => ['publish', 'draft', 'future', 'pending'],
                 'meta_query'     => [
                     [
                         'key'     => 'indice_cible_type',
@@ -677,13 +677,13 @@ require_once __DIR__ . '/indices.php';
                     $est_debloque = indice_est_debloque($user_id, $indice_id);
 
                     if ($etat_systeme === 'programme') {
-                        $classes   = 'indice-link indice-link--upcoming etiquette';
+                        $classes   = 'indice-label indice-link--upcoming etiquette';
                         $etat_icon = 'fa-hourglass';
 
-                        $date_raw = get_field('indice_date_disponibilite', $indice_id);
+                        $date_raw  = get_field('indice_date_disponibilite', $indice_id);
                         $timestamp = $date_raw ? strtotime($date_raw) : false;
-                        $date_txt = $timestamp ? wp_date(get_option('date_format'), $timestamp) : '';
-                        $label = $date_txt !== ''
+                        $date_txt  = $timestamp ? wp_date(get_option('date_format'), $timestamp) : '';
+                        $label     = $date_txt !== ''
                             ? sprintf(
                                 esc_html__('Disponible le %s', 'chassesautresor-com'),
                                 esc_html($date_txt)
@@ -712,12 +712,20 @@ require_once __DIR__ . '/indices.php';
                             . esc_html__('pts', 'chassesautresor-com') . '</sup>'
                         : '';
 
-                    $html .= '<a href="#" class="' . esc_attr($classes) . '"'
-                        . ' data-indice-id="' . esc_attr($indice_id) . '"'
-                        . ' data-cout="' . esc_attr($cout_indice) . '"'
-                        . ' data-unlocked="' . ($est_debloque ? '1' : '0') . '">'
-                        . '<i class="fa-solid ' . esc_attr($etat_icon) . '" aria-hidden="true"></i> '
-                        . $label . $cout_html . '</a>';
+                    if ($etat_systeme === 'programme') {
+                        $html .= '<span class="' . esc_attr($classes) . '">'
+                            . '<i class="fa-solid ' . esc_attr($etat_icon)
+                            . '" aria-hidden="true"></i> '
+                            . $label . $cout_html . '</span>';
+                    } else {
+                        $html .= '<a href="#" class="' . esc_attr($classes) . '"'
+                            . ' data-indice-id="' . esc_attr($indice_id) . '"'
+                            . ' data-cout="' . esc_attr($cout_indice) . '"'
+                            . ' data-unlocked="' . ($est_debloque ? '1' : '0') . '">'
+                            . '<i class="fa-solid ' . esc_attr($etat_icon)
+                            . '" aria-hidden="true"></i> '
+                            . $label . $cout_html . '</a>';
+                    }
                 }
                 $html .= '</div></div>';
                 return $html;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -680,43 +680,44 @@ require_once __DIR__ . '/indices.php';
                         $classes   = 'indice-label indice-link--upcoming etiquette';
                         $etat_icon = 'fa-hourglass';
 
-                        if (function_exists('get_post_timestamp')) {
-                            $timestamp = get_post_timestamp($indice_id, 'date');
-                        } else {
-                            $post_date = function_exists('get_post_field')
-                                ? get_post_field('post_date', $indice_id)
-                                : '';
-                            $timestamp = $post_date ? strtotime($post_date) : false;
+                        $timestamp = false;
+                        $date_raw  = get_field('indice_date_disponibilite', $indice_id);
+
+                        if ($date_raw instanceof DateTimeInterface) {
+                            $timestamp = $date_raw->getTimestamp();
+                        } elseif (is_numeric($date_raw)) {
+                            $timestamp = (int) $date_raw;
+                        } elseif (is_string($date_raw) && trim($date_raw) !== '') {
+                            $formats = [
+                                'Y-m-d H:i:s',
+                                'Y-m-d H:i',
+                                'Y-m-d',
+                                'd/m/Y H:i',
+                                'd/m/Y',
+                            ];
+                            foreach ($formats as $format) {
+                                $dt = date_create_from_format($format, $date_raw, wp_timezone());
+                                if ($dt instanceof DateTimeInterface) {
+                                    $timestamp = $dt->getTimestamp();
+                                    break;
+                                }
+                            }
+                            if ($timestamp === false) {
+                                $dt = date_create($date_raw, wp_timezone());
+                                if ($dt instanceof DateTimeInterface) {
+                                    $timestamp = $dt->getTimestamp();
+                                }
+                            }
                         }
 
                         if ($timestamp === false) {
-                            $date_raw = get_field('indice_date_disponibilite', $indice_id);
-
-                            if ($date_raw instanceof DateTimeInterface) {
-                                $timestamp = $date_raw->getTimestamp();
-                            } elseif (is_numeric($date_raw)) {
-                                $timestamp = (int) $date_raw;
-                            } elseif (is_string($date_raw) && trim($date_raw) !== '') {
-                                $formats = [
-                                    'Y-m-d H:i:s',
-                                    'Y-m-d H:i',
-                                    'Y-m-d',
-                                    'd/m/Y H:i',
-                                    'd/m/Y',
-                                ];
-                                foreach ($formats as $format) {
-                                    $dt = date_create_from_format($format, $date_raw, wp_timezone());
-                                    if ($dt instanceof DateTimeInterface) {
-                                        $timestamp = $dt->getTimestamp();
-                                        break;
-                                    }
-                                }
-                                if ($timestamp === false) {
-                                    $dt = date_create($date_raw, wp_timezone());
-                                    if ($dt instanceof DateTimeInterface) {
-                                        $timestamp = $dt->getTimestamp();
-                                    }
-                                }
+                            if (function_exists('get_post_timestamp')) {
+                                $timestamp = get_post_timestamp($indice_id, 'date');
+                            } else {
+                                $post_date = function_exists('get_post_field')
+                                    ? get_post_field('post_date', $indice_id)
+                                    : '';
+                                $timestamp = $post_date ? strtotime($post_date) : false;
                             }
                         }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -682,19 +682,35 @@ require_once __DIR__ . '/indices.php';
 
                         $date_raw  = get_field('indice_date_disponibilite', $indice_id);
                         $timestamp = $date_raw ? strtotime($date_raw) : false;
-                        $date_txt  = $timestamp
-                            ? wp_date(
-                                /* translators: Date format for a scheduled hint, e.g. 10 novembre 2028. */
-                                _x('j F Y', 'scheduled hint date', 'chassesautresor-com'),
-                                $timestamp
-                            )
-                            : '';
-                        $label     = $date_txt !== ''
-                            ? sprintf(
-                                esc_html__('Disponible le %s', 'chassesautresor-com'),
-                                esc_html($date_txt)
-                            )
-                            : esc_html__('Disponible bientôt', 'chassesautresor-com');
+
+                        if ($timestamp) {
+                            $now = current_time('timestamp');
+                            /* translators: Date format for scheduled hints, e.g. 10/11/28. */
+                            $date_fmt = _x('d/m/y', 'scheduled hint short date', 'chassesautresor-com');
+                            /* translators: Time format for scheduled hints, e.g. 14:30. */
+                            $time_fmt = _x('H:i', 'scheduled hint time', 'chassesautresor-com');
+                            $same_day   = wp_date('Y-m-d', $timestamp) === wp_date('Y-m-d', $now);
+                            $time_part  = esc_html(wp_date($time_fmt, $timestamp));
+
+                            if ($same_day) {
+                                $label = sprintf(
+                                    esc_html__('Aujourd\'hui à %s', 'chassesautresor-com'),
+                                    $time_part
+                                );
+                            } else {
+                                $date_part = esc_html(wp_date($date_fmt, $timestamp));
+                                if ($timestamp < $now + WEEK_IN_SECONDS) {
+                                    $label = $date_part . ' ' . sprintf(
+                                        esc_html__('à %s', 'chassesautresor-com'),
+                                        $time_part
+                                    );
+                                } else {
+                                    $label = $date_part;
+                                }
+                            }
+                        } else {
+                            $label = esc_html__('Disponible bientôt', 'chassesautresor-com');
+                        }
                     } elseif ($est_debloque) {
                         $classes   = 'indice-link indice-link--unlocked etiquette';
                         $etat_icon = 'fa-eye';


### PR DESCRIPTION
## Résumé
- prise en charge des indices programmés
- ajout du style pour les étiquettes d'indices programmés

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3addca7cc83328c8652bb5f6ab05e