### PR TITLE
Génération dynamique des titres d'indice

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ d’énigme pour choisir la cible de l’indice.
 
 ### Titres d’indice et langues
 
-Le champ `post_title` des indices conserve uniquement un libellé neutre. Le rang est
-stocké dans la métadonnée `indice_rank` et l’intitulé final est généré dynamiquement
-(`Indice #n`) en fonction de la langue active lors de l’affichage.
+Le champ `post_title` des indices conserve uniquement un libellé neutre, construit sous
+la forme `clue-[slug-de-la-chasse]`. Le rang est stocké dans la métadonnée
+`indice_rank` et l’intitulé final est généré dynamiquement (`Indice #n`) en fonction de
+la langue active lors de l’affichage.
 
 ### Accessibilité
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ charger via l’endpoint AJAX `chasse_lister_enigmes` la liste des énigmes admi
 ainsi que le rang du prochain indice pour chacune. La modale affiche alors un sélecteur
 d’énigme pour choisir la cible de l’indice.
 
+### Titres d’indice et langues
+
+Le champ `post_title` des indices conserve uniquement un libellé neutre. Le rang est
+stocké dans la métadonnée `indice_rank` et l’intitulé final est généré dynamiquement
+(`Indice #n`) en fonction de la langue active lors de l’affichage.
+
 ### Accessibilité
 
 Les libellés du formulaire utilisent `color: var(--color-editor-text)` afin de rester lisibles sur fond clair. Évitez d'appliquer `--color-text-primary` dans ce contexte pour garantir un contraste suffisant.

