### PR TITLE
Permettre la modification de l'image de la chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -111,6 +111,11 @@ function initChampImage(bloc) {
     frame.open();
   };
 
+  const bouton = bloc.querySelector('.champ-modifier');
+  if (bouton && !bouton.classList.contains('ouvrir-panneau-images')) {
+    bouton.addEventListener('click', ouvrirMedia);
+  }
+
   // ✅ On expose la fonction pour la déclencher manuellement
   bloc.__ouvrirMedia = ouvrirMedia;
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -145,20 +145,33 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                             ?>
                             <div class="champ-affichage">
                                 <?php if ($peut_editer) : ?>
-                                    <button type="button"
-                                        class="champ-modifier"
-                                        data-champ="chasse_principale_image"
-                                        data-cpt="chasse"
-                                        data-post-id="<?= esc_attr($chasse_id); ?>"
-                                        aria-label="<?= esc_attr__('Modifier l’image', 'chassesautresor-com'); ?>">
+                                    <?php if ($image_url) : ?>
                                         <img
-                                            src="<?= esc_url($image_url ?: $transparent); ?>"
+                                            src="<?= esc_url($image_url); ?>"
                                             alt="<?= esc_attr__('Image de la chasse', 'chassesautresor-com'); ?>"
                                         />
-                                        <span class="champ-ajout-image">
-                                            <?= esc_html__('ajouter une image', 'chassesautresor-com'); ?>
-                                        </span>
-                                    </button>
+                                        <button type="button"
+                                            class="champ-modifier"
+                                            data-cpt="chasse"
+                                            data-post-id="<?= esc_attr($chasse_id); ?>"
+                                            aria-label="<?= esc_attr__('Modifier l’image', 'chassesautresor-com'); ?>">
+                                            <?= esc_html__('modifier', 'chassesautresor-com'); ?>
+                                        </button>
+                                    <?php else : ?>
+                                        <button type="button"
+                                            class="champ-modifier"
+                                            data-cpt="chasse"
+                                            data-post-id="<?= esc_attr($chasse_id); ?>"
+                                            aria-label="<?= esc_attr__('Ajouter une image', 'chassesautresor-com'); ?>">
+                                            <img
+                                                src="<?= esc_url($transparent); ?>"
+                                                alt="<?= esc_attr__('Image de la chasse', 'chassesautresor-com'); ?>"
+                                            />
+                                            <span class="champ-ajout-image">
+                                                <?= esc_html__('ajouter une image', 'chassesautresor-com'); ?>
+                                            </span>
+                                        </button>
+                                    <?php endif; ?>
                                 <?php else : ?>
                                     <?php if ($image_url) : ?>
                                         <img


### PR DESCRIPTION
## Résumé
- ajout d'un bouton de modification pour l'image de la chasse
- ouverture de la médiathèque au clic pour remplacer l'image existante

## Testing
- `npm test`
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c834731f6c8332aaea0a109c710bff