### PR TITLE
Ouvrir la médiathèque sur clic du stylo image

### DIFF
--- a/tests/js/champ-init.test.js
+++ b/tests/js/champ-init.test.js
@@ -21,40 +21,33 @@ describe('initChampDeclencheur', () => {
     document.body.innerHTML = `
       <div class="champ-enigme champ-img champ-vide" data-champ="illustration" data-post-id="1" data-cpt="enigme">
         <button class="champ-modifier trigger" data-champ="illustration" data-post-id="1" data-cpt="enigme"></button>
-        <button class="champ-modifier real"></button>
       </div>`;
 
     const bloc = document.querySelector('.champ-enigme');
     bloc.__ouvrirMedia = jest.fn();
     const trigger = bloc.querySelector('.trigger');
-    const vrai = bloc.querySelector('.real');
-    vrai.click = jest.fn();
 
     initChampDeclencheur(trigger);
     trigger.click();
 
     expect(bloc.__ouvrirMedia).toHaveBeenCalledTimes(1);
-    expect(vrai.click).not.toHaveBeenCalled();
   });
 
   it('ouvre la médiathèque même si une illustration existe', () => {
     document.body.innerHTML = `
       <div class="champ-enigme champ-img champ-rempli" data-champ="illustration" data-post-id="1" data-cpt="enigme">
+        <img src="mini.png" alt="" />
         <button class="champ-modifier trigger" data-champ="illustration" data-post-id="1" data-cpt="enigme"></button>
-        <button class="champ-modifier real"></button>
       </div>`;
 
     const bloc = document.querySelector('.champ-enigme');
     bloc.__ouvrirMedia = jest.fn();
     const trigger = bloc.querySelector('.trigger');
-    const vrai = bloc.querySelector('.real');
-    vrai.click = jest.fn();
 
     initChampDeclencheur(trigger);
     trigger.click();
 
     expect(bloc.__ouvrirMedia).toHaveBeenCalledTimes(1);
-    expect(vrai.click).not.toHaveBeenCalled();
   });
 
   it("n'ouvre pas la médiathèque si le bouton ouvre un panneau images", () => {

--- a/tests/js/champ-init.test.js
+++ b/tests/js/champ-init.test.js
@@ -37,7 +37,7 @@ describe('initChampDeclencheur', () => {
     expect(vrai.click).not.toHaveBeenCalled();
   });
 
-  it('ouvre le panneau si une illustration existe', () => {
+  it('ouvre la médiathèque même si une illustration existe', () => {
     document.body.innerHTML = `
       <div class="champ-enigme champ-img champ-rempli" data-champ="illustration" data-post-id="1" data-cpt="enigme">
         <button class="champ-modifier trigger" data-champ="illustration" data-post-id="1" data-cpt="enigme"></button>
@@ -53,8 +53,8 @@ describe('initChampDeclencheur', () => {
     initChampDeclencheur(trigger);
     trigger.click();
 
-    expect(bloc.__ouvrirMedia).not.toHaveBeenCalled();
-    expect(vrai.click).toHaveBeenCalledTimes(1);
+    expect(bloc.__ouvrirMedia).toHaveBeenCalledTimes(1);
+    expect(vrai.click).not.toHaveBeenCalled();
   });
 
   it("n'ouvre pas la médiathèque si le bouton ouvre un panneau images", () => {

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -283,13 +283,9 @@ function initChampDeclencheur(bouton) {
       typeof bloc.__ouvrirMedia === 'function' &&
       !bouton.classList.contains('ouvrir-panneau-images')
     ) {
-      const estVide = bloc.classList.contains('champ-vide');
-      if (estVide) {
-        bloc.__ouvrirMedia();
-        return; // rien d’autre à faire si aucune illustration
-      }
+      bloc.__ouvrirMedia();
+      return; // ouvrir directement la médiathèque
     }
-
 
     // 🎯 Simuler clic sur vrai bouton si présent
     const vraiBouton = [...bloc.querySelectorAll('.champ-modifier')].find(b => b !== bouton);

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -364,11 +364,6 @@ section.enigme-wrapper {
 
 
 /* ========== 🖼️ IMAGE MODIFIABLE ========== */
-body:not(.edition-active-chasse) .chasse-fiche-container .champ-img .champ-modifier .icone-modif,
-body:not(.edition-active) .header-organisateur .champ-img .champ-modifier .icone-modif {
-  display: none;
-}
-
 body:not(.edition-active-chasse) .chasse-fiche-container .champ-img .champ-modifier,
 body:not(.edition-active) .header-organisateur .champ-img .champ-modifier {
   opacity: 1;
@@ -397,53 +392,10 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   gap: var(--space-xs);
 }
 
-.champ-img .champ-modifier {
-  position: relative;
-  display: inline-block;
-  margin: 0;
-  padding: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.champ-img .champ-modifier img {
-  display: block;
-}
-
-.champ-img .champ-modifier img.vignette-enigme {
+.champ-img .champ-affichage img.vignette-enigme {
   display: inline-block;
   max-width: 60px;
   margin-right: var(--space-xxs);
-}
-
-.champ-img .champ-modifier .icone-modif {
-  position: absolute;
-  top: 0.2rem;
-  right: 0.2rem;
-  font-size: 0.9rem;
-  color: var(--color-secondary);
-  background-color: rgba(0, 0, 0, 0.6);
-  width: 1.4rem;
-  height: 1.4rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  transition: transform 0.2s;
-}
-
-.champ-img .champ-modifier:hover .icone-modif {
-  transform: scale(1.1);
-}
-
-.champ-img.champ-vide .champ-modifier .icone-modif {
-  position: static;
-  display: inline;
-  width: auto;
-  height: auto;
-  margin-left: var(--space-xxs);
-  background: none;
 }
 
 .edition-panel .champ-img img {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3352,11 +3352,6 @@ section.enigme-wrapper {
 }
 
 /* ========== 🖼️ IMAGE MODIFIABLE ========== */
-body:not(.edition-active-chasse) .chasse-fiche-container .champ-img .champ-modifier .icone-modif,
-body:not(.edition-active) .header-organisateur .champ-img .champ-modifier .icone-modif {
-  display: none;
-}
-
 body:not(.edition-active-chasse) .chasse-fiche-container .champ-img .champ-modifier,
 body:not(.edition-active) .header-organisateur .champ-img .champ-modifier {
   opacity: 1;
@@ -3385,53 +3380,10 @@ body.edition-active-enigme .single-enigme-main .champ-img .champ-modifier {
   gap: var(--space-xs);
 }
 
-.champ-img .champ-modifier {
-  position: relative;
-  display: inline-block;
-  margin: 0;
-  padding: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.champ-img .champ-modifier img {
-  display: block;
-}
-
-.champ-img .champ-modifier img.vignette-enigme {
+.champ-img .champ-affichage img.vignette-enigme {
   display: inline-block;
   max-width: 60px;
   margin-right: var(--space-xxs);
-}
-
-.champ-img .champ-modifier .icone-modif {
-  position: absolute;
-  top: 0.2rem;
-  right: 0.2rem;
-  font-size: 0.9rem;
-  color: var(--color-secondary);
-  background-color: rgba(0, 0, 0, 0.6);
-  width: 1.4rem;
-  height: 1.4rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  transition: transform 0.2s;
-}
-
-.champ-img .champ-modifier:hover .icone-modif {
-  transform: scale(1.1);
-}
-
-.champ-img.champ-vide .champ-modifier .icone-modif {
-  position: static;
-  display: inline;
-  width: auto;
-  height: auto;
-  margin-left: var(--space-xxs);
-  background: none;
 }
 
 .edition-panel .champ-img img {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -141,24 +141,34 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             <?php
                         },
                         'content' => function () use ($image_url, $image_id, $peut_editer, $chasse_id) {
-                            $transparent = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
                             ?>
                             <div class="champ-affichage">
                                 <?php if ($peut_editer) : ?>
-                                    <button type="button"
-                                        class="champ-modifier"
-                                        data-champ="chasse_principale_image"
-                                        data-cpt="chasse"
-                                        data-post-id="<?= esc_attr($chasse_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier l’image', 'chassesautresor-com'); ?>">
+                                    <?php if ($image_url) : ?>
                                         <img
-                                            src="<?= esc_url($image_url ?: $transparent); ?>"
+                                            src="<?= esc_url($image_url); ?>"
                                             alt="<?= esc_attr__('Image de la chasse', 'chassesautresor-com'); ?>"
                                         />
-                                        <span class="champ-ajout-image">
-                                            <?= esc_html__('ajouter une image', 'chassesautresor-com'); ?>
-                                        </span>
-                                    </button>
+                                        <button type="button"
+                                            class="champ-modifier"
+                                            data-champ="chasse_principale_image"
+                                            data-cpt="chasse"
+                                            data-post-id="<?= esc_attr($chasse_id); ?>"
+                                            aria-label="<?= esc_attr__('Modifier l’image', 'chassesautresor-com'); ?>">
+                                            <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                        </button>
+                                    <?php else : ?>
+                                        <button type="button"
+                                            class="champ-modifier"
+                                            data-champ="chasse_principale_image"
+                                            data-cpt="chasse"
+                                            data-post-id="<?= esc_attr($chasse_id); ?>"
+                                            aria-label="<?= esc_attr__('Ajouter une image', 'chassesautresor-com'); ?>">
+                                            <span class="champ-ajout-image">
+                                                <?= esc_html__('ajouter une image', 'chassesautresor-com'); ?>
+                                            </span>
+                                        </button>
+                                    <?php endif; ?>
                                 <?php else : ?>
                                     <?php if ($image_url) : ?>
                                         <img

--- a/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/enigme-edition-main.php
@@ -165,23 +165,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uid'], $_POST['action
                               ?>
                               <div class="champ-affichage">
                                 <?php if ($peut_editer) : ?>
-                                  <button type="button"
-                                    class="champ-modifier ouvrir-panneau-images"
-                                    data-champ="enigme_visuel_image"
-                                    data-cpt="enigme"
-                                    data-post-id="<?= esc_attr($enigme_id); ?>">
-                                    <?php if ($has_images_utiles && is_array($images_ids)) : ?>
-                                      <?php foreach ($images_ids as $img_id) : ?>
-                                        <?php $thumb_url = esc_url(add_query_arg([
-                                          'id'     => $img_id,
-                                          'taille' => 'thumbnail',
-                                        ], site_url('/voir-image-enigme'))); ?>
-                                        <img src="<?= $thumb_url; ?>" alt="" class="vignette-enigme" />
-                                      <?php endforeach; ?>
-                                    <?php else : ?>
+                                  <?php if ($has_images_utiles && is_array($images_ids)) : ?>
+                                    <?php foreach ($images_ids as $img_id) : ?>
+                                      <?php $thumb_url = esc_url(add_query_arg([
+                                        'id'     => $img_id,
+                                        'taille' => 'thumbnail',
+                                      ], site_url('/voir-image-enigme'))); ?>
+                                      <img src="<?= $thumb_url; ?>" alt="" class="vignette-enigme" />
+                                    <?php endforeach; ?>
+                                    <button type="button"
+                                      class="champ-modifier ouvrir-panneau-images"
+                                      data-champ="enigme_visuel_image"
+                                      data-cpt="enigme"
+                                      data-post-id="<?= esc_attr($enigme_id); ?>"
+                                      aria-label="<?= esc_attr__('Modifier les images', 'chassesautresor-com'); ?>">
+                                      <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                    </button>
+                                  <?php else : ?>
+                                    <button type="button"
+                                      class="champ-modifier ouvrir-panneau-images"
+                                      data-champ="enigme_visuel_image"
+                                      data-cpt="enigme"
+                                      data-post-id="<?= esc_attr($enigme_id); ?>"
+                                      aria-label="<?= esc_attr__('Ajouter une image', 'chassesautresor-com'); ?>">
                                       <span class="champ-ajout-image"><?= esc_html__('ajouter', 'chassesautresor-com'); ?></span>
-                                    <?php endif; ?>
-                                  </button>
+                                    </button>
+                                  <?php endif; ?>
                                 <?php else : ?>
                                   <?php if ($has_images_utiles && is_array($images_ids)) : ?>
                                     <?php foreach ($images_ids as $img_id) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-edition-main.php
@@ -149,24 +149,34 @@ $is_complete = (
                             <?php
                         },
                         'content' => function () use ($logo_url, $logo_id, $peut_editer, $organisateur_id) {
-                            $transparent = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
                             ?>
                             <div class="champ-affichage">
                                 <?php if ($peut_editer) : ?>
-                                    <button type="button"
-                                        class="champ-modifier"
-                                        data-champ="logo_organisateur"
-                                        data-cpt="organisateur"
-                                        data-post-id="<?= esc_attr($organisateur_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier le logo de l\'organisateur', 'chassesautresor-com'); ?>">
+                                    <?php if ($logo_url) : ?>
                                         <img
-                                            src="<?= esc_url($logo_url ?: $transparent); ?>"
+                                            src="<?= esc_url($logo_url); ?>"
                                             alt="<?= esc_attr__('Logo de l\'organisateur', 'chassesautresor-com'); ?>"
                                         />
-                                        <span class="champ-ajout-image">
-                                            <?= esc_html__('ajouter une image', 'chassesautresor-com'); ?>
-                                        </span>
-                                    </button>
+                                        <button type="button"
+                                            class="champ-modifier"
+                                            data-champ="logo_organisateur"
+                                            data-cpt="organisateur"
+                                            data-post-id="<?= esc_attr($organisateur_id); ?>"
+                                            aria-label="<?= esc_attr__('Modifier le logo de l\'organisateur', 'chassesautresor-com'); ?>">
+                                            <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                        </button>
+                                    <?php else : ?>
+                                        <button type="button"
+                                            class="champ-modifier"
+                                            data-champ="logo_organisateur"
+                                            data-cpt="organisateur"
+                                            data-post-id="<?= esc_attr($organisateur_id); ?>"
+                                            aria-label="<?= esc_attr__('Ajouter le logo de l\'organisateur', 'chassesautresor-com'); ?>">
+                                            <span class="champ-ajout-image">
+                                                <?= esc_html__('ajouter une image', 'chassesautresor-com'); ?>
+                                            </span>
+                                        </button>
+                                    <?php endif; ?>
                                 <?php else : ?>
                                     <?php if ($logo_url) : ?>
                                         <img


### PR DESCRIPTION
### Résumé
- ouverture systématique de la médiathèque lorsque l’on clique sur l’icône d’édition d’une image
- mise à jour des tests pour refléter ce comportement

### Changements notables
- appel direct à `bloc.__ouvrirMedia()` dans `champ-init.js`
- tests ajustés pour vérifier l’ouverture de la médiathèque pour les images existantes

### Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c830263e90833287977f03305d9418