### PR TITLE
Fix chasse footer layout on wide cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -233,8 +233,15 @@
 .chasse-footer {
     margin-top: var(--space-md);
     display: flex;
-    justify-content: flex-start;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-xs);
+
+    @media (--bp-desktop) {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
 
     &__reward {
         font-weight: 700;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1006,8 +1006,16 @@
 .chasse-footer {
   margin-top: var(--space-md);
   display: flex;
-  justify-content: flex-start;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
+}
+@media (min-width: 1024px) {
+  .chasse-footer {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
 }
 .chasse-footer__reward {
   font-weight: 700;


### PR DESCRIPTION
## Summary
- corrige l’alignement du footer des cartes de chasse en mode pleine largeur
- ajoute un style responsive pour séparer récompense et organisateur

## Testing
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c631e7e42083329b2b1d71eda647a4