### PR TITLE
Réduire la limite de mots des cartes de chasse larges

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -53,7 +53,7 @@ $chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use (
             get_template_part('template-parts/chasse/chasse-card-wide', null, [
                 'chasse_id'        => $chasse_id,
                 'completion_class' => $classe_completion,
-                'word_limit'       => 150,
+                'word_limit'       => 75,
             ]);
             ?>
         </div>


### PR DESCRIPTION
## Résumé
- Limite la description des cartes de chasse larges à 75 mots

## Modifications
- Ajuste `word_limit` dans `organisateur-partial-boucle-chasses` à 75 mots

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c4f562dc248332be5cc9a7e4eb8e73