### PR TITLE
Affiche la récompense sous le titre dans les cartes compactes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -148,13 +148,16 @@
 .carte-cart .chasse-lot {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-xxs);
   font-size: 0.875rem;
+  color: var(--color-text-primary);
 }
 
 .carte-compact .chasse-lot .badge-recompense,
 .carte-cart .chasse-lot .badge-recompense {
   margin-left: 0;
+  color: var(--color-text-primary);
 }
 
 .carte-compact .chasse-lot__title,

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -143,6 +143,34 @@
   }
 }
 
+/* ========== 🎁 Récompense dans les cartes compactes ========== */
+.carte-compact .chasse-lot,
+.carte-cart .chasse-lot {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  font-size: 0.875rem;
+}
+
+.carte-compact .chasse-lot .badge-recompense,
+.carte-cart .chasse-lot .badge-recompense {
+  margin-left: 0;
+}
+
+.carte-compact .chasse-lot__title,
+.carte-cart .chasse-lot__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.carte-compact .chasse-lot__icon svg,
+.carte-cart .chasse-lot__icon svg {
+  width: 20px;
+  height: 20px;
+  color: var(--color-grey-light);
+}
+
 /* ========== 🌟 Carte mise en avant ========== */
 .carte-featured {
   position: relative;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -134,13 +134,16 @@
 .carte-cart .chasse-lot {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-xxs);
   font-size: 0.875rem;
+  color: var(--color-text-primary);
 }
 
 .carte-compact .chasse-lot .badge-recompense,
 .carte-cart .chasse-lot .badge-recompense {
   margin-left: 0;
+  color: var(--color-text-primary);
 }
 
 .carte-compact .chasse-lot__title,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -129,6 +129,34 @@
   flex-wrap: nowrap;
 }
 
+/* ========== 🎁 Récompense dans les cartes compactes ========== */
+.carte-compact .chasse-lot,
+.carte-cart .chasse-lot {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  font-size: 0.875rem;
+}
+
+.carte-compact .chasse-lot .badge-recompense,
+.carte-cart .chasse-lot .badge-recompense {
+  margin-left: 0;
+}
+
+.carte-compact .chasse-lot__title,
+.carte-cart .chasse-lot__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.carte-compact .chasse-lot__icon svg,
+.carte-cart .chasse-lot__icon svg {
+  width: 20px;
+  height: 20px;
+  color: var(--color-grey-light);
+}
+
 /* ========== 🌟 Carte mise en avant ========== */
 .carte-featured {
   position: relative;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1540,9 +1540,13 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     if (!empty($titre_recompense) && (float) $valeur_recompense > 0) {
         $footer_icones[] = 'trophy';
         $lot_html       = '<div class="chasse-lot" aria-live="polite">'
-            . get_svg_icon('trophy')
+            . '<span class="chasse-lot__icon">' . get_svg_icon('trophy') . '</span>'
             . '<span class="screen-reader-text">' . esc_html__('Récompense :', 'chassesautresor-com') . '</span>'
-            . esc_html($titre_recompense) . ' — ' . esc_html($valeur_recompense) . ' €'
+            . '<span class="badge-recompense avec-recompense">'
+            . esc_html(number_format_i18n(round((float) $valeur_recompense), 0))
+            . '<span class="badge-recompense__devise">€</span>'
+            . '</span>'
+            . '<span class="chasse-lot__title">' . esc_html($titre_recompense) . '</span>'
             . '</div>';
     }
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1539,8 +1539,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $lot_html = '';
     if (!empty($titre_recompense) && (float) $valeur_recompense > 0) {
         $footer_icones[] = 'trophy';
-        $lot_html = '<div class="chasse-lot" aria-live="polite">'
-            . '<strong>Récompense :</strong> '
+        $lot_html       = '<div class="chasse-lot" aria-live="polite">'
+            . get_svg_icon('trophy')
+            . '<span class="screen-reader-text">' . esc_html__('Récompense :', 'chassesautresor-com') . '</span>'
             . esc_html($titre_recompense) . ' — ' . esc_html($valeur_recompense) . ' €'
             . '</div>';
     }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -30,6 +30,7 @@ if (empty($infos)) {
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
+            <?php echo $infos['lot_html']; ?>
         </div>
     </a>
     <div class="carte-cart__footer meta-row svg-xsmall">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -22,6 +22,7 @@ if (empty($infos)) {
         </div>
         <div class="carte-compact__contenu">
             <h3 class="carte-compact__titre"><?php echo esc_html($infos['titre']); ?></h3>
+            <?php echo $infos['lot_html']; ?>
             <div class="carte-compact__meta meta-row svg-xsmall">
                 <div class="meta-regular">
                     <?php echo get_svg_icon('enigme'); ?>


### PR DESCRIPTION
## Résumé
- Affiche la récompense directement sous le titre dans les cartes compactes des chasses

## Changements notables
- Ajout du rendu de la récompense dans le template `chasse-card-compact.php`

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c6383b1e148332ae60cc7408fb735f