### PR TITLE
N'ouvrir la médiathèque que si aucune illustration

### DIFF
--- a/tests/js/champ-init.test.js
+++ b/tests/js/champ-init.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('initChampDeclencheur', () => {
+  let script;
+
+  beforeAll(() => {
+    script = fs.readFileSync(
+      path.resolve(__dirname, '../../wp-content/themes/chassesautresor/assets/js/core/champ-init.js'),
+      'utf8'
+    );
+    eval(script);
+    global.initChampDeclencheur = initChampDeclencheur;
+  });
+
+  beforeEach(() => {
+    global.initChampImage = jest.fn();
+  });
+
+  it('ouvre la médiathèque si le champ est vide', () => {
+    document.body.innerHTML = `
+      <div class="champ-enigme champ-img champ-vide" data-champ="illustration" data-post-id="1" data-cpt="enigme">
+        <button class="champ-modifier trigger" data-champ="illustration" data-post-id="1" data-cpt="enigme"></button>
+        <button class="champ-modifier real"></button>
+      </div>`;
+
+    const bloc = document.querySelector('.champ-enigme');
+    bloc.__ouvrirMedia = jest.fn();
+    const trigger = bloc.querySelector('.trigger');
+    const vrai = bloc.querySelector('.real');
+    vrai.click = jest.fn();
+
+    initChampDeclencheur(trigger);
+    trigger.click();
+
+    expect(bloc.__ouvrirMedia).toHaveBeenCalledTimes(1);
+    expect(vrai.click).not.toHaveBeenCalled();
+  });
+
+  it('ouvre le panneau si une illustration existe', () => {
+    document.body.innerHTML = `
+      <div class="champ-enigme champ-img champ-rempli" data-champ="illustration" data-post-id="1" data-cpt="enigme">
+        <button class="champ-modifier trigger" data-champ="illustration" data-post-id="1" data-cpt="enigme"></button>
+        <button class="champ-modifier real"></button>
+      </div>`;
+
+    const bloc = document.querySelector('.champ-enigme');
+    bloc.__ouvrirMedia = jest.fn();
+    const trigger = bloc.querySelector('.trigger');
+    const vrai = bloc.querySelector('.real');
+    vrai.click = jest.fn();
+
+    initChampDeclencheur(trigger);
+    trigger.click();
+
+    expect(bloc.__ouvrirMedia).not.toHaveBeenCalled();
+    expect(vrai.click).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -277,10 +277,13 @@ function initChampDeclencheur(bouton) {
     if (bloc.classList.contains('champ-img') && typeof initChampImage === 'function') {
       initChampImage(bloc);
     }
-    // ✅ Cas particulier : clic sur le stylo image → déclencher manuellement l’ouverture
+    // ✅ Cas particulier : clic sur le stylo image
     if (bloc.classList.contains('champ-img') && typeof bloc.__ouvrirMedia === 'function') {
-      bloc.__ouvrirMedia();
-      return; // rien d’autre à faire
+      const estVide = bloc.classList.contains('champ-vide');
+      if (estVide) {
+        bloc.__ouvrirMedia();
+        return; // rien d’autre à faire si aucune illustration
+      }
     }
 
 


### PR DESCRIPTION
## Résumé
- Empêche l'ouverture automatique de WordPress Média lorsqu'une illustration est déjà présente
- Ajoute des tests garantissant l'ouverture conditionnelle du panneau ou de la médiathèque

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c66007b2408332a2933a6a128f47f1