### PR TITLE
Affiche une bordure sur l’indice actif

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
+++ b/wp-content/themes/chassesautresor/assets/js/indices-deblocage.js
@@ -53,6 +53,11 @@ document.addEventListener('DOMContentLoaded', function () {
       var zone = link.closest('.zone-indices');
       var container = zone ? zone.querySelector('.indice-display') : null;
       if (!container) return;
+      var active = zone ? zone.querySelector('.indice-link--active') : null;
+      if (active) {
+        active.classList.remove('indice-link--active');
+      }
+      link.classList.add('indice-link--active');
       var cout = link.dataset.cout || '0';
       if (link.dataset.unlocked === '1' || cout === '0') {
         fetchIndice(link.dataset.indiceId, link, container);
@@ -71,6 +76,13 @@ document.addEventListener('DOMContentLoaded', function () {
       var closeContainer = closeBtn.closest('.indice-display');
       if (closeContainer) {
         closeContainer.innerHTML = '';
+      }
+      var closeZone = closeBtn.closest('.zone-indices');
+      if (closeZone) {
+        var activeLink = closeZone.querySelector('.indice-link--active');
+        if (activeLink) {
+          activeLink.classList.remove('indice-link--active');
+        }
       }
       return;
     }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -69,7 +69,9 @@
     }
 
     &--active {
+      background-color: var(--color-secondary);
       border-color: var(--color-secondary);
+      color: var(--color-white);
     }
   }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -55,6 +55,7 @@
     border-radius: 4px;
     font-weight: 600;
     font-size: 0.875rem;
+    border: 2px solid transparent;
   }
 
   .indice-link {
@@ -65,6 +66,10 @@
     &--upcoming {
       background-color: var(--color-gris-3);
       color: var(--color-white);
+    }
+
+    &--active {
+      border-color: var(--color-secondary);
     }
   }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5578,6 +5578,7 @@ body.panneau-ouvert::before {
   border-radius: 4px;
   font-weight: 600;
   font-size: 0.875rem;
+  border: 2px solid transparent;
 }
 .zone-indices .indice-link {
   text-decoration: none;
@@ -5585,6 +5586,9 @@ body.panneau-ouvert::before {
 .zone-indices .indice-link--locked, .zone-indices .indice-link--unlocked, .zone-indices .indice-link--upcoming {
   background-color: var(--color-gris-3);
   color: var(--color-white);
+}
+.zone-indices .indice-link--active {
+  border-color: var(--color-secondary);
 }
 .zone-indices .indice-label.indice-link--upcoming {
   background-color: var(--color-gris-3);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5588,7 +5588,9 @@ body.panneau-ouvert::before {
   color: var(--color-white);
 }
 .zone-indices .indice-link--active {
+  background-color: var(--color-secondary);
   border-color: var(--color-secondary);
+  color: var(--color-white);
 }
 .zone-indices .indice-label.indice-link--upcoming {
   background-color: var(--color-gris-3);


### PR DESCRIPTION
## Résumé
- met en évidence l’indice sélectionné avec une bordure aux couleurs du thème
- gère l’ajout et le retrait de cette bordure côté JavaScript
- régénère le CSS compilé

## Testing
- `npm ci`
- `node build-css.js`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4db1bb610833294898c53374a1e77