### PR TITLE
Fix reward currency wrapping on hunt cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -728,6 +728,8 @@ a.ajout-link:focus-visible {
   border-radius: 0.4rem;
   background-color: rgba(255, 255, 255, 0.05);
   color: var(--color-text-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .badge-recompense__label,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2014,6 +2014,8 @@ a.ajout-link:focus-visible {
   border-radius: 0.4rem;
   background-color: rgba(255, 255, 255, 0.05);
   color: var(--color-text-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .badge-recompense__label,


### PR DESCRIPTION
## Résumé
- Empêche le retour à la ligne entre le montant et la devise sur les cartes de chasse
- Compile les feuilles de style

## Testing
- `npm ci`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68c6423d7e3883328fdd4564f2a5a88e