### PR TITLE
Rendre le logo organisateur cliquable sur la page chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -272,25 +272,30 @@ if ($edition_active && !$est_complet) {
         <?php endif; ?>
       </div>
 
-      <?php if ($organisateur_id) :
-          $logo_id = get_field('logo_organisateur', $organisateur_id, false);
-          $logo    = wp_get_attachment_image_src($logo_id, 'thumbnail');
-          $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
-      ?>
-        <div class="chasse-organisateur">
-          <img
-            class="chasse-organisateur__logo visuel-cpt"
-            src="<?= esc_url($logo_url); ?>"
-            alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
-            data-cpt="organisateur"
-            data-post-id="<?= esc_attr($organisateur_id); ?>"
-          />
-          <span class="chasse-organisateur__texte">
-            <a class="chasse-organisateur__nom" href="<?= esc_url(get_permalink($organisateur_id)); ?>"><?= esc_html($organisateur_nom); ?></a>
-            <span class="chasse-organisateur__presente"><?php esc_html_e('présente', 'chassesautresor-com'); ?></span>
-          </span>
-        </div>
-      <?php endif; ?>
+        <?php if ($organisateur_id) :
+            $logo_id = get_field('logo_organisateur', $organisateur_id, false);
+            $logo    = wp_get_attachment_image_src($logo_id, 'thumbnail');
+            $logo_url = $logo ? $logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
+        ?>
+          <div class="chasse-organisateur">
+            <a
+              href="<?= esc_url(get_permalink($organisateur_id)); ?>"
+              aria-label="<?= esc_attr__('Voir la page de l\u2019organisateur', 'chassesautresor-com'); ?>"
+            >
+              <img
+                class="chasse-organisateur__logo visuel-cpt"
+                src="<?= esc_url($logo_url); ?>"
+                alt="<?= esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
+                data-cpt="organisateur"
+                data-post-id="<?= esc_attr($organisateur_id); ?>"
+              />
+            </a>
+            <span class="chasse-organisateur__texte">
+              <a class="chasse-organisateur__nom" href="<?= esc_url(get_permalink($organisateur_id)); ?>"><?= esc_html($organisateur_nom); ?></a>
+              <span class="chasse-organisateur__presente"><?php esc_html_e('présente', 'chassesautresor-com'); ?></span>
+            </span>
+          </div>
+        <?php endif; ?>
 
       <!-- Titre dynamique -->
       <h1 class="titre-objet header-chasse"


### PR DESCRIPTION
## Résumé
- Permettre de cliquer sur le logo de l’organisateur depuis la fiche chasse

## Changements notables
- Encapsule le logo de l’organisateur dans un lien menant à sa page

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4f5c7268c8332bf39d1aedd1297f1