### PR TITLE
Ajout d'un CTA pour afficher la solution de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -3010,3 +3010,7 @@ msgstr ""
 #: template-parts/chasse/chasse-affichage-complet.php:313
 msgid "Voir les solutions"
 msgstr ""
+
+#: template-parts/enigme/partials/enigme-partial-solution.php:32
+msgid "Voir la solution de la chasse"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3294,3 +3294,7 @@ msgstr "Rediscover"
 #: template-parts/chasse/chasse-affichage-complet.php:313
 msgid "Voir les solutions"
 msgstr "View solutions"
+
+#: template-parts/enigme/partials/enigme-partial-solution.php:32
+msgid "Voir la solution de la chasse"
+msgstr "View hunt solution"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3256,3 +3256,7 @@ msgstr "Redécouvrir"
 #: template-parts/chasse/chasse-affichage-complet.php:313
 msgid "Voir les solutions"
 msgstr "Voir les solutions"
+
+#: template-parts/enigme/partials/enigme-partial-solution.php:32
+msgid "Voir la solution de la chasse"
+msgstr "Voir la solution de la chasse"

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-solution.php
@@ -28,8 +28,11 @@ if (
     $chasse_solution = solution_recuperer_par_objet($chasse_id, 'chasse');
     if ($chasse_solution) {
         echo '<section class="solution-chasse">';
+        echo '<details>';
+        echo '<summary>' . esc_html__('Voir la solution de la chasse', 'chassesautresor-com') . '</summary>';
         echo '<h4>' . esc_html__('Solution de la chasse', 'chassesautresor-com') . '</h4>';
         echo solution_contenu_html($chasse_solution);
+        echo '</details>';
         echo '</section>';
     }
 }


### PR DESCRIPTION
## Résumé
- ajout d'un bouton pour révéler la solution de la chasse depuis une page énigme
- mise à jour des fichiers de traduction

## Changements notables
- remplace l'affichage automatique de la solution de la chasse par un `<details>` dépliable
- ajoute les entrées de traduction pour le nouveau CTA

## Testing
- `source ./setup-env.sh && echo SetupDone`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4ee7f09f883328f67de62429e6aef