### PR TITLE
Optimise la gestion des images du header

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -11,7 +11,19 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+    exit; // Exit if accessed directly.
+}
+
+$hero_image_url = '';
+
+if ( is_front_page() ) {
+    $hero_image_url = imagify_get_webp_url( wp_get_attachment_image_url( 8810, 'full' ) );
+} elseif ( is_page() && ! is_user_account_area() ) {
+    $featured_image_id = get_post_thumbnail_id();
+
+    if ( $featured_image_id ) {
+        $hero_image_url = imagify_get_webp_url( wp_get_attachment_image_url( $featured_image_id, 'full' ) );
+    }
 }
 
 ?><!DOCTYPE html>
@@ -31,6 +43,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php astra_head_top(); ?>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<?php if ( $hero_image_url ) : ?>
+<link rel="preload" as="image" href="<?php echo esc_url( $hero_image_url ); ?>">
+<?php endif; ?>
 <style id="cta-critical-css">
 :root {
     --font-main: "Poppins", sans-serif;
@@ -383,8 +398,6 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
     if ( is_cart() ) {
         get_template_part('template-parts/header-panier');
     } elseif ( is_front_page() ) {
-        $image_url = imagify_get_webp_url( wp_get_attachment_image_url( 8810, 'full' ) );
-
         $line1 = sprintf(
             /* translators: 1: ordinal suffix, 2: phrase 'plateforme de'. */
             __( '1<sup>%1$s</sup> %2$s', 'chassesautresor-com' ),
@@ -401,17 +414,14 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
         get_header_fallback([
             'titre'      => $titre,
             'sous_titre' => '',
-            'image_fond' => $image_url,
+            'image_fond' => $hero_image_url,
             'logo_id'    => 475,
         ]);
     } elseif ( is_page() && ! is_user_account_area() ) {
-        $image_id  = get_post_thumbnail_id();
-        $image_url = $image_id ? imagify_get_webp_url( wp_get_attachment_image_url( $image_id, 'full' ) ) : '';
-
         get_header_fallback([
             'titre'       => get_the_title(),
             'sous_titre'  => '',
-            'image_fond'  => $image_url,
+            'image_fond'  => $hero_image_url,
         ]);
     }
     

--- a/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
@@ -27,7 +27,10 @@ $logo_id     = isset( $args['logo_id'] ) ? absint( $args['logo_id'] ) : 0;
   <div class="hero-overlay" <?php if ( $image_url ) : ?>style="background-image: url('<?php echo $image_url; ?>');"<?php endif; ?>>
     <div class="contenu-hero">
       <?php if ( $logo_id ) : ?>
-        <?php echo wp_get_attachment_image( $logo_id, 'full', false, [ 'class' => 'hero-logo' ] ); ?>
+        <?php echo wp_get_attachment_image( $logo_id, 'full', false, [
+            'class'   => 'hero-logo',
+            'loading' => 'eager',
+        ] ); ?>
       <?php endif; ?>
 
       <?php if ( $titre ) : ?>


### PR DESCRIPTION
Optimise la précharge et la réutilisation des images du bandeau.

- Centralise la récupération de l'image hero pour l'accueil et les pages.
- Précharge l'image d'arrière-plan du header lorsqu'elle est disponible.
- Force le chargement immédiat du logo dans le bandeau fallback.

## Testing
- ✅ `composer install`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c8fa4080a88332966095675ddd1f19