### PR TITLE
Use lightbox for hint images

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -12,6 +12,9 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(function (res) {
         if (res.success) {
           displayContent(container, res.data.html);
+          if (window.jQuery && typeof jQuery.fn.fancybox === 'function') {
+            jQuery(container).find('a.fancybox').fancybox();
+          }
           if (link) {
             link.dataset.unlocked = '1';
             link.classList.remove('indice-link--locked');

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -50,7 +50,9 @@ function debloquer_indice(): void
         if ($image_id) {
             $thumb = wp_get_attachment_image($image_id, 'thumbnail');
             $full  = wp_get_attachment_image_url($image_id, 'full');
-            $image = $full ? '<a href="' . esc_url($full) . '">' . $thumb . '</a>' : $thumb;
+            $image = $full
+                ? '<a href="' . esc_url($full) . '" class="fancybox image">' . $thumb . '</a>'
+                : $thumb;
         }
         $html = '<div class="indice-contenu">';
         if ($image !== '') {
@@ -110,7 +112,9 @@ function debloquer_indice(): void
     if ($image_id) {
         $thumb = wp_get_attachment_image($image_id, 'thumbnail');
         $full  = wp_get_attachment_image_url($image_id, 'full');
-        $image = $full ? '<a href="' . esc_url($full) . '">' . $thumb . '</a>' : $thumb;
+        $image = $full
+            ? '<a href="' . esc_url($full) . '" class="fancybox image">' . $thumb . '</a>'
+            : $thumb;
     }
     $html = '<div class="indice-contenu">';
     if ($image !== '') {


### PR DESCRIPTION
### Résumé
- affiche les images d'indice dans une lightbox Firelight
- réinitialise Fancybox après déblocage d'un indice

### Modifications notables
- ajoute la classe `fancybox image` aux liens d'images d'indice
- relance `fancybox` pour les contenus chargés via AJAX

### Testing
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3bd5a62948332bc56be0d65803b6f