### PR TITLE
Remplacer le bouton d'ajout de chasse par une carte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -633,7 +633,8 @@
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.carte-ajout-enigme {
+.carte-ajout-enigme,
+.carte-ajout-chasse {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -647,7 +648,8 @@
   height: 100%;
 }
 
-.carte-ajout-enigme:hover {
+.carte-ajout-enigme:hover,
+.carte-ajout-chasse:hover {
   background: var(--color-text-primary);
   color: var(--color-background);
   border-style: solid;
@@ -656,17 +658,21 @@
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
-.carte-ajout-enigme:focus-visible {
+.carte-ajout-enigme:focus-visible,
+.carte-ajout-chasse:focus-visible {
   outline: 3px solid var(--color-primary);
   outline-offset: 2px;
 }
 
 .carte-ajout-enigme.disabled,
-.carte-ajout-enigme[disabled] {
+.carte-ajout-chasse.disabled,
+.carte-ajout-enigme[disabled],
+.carte-ajout-chasse[disabled] {
   cursor: not-allowed;
 }
 
-.carte-ajout-enigme .carte-core {
+.carte-ajout-enigme .carte-core,
+.carte-ajout-chasse .carte-core {
   border: none;
   display: flex;
   flex-direction: column;
@@ -678,22 +684,26 @@
   z-index: 1;
 }
 
-.carte-ajout-enigme .carte-core i {
+.carte-ajout-enigme .carte-core i,
+.carte-ajout-chasse .carte-core i {
   color: var(--color-gris-3);
   font-size: 28px;
 }
 
 @media (min-width: 768px) {
-  .carte-ajout-enigme .carte-core i {
+  .carte-ajout-enigme .carte-core i,
+  .carte-ajout-chasse .carte-core i {
     font-size: 32px;
   }
 }
 
-.carte-ajout-enigme .carte-ajout-libelle {
+.carte-ajout-enigme .carte-ajout-libelle,
+.carte-ajout-chasse .carte-ajout-libelle {
   font-weight: 600;
 }
 
-.carte-ajout-enigme::after {
+.carte-ajout-enigme::after,
+.carte-ajout-chasse::after {
   content: '';
   position: absolute;
   bottom: var(--space-sm);
@@ -705,19 +715,6 @@
   background-size: 80px 80px;
   opacity: 0.08;
   pointer-events: none;
-}
-
-.carte-ajout-chasse .carte-ligne__image,
-.carte-ajout-chasse .carte-ligne__contenu {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-}
-
-.carte-ajout-chasse .icone-ajout i {
-  color: var(--color-secondary);
 }
 
 .carte-ajout-chasse .overlay-message {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -598,7 +598,8 @@
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.carte-ajout-enigme {
+.carte-ajout-enigme,
+.carte-ajout-chasse {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -612,7 +613,8 @@
   height: 100%;
 }
 
-.carte-ajout-enigme:hover {
+.carte-ajout-enigme:hover,
+.carte-ajout-chasse:hover {
   background: var(--color-text-primary);
   color: var(--color-background);
   border-style: solid;
@@ -621,17 +623,21 @@
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
-.carte-ajout-enigme:focus-visible {
+.carte-ajout-enigme:focus-visible,
+.carte-ajout-chasse:focus-visible {
   outline: 3px solid var(--color-primary);
   outline-offset: 2px;
 }
 
 .carte-ajout-enigme.disabled,
-.carte-ajout-enigme[disabled] {
+.carte-ajout-chasse.disabled,
+.carte-ajout-enigme[disabled],
+.carte-ajout-chasse[disabled] {
   cursor: not-allowed;
 }
 
-.carte-ajout-enigme .carte-core {
+.carte-ajout-enigme .carte-core,
+.carte-ajout-chasse .carte-core {
   border: none;
   display: flex;
   flex-direction: column;
@@ -643,21 +649,25 @@
   z-index: 1;
 }
 
-.carte-ajout-enigme .carte-core i {
+.carte-ajout-enigme .carte-core i,
+.carte-ajout-chasse .carte-core i {
   color: var(--color-gris-3);
   font-size: 28px;
 }
 
 @media (min-width: 768px) {
-  .carte-ajout-enigme .carte-core i {
+  .carte-ajout-enigme .carte-core i,
+  .carte-ajout-chasse .carte-core i {
     font-size: 32px;
   }
 }
-.carte-ajout-enigme .carte-ajout-libelle {
+.carte-ajout-enigme .carte-ajout-libelle,
+.carte-ajout-chasse .carte-ajout-libelle {
   font-weight: 600;
 }
 
-.carte-ajout-enigme::after {
+.carte-ajout-enigme::after,
+.carte-ajout-chasse::after {
   content: "";
   position: absolute;
   bottom: var(--space-sm);
@@ -669,19 +679,6 @@
   background-size: 80px 80px;
   opacity: 0.08;
   pointer-events: none;
-}
-
-.carte-ajout-chasse .carte-ligne__image,
-.carte-ajout-chasse .carte-ligne__contenu {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-}
-
-.carte-ajout-chasse .icone-ajout i {
-  color: var(--color-secondary);
 }
 
 .carte-ajout-chasse .overlay-message {

--- a/wp-content/themes/chassesautresor/single-organisateur.php
+++ b/wp-content/themes/chassesautresor/single-organisateur.php
@@ -90,20 +90,12 @@ get_header();
                             <?php echo file_get_contents(get_theme_file_path('assets/svg/star-line-left.svg')); ?>
                         </span>
                     </div>
-                    <?php if ($peut_ajouter && $statut_organisateur === 'publish') :
-                        get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
-                            'has_chasses'     => $has_chasses,
-                            'organisateur_id' => $organisateur_id,
-                            'highlight_pulse' => $highlight_pulse,
-                            'use_button'      => true,
-                        ]);
-                    endif; ?>
                 </div>
                 <div class="ligne-chasses"></div>
                 <div class="liste-chasses">
                     <?php
                     ob_start();
-                    if ($peut_ajouter && $statut_organisateur !== 'publish') {
+                    if ($peut_ajouter) {
                         get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
                             'has_chasses'     => $has_chasses,
                             'organisateur_id' => $organisateur_id,

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php
@@ -4,42 +4,44 @@ defined('ABSPATH') || exit;
 $organisateur_id = $args['organisateur_id'] ?? null;
 $has_chasses     = $args['has_chasses'] ?? false;
 $highlight_pulse = $args['highlight_pulse'] ?? false;
-$use_button      = $args['use_button'] ?? false;
 
 
 if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
-  return;
+    return;
 }
+
+$classes = [
+    'carte',
+    'carte-chasse',
+    'carte-ajout-chasse',
+    $has_chasses ? 'etat-suivante' : 'etat-vide',
+    'disabled',
+];
+
+if ($highlight_pulse) {
+    $classes[] = 'pulsation';
+}
+
+$ajout_url = esc_url(site_url('/creer-chasse/'));
 ?>
-
-<?php if ($use_button) : ?>
-  <a
-    href="<?= esc_url(site_url('/creer-chasse/')); ?>"
+<button
+    type="button"
     id="carte-ajout-chasse"
+    class="<?php echo esc_attr(implode(' ', $classes)); ?>"
     data-post-id="0"
-  >
-    <i class="fa-solid fa-circle-plus fa-lg"></i>
-    <span class="screen-reader-text">Ajouter une chasse</span>
-  </a>
-<?php else : ?>
-  <a
-    href="<?= esc_url(site_url('/creer-chasse/')); ?>"
-    id="carte-ajout-chasse"
-    class="carte carte-ligne carte-chasse carte-ajout-chasse disabled<?= $highlight_pulse ? ' pulsation' : ''; ?>"
-    data-post-id="0">
-
-    <div class="carte-ligne__image">
-      <div class="icone-ajout">
-        <i class="fa-solid fa-circle-plus fa-3x"></i>
-      </div>
+    aria-label="<?php echo esc_attr__('Ajouter une chasse', 'chassesautresor-com'); ?>"
+    onclick="if(!this.classList.contains('disabled')){window.location.href='<?php echo $ajout_url; ?>';}"
+>
+    <div class="carte-core">
+        <i class="fa-solid fa-circle-plus" aria-hidden="true"></i>
+        <span class="carte-ajout-libelle">
+            <?php echo $has_chasses
+                ? esc_html__('Ajouter une nouvelle chasse', 'chassesautresor-com')
+                : esc_html__('Créer ma première chasse', 'chassesautresor-com'); ?>
+        </span>
     </div>
-
-    <div class="carte-ligne__contenu">
-      <h3 class="carte-ligne__titre"><?= $has_chasses ? 'Ajouter une nouvelle chasse' : 'Créer ma première chasse'; ?></h3>
-      <div class="overlay-message">
-        <i class="fa-solid fa-circle-info"></i>
-        <p>Complétez d’abord : titre, logo, description</p>
-      </div>
+    <div class="overlay-message">
+        <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+        <p><?php esc_html_e('Complétez d\u2019abord : titre, logo, description', 'chassesautresor-com'); ?></p>
     </div>
-  </a>
-<?php endif; ?>
+</button>


### PR DESCRIPTION
### Résumé
- remplace le bouton d’ajout de chasse par une carte cohérente avec l’ajout d’énigme
- factorise les styles SCSS des cartes d’ajout

### Changements notables
- suppression du bouton d’ajout dans l’en-tête des chasses et insertion d’une carte dédiée dans la liste【F:wp-content/themes/chassesautresor/single-organisateur.php†L83-L104】
- nouvelle carte d’ajout de chasse calquée sur la carte d’ajout d’énigme【F:wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php†L13-L47】
- mutualisation des styles pour les cartes d’ajout de chasse et d’énigme【F:wp-content/themes/chassesautresor/assets/scss/_cartes.scss†L636-L706】

### Testing
- `npm run build:css`【225102†L1-L8】
- `composer install`【5d2c0b†L1-L33】
- `vendor/bin/phpunit -c tests/phpunit.xml`【4984fd†L1-L11】
- `npm test --silent 2>&1 | tail -n 20`【f221e8†L16-L20】

------
https://chatgpt.com/codex/tasks/task_e_68c830adea2083329e54b01fef6199e9