### PR TITLE
Ajoute l'heure dans le message de fin de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -620,7 +620,9 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
       const dateValue = now.toISOString().slice(0, 19).replace('T', ' ');
       const dateDisplay = `${String(now.getDate()).padStart(2, '0')}/${String(
         now.getMonth() + 1
-      ).padStart(2, '0')}/${now.getFullYear()}`;
+      ).padStart(2, '0')}/${now.getFullYear()} à ${String(
+        now.getHours()
+      ).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
       const gagnantsEsc = gagnants.replace(/[&<>\"']/g, (c) => ({
         '&': '&amp;',
         '<': '&lt;',


### PR DESCRIPTION
## Résumé
- inclut l'heure dans l'avis de chasse gagnée coté édition

## Changements notables
- format date HH:mm ajouté lors de l'arrêt manuel d'une chasse

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c3a7c509488332bfa9bd5f1530fd33