### PR TITLE
Formatage du montant de récompense avec séparateur de milliers

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -491,7 +491,7 @@ if ($edition_active && !$est_complet) {
                                     <span class="badge-recompense__label">
                                         <?= esc_html__('Valeur estimée', 'chassesautresor-com'); ?>
                                     </span>
-                                    <?= esc_html($valeur_recompense); ?>
+                                    <?= esc_html(number_format_i18n(round((float) $valeur_recompense), 0)); ?>
                                     <span class="badge-recompense__devise">€</span>
                                 </span>
                             </p>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -119,7 +119,7 @@ if (empty($infos)) {
                             printf(
                                 esc_html__('%1$s — %2$s €', 'chassesautresor-com'),
                                 esc_html($reward_title),
-                                esc_html($reward_value)
+                                esc_html(number_format_i18n(round((float) $reward_value), 0))
                             );
                             ?>
                         </span>

--- a/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
+++ b/wp-content/themes/chassesautresor/tests/chasse_gagnant_info.test.php
@@ -107,6 +107,11 @@ class ChasseGagnantInfoTest extends TestCase
         if (!function_exists('wp_get_attachment_image_src')) {
             function wp_get_attachment_image_src($id, $size) { return ['']; }
         }
+        if (!function_exists('number_format_i18n')) {
+            function number_format_i18n($number, $decimals = 0) {
+                return number_format($number, $decimals);
+            }
+        }
 
         global $fields;
         $fields = [
@@ -255,6 +260,11 @@ class ChasseGagnantInfoTest extends TestCase
         }
         if (!function_exists('wp_get_attachment_image_src')) {
             function wp_get_attachment_image_src($id, $size) { return ['']; }
+        }
+        if (!function_exists('number_format_i18n')) {
+            function number_format_i18n($number, $decimals = 0) {
+                return number_format($number, $decimals);
+            }
         }
         if (!function_exists('solution_chasse_peut_etre_affichee')) {
             function solution_chasse_peut_etre_affichee($id) { return true; }


### PR DESCRIPTION
## Résumé
- Ajout d'un séparateur de milliers pour les montants de récompense affichés.

## Changements notables
- Formatage des valeurs de récompense via `number_format_i18n` dans l'affichage complet de la chasse et sur la carte large.
- Adaptation des tests pour fournir un stub de `number_format_i18n`.

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c433c3ab54833299a8f1b1943f7e06