### PR TITLE
Align left hint text in participation section

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -93,6 +93,7 @@
       padding: var(--space-sm);
       border: 1px solid var(--color-gris-3);
       border-radius: 4px;
+      text-align: left;
     }
 
     .indice-close {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5609,6 +5609,7 @@ body.panneau-ouvert::before {
   padding: var(--space-sm);
   border: 1px solid var(--color-gris-3);
   border-radius: 4px;
+  text-align: left;
 }
 .zone-indices .indice-display .indice-close {
   position: absolute;


### PR DESCRIPTION
## Résumé
- Aligne le texte des indices dans la section participation de la page énigme

## Changements notables
- Ajout d’un alignement gauche pour les indices textuels
- Recompilation du CSS du thème

## Tests
- `source ./setup-env.sh`
- `composer install`
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c481ee70b883328c910b072bfa8e7d