### PR TITLE
Fusionner les cartes d'ajout de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/organisateur-edit.js
@@ -257,11 +257,13 @@ window.mettreAJourCarteAjoutChasse = function () {
   DEBUG && console.log('🧩 Vérif carte-ajout → champs vides détectés :', incomplets);
   DEBUG && console.log('🧩 carte actuelle :', carte);
 
-  let overlay = carte.querySelector('.overlay-message');
+  const message = carte.querySelector('.carte-ajout-message');
 
   if (incomplets.length === 0) {
     carte.classList.remove('disabled');
-    overlay?.remove();
+    if (message) {
+      message.textContent = '';
+    }
   } else {
     carte.classList.add('disabled');
 
@@ -272,16 +274,9 @@ window.mettreAJourCarteAjoutChasse = function () {
       return 'champ requis';
     }).join(', ');
 
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.className = 'overlay-message';
-      carte.appendChild(overlay);
+    if (message) {
+      message.textContent = `Complétez d’abord : ${texte}`;
     }
-
-    overlay.innerHTML = `
-      <i class="fa-solid fa-circle-info"></i>
-      <p>Complétez d’abord : ${texte}</p>
-    `;
   }
 };
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -717,21 +717,16 @@
   pointer-events: none;
 }
 
-.carte-ajout-chasse .overlay-message {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-primary);
+.carte-ajout-chasse .carte-ajout-message {
+  color: var(--color-gris-4);
+  font-size: 0.875rem;
+  line-height: 1.3;
   text-align: center;
-  gap: var(--space-xs);
-  padding: 0 var(--space-md);
+  margin-top: var(--space-xxs);
+}
+
+.carte-ajout-chasse .carte-ajout-message:empty {
+  display: none;
 }
 
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -681,21 +681,16 @@
   pointer-events: none;
 }
 
-.carte-ajout-chasse .overlay-message {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-primary);
+.carte-ajout-chasse .carte-ajout-message {
+  color: var(--color-gris-4);
+  font-size: 0.875rem;
+  line-height: 1.3;
   text-align: center;
-  gap: var(--space-xs);
-  padding: 0 var(--space-md);
+  margin-top: var(--space-xxs);
+}
+
+.carte-ajout-chasse .carte-ajout-message:empty {
+  display: none;
 }
 
 /* ========== ✅ Indicateurs de complétion ========== */

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-partial-ajout-chasse.php
@@ -39,9 +39,8 @@ $ajout_url = esc_url(site_url('/creer-chasse/'));
                 ? esc_html__('Ajouter une nouvelle chasse', 'chassesautresor-com')
                 : esc_html__('Créer ma première chasse', 'chassesautresor-com'); ?>
         </span>
-    </div>
-    <div class="overlay-message">
-        <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
-        <p><?php esc_html_e('Complétez d\u2019abord : titre, logo, description', 'chassesautresor-com'); ?></p>
+        <span class="carte-ajout-message" aria-live="polite">
+            <?php esc_html_e('Complétez d\u2019abord : titre, logo, description', 'chassesautresor-com'); ?>
+        </span>
     </div>
 </button>


### PR DESCRIPTION
## Résumé
Fusion de la carte d'ajout de chasse pour l'organisateur en création afin de conserver le nouveau design tout en réintégrant l'indication des champs manquants.

## Changements notables
- suppression de l'overlay hérité au profit d'un message intégré dans la carte d'ajout de chasse
- ajustement du script organisateur pour mettre à jour dynamiquement le message listant les champs requis
- stylisation discrète du nouveau message et recompilation de la feuille de style

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c8f3ba71888332a0f2865e4d6f4ad8