### PR TITLE
feat: add organizer logo to hunt card

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -254,6 +254,22 @@
 
     &__texte {
         color: var(--color-gris-3);
+        display: flex;
+        align-items: center;
+        gap: var(--space-xs);
+    }
+
+    &__logo {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        object-fit: cover;
+        filter: grayscale(1);
+        transition: filter 0.3s;
+    }
+
+    &__logo-link:hover &__logo {
+        filter: none;
     }
 
     &__nom {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1026,6 +1026,21 @@
 }
 .chasse-footer__texte {
   color: var(--color-gris-3);
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+.chasse-footer__logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  filter: grayscale(1);
+  transition: filter 0.3s;
+}
+.chasse-footer__logo-link:hover .chasse-footer__logo {
+  filter: none;
 }
 .chasse-footer__nom {
   font-weight: 700;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -133,6 +133,7 @@ if (empty($infos)) {
                         </span>
                     <?php endif; ?>
                     <span class="chasse-footer__texte">
+                        <?php echo esc_html__('Proposé par', 'chassesautresor-com'); ?>
                         <a class="chasse-footer__logo-link" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
                             <img
                                 class="chasse-organisateur__logo chasse-footer__logo visuel-cpt"
@@ -142,7 +143,6 @@ if (empty($infos)) {
                                 data-post-id="<?php echo esc_attr($orga_id); ?>"
                             />
                         </a>
-                        <?php echo esc_html__('Proposé par', 'chassesautresor-com'); ?>
                         <a class="chasse-footer__nom" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
                             <?php echo esc_html(get_the_title($orga_id)); ?>
                         </a>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -15,6 +15,13 @@ $title_mode      = $mode_fin === 'automatique'
     : esc_html__('mode de fin de chasse : manuelle', 'chassesautresor-com');
 
 $orga_id = get_organisateur_from_chasse($chasse_id);
+$orga_logo_url = '';
+
+if ($orga_id) {
+    $orga_logo_id  = get_field('logo_organisateur', $orga_id, false);
+    $orga_logo     = wp_get_attachment_image_src($orga_logo_id, 'thumbnail');
+    $orga_logo_url = $orga_logo ? $orga_logo[0] : wp_get_attachment_image_src(3927, 'thumbnail')[0];
+}
 
 if (empty($infos)) {
     return;
@@ -126,6 +133,15 @@ if (empty($infos)) {
                         </span>
                     <?php endif; ?>
                     <span class="chasse-footer__texte">
+                        <a class="chasse-footer__logo-link" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
+                            <img
+                                class="chasse-organisateur__logo chasse-footer__logo visuel-cpt"
+                                src="<?php echo esc_url($orga_logo_url); ?>"
+                                alt="<?php echo esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
+                                data-cpt="organisateur"
+                                data-post-id="<?php echo esc_attr($orga_id); ?>"
+                            />
+                        </a>
                         <?php echo esc_html__('Proposé par', 'chassesautresor-com'); ?>
                         <a class="chasse-footer__nom" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
                             <?php echo esc_html(get_the_title($orga_id)); ?>


### PR DESCRIPTION
## Résumé
- affiche le logo de l'organisateur dans le footer des cartes de chasse
- applique un filtre noir et blanc par défaut avec retour à la couleur au survol

## Testing
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c6359cf4148332b4f8641e7b64d508