### PR TITLE
Ajout d'un eyebox pour les images d'indice

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -12,9 +12,6 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(function (res) {
         if (res.success) {
           displayContent(container, res.data.html);
-          if (window.jQuery && typeof jQuery.fn.fancybox === 'function') {
-            jQuery(container).find('a.fancybox').fancybox();
-          }
           if (link) {
             link.dataset.unlocked = '1';
             link.classList.remove('indice-link--locked');
@@ -36,6 +33,20 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   document.body.addEventListener('click', function (e) {
+    var eye = e.target.closest('.eyebox-trigger');
+    if (eye) {
+      e.preventDefault();
+      var url = eye.dataset.full || eye.getAttribute('href');
+      var overlay = document.createElement('div');
+      overlay.className = 'eyebox-overlay';
+      overlay.innerHTML = '<img src="' + url + '" alt="" />';
+      document.body.appendChild(overlay);
+      overlay.addEventListener('click', function () {
+        overlay.remove();
+      });
+      return;
+    }
+
     var link = e.target.closest('.indice-link');
     if (link) {
       e.preventDefault();

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -131,6 +131,29 @@
 
     &__image {
       flex: 0 0 auto;
+      position: relative;
+
+      .eyebox-trigger {
+        display: inline-block;
+        position: relative;
+      }
+
+      .eyebox-icon {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 2rem;
+        color: var(--color-white);
+        opacity: 0;
+        transition: opacity 0.2s;
+        pointer-events: none;
+      }
+
+      .eyebox-trigger:hover .eyebox-icon,
+      .eyebox-trigger:focus .eyebox-icon {
+        opacity: 1;
+      }
 
       img {
         width: 150px;
@@ -143,6 +166,24 @@
     &__texte {
       flex: 1 1 auto;
     }
+  }
+}
+
+.eyebox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+
+  img {
+    max-width: 90%;
+    max-height: 90%;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5632,6 +5632,26 @@ body.panneau-ouvert::before {
 }
 .zone-indices .indice-contenu__image {
   flex: 0 0 auto;
+  position: relative;
+}
+.zone-indices .indice-contenu__image .eyebox-trigger {
+  display: inline-block;
+  position: relative;
+}
+.zone-indices .indice-contenu__image .eyebox-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2rem;
+  color: var(--color-white);
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+.zone-indices .indice-contenu__image .eyebox-trigger:hover .eyebox-icon,
+.zone-indices .indice-contenu__image .eyebox-trigger:focus .eyebox-icon {
+  opacity: 1;
 }
 .zone-indices .indice-contenu__image img {
   width: 150px;
@@ -5642,6 +5662,23 @@ body.panneau-ouvert::before {
 }
 .zone-indices .indice-contenu__texte {
   flex: 1 1 auto;
+}
+
+.eyebox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.eyebox-overlay img {
+  max-width: 90%;
+  max-height: 90%;
 }
 
 .menu-lateral .stats-bar-chart .bar-value,

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -51,7 +51,7 @@ function debloquer_indice(): void
             $thumb = wp_get_attachment_image($image_id, 'thumbnail');
             $full  = wp_get_attachment_image_url($image_id, 'full');
             $image = $full
-                ? '<a href="' . esc_url($full) . '" class="fancybox image">' . $thumb . '</a>'
+                ? '<a href="' . esc_url($full) . '" class="image eyebox-trigger" data-full="' . esc_url($full) . '">' . $thumb . '<i class="fa-solid fa-eye eyebox-icon" aria-hidden="true"></i></a>'
                 : $thumb;
         }
         $html = '<div class="indice-contenu">';
@@ -113,7 +113,7 @@ function debloquer_indice(): void
         $thumb = wp_get_attachment_image($image_id, 'thumbnail');
         $full  = wp_get_attachment_image_url($image_id, 'full');
         $image = $full
-            ? '<a href="' . esc_url($full) . '" class="fancybox image">' . $thumb . '</a>'
+            ? '<a href="' . esc_url($full) . '" class="image eyebox-trigger" data-full="' . esc_url($full) . '">' . $thumb . '<i class="fa-solid fa-eye eyebox-icon" aria-hidden="true"></i></a>'
             : $thumb;
     }
     $html = '<div class="indice-contenu">';


### PR DESCRIPTION
## Résumé
- permet d'afficher les images d'indice dans un eyebox
- ajoute les scripts et styles associés à l'ouverture de l'image

## Changements notables
- ajout d'un lien `eyebox-trigger` avec icône *eye* pour les images d'indice
- nouvelle gestion JavaScript de l'overlay d'image
- styles SCSS/CSS pour l'icône et la superposition

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c43063090883328fb19e8508062125