### PR TITLE
Restrict hunt solutions to engaged players

### DIFF
--- a/tests/SolutionAccessTest.php
+++ b/tests/SolutionAccessTest.php
@@ -10,7 +10,7 @@ final class SolutionAccessTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_anonymous_can_view_solution_when_hunt_finished(): void
+    public function test_anonymous_cannot_view_solution_when_hunt_finished(): void
     {
         if (!function_exists('solution_recuperer_par_objet')) {
             function solution_recuperer_par_objet(int $id, string $type) {
@@ -34,7 +34,7 @@ final class SolutionAccessTest extends TestCase
 
         require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
 
-        $this->assertTrue(utilisateur_peut_voir_solution_chasse(1, 0));
+        $this->assertFalse(utilisateur_peut_voir_solution_chasse(1, 0));
     }
 
     /**
@@ -66,6 +66,37 @@ final class SolutionAccessTest extends TestCase
         require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
 
         $this->assertFalse(utilisateur_peut_voir_solution_chasse(1, 0));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_player_can_view_hunt_solution_after_hunt_finished(): void
+    {
+        if (!function_exists('solution_recuperer_par_objet')) {
+            function solution_recuperer_par_objet(int $id, string $type) {
+                return (object) ['ID' => 99];
+            }
+        }
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id) {
+                return $key === 'chasse_cache_statut' ? 'termine' : null;
+            }
+        }
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $capability) { return false; }
+        }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) { return false; }
+        }
+        if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+            function utilisateur_est_engage_dans_chasse($user_id, $chasse_id) { return true; }
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/access-functions.php';
+
+        $this->assertTrue(utilisateur_peut_voir_solution_chasse(1, 2));
     }
 
     /**

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -1222,8 +1222,7 @@ function utilisateur_peut_voir_solution_chasse(int $chasse_id, int $user_id): bo
         }
     }
 
-    $statut = get_field('chasse_cache_statut', $chasse_id);
-    return $statut === 'termine';
+    return false;
 }
 
 


### PR DESCRIPTION
## Résumé
- Limite l'accès aux solutions d'une chasse aux seuls joueurs engagés
- Ajoute des tests pour valider l'accès selon l'engagement

## Changements notables
- Renforce `utilisateur_peut_voir_solution_chasse` pour refuser les visiteurs non engagés
- Couvre les cas anonymes et joueurs dans les tests d'accès aux solutions

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c431b2575083328e78d57b4b9f5505