### PR TITLE
Activer le cache et la compression

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -16,6 +16,41 @@ Header append Vary Accept env=REDIRECT_accept
 </IfModule>
 # END WebP
 
+# BEGIN Compression
+<IfModule mod_brotli.c>
+    BrotliCompressionQuality 5
+    BrotliWindowSize 22
+    BrotliMinLength 1024
+    AddOutputFilterByType BROTLI_COMPRESS \
+        text/plain \
+        text/html \
+        text/xml \
+        text/css \
+        text/javascript \
+        application/javascript \
+        application/x-javascript \
+        application/json \
+        application/xml \
+        image/svg+xml
+</IfModule>
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE \
+        text/plain \
+        text/html \
+        text/xml \
+        text/css \
+        text/javascript \
+        application/javascript \
+        application/x-javascript \
+        application/json \
+        application/xml \
+        image/svg+xml
+    <IfModule mod_headers.c>
+        Header append Vary Accept-Encoding
+    </IfModule>
+</IfModule>
+# END Compression
+
 # BEGIN WordPress
 # The directives (lines) between "BEGIN WordPress" and "END WordPress" are
 # dynamically generated, and should only be modified via WordPress filters.

--- a/wp-config.php
+++ b/wp-config.php
@@ -77,7 +77,36 @@ $table_prefix = 'wp_';
 
 /* Add any custom values between this line and the "stop editing" line. */
 
+if (! defined('WP_CACHE')) {
+    define('WP_CACHE', true);
+}
 
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && is_string($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+    $forwardedProto = explode(',', strtolower(trim($_SERVER['HTTP_X_FORWARDED_PROTO'])));
+    $primaryProto = trim((string) $forwardedProto[0]);
+
+    if ('https' === $primaryProto) {
+        $_SERVER['HTTPS'] = 'on';
+        $_SERVER['REQUEST_SCHEME'] = 'https';
+    }
+}
+
+if (isset($_SERVER['HTTP_X_FORWARDED_HOST']) && is_string($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+    $forwardedHosts = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
+    $primaryHost = trim((string) $forwardedHosts[0]);
+
+    if ('' !== $primaryHost) {
+        $_SERVER['HTTP_HOST'] = $primaryHost;
+    }
+}
+
+if (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && is_string($_SERVER['HTTP_X_FORWARDED_PORT'])) {
+    $forwardedPort = (int) trim($_SERVER['HTTP_X_FORWARDED_PORT']);
+
+    if ($forwardedPort > 0) {
+        $_SERVER['SERVER_PORT'] = (string) $forwardedPort;
+    }
+}
 
 /**
  * For developers: WordPress debugging mode.

--- a/wp-content/mu-plugins/performance-bootstrap.php
+++ b/wp-content/mu-plugins/performance-bootstrap.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Chassesautresor_Performance_Bootstrap
+{
+    private const CACHE_PLUGIN = 'litespeed-cache/litespeed-cache.php';
+
+    private const OPTIMIZATION_OPTION = 'chassesautresor_last_db_optimization';
+
+    private const OPTIMIZATION_INTERVAL_DAYS = 7;
+
+    public static function boot(): void
+    {
+        add_action('muplugins_loaded', [self::class, 'ensureCachePluginActive'], 5);
+        add_action('admin_init', [self::class, 'optimizeDatabase'], 20);
+    }
+
+    public static function ensureCachePluginActive(): void
+    {
+        if (!defined('WP_PLUGIN_DIR')) {
+            return;
+        }
+
+        $pluginPath = WP_PLUGIN_DIR . '/' . self::CACHE_PLUGIN;
+
+        if (!file_exists($pluginPath)) {
+            return;
+        }
+
+        if (!function_exists('activate_plugin')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        if (function_exists('is_plugin_active') && is_plugin_active(self::CACHE_PLUGIN)) {
+            return;
+        }
+
+        $result = activate_plugin(self::CACHE_PLUGIN);
+
+        if (is_wp_error($result)) {
+            add_action('admin_notices', static function () use ($result): void {
+                printf(
+                    '<div class="notice notice-error"><p>%s</p></div>',
+                    esc_html($result->get_error_message())
+                );
+            });
+        }
+    }
+
+    public static function optimizeDatabase(): void
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $lastOptimization = (int) get_site_option(self::OPTIMIZATION_OPTION, 0);
+        $interval = self::getOptimizationInterval();
+
+        if ($lastOptimization > 0 && (time() - $lastOptimization) < $interval) {
+            return;
+        }
+
+        global $wpdb;
+
+        $tables = $wpdb->tables('all', true);
+
+        if (empty($tables)) {
+            update_site_option(self::OPTIMIZATION_OPTION, time());
+            return;
+        }
+
+        $failedTables = [];
+
+        foreach ($tables as $table) {
+            $sanitizedTable = sprintf('`%s`', str_replace('`', '', esc_sql($table)));
+            $result = $wpdb->query("OPTIMIZE TABLE {$sanitizedTable}");
+
+            if (false === $result) {
+                $failedTables[] = $table;
+            }
+        }
+
+        update_site_option(self::OPTIMIZATION_OPTION, time());
+
+        add_action('admin_notices', static function () use ($failedTables): void {
+            if (empty($failedTables)) {
+                printf(
+                    '<div class="notice notice-success"><p>%s</p></div>',
+                    esc_html__(
+                        'La base de données a été optimisée avec succès.',
+                        'chassesautresor-com'
+                    )
+                );
+
+                return;
+            }
+
+            $failedList = implode(
+                ', ',
+                array_map(
+                    static function (string $table): string {
+                        return sanitize_text_field($table);
+                    },
+                    $failedTables
+                )
+            );
+
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                esc_html(
+                    sprintf(
+                        /* translators: %s: database table names. */
+                        __(
+                            'La base de données a été optimisée mais certaines tables n\'ont pas pu être traitées : %s.',
+                            'chassesautresor-com'
+                        ),
+                        $failedList
+                    )
+                )
+            );
+        });
+    }
+
+    private static function getOptimizationInterval(): int
+    {
+        if (defined('DAY_IN_SECONDS')) {
+            return (int) DAY_IN_SECONDS * self::OPTIMIZATION_INTERVAL_DAYS;
+        }
+
+        return self::OPTIMIZATION_INTERVAL_DAYS * 24 * 60 * 60;
+    }
+}
+
+Chassesautresor_Performance_Bootstrap::boot();


### PR DESCRIPTION
Résumé rapide : activation automatique du cache et configuration de la compression.

## Changements notables
- Activation programmée du plugin LiteSpeed Cache et ajout d'une routine d'optimisation de base de données via un mu-plugin dédié.
- Ajout de la constante `WP_CACHE` et harmonisation des en-têtes *forwarded* pour éviter les redirections inutiles derrière un proxy.
- Configuration de la compression Brotli/Gzip dans `.htaccess` pour optimiser les réponses HTTP.

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c8fc58ede08332b51273cd8f4a57c1