### PR TITLE
Fix duplicate translations in po files

### DIFF
--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -376,7 +376,7 @@ msgid "Erreur lors de la création de la chasse."
 msgstr "Error creating hunt."
 
 #: inc/edition/edition-core.php:147 inc/edition/edition-core.php:179
-#: assets/js/help-modal.js:19
+#: assets/js/help-modal.js:19 inc/enigme/affichage.php:637
 #, fuzzy
 msgid "Fermer"
 msgstr "Close"
@@ -420,10 +420,10 @@ msgid "Sélectionner une image"
 msgstr "Select a riddle"
 
 #: inc/edition/edition-core.php:156 inc/edition/edition-indice.php:164
-#: inc/edition/edition-indice.php:262
+#: inc/edition/edition-indice.php:262 inc/enigme/affichage.php:625
 #, php-format
 msgid "Indice #%d"
-msgstr "Clue #%d"
+msgstr "Hint #%d"
 
 #: inc/edition/edition-core.php:157 inc/edition/edition-core.php:196
 msgid "liée à"
@@ -3267,19 +3267,12 @@ msgstr "Send the validation request"
 msgid "Indice débloqué"
 msgstr "Hint unlocked"
 
-#: inc/enigme/affichage.php:625
-#, php-format
-msgid "Indice #%d"
-msgstr "Hint #%d"
 
 #: inc/enigme/affichage.php:630
 #, php-format
 msgid "Indice #%1$d - %2$d pts"
 msgstr "Hint #%1$d - %2$d pts"
 
-#: inc/enigme/affichage.php:637
-msgid "Fermer"
-msgstr "Close"
 
 #: inc/enigme/indices.php:120
 msgid "Débloquer l'indice"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -380,7 +380,7 @@ msgid "Erreur lors de la création de la chasse."
 msgstr "Erreur lors de la création de la chasse."
 
 #: inc/edition/edition-core.php:147 inc/edition/edition-core.php:179
-#: assets/js/help-modal.js:19
+#: assets/js/help-modal.js:19 inc/enigme/affichage.php:637
 msgid "Fermer"
 msgstr "Fermer"
 
@@ -422,7 +422,7 @@ msgid "Sélectionner une image"
 msgstr "Sélectionner une image"
 
 #: inc/edition/edition-core.php:156 inc/edition/edition-indice.php:164
-#: inc/edition/edition-indice.php:262
+#: inc/edition/edition-indice.php:262 inc/enigme/affichage.php:625
 #, php-format
 msgid "Indice #%d"
 msgstr "Indice #%d"
@@ -3229,19 +3229,12 @@ msgstr "Envoyer la demande de validation"
 msgid "Indice débloqué"
 msgstr "Indice débloqué"
 
-#: inc/enigme/affichage.php:625
-#, php-format
-msgid "Indice #%d"
-msgstr "Indice #%d"
 
 #: inc/enigme/affichage.php:630
 #, php-format
 msgid "Indice #%1$d - %2$d pts"
 msgstr "Indice #%1$d - %2$d pts"
 
-#: inc/enigme/affichage.php:637
-msgid "Fermer"
-msgstr "Fermer"
 
 #: inc/enigme/indices.php:120
 msgid "Débloquer l'indice"


### PR DESCRIPTION
## Résumé
- Corrige les erreurs `msgfmt` dues à des entrées de traduction en double
- Met à jour les fichiers `en_US.po` et `fr_FR.po`

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c643987af08332aac9d23816438fdf