### PR TITLE
Affiche l’euro en exposant dans les cartes de récompense

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1544,7 +1544,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
             . '<span class="screen-reader-text">' . esc_html__('Récompense :', 'chassesautresor-com') . '</span>'
             . '<span class="badge-recompense avec-recompense">'
             . esc_html(number_format_i18n(round((float) $valeur_recompense), 0))
-            . '<span class="badge-recompense__devise">€</span>'
+            . '<span class="badge-recompense__devise prix-devise">€</span>'
             . '</span>'
             . '<span class="chasse-lot__title">' . esc_html($titre_recompense) . '</span>'
             . '</div>';

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -513,7 +513,7 @@ if ($edition_active && !$est_complet) {
                                         <?= esc_html__('Valeur estimée', 'chassesautresor-com'); ?>
                                     </span>
                                     <?= esc_html(number_format_i18n(round((float) $valeur_recompense), 0)); ?>
-                                    <span class="badge-recompense__devise">€</span>
+                                    <span class="badge-recompense__devise prix-devise">€</span>
                                 </span>
                             </p>
                         <?php endif; ?>


### PR DESCRIPTION
## Résumé
- euro des récompenses affiché en exposant sur les cartes de chasse
- harmonisation avec la présentation pleine largeur

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c640b53a4c8332b03c6f639e4dce0f