### PR TITLE
Affiche l'heure de découverte de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/inc/edition/edition-core.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-core.php
@@ -650,19 +650,27 @@ function formater_date_heure($date): string
         return __('Non spécifiée', 'chassesautresor-com');
     }
 
+    $original = '';
     if ($date instanceof DateTimeInterface) {
         $timestamp = $date->getTimestamp();
+        $original  = $date->format('Y-m-d H:i:s');
     } elseif (is_array($date) && isset($date['date'])) {
-        $timestamp = convertir_en_timestamp($date['date']);
+        $original  = $date['date'];
+        $timestamp = convertir_en_timestamp($original);
     } else {
-        $timestamp = convertir_en_timestamp((string) $date);
+        $original  = (string) $date;
+        $timestamp = convertir_en_timestamp($original);
     }
 
     if ($timestamp === false) {
         return __('Non spécifiée', 'chassesautresor-com');
     }
 
-    $format = _x('j F Y \\à H:i', 'formatting for datetime', 'chassesautresor-com');
+    if (!preg_match('/\d{1,2}:\d{2}/', $original)) {
+        return formater_date($date);
+    }
+
+    $format = _x('j F Y à H:i', 'formatting for datetime', 'chassesautresor-com');
 
     return wp_date($format, $timestamp);
 }

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -1562,7 +1562,7 @@ msgstr "F j, Y"
 
 #: inc/edition/edition-core.php:665
 msgctxt "formatting for datetime"
-msgid "j F Y \\à H:i"
+msgid "j F Y à H:i"
 msgstr "F j, Y \\a\\t g:i a"
 
 #: template-parts/chasse/chasse-edition-main.php:606

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -1580,8 +1580,8 @@ msgstr "j F Y"
 
 #: inc/edition/edition-core.php:665
 msgctxt "formatting for datetime"
-msgid "j F Y \\à H:i"
-msgstr "j F Y \\à H:i"
+msgid "j F Y à H:i"
+msgstr "j F Y à H:i"
 
 #: template-parts/chasse/chasse-edition-main.php:606
 msgid "Coût d’accès à une chasse"

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -51,7 +51,7 @@ $date_debut_formatee       = formater_date($date_debut);
 $date_fin_formatee         = $illimitee
     ? __('Illimitée', 'chassesautresor-com')
     : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
-$date_decouverte_formatee = $date_decouverte ? formater_date($date_decouverte) : '';
+$date_decouverte_formatee = $date_decouverte ? formater_date_heure($date_decouverte) : '';
 
 $timestamp_debut = convertir_en_timestamp($date_debut);
 $timestamp_fin = (!$illimitee && $date_fin) ? convertir_en_timestamp($date_fin) : false;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -52,7 +52,7 @@ $date_debut_formatee        = formater_date($date_debut);
 $date_fin_formatee          = $illimitee
     ? __('Illimitée', 'chassesautresor-com')
     : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
-$date_decouverte_formatee   = $date_decouverte ? formater_date($date_decouverte) : '';
+$date_decouverte_formatee   = $date_decouverte ? formater_date_heure($date_decouverte) : '';
 
 $now        = current_time('timestamp');
 $date_label = '';

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -31,7 +31,7 @@ $cout       = $infos_chasse['champs']['cout_points'];
 $date_debut = $infos_chasse['champs']['date_debut'];
 $date_fin   = $infos_chasse['champs']['date_fin'];
 $date_decouverte = $infos_chasse['champs']['date_decouverte'];
-$date_decouverte_formatee = $date_decouverte ? formater_date($date_decouverte) : '';
+$date_decouverte_formatee = $date_decouverte ? formater_date_heure($date_decouverte) : '';
 $gagnants = $infos_chasse['champs']['gagnants'];
 
 // 🎯 Conversion des dates pour les champs <input>

--- a/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
+++ b/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
@@ -27,6 +27,9 @@ class ChasseGagnantInfoTest extends TestCase
         if (!function_exists('formater_date')) {
             function formater_date($date) { return $date; }
         }
+        if (!function_exists('formater_date_heure')) {
+            function formater_date_heure($date) { return formater_date($date); }
+        }
         if (!function_exists('current_time')) {
             function current_time($type) { return 0; }
         }


### PR DESCRIPTION
## Résumé
- ajoute l'heure au format d'affichage de la date de découverte
- applique ce format aux modèles de chasse concernés
- ajuste les tests et traductions associés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3af61cd488332b5e8f2bda25d2a34