### PR TITLE
feat: ajoute un séparateur dans la participation des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -563,6 +563,10 @@ li.active .enigme-menu__edit {
   align-items: center;
 }
 
+.participation .wp-block-separator {
+  margin: var(--space-md) 0;
+}
+
 .zone-reponse form {
   display: flex;
   flex-direction: column;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -565,6 +565,8 @@ li.active .enigme-menu__edit {
 
 .participation .wp-block-separator {
   margin: var(--space-md) 0;
+  border: 0;
+  border-top: 1px solid rgba(var(--color-black-rgb, 0, 0, 0), 0.2);
 }
 
 .zone-reponse form {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6046,6 +6046,8 @@ li.active .enigme-menu__edit {
 
 .participation .wp-block-separator {
   margin: var(--space-md) 0;
+  border: 0;
+  border-top: 1px solid rgba(var(--color-black-rgb, 0, 0, 0), 0.2);
 }
 
 .zone-reponse form {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6044,6 +6044,10 @@ li.active .enigme-menu__edit {
   align-items: center;
 }
 
+.participation .wp-block-separator {
+  margin: var(--space-md) 0;
+}
+
 .zone-reponse form {
   display: flex;
   flex-direction: column;

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -667,6 +667,10 @@ require_once __DIR__ . '/indices.php';
         }
 
         if (!empty($indices_enigme) || !empty($indices_chasse)) {
+            if ($bloc_reponse !== '') {
+                $content .= '<hr class="wp-block-separator" />';
+            }
+
             $build_line = function (array $indices, string $title) use ($user_id) {
                 $html = '<div class="zone-indices-line"><span class="zone-indices-line__label">'
                     . esc_html($title)


### PR DESCRIPTION
## Résumé
- ajoute un séparateur discret entre la réponse et les indices
- espace davantage la zone de participation

## Testing
- `npm run build:css`
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3bc87bbfc8332bff1b2aff1187577