### PR TITLE
Utiliser la date de découverte comme date de fin

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1432,6 +1432,15 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $date_debut        = $champs['date_debut'];
     $date_fin          = $champs['date_fin'];
     $illimitee         = $champs['illimitee'];
+    $date_decouverte   = $champs['date_decouverte'];
+
+    verifier_ou_recalculer_statut_chasse($chasse_id);
+    $statut            = get_field('chasse_cache_statut', $chasse_id) ?: 'revision';
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+
+    if ($statut === 'termine' && $date_decouverte) {
+        $date_fin = $date_decouverte;
+    }
 
     $date_debut_affichage = formater_date($date_debut);
     $date_fin_affichage   = $illimitee
@@ -1440,10 +1449,6 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
 
     $nb_joueurs       = compter_joueurs_engages_chasse($chasse_id);
     $nb_joueurs_label = formater_nombre_joueurs($nb_joueurs);
-
-    verifier_ou_recalculer_statut_chasse($chasse_id);
-    $statut            = get_field('chasse_cache_statut', $chasse_id) ?: 'revision';
-    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
     $badge_class       = 'statut-' . $statut;
     $statut_label      = '';
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -12,6 +12,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
 // Récupération centralisée des informations
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
+$statut = $infos_chasse['statut'];
 
 
 // Champs principaux (avec fallback direct en meta)
@@ -29,6 +30,10 @@ $cout_points       = (int) ($champs['cout_points'] ?? 0);
 $date_decouverte      = $champs['date_decouverte'];
 $gagnants             = $champs['gagnants'];
 $current_stored_statut = $champs['current_stored_statut'];
+
+if ($statut === 'termine' && !empty($date_decouverte)) {
+    $date_fin = $date_decouverte;
+}
 
 
 $image_raw = $infos_chasse['image_raw'];
@@ -117,7 +122,6 @@ if ($edition_active && !$est_complet) {
 
   <div class="chasse-fiche-container">
     <?php
-    $statut = $infos_chasse['statut'];
     $statut_validation = $infos_chasse['statut_validation'];
     $statut_label = '';
     $statut_for_class = $statut;


### PR DESCRIPTION
## Résumé
- Affiche la date de découverte comme date de fin pour les chasses terminées
- Corrige l'affichage sur les fiches et cartes de chasses

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c44556645c83328a5bab6edb88578e