### PR TITLE
Gère les formats de date 12h pour les indices programmés

### DIFF
--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -682,8 +682,31 @@ require_once __DIR__ . '/indices.php';
                         $etat_icon = 'fa-hourglass';
 
                         $date_raw = get_field('indice_date_disponibilite', $indice_id);
-                        $timestamp = $date_raw ? strtotime($date_raw) : false;
-                        $date_txt = $timestamp ? wp_date(get_option('date_format'), $timestamp) : '';
+                        $timestamp = false;
+                        if ($date_raw) {
+                            $formats = [
+                                'Y-m-d H:i:s',
+                                'd/m/Y H:i',
+                                'Y-m-d\TH:i:s',
+                                'd/m/Y g:i a',
+                                'd/m/Y g:i A',
+                                'Y-m-d g:i a',
+                            ];
+                            foreach ($formats as $format) {
+                                $date = date_create_from_format($format, $date_raw, wp_timezone());
+                                if ($date !== false) {
+                                    $timestamp = $date->getTimestamp();
+                                    break;
+                                }
+                            }
+                            if ($timestamp === false) {
+                                $date = date_create_from_format('d/m/Y g:i a', $date_raw, wp_timezone());
+                                if ($date !== false) {
+                                    $timestamp = $date->getTimestamp();
+                                }
+                            }
+                        }
+                        $date_txt = $timestamp ? wp_date(get_option('date_format') . ' H:i', $timestamp) : '';
                         $label = $date_txt !== ''
                             ? sprintf(
                                 esc_html__('Disponible le %s', 'chassesautresor-com'),


### PR DESCRIPTION
## Summary
- support des formats de date 12h lors de l'affichage des indices programmés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `php -r '$tz=new DateTimeZone("Europe/Paris"); $date_raw="12/09/2025 8:47 am"; $formats=["Y-m-d H:i:s","d/m/Y H:i","Y-m-d\\TH:i:s","d/m/Y g:i a","d/m/Y g:i A","Y-m-d g:i a"]; $timestamp=false; foreach($formats as $format){$date=date_create_from_format($format,$date_raw,$tz); if($date){$timestamp=$date->getTimestamp(); break;}} if($timestamp===false){$date=date_create_from_format("d/m/Y g:i a",$date_raw,$tz); if($date){$timestamp=$date->getTimestamp();}} echo (new DateTime("@".$timestamp))->setTimezone($tz)->format("d F Y H:i");'`

------
https://chatgpt.com/codex/tasks/task_e_68c3c901e9ac8332bb566de9e7dbcb76