### PR TITLE
Alignement gauche du contenu des solutions d’énigme

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -654,6 +654,20 @@ li.active .enigme-menu__edit {
   text-align: center;
 }
 
+.solution-content {
+  .solution-enigme {
+    margin-bottom: var(--space-xl);
+
+    p {
+      padding-inline: var(--space-xl);
+
+      @media (--bp-tablet) {
+        padding-inline: var(--space-3xl);
+      }
+    }
+  }
+}
+
 /* 📝 Mise en forme du texte d'énigme */
 .enigme-texte {
   max-width: 65ch;

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -641,12 +641,17 @@ li.active .enigme-menu__edit {
   padding: var(--space-md);
   border-radius: 6px;
   color: var(--color-text-fond-clair);
+  text-align: left;
 }
 
 .solution summary {
   cursor: pointer;
   font-weight: 600;
   color: var(--color-text-fond-clair);
+}
+
+.solution > details > summary {
+  text-align: center;
 }
 
 /* 📝 Mise en forme du texte d'énigme */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6123,12 +6123,17 @@ li.active .enigme-menu__edit {
   padding: var(--space-md);
   border-radius: 6px;
   color: var(--color-text-fond-clair);
+  text-align: left;
 }
 
 .solution summary {
   cursor: pointer;
   font-weight: 600;
   color: var(--color-text-fond-clair);
+}
+
+.solution > details > summary {
+  text-align: center;
 }
 
 /* 📝 Mise en forme du texte d'énigme */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6136,6 +6136,18 @@ li.active .enigme-menu__edit {
   text-align: center;
 }
 
+.solution-content .solution-enigme {
+  margin-bottom: var(--space-xl);
+}
+.solution-content .solution-enigme p {
+  padding-inline: var(--space-xl);
+}
+@media (min-width: 768px) {
+  .solution-content .solution-enigme p {
+    padding-inline: var(--space-3xl);
+  }
+}
+
 /* 📝 Mise en forme du texte d'énigme */
 .enigme-texte {
   max-width: 65ch;


### PR DESCRIPTION
## Résumé
- Aligne le contenu des solutions sur la gauche pour une meilleure lisibilité.
- Garde le bouton "Voir la solution" centré en haut du bloc.

## Testing
- `npm install`
- `node build-css.js`
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4f11937dc8332ad3f8db2bd55727a