### PR TITLE
Corriger l'affichage du header mobile des énigmes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -718,7 +718,7 @@ li.active .enigme-menu__edit {
     gap: var(--space-md);
     padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
     padding-right: calc(var(--space-md) + env(safe-area-inset-right));
-    padding-bottom: var(--space-sm);
+    padding-bottom: 0;
     background-color: transparent;
   }
 
@@ -858,7 +858,7 @@ li.active .enigme-menu__edit {
   }
 
   .page-enigme {
-    margin-top: calc(var(--space-3xl) + var(--space-lg) + env(safe-area-inset-top));
+    margin-top: 0;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -715,14 +715,11 @@ li.active .enigme-menu__edit {
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    position: fixed;
-    top: calc(var(--space-4xl) + env(safe-area-inset-top));
-    left: auto;
-    right: calc(var(--space-md) + env(safe-area-inset-right));
+    gap: var(--space-md);
     padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
+    padding-right: calc(var(--space-md) + env(safe-area-inset-right));
     padding-bottom: var(--space-sm);
     background-color: transparent;
-    z-index: 10;
   }
 
   .enigme-mobile-actions {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6196,14 +6196,11 @@ li.active .enigme-menu__edit {
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    position: fixed;
-    top: calc(var(--space-4xl) + env(safe-area-inset-top));
-    left: auto;
-    right: calc(var(--space-md) + env(safe-area-inset-right));
+    gap: var(--space-md);
     padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
+    padding-right: calc(var(--space-md) + env(safe-area-inset-right));
     padding-bottom: var(--space-sm);
     background-color: transparent;
-    z-index: 10;
   }
   .enigme-mobile-actions {
     display: flex;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6199,7 +6199,7 @@ li.active .enigme-menu__edit {
     gap: var(--space-md);
     padding-top: calc(var(--space-sm) + env(safe-area-inset-top));
     padding-right: calc(var(--space-md) + env(safe-area-inset-right));
-    padding-bottom: var(--space-sm);
+    padding-bottom: 0;
     background-color: transparent;
   }
   .enigme-mobile-actions {
@@ -6320,7 +6320,7 @@ li.active .enigme-menu__edit {
     max-height: calc(100vh - var(--space-xl));
   }
   .page-enigme {
-    margin-top: calc(var(--space-3xl) + var(--space-lg) + env(safe-area-inset-top));
+    margin-top: 0;
   }
 }
 body.no-scroll {


### PR DESCRIPTION
Supprime la position fixe du header mobile et espace ses boutons.

- Retrait de la position `fixed` du header mobile pour qu'il suive le défilement de la page
- Ajout d'un `gap` et d'un `padding-right` pour séparer correctement les boutons

**Testing**
- `source ./setup-env.sh && composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4f36184f083329c82f42f0066cce4