### PR TITLE
fix: prevent auto media popup on enigme image panel

### DIFF
--- a/tests/js/champ-init.test.js
+++ b/tests/js/champ-init.test.js
@@ -56,4 +56,20 @@ describe('initChampDeclencheur', () => {
     expect(bloc.__ouvrirMedia).not.toHaveBeenCalled();
     expect(vrai.click).toHaveBeenCalledTimes(1);
   });
+
+  it("n'ouvre pas la médiathèque si le bouton ouvre un panneau images", () => {
+    document.body.innerHTML = `
+      <div class="champ-enigme champ-img champ-vide" data-champ="illustration" data-post-id="1" data-cpt="enigme">
+        <button class="champ-modifier trigger ouvrir-panneau-images" data-champ="illustration" data-post-id="1" data-cpt="enigme"></button>
+      </div>`;
+
+    const bloc = document.querySelector('.champ-enigme');
+    bloc.__ouvrirMedia = jest.fn();
+    const trigger = bloc.querySelector('.trigger');
+
+    initChampDeclencheur(trigger);
+    trigger.click();
+
+    expect(bloc.__ouvrirMedia).not.toHaveBeenCalled();
+  });
 });

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -278,7 +278,11 @@ function initChampDeclencheur(bouton) {
       initChampImage(bloc);
     }
     // ✅ Cas particulier : clic sur le stylo image
-    if (bloc.classList.contains('champ-img') && typeof bloc.__ouvrirMedia === 'function') {
+    if (
+      bloc.classList.contains('champ-img') &&
+      typeof bloc.__ouvrirMedia === 'function' &&
+      !bouton.classList.contains('ouvrir-panneau-images')
+    ) {
       const estVide = bloc.classList.contains('champ-vide');
       if (estVide) {
         bloc.__ouvrirMedia();


### PR DESCRIPTION
Empêche l'ouverture automatique de la médiathèque lors de l'ajout d'une illustration dans une énigme.

- Empêche l'ouverture de la médiathèque pour le bouton `ouvrir-panneau-images`.
- Ajoute un test unitaire pour ce comportement.

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8176b217c83328fb3fcdad59bf525