### PR TITLE
feat: afficher la devise en exposant

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -124,10 +124,18 @@ if (empty($infos)) {
                         <span class="chasse-footer__reward">
                             <i class="fa-solid fa-trophy" aria-hidden="true"></i>
                             <?php
-                            printf(
-                                esc_html__('%1$s — %2$s €', 'chassesautresor-com'),
-                                esc_html($reward_title),
-                                esc_html(number_format_i18n(round((float) $reward_value), 0))
+                            echo wp_kses(
+                                sprintf(
+                                    esc_html__('%1$s — %2$s%3$s', 'chassesautresor-com'),
+                                    esc_html($reward_title),
+                                    esc_html(number_format_i18n(round((float) $reward_value), 0)),
+                                    '<span class="prix-devise">' . esc_html__('€', 'chassesautresor-com') . '</span>'
+                                ),
+                                [
+                                    'span' => [
+                                        'class' => [],
+                                    ],
+                                ]
                             );
                             ?>
                         </span>


### PR DESCRIPTION
## Résumé
- affiche la devise des récompenses en exposant dans les cartes de chasse pleine largeur

## Changements notables
- ajoute un `<span class="prix-devise">` autour du symbole euro
- sécurise l'affichage avec `wp_kses`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68c638c982688332b00f0c95f4c8030c