### PR TITLE
Support combined solution content

### DIFF
--- a/tests/SolutionContentHtmlTest.php
+++ b/tests/SolutionContentHtmlTest.php
@@ -63,4 +63,57 @@ final class SolutionContentHtmlTest extends TestCase
         $this->assertStringContainsString('<object', $html);
         $this->assertStringContainsString('solution.pdf', $html);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_returns_pdf_and_text_when_both_provided(): void
+    {
+        $solution = new WP_Post(10);
+
+        if (!function_exists('get_field')) {
+            function get_field($key, $post_id, $format = true) {
+                if ($key === 'solution_fichier') {
+                    return 55;
+                }
+                if ($key === 'solution_explication') {
+                    return 'Explication';
+                }
+                return '';
+            }
+        }
+        if (!function_exists('wp_get_attachment_url')) {
+            function wp_get_attachment_url($id) {
+                return $id === 55 ? 'https://example.com/solution.pdf' : '';
+            }
+        }
+        if (!function_exists('get_attached_file')) {
+            function get_attached_file($id) {
+                return $id === 55 ? '/tmp/solution.pdf' : '';
+            }
+        }
+        if (!function_exists('esc_url')) {
+            function esc_url($url) { return $url; }
+        }
+        if (!function_exists('esc_html')) {
+            function esc_html($text) { return $text; }
+        }
+        if (!function_exists('esc_html__')) {
+            function esc_html__($text, $domain = '') { return $text; }
+        }
+        if (!function_exists('wp_kses_post')) {
+            function wp_kses_post($text) { return $text; }
+        }
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callback, $priority = 10, $args = 1) {}
+        }
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+        $html = solution_contenu_html($solution);
+        $this->assertStringContainsString('<object', $html);
+        $this->assertStringContainsString('solution.pdf', $html);
+        $this->assertStringContainsString('<p>Explication</p>', $html);
+    }
 }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1317,18 +1317,17 @@ function solution_contenu_html(WP_Post $solution): string
 {
     $fichier = get_field('solution_fichier', $solution->ID);
     $texte   = get_field('solution_explication', $solution->ID);
+    $content = '';
 
     if ($fichier) {
         if (is_array($fichier)) {
             $fichier_url = $fichier['url'] ?? '';
-            $fichier_nom = $fichier['filename'] ?? basename($fichier_url);
         } else {
             $fichier_url = wp_get_attachment_url($fichier);
-            $fichier_nom = basename(get_attached_file($fichier)) ?: basename($fichier_url);
         }
 
-        if ($fichier_url) {
-            return '<object data="' . esc_url($fichier_url)
+        if (!empty($fichier_url)) {
+            $content .= '<object data="' . esc_url($fichier_url)
                 . '" type="application/pdf" width="100%" height="800">'
                 . '<p>'
                 . esc_html__(
@@ -1343,10 +1342,10 @@ function solution_contenu_html(WP_Post $solution): string
     }
 
     if ($texte) {
-        return '<p>' . wp_kses_post($texte) . '</p>';
+        $content .= '<p>' . wp_kses_post($texte) . '</p>';
     }
 
-    return '';
+    return $content;
 }
 
 /**


### PR DESCRIPTION
## Résumé
- unifie la génération HTML des solutions
- affiche simultanément PDF et texte lorsqu'ils existent
- ajoute un test de rendu combiné

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4e53b3ff88332a90a6c8972579829