### PR TITLE
feat: add trophy icon to rewards block

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -245,6 +245,11 @@
 
     &__reward {
         font-weight: 700;
+
+        .fa-trophy {
+            margin-right: 0.3em;
+            color: var(--color-gris-3);
+        }
     }
 
     &__texte {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1020,6 +1020,10 @@
 .chasse-footer__reward {
   font-weight: 700;
 }
+.chasse-footer__reward .fa-trophy {
+  margin-right: 0.3em;
+  color: var(--color-gris-3);
+}
 .chasse-footer__texte {
   color: var(--color-gris-3);
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -115,6 +115,7 @@ if (empty($infos)) {
                 <footer class="chasse-footer">
                     <?php if (!empty($reward_title) && (float) $reward_value > 0) : ?>
                         <span class="chasse-footer__reward">
+                            <i class="fa-solid fa-trophy" aria-hidden="true"></i>
                             <?php
                             printf(
                                 esc_html__('%1$s — %2$s €', 'chassesautresor-com'),


### PR DESCRIPTION
## Résumé
- ajout d'une icône trophée dans le bloc récompenses des cartes de chasse
- harmonisation du style pour respecter la couleur des pictogrammes

## Changements notables
- ajout d'une icône Font Awesome pour les récompenses
- style dédié à l'icône dans les SCSS et CSS compilés

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c633694c2c83328476fb4a1c6b9e60