--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -3,6 +3,9 @@ namespace {
     if (!defined('TITRE_DEFAUT_INDICE')) {
         define('TITRE_DEFAUT_INDICE', 'indice');
     }
+    if (!defined('INDICE_DEFAULT_PREFIX')) {
+        define('INDICE_DEFAULT_PREFIX', 'clue-');
+    }
 
     if (!function_exists('__')) {
         function __($text, $domain = null) { return $text; }

--- a/tests/CreerIndicePermissionsTest.php
+++ b/tests/CreerIndicePermissionsTest.php
@@ -81,6 +81,9 @@ namespace {
     if (!function_exists('wp_update_post')) {
         function wp_update_post($args) { global $updated_posts; $updated_posts[] = $args; return $args['ID'] ?? 123; }
     }
+    if (!function_exists('update_post_meta')) {
+        function update_post_meta($post_id, $key, $value) { global $updated_meta; $updated_meta[$post_id][$key] = $value; }
+    }
 
     if (!function_exists('update_field')) {
         function update_field($field, $value, $post_id) { global $updated_fields; $updated_fields[$field] = $value; }
@@ -129,28 +132,31 @@ class CreerIndicePermissionsTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $is_logged_in, $can_edit, $mocked_existing_indices, $mocked_fields;
-        $is_logged_in = true;
-        $can_edit = false;
+        global $is_logged_in, $can_edit, $mocked_existing_indices, $mocked_fields, $updated_meta;
+        $is_logged_in           = true;
+        $can_edit               = false;
         $mocked_existing_indices = [];
-        $mocked_fields = [];
+        $mocked_fields          = [];
+        $updated_meta           = [];
     }
 
     protected function tearDown(): void
     {
-        global $is_logged_in, $can_edit, $mocked_existing_indices, $mocked_fields;
-        $is_logged_in = true;
-        $can_edit = false;
+        global $is_logged_in, $can_edit, $mocked_existing_indices, $mocked_fields, $updated_meta;
+        $is_logged_in           = true;
+        $can_edit               = false;
         $mocked_existing_indices = [];
-        $mocked_fields = [];
+        $mocked_fields          = [];
+        $updated_meta           = [];
     }
 
     public function test_creates_indice_when_authorised(): void
     {
-        global $can_edit, $updated_fields, $updated_posts, $mocked_existing_indices;
-        $can_edit = true;
-        $updated_fields = [];
-        $updated_posts = [];
+        global $can_edit, $updated_fields, $updated_posts, $mocked_existing_indices, $updated_meta;
+        $can_edit               = true;
+        $updated_fields         = [];
+        $updated_posts          = [];
+        $updated_meta           = [];
         $mocked_existing_indices = [10, 11];
 
         $result = \creer_indice_pour_objet(42, 'chasse');
@@ -162,7 +168,7 @@ class CreerIndicePermissionsTest extends TestCase
         $this->assertSame($expected_date, $updated_fields['indice_date_disponibilite']);
         $this->assertSame('desactive', $updated_fields['indice_cache_etat_systeme']);
         $this->assertFalse($updated_fields['indice_cache_complet']);
-        $this->assertSame('Indice #3', $updated_posts[0]['post_title']);
+        $this->assertSame(3, $updated_meta[123]['indice_rank']);
     }
 
     public function test_utilisateur_peut_editer_indice_desactive(): void

--- a/tests/EnigmeParticipationInfosTest.php
+++ b/tests/EnigmeParticipationInfosTest.php
@@ -8,6 +8,9 @@ if (!defined('ABSPATH')) {
 if (!defined('TITRE_DEFAUT_INDICE')) {
     define('TITRE_DEFAUT_INDICE', 'indice');
 }
+if (!defined('INDICE_DEFAULT_PREFIX')) {
+    define('INDICE_DEFAULT_PREFIX', 'clue-');
+}
 
 if (!function_exists('esc_html')) {
     function esc_html($text)

--- a/tests/IndiceCreationTest.php
+++ b/tests/IndiceCreationTest.php
@@ -3,6 +3,9 @@ namespace {
     if (!defined('TITRE_DEFAUT_INDICE')) {
         define('TITRE_DEFAUT_INDICE', 'indice');
     }
+    if (!defined('INDICE_DEFAULT_PREFIX')) {
+        define('INDICE_DEFAULT_PREFIX', 'clue-');
+    }
 
     if (!function_exists('__')) {
         function __($text, $domain = null) { return $text; }

--- a/tests/IndiceDatePrefillTest.php
+++ b/tests/IndiceDatePrefillTest.php
@@ -65,6 +65,19 @@ namespace {
             return null;
         }
     }
+    if (!function_exists('get_post_meta')) {
+        function get_post_meta($post_id, $key, $single = false)
+        {
+            global $post_meta;
+            return $post_meta[$post_id][$key] ?? '';
+        }
+    }
+    if (!function_exists('get_indice_title')) {
+        function get_indice_title($post)
+        {
+            return get_the_title(is_object($post) ? $post->ID : $post);
+        }
+    }
 }
 
 namespace IndiceDatePrefill {
@@ -101,6 +114,8 @@ namespace IndiceDatePrefill {
             $objet_id = 10;
             $img_url = '';
 
+            global $post_meta;
+            $post_meta = [123 => ['indice_rank' => 1]];
             ob_start();
             require __DIR__ . '/../wp-content/themes/chassesautresor/template-parts/common/indices-table.php';
             $output = ob_get_clean();

--- a/tests/IndiceEnigmeCreationTest.php
+++ b/tests/IndiceEnigmeCreationTest.php
@@ -32,6 +32,10 @@ if (!function_exists('get_post_type')) {
     function get_post_type($id) { return 'enigme'; }
 }
 
+if (!function_exists('get_post_field')) {
+    function get_post_field($field, $post_id) { return $field === 'post_title' ? 'Chasse' : ''; }
+}
+
 if (!function_exists('indice_action_autorisee')) {
     function indice_action_autorisee($action, $type, $id) { return true; }
 }
@@ -54,6 +58,9 @@ if (!function_exists('sanitize_text_field')) {
 
 if (!defined('TITRE_DEFAUT_INDICE')) {
     define('TITRE_DEFAUT_INDICE', 'indice');
+}
+if (!defined('INDICE_DEFAULT_PREFIX')) {
+    define('INDICE_DEFAULT_PREFIX', 'clue-');
 }
 
 if (!defined('DAY_IN_SECONDS')) {

--- a/tests/IndiceEnigmeCreationTest.php
+++ b/tests/IndiceEnigmeCreationTest.php
@@ -79,6 +79,9 @@ if (!function_exists('wp_insert_post')) {
 if (!function_exists('wp_update_post')) {
     function wp_update_post($args) { return true; }
 }
+if (!function_exists('update_post_meta')) {
+    function update_post_meta($post_id, $key, $value) { }
+}
 
 if (!function_exists('get_posts')) {
     function get_posts($args) { return []; }

--- a/tests/ReordonnerIndicesTest.php
+++ b/tests/ReordonnerIndicesTest.php
@@ -3,6 +3,9 @@ namespace {
     if (!defined('TITRE_DEFAUT_INDICE')) {
         define('TITRE_DEFAUT_INDICE', 'indice');
     }
+    if (!defined('INDICE_DEFAULT_PREFIX')) {
+        define('INDICE_DEFAULT_PREFIX', 'clue-');
+    }
     if (!function_exists('get_posts')) {
         function get_posts($args)
         {
@@ -74,7 +77,7 @@ namespace ReordonnerIndicesTest {
             global $updated_posts, $simulate_recursion, $get_field_overrides, $captured_args, $updated_meta, $post_titles;
             $updated_posts      = [];
             $updated_meta       = [];
-            $post_titles        = [10 => 'Indice #1', 20 => 'Indice #2', 30 => 'Indice #3'];
+            $post_titles        = [5 => 'Mocked chasse', 10 => 'Indice #1', 20 => 'Indice #2', 30 => 'Indice #3'];
             $simulate_recursion = 0;
             $captured_args      = [];
             $get_field_overrides = [
@@ -95,9 +98,9 @@ namespace ReordonnerIndicesTest {
             \reordonner_indices(5, 'chasse');
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'clue-mocked-chasse'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'clue-mocked-chasse'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'clue-mocked-chasse'], $updated_posts[2]);
             $this->assertSame(1, $updated_meta[10]['indice_rank']);
             $this->assertSame(2, $updated_meta[20]['indice_rank']);
             $this->assertSame(3, $updated_meta[30]['indice_rank']);
@@ -118,9 +121,9 @@ namespace ReordonnerIndicesTest {
             \reordonner_indices_apres_suppression(99);
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'clue-mocked-chasse'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'clue-mocked-chasse'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'clue-mocked-chasse'], $updated_posts[2]);
             $this->assertSame(1, $updated_meta[10]['indice_rank']);
             $this->assertSame(2, $updated_meta[20]['indice_rank']);
             $this->assertSame(3, $updated_meta[30]['indice_rank']);
@@ -140,9 +143,9 @@ namespace ReordonnerIndicesTest {
             \reordonner_indices(5, 'chasse');
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'clue-mocked-chasse'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'clue-mocked-chasse'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'clue-mocked-chasse'], $updated_posts[2]);
             $this->assertSame(1, $updated_meta[10]['indice_rank']);
             $this->assertSame(2, $updated_meta[20]['indice_rank']);
             $this->assertSame(3, $updated_meta[30]['indice_rank']);
@@ -160,9 +163,9 @@ namespace ReordonnerIndicesTest {
             \reordonner_indices_apres_enregistrement(99);
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'clue-mocked-chasse'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'clue-mocked-chasse'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'clue-mocked-chasse'], $updated_posts[2]);
             $this->assertSame(1, $updated_meta[10]['indice_rank']);
             $this->assertSame(2, $updated_meta[20]['indice_rank']);
             $this->assertSame(3, $updated_meta[30]['indice_rank']);
@@ -184,7 +187,7 @@ namespace ReordonnerIndicesTest {
             \reordonner_indices_pour_indice(99);
 
             $this->assertCount(6, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'clue-mocked-chasse'], $updated_posts[0]);
             $this->assertCount(2, $captured_args);
             $this->assertSame('indice_enigme_linked', $captured_args[0]['meta_query'][1]['key']);
             $this->assertSame('indice_chasse_linked', $captured_args[1]['meta_query'][0]['key']);

--- a/tests/ReordonnerIndicesTest.php
+++ b/tests/ReordonnerIndicesTest.php
@@ -37,7 +37,14 @@ namespace {
         function get_post_field($field, $post_id)
         {
             global $post_titles;
-            return $field === 'post_title' ? ($post_titles[$post_id] ?? '') : '';
+            if ($field === 'post_title') {
+                return $post_titles[$post_id] ?? '';
+            }
+            if ($field === 'post_name') {
+                $title = $post_titles[$post_id] ?? '';
+                return strtolower(str_replace(' ', '-', $title));
+            }
+            return '';
         }
     }
     if (!function_exists('__')) {
@@ -82,7 +89,7 @@ namespace ReordonnerIndicesTest {
             $captured_args      = [];
             $get_field_overrides = [
                 'indice_cible_type'    => 'chasse',
-                'indice_chasse_linked' => 5,
+                'indice_chasse_linked' => [['ID' => 5]],
             ];
         }
 
@@ -179,8 +186,8 @@ namespace ReordonnerIndicesTest {
         {
             global $updated_posts, $get_field_overrides, $captured_args, $updated_meta;
             $get_field_overrides['indice_cible_type']   = 'enigme';
-            $get_field_overrides['indice_chasse_linked'] = 5;
-            $get_field_overrides['indice_enigme_linked'] = 15;
+            $get_field_overrides['indice_chasse_linked'] = [['ID' => 5]];
+            $get_field_overrides['indice_enigme_linked'] = [['ID' => 15]];
 
             require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
 

--- a/tests/ReordonnerIndicesTest.php
+++ b/tests/ReordonnerIndicesTest.php
@@ -1,5 +1,8 @@
 <?php
 namespace {
+    if (!defined('TITRE_DEFAUT_INDICE')) {
+        define('TITRE_DEFAUT_INDICE', 'indice');
+    }
     if (!function_exists('get_posts')) {
         function get_posts($args)
         {
@@ -17,6 +20,21 @@ namespace {
                 \reordonner_indices(5, 'chasse');
             }
             return true;
+        }
+    }
+    if (!function_exists('update_post_meta')) {
+        function update_post_meta($post_id, $key, $value)
+        {
+            global $updated_meta;
+            $updated_meta[$post_id][$key] = $value;
+            return true;
+        }
+    }
+    if (!function_exists('get_post_field')) {
+        function get_post_field($field, $post_id)
+        {
+            global $post_titles;
+            return $field === 'post_title' ? ($post_titles[$post_id] ?? '') : '';
         }
     }
     if (!function_exists('__')) {
@@ -53,12 +71,14 @@ namespace ReordonnerIndicesTest {
     {
         protected function setUp(): void
         {
-            global $updated_posts, $simulate_recursion, $get_field_overrides, $captured_args;
+            global $updated_posts, $simulate_recursion, $get_field_overrides, $captured_args, $updated_meta, $post_titles;
             $updated_posts      = [];
+            $updated_meta       = [];
+            $post_titles        = [10 => 'Indice #1', 20 => 'Indice #2', 30 => 'Indice #3'];
             $simulate_recursion = 0;
             $captured_args      = [];
             $get_field_overrides = [
-                'indice_cible_type'   => 'chasse',
+                'indice_cible_type'    => 'chasse',
                 'indice_chasse_linked' => 5,
             ];
         }
@@ -69,15 +89,18 @@ namespace ReordonnerIndicesTest {
          */
         public function test_renames_indices_sequentially(): void
         {
-            global $updated_posts, $captured_args;
+            global $updated_posts, $captured_args, $updated_meta;
             require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
 
             \reordonner_indices(5, 'chasse');
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'Indice #1'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'Indice #2'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'Indice #3'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(1, $updated_meta[10]['indice_rank']);
+            $this->assertSame(2, $updated_meta[20]['indice_rank']);
+            $this->assertSame(3, $updated_meta[30]['indice_rank']);
             $this->assertSame('indice_chasse_linked', $captured_args[0]['meta_query'][0]['key']);
             $this->assertCount(2, $captured_args[0]['meta_query']);
         }
@@ -88,16 +111,19 @@ namespace ReordonnerIndicesTest {
          */
         public function test_reorders_after_permanent_deletion(): void
         {
-            global $updated_posts, $indice_delete_context, $captured_args;
+            global $updated_posts, $indice_delete_context, $captured_args, $updated_meta;
             require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
 
             $indice_delete_context = ['objet_id' => 5, 'objet_type' => 'chasse', 'chasse_id' => 5];
             \reordonner_indices_apres_suppression(99);
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'Indice #1'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'Indice #2'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'Indice #3'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(1, $updated_meta[10]['indice_rank']);
+            $this->assertSame(2, $updated_meta[20]['indice_rank']);
+            $this->assertSame(3, $updated_meta[30]['indice_rank']);
             $this->assertSame('indice_chasse_linked', $captured_args[0]['meta_query'][0]['key']);
         }
 
@@ -107,16 +133,19 @@ namespace ReordonnerIndicesTest {
          */
         public function test_prevents_recursive_reordering(): void
         {
-            global $updated_posts, $simulate_recursion;
+            global $updated_posts, $simulate_recursion, $updated_meta;
             $simulate_recursion = 1;
             require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
 
             \reordonner_indices(5, 'chasse');
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'Indice #1'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'Indice #2'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'Indice #3'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(1, $updated_meta[10]['indice_rank']);
+            $this->assertSame(2, $updated_meta[20]['indice_rank']);
+            $this->assertSame(3, $updated_meta[30]['indice_rank']);
         }
 
         /**
@@ -125,15 +154,18 @@ namespace ReordonnerIndicesTest {
          */
         public function test_reorders_after_save_post(): void
         {
-            global $updated_posts;
+            global $updated_posts, $updated_meta;
             require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-indice.php';
 
             \reordonner_indices_apres_enregistrement(99);
 
             $this->assertCount(3, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'Indice #1'], $updated_posts[0]);
-            $this->assertSame(['ID' => 20, 'post_title' => 'Indice #2'], $updated_posts[1]);
-            $this->assertSame(['ID' => 30, 'post_title' => 'Indice #3'], $updated_posts[2]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
+            $this->assertSame(['ID' => 20, 'post_title' => 'indice'], $updated_posts[1]);
+            $this->assertSame(['ID' => 30, 'post_title' => 'indice'], $updated_posts[2]);
+            $this->assertSame(1, $updated_meta[10]['indice_rank']);
+            $this->assertSame(2, $updated_meta[20]['indice_rank']);
+            $this->assertSame(3, $updated_meta[30]['indice_rank']);
         }
 
         /**
@@ -142,7 +174,7 @@ namespace ReordonnerIndicesTest {
          */
         public function test_reorders_enigme_indices_using_chasse_context(): void
         {
-            global $updated_posts, $get_field_overrides, $captured_args;
+            global $updated_posts, $get_field_overrides, $captured_args, $updated_meta;
             $get_field_overrides['indice_cible_type']   = 'enigme';
             $get_field_overrides['indice_chasse_linked'] = 5;
             $get_field_overrides['indice_enigme_linked'] = 15;
@@ -152,10 +184,11 @@ namespace ReordonnerIndicesTest {
             \reordonner_indices_pour_indice(99);
 
             $this->assertCount(6, $updated_posts);
-            $this->assertSame(['ID' => 10, 'post_title' => 'Indice #1'], $updated_posts[0]);
+            $this->assertSame(['ID' => 10, 'post_title' => 'indice'], $updated_posts[0]);
             $this->assertCount(2, $captured_args);
             $this->assertSame('indice_enigme_linked', $captured_args[0]['meta_query'][1]['key']);
             $this->assertSame('indice_chasse_linked', $captured_args[1]['meta_query'][0]['key']);
+            $this->assertSame(1, $updated_meta[10]['indice_rank']);
         }
     }
 }

--- a/wp-content/themes/chassesautresor/inc/enigme/affichage.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/affichage.php
@@ -733,20 +733,13 @@ require_once __DIR__ . '/indices.php';
                     if ($est_debloque) {
                         $classes   = 'indice-link indice-link--unlocked etiquette';
                         $etat_icon = 'fa-eye';
-                        $title_ind = get_the_title($indice_id);
-                        $label     = $title_ind !== '' ? esc_html($title_ind) : sprintf(
-                            esc_html__('Indice #%d', 'chassesautresor-com'),
-                            $i + 1
-                        );
                     } else {
                         $classes   = 'indice-link indice-link--locked etiquette';
                         $etat_icon = 'fa-lightbulb';
-                        $title_ind = get_the_title($indice_id);
-                        $label     = $title_ind !== '' ? esc_html($title_ind) : sprintf(
-                            esc_html__('Indice #%d', 'chassesautresor-com'),
-                            $i + 1
-                        );
                     }
+
+                    $title_ind = get_indice_title($indice_id);
+                    $label     = esc_html($title_ind);
 
                     $cout_html = $cout_indice > 0
                         ? ' - ' . $cout_indice . ' <sup>'

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -14,11 +14,16 @@ function get_indice_title($post): string
         return '';
     }
 
-    $title        = (string) $post->post_title;
-    $rank         = (int) get_post_meta($post->ID, 'indice_rank', true);
-    $default      = defined('TITRE_DEFAUT_INDICE') ? TITRE_DEFAUT_INDICE : '';
+    $title   = (string) $post->post_title;
+    $rank    = (int) get_post_meta($post->ID, 'indice_rank', true);
+    $default = defined('TITRE_DEFAUT_INDICE') ? TITRE_DEFAUT_INDICE : '';
+    $prefix  = defined('INDICE_DEFAULT_PREFIX') ? INDICE_DEFAULT_PREFIX : '';
 
-    if ($title === '' || $title === $default) {
+    if (
+        $title === ''
+        || $title === $default
+        || ($prefix !== '' && strpos($title, $prefix) === 0)
+    ) {
         return sprintf(__('Indice #%d', 'chassesautresor-com'), $rank);
     }
 

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -95,8 +95,14 @@ function debloquer_indice(): void
         ]);
     }
 
-    $cout      = (int) get_field('indice_cout_points', $indice_id);
-    $chasse_id = (int) get_field('indice_chasse_linked', $indice_id);
+    $cout        = (int) get_field('indice_cout_points', $indice_id);
+    $chasse_raw  = get_field('indice_chasse_linked', $indice_id);
+    if (is_array($chasse_raw)) {
+        $first     = $chasse_raw[0] ?? null;
+        $chasse_id = is_array($first) ? (int) ($first['ID'] ?? 0) : (int) $first;
+    } else {
+        $chasse_id = (int) $chasse_raw;
+    }
     $enigme_id = (int) get_field('indice_enigme_linked', $indice_id);
 
     if ($cout > 0) {

--- a/wp-content/themes/chassesautresor/inc/enigme/indices.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/indices.php
@@ -2,6 +2,30 @@
 defined('ABSPATH') || exit;
 
 /**
+ * Retrieve the display title for an indice.
+ *
+ * @param int|WP_Post $post Indice object or ID.
+ * @return string
+ */
+function get_indice_title($post): string
+{
+    $post        = get_post($post);
+    if (!$post) {
+        return '';
+    }
+
+    $title        = (string) $post->post_title;
+    $rank         = (int) get_post_meta($post->ID, 'indice_rank', true);
+    $default      = defined('TITRE_DEFAUT_INDICE') ? TITRE_DEFAUT_INDICE : '';
+
+    if ($title === '' || $title === $default) {
+        return sprintf(__('Indice #%d', 'chassesautresor-com'), $rank);
+    }
+
+    return $title;
+}
+
+/**
  * Check if a hint has been unlocked by a user.
  *
  * @param int $user_id   User identifier.

--- a/wp-content/themes/chassesautresor/inc/utils/titres.php
+++ b/wp-content/themes/chassesautresor/inc/utils/titres.php
@@ -17,6 +17,7 @@ define('TITRE_DEFAUT_CHASSE', 'Nouvelle chasse');
 define('TITRE_DEFAUT_ENIGME', 'en création');
 define('TITRE_DEFAUT_INDICE', 'Nouvel indice');
 define('TITRE_DEFAUT_SOLUTION', 'Nouvelle solution');
+define('INDICE_DEFAULT_PREFIX', 'clue-');
 
 /**
  * Retourne le titre par défaut associé à un type de post donné.
@@ -59,6 +60,13 @@ function titre_est_valide(int $post_id): bool {
     $defaut = get_titre_defaut(get_post_type($post_id));
     if ($defaut !== '' && strcasecmp($titre, $defaut) === 0) {
         return false;
+    }
+
+    if (get_post_type($post_id) === 'indice') {
+        $prefix = defined('INDICE_DEFAULT_PREFIX') ? INDICE_DEFAULT_PREFIX : '';
+        if ($prefix !== '' && strpos($titre, $prefix) === 0) {
+            return false;
+        }
     }
 
     return true;

--- a/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
+++ b/wp-content/themes/chassesautresor/template-parts/common/indices-table.php
@@ -68,8 +68,8 @@ if (empty($indices)) {
         </tr>
     </thead>
     <tbody>
-        <?php foreach ($indices as $index => $indice) :
-            $indice_rank = $index + 1;
+        <?php foreach ($indices as $indice) :
+            $indice_rank = (int) get_post_meta($indice->ID, 'indice_rank', true);
             $timestamp   = strtotime($indice->post_date);
             $locale      = function_exists('determine_locale')
                 ? determine_locale()
@@ -87,12 +87,8 @@ if (empty($indices)) {
                 $img_url = wp_get_attachment_image_url($img_id, 'thumbnail') ?: '';
             }
 
-            $indice_title_raw = get_the_title($indice->ID);
-            $default_title    = defined('TITRE_DEFAUT_INDICE') ? TITRE_DEFAUT_INDICE : '';
-            $indice_title     = $indice_title_raw !== '' && $indice_title_raw !== $default_title
-                ? $indice_title_raw
-                : sprintf(__('Indice #%d', 'chassesautresor-com'), $indice_rank);
-            $contenu          = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
+            $indice_title = get_indice_title($indice);
+            $contenu      = wp_strip_all_tags(get_field('indice_contenu', $indice->ID) ?: '');
             $dispo   = get_field('indice_disponibilite', $indice->ID) ?: 'immediate';
 
             $date_raw   = get_field('indice_date_disponibilite', $indice->ID) ?: '';


### PR DESCRIPTION
## Résumé
- Gérer les titres d'indice via une métadonnée de rang et un placeholder neutre
- Afficher le titre via `get_indice_title()` selon la langue active

## Changements notables
- Enregistrement du rang dans `indice_rank` et suppression du numéro dans `post_title`
- Ajout de `get_indice_title()` et usage dans les templates et l'affichage des énigmes
- Documentation sur la gestion multi‑langue des titres

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c579ce10048332b65df07c71e0b911