### PR TITLE
Remove treasure hunt section banner from homepage

### DIFF
--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -27,18 +27,6 @@ $chasse_ids = $query->posts;
     <main id="home-page">
         <section class="chasses">
             <div class="conteneur">
-                <div class="titre-chasses-wrapper">
-                    <div class="titre-chasses">
-                        <span class="decor decor-gauche">
-                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-right.svg')); ?>
-                        </span>
-                        <h2><?php esc_html_e('Chasses au trésor', 'chassesautresor-com'); ?></h2>
-                        <span class="decor decor-droite">
-                            <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
-                        </span>
-                    </div>
-                </div>
-                <div class="ligne-chasses"></div>
                 <div class="liste-chasses">
                     <?php
                     get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [


### PR DESCRIPTION
Supprime le bandeau et le titre de section "Chasses au trésor" de la page d'accueil.

- Retire le wrapper du titre et la ligne décorative de la page d'accueil pour afficher directement la liste des chasses

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c640e4fc48833285b3be165c7041c7