### PR TITLE
Restore bullet list styling in hunt and enigma text

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -340,6 +340,15 @@
   padding-left: var(--space-md);
   padding-right: var(--space-md);
 
+  ul {
+    list-style: disc;
+    padding-left: var(--space-lg);
+
+    li::marker {
+      color: currentColor;
+    }
+  }
+
   p {
     margin-bottom: var(--space-md);
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -683,6 +683,15 @@ li.active .enigme-menu__edit {
   font-size: clamp(1rem, 1.2vw + 0.9rem, 1.25rem);
   line-height: 1.6;
   overflow-wrap: anywhere;
+
+  ul {
+    list-style: disc;
+    padding-left: var(--space-lg);
+
+    li::marker {
+      color: currentColor;
+    }
+  }
 }
 
 .enigme-texte > * + * {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1141,6 +1141,13 @@
   padding-left: var(--space-md);
   padding-right: var(--space-md);
 }
+.chasse-description ul {
+  list-style: disc;
+  padding-left: var(--space-lg);
+}
+.chasse-description ul li::marker {
+  color: currentColor;
+}
 .chasse-description p {
   margin-bottom: var(--space-md);
 }
@@ -6238,6 +6245,13 @@ li.active .enigme-menu__edit {
   font-size: clamp(1rem, 1.2vw + 0.9rem, 1.25rem);
   line-height: 1.6;
   overflow-wrap: anywhere;
+}
+.enigme-texte ul {
+  list-style: disc;
+  padding-left: var(--space-lg);
+}
+.enigme-texte ul li::marker {
+  color: currentColor;
 }
 
 .enigme-texte > * + * {


### PR DESCRIPTION
## Résumé
- Affiche les listes à puces dans les descriptions de chasse et les textes d'énigme

## Changements notables
- Ajout de styles pour afficher les listes non ordonnées avec indentations
- Regénération du fichier CSS compilé

## Testing
- `npm install`
- `npm run build:css`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c65adc56dc8332b7bea73f5a7866ea