### PR TITLE
Afficher le texte des solutions avant le PDF

### DIFF
--- a/tests/SolutionContentHtmlTest.php
+++ b/tests/SolutionContentHtmlTest.php
@@ -115,5 +115,8 @@ final class SolutionContentHtmlTest extends TestCase
         $this->assertStringContainsString('<object', $html);
         $this->assertStringContainsString('solution.pdf', $html);
         $this->assertStringContainsString('<p>Explication</p>', $html);
+        $pdf_pos  = strpos($html, '<object');
+        $text_pos = strpos($html, '<p>Explication</p>');
+        $this->assertLessThan($pdf_pos, $text_pos);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1319,6 +1319,10 @@ function solution_contenu_html(WP_Post $solution): string
     $texte   = get_field('solution_explication', $solution->ID);
     $content = '';
 
+    if ($texte) {
+        $content .= '<p>' . wp_kses_post($texte) . '</p>';
+    }
+
     if ($fichier) {
         if (is_array($fichier)) {
             $fichier_url = $fichier['url'] ?? '';
@@ -1339,10 +1343,6 @@ function solution_contenu_html(WP_Post $solution): string
                 . esc_html__('Télécharger', 'chassesautresor-com')
                 . '</a></p></object>';
         }
-    }
-
-    if ($texte) {
-        $content .= '<p>' . wp_kses_post($texte) . '</p>';
     }
 
     return $content;


### PR DESCRIPTION
## Résumé
- Inverse l'ordre d'affichage pour présenter le texte de la solution avant le PDF
- Ajoute un test pour vérifier cet ordre

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4eee38a888332b9783cac7a3ec4d4