### PR TITLE
Ajouter le logo dans le hero de la page d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -142,6 +142,10 @@ header.site-header {
     transform: translateY(0);
   }
 }
+.hero-logo {
+  max-width: 150px;
+  margin-bottom: var(--space-sm);
+}
 .hero-title {
   font-size: 1.5rem;
   font-weight: 700;
@@ -198,6 +202,9 @@ header.site-header {
   .hero-title__line2 {
     font-size: 2rem;
   }
+  .hero-logo {
+    max-width: 180px;
+  }
   .has-hero .hero-overlay {
     height: 280px;
   }
@@ -219,6 +226,9 @@ header.site-header {
   }
   .hero-title__line2 {
     font-size: 2.6rem;
+  }
+  .hero-logo {
+    max-width: 200px;
   }
   .has-hero .hero-overlay {
     height: 475px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7980,6 +7980,11 @@ header.site-header {
     transform: translateY(0);
   }
 }
+.hero-logo {
+  max-width: 150px;
+  margin-bottom: var(--space-sm);
+}
+
 .hero-title {
   font-size: 1.5rem;
   font-weight: 700;
@@ -8039,6 +8044,9 @@ header.site-header {
   .hero-title__line2 {
     font-size: 2rem;
   }
+  .hero-logo {
+    max-width: 180px;
+  }
   .has-hero .hero-overlay {
     height: 280px;
   }
@@ -8059,6 +8067,9 @@ header.site-header {
   }
   .hero-title__line2 {
     font-size: 2.6rem;
+  }
+  .hero-logo {
+    max-width: 200px;
   }
   .has-hero .hero-overlay {
     height: 475px;

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -100,6 +100,7 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
             'titre'      => $titre,
             'sous_titre' => '',
             'image_fond' => $image_url,
+            'logo_id'    => 475,
         ]);
     } elseif ( is_page() && ! is_user_account_area() ) {
         $image_id  = get_post_thumbnail_id();

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -331,6 +331,7 @@ function is_user_account_area(): bool
  *     @type string $titre       Le titre principal (H1).
  *     @type string $sous_titre  Le sous-titre affiché sous le titre.
  *     @type int|string $image_fond  ID de média WordPress ou URL d'image directe.
+ *     @type int $logo_id        ID de l'image du logo affichée au-dessus du titre.
  * }
  */
 function get_header_fallback($args = []) {
@@ -338,6 +339,7 @@ function get_header_fallback($args = []) {
         'titre'      => '',
         'sous_titre' => '',
         'image_fond' => '', // URL déjà optimisée
+        'logo_id'    => 0,
     ];
     $args = wp_parse_args($args, $defaults);
 
@@ -345,6 +347,7 @@ function get_header_fallback($args = []) {
         'titre'      => $args['titre'],
         'sous_titre' => $args['sous_titre'],
         'image_fond' => esc_url( $args['image_fond'] ),
+        'logo_id'    => absint( $args['logo_id'] ),
     ]);
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
  * - $args['titre'] : Titre principal
  * - $args['sous_titre'] : Sous-titre (optionnel)
  * - $args['image_fond'] : URL d'image de fond (optimisée en .webp par ex.)
+ * - $args['logo_id'] : ID du logo à afficher (optionnel)
  */
 
 if ( ! isset( $args ) || ! is_array( $args ) ) {
@@ -19,11 +20,16 @@ if ( ! isset( $args ) || ! is_array( $args ) ) {
 $titre       = isset( $args['titre'] ) ? wp_kses_post( $args['titre'] ) : '';
 $sous_titre  = isset( $args['sous_titre'] ) ? esc_html( $args['sous_titre'] ) : '';
 $image_url   = isset( $args['image_fond'] ) ? esc_url( $args['image_fond'] ) : '';
+$logo_id     = isset( $args['logo_id'] ) ? absint( $args['logo_id'] ) : 0;
 ?>
 
 <section class="bandeau-hero fallback-header">
   <div class="hero-overlay" <?php if ( $image_url ) : ?>style="background-image: url('<?php echo $image_url; ?>');"<?php endif; ?>>
     <div class="contenu-hero">
+      <?php if ( $logo_id ) : ?>
+        <?php echo wp_get_attachment_image( $logo_id, 'full', false, [ 'class' => 'hero-logo' ] ); ?>
+      <?php endif; ?>
+
       <?php if ( $titre ) : ?>
         <h1 class="hero-title"><?php echo $titre; ?></h1>
       <?php endif; ?>


### PR DESCRIPTION
## Résumé
- ajout du logo du site dans le hero d'accueil
- paramètre optionnel `logo_id` pour les headers immersifs
- styles CSS/SCSS responsive pour le logo du hero

## Testing
- `npm install`
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c68bdfb950833292da6e0e698469d2