### PR TITLE
fix: refresh hunt end mode CTA dynamically

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1181,6 +1181,8 @@ function initModeFinChasse() {
   const templateNb = document.getElementById('template-nb-gagnants');
   const modeFinLi = document.querySelector('.champ-mode-fin');
   const finCard = document.querySelector('.carte-arret-chasse');
+  const caracLimite = document.querySelector('.caracteristique-limite');
+  const caracFinVal = document.querySelector('.caracteristique-fin .caracteristique-valeur');
 
   if (!toggle || !templateNb || !modeFinLi || !finCard) return;
 
@@ -1214,12 +1216,16 @@ function initModeFinChasse() {
       if (inputNb) {
         mettreAJourAffichageNbGagnants(postId, inputNb.value.trim());
       }
+      if (caracLimite) caracLimite.style.display = '';
+      if (caracFinVal) caracFinVal.textContent = ChasseModeFinI18n.auto;
     } else {
       if (existingNb) existingNb.remove();
 
       if (finCard) finCard.style.display = '';
 
       mettreAJourAffichageNbGagnants(postId, 0);
+      if (caracLimite) caracLimite.style.display = 'none';
+      if (caracFinVal) caracFinVal.textContent = ChasseModeFinI18n.manual;
     }
 
     mettreAJourBadgeModeFinChasse(selected);

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -81,6 +81,15 @@ function enqueue_script_chasse_edit()
         ]
     );
 
+    wp_localize_script(
+        'chasse-edit',
+        'ChasseModeFinI18n',
+        [
+            'auto'   => __('automatique', 'chassesautresor-com'),
+            'manual' => __('manuelle', 'chassesautresor-com'),
+        ]
+    );
+
     // Injecte les valeurs par défaut pour JS
     wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [
         'titre' => strtolower(TITRE_DEFAUT_CHASSE),

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -358,22 +358,34 @@ if ($edition_active && !$est_complet) {
                 <span class="caracteristique-valeur"><?= esc_html($date_value); ?></span>
               </div>
             <?php endif; ?>
-            <?php if ($mode_fin === 'automatique') : ?>
-              <div class="caracteristique caracteristique-limite">
-                <span class="caracteristique-icone" aria-hidden="true">👥</span>
-                <?php if ((int) $nb_max === 0) : ?>
-                  <span class="caracteristique-label"><?= esc_html__('Gagnants', 'chassesautresor-com'); ?></span>
-                  <span class="caracteristique-valeur nb-gagnants-affichage" data-post-id="<?= esc_attr($chasse_id); ?>">
-                    <?= esc_html__('illimitée', 'chassesautresor-com'); ?>
-                  </span>
-                <?php else : ?>
-                  <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
-                  <span class="caracteristique-valeur nb-gagnants-affichage" data-post-id="<?= esc_attr($chasse_id); ?>">
-                    <?= esc_html(sprintf(_n('%d gagnant', '%d gagnants', $nb_max, 'chassesautresor-com'), $nb_max)); ?>
-                  </span>
-                <?php endif; ?>
-              </div>
-            <?php endif; ?>
+            <div
+              class="caracteristique caracteristique-limite"
+              style="<?= $mode_fin === 'automatique' ? '' : 'display:none;'; ?>"
+            >
+              <span class="caracteristique-icone" aria-hidden="true">👥</span>
+              <?php if ((int) $nb_max === 0) : ?>
+                <span class="caracteristique-label"><?= esc_html__('Gagnants', 'chassesautresor-com'); ?></span>
+                <span
+                  class="caracteristique-valeur nb-gagnants-affichage"
+                  data-post-id="<?= esc_attr($chasse_id); ?>"
+                >
+                  <?= esc_html__('illimitée', 'chassesautresor-com'); ?>
+                </span>
+              <?php else : ?>
+                <span class="caracteristique-label"><?= esc_html__('Limite', 'chassesautresor-com'); ?></span>
+                <span
+                  class="caracteristique-valeur nb-gagnants-affichage"
+                  data-post-id="<?= esc_attr($chasse_id); ?>"
+                >
+                  <?= esc_html(
+                      sprintf(
+                          _n('%d gagnant', '%d gagnants', $nb_max, 'chassesautresor-com'),
+                          $nb_max
+                      )
+                  ); ?>
+                </span>
+              <?php endif; ?>
+            </div>
 
             <div class="caracteristique caracteristique-fin">
               <span class="caracteristique-icone" aria-hidden="true">⏱️</span>


### PR DESCRIPTION
## Summary
- corrige la mise à jour du mode de fin dans le CTA de chasse
- ajoute les libellés JS pour le mode de fin
- actualise l'affichage des gagnants et du mode dans le panneau

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c46885f9b88332933688189a053b32