### PR TITLE
Gérer l’affichage des indices programmés

### DIFF
--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -319,6 +319,26 @@ class EnigmeParticipationInfosTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function test_programmed_indices_past_date_is_available(): void
+    {
+        global $mocked_posts, $fields;
+        $mocked_posts = [503];
+        $fields[503]['indice_cout_points']        = 0;
+        $fields[503]['indice_cache_etat_systeme'] = 'programme';
+        $fields[503]['indice_date_disponibilite'] = date('d/m/Y H:i', time() - HOUR_IN_SECONDS);
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('indice-link', $html);
+        $this->assertStringNotContainsString('indice-link--upcoming', $html);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_get_posts_includes_pending_status(): void
     {
         global $last_get_posts_args;

--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -112,7 +112,8 @@ if (!function_exists('cat_debug')) {
 if (!function_exists('get_posts')) {
     function get_posts($args = [])
     {
-        global $mocked_posts;
+        global $mocked_posts, $last_get_posts_args;
+        $last_get_posts_args[] = $args;
         return $mocked_posts ?? [];
     }
 }
@@ -153,6 +154,13 @@ if (!function_exists('wp_timezone')) {
     }
 }
 
+if (!function_exists('current_time')) {
+    function current_time($type, $gmt = 0)
+    {
+        return time();
+    }
+}
+
 if (!function_exists('get_option')) {
     function get_option($name, $default = false)
     {
@@ -167,6 +175,12 @@ if (!function_exists('get_option')) {
 if (!defined('HOUR_IN_SECONDS')) {
     define('HOUR_IN_SECONDS', 3600);
 }
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+if (!defined('WEEK_IN_SECONDS')) {
+    define('WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS);
+}
 
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/enigme/affichage.php';
 
@@ -174,7 +188,7 @@ class EnigmeParticipationInfosTest extends TestCase
 {
     public function setUp(): void
     {
-        global $fields, $resolved, $wpdb, $mocked_posts, $mocked_titles;
+        global $fields, $resolved, $wpdb, $mocked_posts, $mocked_titles, $last_get_posts_args;
         $fields = [
             10 => [
                 'indices'                      => [],
@@ -184,8 +198,9 @@ class EnigmeParticipationInfosTest extends TestCase
             ],
         ];
         $resolved = false;
-        $mocked_posts  = [];
-        $mocked_titles = [];
+        $mocked_posts        = [];
+        $mocked_titles       = [];
+        $last_get_posts_args = [];
         $wpdb = new class {
             public string $prefix = 'wp_';
             public function prepare($query, ...$args)
@@ -250,13 +265,68 @@ class EnigmeParticipationInfosTest extends TestCase
         $mocked_posts = [405];
         $fields[405]['indice_cout_points']        = 0;
         $fields[405]['indice_cache_etat_systeme'] = 'programme';
-        $fields[405]['indice_date_disponibilite'] = '12/09/2025 8:47 am';
+        $fields[405]['indice_date_disponibilite'] = date('d/m/Y H:i', time() + 30 * DAY_IN_SECONDS);
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+        $this->assertStringContainsString('<span class="indice-label', $html);
+        $expected = date('d/m/y', time() + 30 * DAY_IN_SECONDS);
+        $this->assertStringContainsString($expected, $html);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_programmed_indices_label_today(): void
+    {
+        global $mocked_posts, $fields;
+        $mocked_posts = [501];
+        $fields[501]['indice_cout_points']        = 0;
+        $fields[501]['indice_cache_etat_systeme'] = 'programme';
+        $fields[501]['indice_date_disponibilite'] = date('d/m/Y H:i', time() + HOUR_IN_SECONDS);
 
         ob_start();
         render_enigme_participation(10, 'defaut', 1);
         $html = ob_get_clean();
 
-        $this->assertMatchesRegularExpression('/12\/09\/25( à 08:47)?/', $html);
+        $this->assertStringContainsString('indice-label', $html);
+        $this->assertMatchesRegularExpression('/Aujourd’hui à \d{2}:\d{2}/', $html);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_programmed_indices_label_within_week(): void
+    {
+        global $mocked_posts, $fields;
+        $mocked_posts = [502];
+        $fields[502]['indice_cout_points']        = 0;
+        $fields[502]['indice_cache_etat_systeme'] = 'programme';
+        $fields[502]['indice_date_disponibilite'] = date('d/m/Y H:i', time() + 2 * DAY_IN_SECONDS);
+
+        ob_start();
+        render_enigme_participation(10, 'defaut', 1);
+        $html = ob_get_clean();
+
+        $expected = date('d/m/y \à H:i', time() + 2 * DAY_IN_SECONDS);
+        $this->assertStringContainsString($expected, $html);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_get_posts_includes_pending_status(): void
+    {
+        global $last_get_posts_args;
+        render_enigme_participation(10, 'defaut', 1);
+        $this->assertNotEmpty($last_get_posts_args);
+        foreach ($last_get_posts_args as $args) {
+            $this->assertContains('pending', $args['post_status']);
+        }
     }
 
     /**

--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -42,10 +42,10 @@ document.addEventListener('DOMContentLoaded', function () {
       var zone = link.closest('.zone-indices');
       var container = zone ? zone.querySelector('.indice-display') : null;
       if (!container) return;
-      if (link.dataset.unlocked === '1') {
+      var cout = link.dataset.cout || '0';
+      if (link.dataset.unlocked === '1' || cout === '0') {
         fetchIndice(link.dataset.indiceId, link, container);
       } else {
-        var cout = link.dataset.cout || '0';
         var html = '<p>' + indicesUnlock.texts.unlock + ' - ' + cout + ' ' + indicesUnlock.texts.pts + '</p>'
           + '<button type="button" class="btn-debloquer-indice" data-indice-id="' + link.dataset.indiceId + '">'
           + indicesUnlock.texts.unlock + '</button>';

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -46,15 +46,19 @@
     flex: 1 1 auto;
   }
 
-  .indice-link {
+  .indice-link,
+  .indice-label {
     display: inline-flex;
     align-items: center;
     gap: var(--space-xs);
     padding: calc(var(--space-xs) / 2) var(--space-sm);
     border-radius: 4px;
-    text-decoration: none;
     font-weight: 600;
     font-size: 0.875rem;
+  }
+
+  .indice-link {
+    text-decoration: none;
 
     &--locked,
     &--unlocked,
@@ -62,6 +66,11 @@
       background-color: var(--color-gris-3);
       color: var(--color-white);
     }
+  }
+
+  .indice-label.indice-link--upcoming {
+    background-color: var(--color-gris-3);
+    color: var(--color-white);
   }
 
   .btn-debloquer-indice {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5560,17 +5560,24 @@ body.panneau-ouvert::before {
   justify-content: flex-start;
   flex: 1 1 auto;
 }
-.zone-indices .indice-link {
+.zone-indices .indice-link,
+.zone-indices .indice-label {
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
   padding: calc(var(--space-xs) / 2) var(--space-sm);
   border-radius: 4px;
-  text-decoration: none;
   font-weight: 600;
   font-size: 0.875rem;
 }
+.zone-indices .indice-link {
+  text-decoration: none;
+}
 .zone-indices .indice-link--locked, .zone-indices .indice-link--unlocked, .zone-indices .indice-link--upcoming {
+  background-color: var(--color-gris-3);
+  color: var(--color-white);
+}
+.zone-indices .indice-label.indice-link--upcoming {
   background-color: var(--color-gris-3);
   color: var(--color-white);
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -704,30 +704,33 @@ require_once __DIR__ . '/indices.php';
                             }
                         }
 
-                        $date_txt = '';
-                        if ($timestamp !== false) {
-                            $now = current_time('timestamp');
-                            if (wp_date('Y-m-d', $timestamp) === wp_date('Y-m-d', $now)) {
-                                $date_txt = sprintf(
-                                    esc_html__("Aujourd’hui à %s", 'chassesautresor-com'),
-                                    wp_date('H:i', $timestamp)
-                                );
-                            } elseif ($timestamp <= $now + WEEK_IN_SECONDS) {
-                                $date_txt = wp_date('d/m/y \\à H:i', $timestamp);
-                            } else {
-                                $date_txt = wp_date('d/m/y', $timestamp);
+                        $now = current_time('timestamp');
+                        if ($timestamp === false || $timestamp > $now) {
+                            $date_txt = '';
+                            if ($timestamp !== false) {
+                                if (wp_date('Y-m-d', $timestamp) === wp_date('Y-m-d', $now)) {
+                                    $date_txt = sprintf(
+                                        esc_html__("Aujourd’hui à %s", 'chassesautresor-com'),
+                                        wp_date('H:i', $timestamp)
+                                    );
+                                } elseif ($timestamp <= $now + WEEK_IN_SECONDS) {
+                                    $date_txt = wp_date('d/m/y \\à H:i', $timestamp);
+                                } else {
+                                    $date_txt = wp_date('d/m/y', $timestamp);
+                                }
                             }
-                        }
-                        if ($date_txt === '') {
-                            $date_txt = esc_html__('Bientôt disponible', 'chassesautresor-com');
-                        }
+                            if ($date_txt === '') {
+                                $date_txt = esc_html__('Bientôt disponible', 'chassesautresor-com');
+                            }
 
-                        $html .= '<span class="indice-label indice-link--upcoming etiquette">'
-                            . '<i class="fa-solid fa-hourglass" aria-hidden="true"></i> '
-                            . esc_html($date_txt)
-                            . '</span>';
-                        continue;
-                    } elseif ($est_debloque) {
+                            $html .= '<span class="indice-label indice-link--upcoming etiquette">'
+                                . '<i class="fa-solid fa-hourglass" aria-hidden="true"></i> '
+                                . esc_html($date_txt)
+                                . '</span>';
+                            continue;
+                        }
+                    }
+                    if ($est_debloque) {
                         $classes   = 'indice-link indice-link--unlocked etiquette';
                         $etat_icon = 'fa-eye';
                         $title_ind = get_the_title($indice_id);


### PR DESCRIPTION
## Résumé
- gère l’affichage des indices dont la disponibilité est future
- ajoute le style d’étiquette pour les indices programmés et compile le CSS
- couvre les cas d’indice programmé par des tests unitaires

## Tests
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh && composer install`
- `source ./setup-env.sh && vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c401cfb06c833299e158c09586a0cb