### PR TITLE
Align reward value badge with title

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -404,14 +404,19 @@
   margin-right: 0.3em;
 }
 
-.chasse-lot-complet .lot-titre,
-.chasse-lot-complet .lot-valeur {
-  margin: 0 0 var(--space-xs);
+.chasse-lot-complet .champ-lot-titre,
+.chasse-lot-complet .champ-lot-valeur {
+  display: inline-block;
 }
 
 .chasse-lot-complet .lot-titre {
+  margin: 0 var(--space-xs) 0 0;
   font-size: 1.25rem;
   font-weight: 600;
+}
+
+.chasse-lot-complet .lot-valeur {
+  margin: 0;
 }
 
 .chasse-lot-complet .lot-description {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -419,6 +419,10 @@
   margin: 0;
 }
 
+.chasse-lot-complet .champ-lot-description {
+  margin-top: var(--space-sm);
+}
+
 .chasse-lot-complet .lot-description {
   margin: 0;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1186,6 +1186,10 @@
   margin: 0;
 }
 
+.chasse-lot-complet .champ-lot-description {
+  margin-top: var(--space-sm);
+}
+
 .chasse-lot-complet .lot-description {
   margin: 0;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1171,14 +1171,19 @@
   margin-right: 0.3em;
 }
 
-.chasse-lot-complet .lot-titre,
-.chasse-lot-complet .lot-valeur {
-  margin: 0 0 var(--space-xs);
+.chasse-lot-complet .champ-lot-titre,
+.chasse-lot-complet .champ-lot-valeur {
+  display: inline-block;
 }
 
 .chasse-lot-complet .lot-titre {
+  margin: 0 var(--space-xs) 0 0;
   font-size: 1.25rem;
   font-weight: 600;
+}
+
+.chasse-lot-complet .lot-valeur {
+  margin: 0;
 }
 
 .chasse-lot-complet .lot-description {


### PR DESCRIPTION
### Résumé
- Aligne la valeur estimée de la récompense sur la même ligne que son titre
- Met à jour les styles SCSS/CSS pour un affichage inline des informations de récompense

### Changements notables
- Affichage inline pour `champ-lot-titre` et `champ-lot-valeur`
- Mise à jour du CSS compilé

### Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4374e67248332893dd436526c450e