### PR TITLE
Réduction des métadonnées des chasses sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/meta-tap-info.js
+++ b/wp-content/themes/chassesautresor/assets/js/meta-tap-info.js
@@ -1,0 +1,12 @@
+// Affiche un message lors du tap sur les métadonnées
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.meta-indic[data-tap]').forEach(btn => {
+    const msg = btn.dataset.tap;
+    if (!msg) {
+      return;
+    }
+    btn.addEventListener('click', () => {
+      alert(msg);
+    });
+  });
+});

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -136,10 +136,10 @@
     padding: 0 var(--space-md) var(--space-md);
     font-size: 0.875rem;
     display: flex;
-    flex-direction: column;
     align-items: center;
-    gap: var(--space-xs);
-    text-align: center;
+    justify-content: flex-start;
+    gap: var(--space-sm);
+    flex-wrap: nowrap;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -233,7 +233,7 @@
 .chasse-footer {
     margin-top: var(--space-md);
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
 
     &__reward {
@@ -259,10 +259,10 @@
 .carte-wide__content .meta-row,
 .carte-compact__meta {
     display: flex;
-    gap: var(--space-xl);
+    gap: var(--space-md);
     align-items: center;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
     font-size: 93%;
     color: var(--color-gris-3);
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -266,6 +266,22 @@
     font-size: 93%;
     color: var(--color-gris-3);
 }
+
+.meta-regular .meta-indic {
+    background: none;
+    border: none;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+.meta-regular .meta-indic__count {
+    font-weight: 600;
+}
 .chasse-details-wrapper .bloc-metas-inline {
     margin: var(--space-xl) 0;
     color: white;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -123,10 +123,10 @@
   padding: 0 var(--space-md) var(--space-md);
   font-size: 0.875rem;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: var(--space-xs);
-  text-align: center;
+  justify-content: flex-start;
+  gap: var(--space-sm);
+  flex-wrap: nowrap;
 }
 
 /* ========== 🌟 Carte mise en avant ========== */
@@ -1006,7 +1006,7 @@
 .chasse-footer {
   margin-top: var(--space-md);
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
 }
 .chasse-footer__reward {
@@ -1028,10 +1028,10 @@
 .carte-wide__content .meta-row,
 .carte-compact__meta {
   display: flex;
-  gap: var(--space-xl);
+  gap: var(--space-md);
   align-items: center;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
   font-size: 93%;
   color: var(--color-gris-3);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1036,6 +1036,22 @@
   color: var(--color-gris-3);
 }
 
+.meta-regular .meta-indic {
+  background: none;
+  border: none;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.meta-regular .meta-indic__count {
+  font-weight: 600;
+}
+
 .chasse-details-wrapper .bloc-metas-inline {
   margin: var(--space-xl) 0;
   color: white;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1446,6 +1446,15 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         ? __('Illimitée', 'chassesautresor-com')
         : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
 
+    $timestamp_debut = convertir_en_timestamp($date_debut);
+    $timestamp_fin   = (!$illimitee && $date_fin) ? convertir_en_timestamp($date_fin) : false;
+    $date_debut_court = $timestamp_debut
+        ? wp_date('d/m/y', $timestamp_debut)
+        : __('Non spécifiée', 'chassesautresor-com');
+    $date_fin_court   = $illimitee
+        ? __('Illimitée', 'chassesautresor-com')
+        : ($timestamp_fin ? wp_date('d/m/y', $timestamp_fin) : __('Non spécifiée', 'chassesautresor-com'));
+
     $nb_joueurs       = compter_joueurs_engages_chasse($chasse_id);
     $nb_joueurs_label = formater_nombre_joueurs($nb_joueurs);
     $badge_class       = 'statut-' . $statut;
@@ -1570,12 +1579,15 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'image_id'          => $image_id,
         'image'             => $image,
         'total_enigmes'     => $total_enigmes,
+        'nb_joueurs'        => $nb_joueurs,
         'nb_joueurs_label'  => $nb_joueurs_label,
         'cout_points'       => $cout_points,
         'mode_validation'   => $mode_validation,
         'mode_fin'          => $champs['mode_fin'],
         'date_debut'        => $date_debut_affichage,
         'date_fin'          => $date_fin_affichage,
+        'date_debut_court'  => $date_debut_court,
+        'date_fin_court'    => $date_fin_court,
         'badge_class'       => $badge_class,
         'statut_label'      => $statut_label,
         'classe_statut'     => $badge_class,

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -139,6 +139,13 @@ function charger_scripts_personnalises() {
         true
     );
     wp_enqueue_script(
+        'meta-tap-info',
+        $theme_dir . 'meta-tap-info.js',
+        [],
+        filemtime(get_stylesheet_directory() . '/assets/js/meta-tap-info.js'),
+        true
+    );
+    wp_enqueue_script(
         'chasse-description-toggle',
         $theme_dir . 'chasse-description-toggle.js',
         [],

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -2813,6 +2813,12 @@ msgstr ""
 msgid "nombre de joueurs ayant trouvé la bonne réponse"
 msgstr ""
 
+msgid "nombre d'énigmes"
+msgstr ""
+
+msgid "nombre de joueurs"
+msgstr ""
+
 #: wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php:189
 msgid "tentatives quotidiennes utilisées"
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -2356,6 +2356,12 @@ msgstr "number of participants for this puzzle"
 msgid "nombre de joueurs ayant trouvé la bonne réponse"
 msgstr "number of players who found the correct answer"
 
+msgid "nombre d'énigmes"
+msgstr "number of puzzles"
+
+msgid "nombre de joueurs"
+msgstr "number of players"
+
 #: template-parts/enigme/chasse-partial-boucle-enigmes.php:189
 msgid "tentatives quotidiennes utilisées"
 msgstr "daily attempts used"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -2385,6 +2385,12 @@ msgstr "nombre de participants à cette énigme"
 msgid "nombre de joueurs ayant trouvé la bonne réponse"
 msgstr "nombre de joueurs ayant trouvé la bonne réponse"
 
+msgid "nombre d'énigmes"
+msgstr "nombre d'énigmes"
+
+msgid "nombre de joueurs"
+msgstr "nombre de joueurs"
+
 #: template-parts/enigme/chasse-partial-boucle-enigmes.php:189
 msgid "tentatives quotidiennes utilisées"
 msgstr "tentatives quotidiennes utilisées"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -34,23 +34,20 @@ if (empty($infos)) {
     </a>
     <div class="carte-cart__footer meta-row svg-xsmall">
         <div class="meta-regular">
-            <?php echo get_svg_icon('enigme'); ?>
-            <?php
-            echo esc_html(
-                sprintf(
-                    _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
-                    $infos['total_enigmes']
-                )
-            );
-            ?>
-            —
-            <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+            <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre d\'énigmes', 'chassesautresor-com'); ?>">
+                <?php echo get_svg_icon('enigme'); ?>
+                <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['total_enigmes'])); ?></span>
+            </button>
+            <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre de joueurs', 'chassesautresor-com'); ?>">
+                <?php echo get_svg_icon('participants'); ?>
+                <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['nb_joueurs'])); ?></span>
+            </button>
         </div>
         <div class="meta-etiquette">
             <?php echo get_svg_icon('calendar'); ?>
             <span class="chasse-date-plage">
-                <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
-                <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                <span class="date-debut"><?php echo esc_html($infos['date_debut_court']); ?></span> –
+                <span class="date-fin"><?php echo esc_html($infos['date_fin_court']); ?></span>
             </span>
         </div>
     </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -29,15 +29,20 @@ if (empty($infos)) {
 
         <div class="meta-row svg-xsmall">
             <div class="meta-regular">
-                <?php echo get_svg_icon('enigme'); ?>
-                <?php echo esc_html(sprintf(_n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'), $infos['total_enigmes'])); ?> —
-                <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+                <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre d\'énigmes', 'chassesautresor-com'); ?>">
+                    <?php echo get_svg_icon('enigme'); ?>
+                    <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['total_enigmes'])); ?></span>
+                </button>
+                <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre de joueurs', 'chassesautresor-com'); ?>">
+                    <?php echo get_svg_icon('participants'); ?>
+                    <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['nb_joueurs'])); ?></span>
+                </button>
             </div>
             <div class="meta-etiquette">
                 <?php echo get_svg_icon('calendar'); ?>
                 <span class="chasse-date-plage">
-                    <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
-                    <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                    <span class="date-debut"><?php echo esc_html($infos['date_debut_court']); ?></span> –
+                    <span class="date-fin"><?php echo esc_html($infos['date_fin_court']); ?></span>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
## Résumé
- Simplifie les métas des cartes de chasse avec icônes et nombres uniquement
- Affiche les dates au format court et ajoute des messages au tap
- Ajoute les traductions et les styles associés

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c50a43330c83329b167bc9984f30b9