### PR TITLE
Ajout d'une séparation entre réponse et indices

### DIFF
--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -241,4 +241,37 @@ class EnigmeParticipationInfosTest extends TestCase
             'La section "Votre réponse" doit précéder les indices.'
         );
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_separator_displayed_with_indices(): void
+    {
+        global $mocked_posts, $fields;
+        $mocked_posts = [401];
+        $fields[401]['indice_cout_points'] = 0;
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('reponse-indices-separator', $html);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_no_separator_without_indices(): void
+    {
+        global $mocked_posts;
+        $mocked_posts = [];
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $this->assertStringNotContainsString('reponse-indices-separator', $html);
+    }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -21,8 +21,17 @@
   height: auto;
 }
 
+
+.reponse-indices-separator {
+  margin-top: var(--space-xl);
+  margin-bottom: var(--space-lg);
+  border: 0;
+  border-top: 1px solid var(--color-gris-3);
+  opacity: 0.5;
+}
+
 .zone-indices {
-  margin-top: var(--space-lg);
+  margin-top: 0;
   font-size: 0.9rem;
   opacity: 0.85;
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5537,8 +5537,16 @@ body.panneau-ouvert::before {
   height: auto;
 }
 
+.reponse-indices-separator {
+  margin-top: var(--space-xl);
+  margin-bottom: var(--space-lg);
+  border: 0;
+  border-top: 1px solid var(--color-gris-3);
+  opacity: 0.5;
+}
+
 .zone-indices {
-  margin-top: var(--space-lg);
+  margin-top: 0;
   font-size: 0.9rem;
   opacity: 0.85;
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -667,6 +667,7 @@ require_once __DIR__ . '/indices.php';
         }
 
         if (!empty($indices_enigme) || !empty($indices_chasse)) {
+            $content .= '<hr class="reponse-indices-separator" />';
             $build_line = function (array $indices, string $title) use ($user_id) {
                 $html = '<div class="zone-indices-line"><span class="zone-indices-line__label">'
                     . esc_html($title)


### PR DESCRIPTION
## Résumé
- Ligne horizontale discrète entre la réponse et les indices lorsqu'ils existent
- Styles SCSS/CSS dédiés pour espacement et affichage
- Tests couvrant l'affichage ou non de cette ligne

## Testing
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c1376cf08332a05152dc30e3b8dd