### PR TITLE
Déplace les cartes points des administrateurs

### DIFF
--- a/wp-content/themes/chassesautresor/templates/myaccount/content-outils.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-outils.php
@@ -17,6 +17,44 @@ $taux_conversion = get_taux_conversion_actuel();
 <section>
     <h1 class="mb-4 text-xl font-semibold"><?php esc_html_e('Outils', 'chassesautresor-com'); ?></h1>
     <div class="dashboard-grid">
+        <div class="dashboard-card">
+            <div class="dashboard-card-header">
+                <i class="fas fa-coins"></i>
+                <h3><?php esc_html_e('Gestion Points', 'chassesautresor-com'); ?></h3>
+            </div>
+            <div class="stats-content">
+                <form method="POST" class="form-gestion-points">
+                    <?php wp_nonce_field('gestion_points_action', 'gestion_points_nonce'); ?>
+                    <div class="gestion-points-ligne">
+                        <label for="utilisateur-points"></label>
+                        <input
+                            type="text"
+                            id="utilisateur-points"
+                            placeholder="<?php esc_attr_e('Rechercher un utilisateur...', 'chassesautresor-com'); ?>"
+                            required
+                        >
+                        <input type="hidden" id="utilisateur-id" name="utilisateur">
+                        <label for="type-modification"></label>
+                        <select id="type-modification" name="type_modification" required>
+                            <option value="ajouter">➕</option>
+                            <option value="retirer">➖</option>
+                        </select>
+                    </div>
+                    <div class="gestion-points-ligne">
+                        <label for="nombre-points"></label>
+                        <input
+                            type="number"
+                            id="nombre-points"
+                            name="nombre_points"
+                            placeholder="<?php esc_attr_e('Nombre de points', 'chassesautresor-com'); ?>"
+                            min="1"
+                            required
+                        >
+                        <button type="submit" name="modifier_points" class="btn-icon bouton-tertiaire">✅</button>
+                    </div>
+                </form>
+            </div>
+        </div>
         <?php $protection_active = get_option('ca_site_password_enabled', '1') === '1'; ?>
         <div class="dashboard-card">
             <div class="dashboard-card-header">

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-points.php
@@ -10,61 +10,15 @@
 defined('ABSPATH') || exit;
 
 $current_user = wp_get_current_user();
+
+if (current_user_can('administrator')) {
+    return;
+}
+
 $roles        = (array) $current_user->roles;
 $is_organizer = in_array(ROLE_ORGANISATEUR, $roles, true) || in_array(ROLE_ORGANISATEUR_CREATION, $roles, true);
 
-if (current_user_can('administrator')) {
-    global $wpdb;
-    $repo               = new PointsRepository($wpdb);
-    $used_points        = $repo->getTotalPointsUsed();
-    $circulation_points = $repo->getTotalPointsInCirculation();
-    ?>
-    <div class="dashboard-grid stats-cards myaccount-points-cards">
-        <div class="dashboard-card" data-stat="points-used">
-            <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
-            <h3><?php esc_html_e('Points utilisés', 'chassesautresor-com'); ?></h3>
-            <p class="stat-value"><?php echo esc_html($used_points); ?></p>
-        </div>
-        <div class="dashboard-card" data-stat="points-bought">
-            <i class="fa-solid fa-cart-shopping" aria-hidden="true"></i>
-            <h3><?php esc_html_e('Points achetés', 'chassesautresor-com'); ?></h3>
-            <p class="stat-value"><?php esc_html_e('À implémenter', 'chassesautresor-com'); ?></p>
-        </div>
-        <div class="dashboard-card" data-stat="points-circulation">
-            <i class="fa-solid fa-arrows-rotate" aria-hidden="true"></i>
-            <h3><?php esc_html_e('Points en circulation', 'chassesautresor-com'); ?></h3>
-            <p class="stat-value"><?php echo esc_html($circulation_points); ?></p>
-        </div>
-        <div class="dashboard-card">
-            <div class="dashboard-card-header">
-                <i class="fas fa-coins"></i>
-                <h3><?php esc_html_e('Gestion Points', 'chassesautresor'); ?></h3>
-            </div>
-            <div class="stats-content">
-                <form method="POST" class="form-gestion-points">
-                    <?php wp_nonce_field('gestion_points_action', 'gestion_points_nonce'); ?>
-                    <div class="gestion-points-ligne">
-                        <label for="utilisateur-points"></label>
-                        <input type="text" id="utilisateur-points" placeholder="Rechercher un utilisateur..." required>
-                        <input type="hidden" id="utilisateur-id" name="utilisateur">
-                        <label for="type-modification"></label>
-                        <select id="type-modification" name="type_modification" required>
-                            <option value="ajouter">➕</option>
-                            <option value="retirer">➖</option>
-                        </select>
-                    </div>
-                    <div class="gestion-points-ligne">
-                        <label for="nombre-points"></label>
-                        <input type="number" id="nombre-points" name="nombre_points" placeholder="nb de points" min="1" required>
-                        <button type="submit" name="modifier_points" class="btn-icon bouton-tertiaire">✅</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-    <?php echo render_conversion_history(); ?>
-    <?php
-} elseif ($is_organizer) {
+if ($is_organizer) {
     $user_id         = (int) $current_user->ID;
     $organisateur_id = function_exists('get_organisateur_from_user') ? get_organisateur_from_user($user_id) : null;
     $user_points     = function_exists('get_user_points') ? get_user_points($user_id) : 0;

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-statistiques.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-statistiques.php
@@ -13,9 +13,31 @@ if (!current_user_can('administrator')) {
 }
 
 $user_id = get_current_user_id();
-$wins = compter_chasses_gagnees($user_id);
+$wins    = compter_chasses_gagnees($user_id);
+
+global $wpdb;
+$repo               = new PointsRepository($wpdb);
+$used_points        = $repo->getTotalPointsUsed();
+$circulation_points = $repo->getTotalPointsInCirculation();
 ?>
 <section>
     <h1 class="mb-4 text-xl font-semibold"><?php esc_html_e('Statistiques', 'chassesautresor'); ?></h1>
+    <div class="dashboard-grid stats-cards myaccount-points-cards">
+        <div class="dashboard-card" data-stat="points-used">
+            <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points utilisés', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php echo esc_html($used_points); ?></p>
+        </div>
+        <div class="dashboard-card" data-stat="points-bought">
+            <i class="fa-solid fa-cart-shopping" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points achetés', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php esc_html_e('À implémenter', 'chassesautresor-com'); ?></p>
+        </div>
+        <div class="dashboard-card" data-stat="points-circulation">
+            <i class="fa-solid fa-arrows-rotate" aria-hidden="true"></i>
+            <h3><?php esc_html_e('Points en circulation', 'chassesautresor-com'); ?></h3>
+            <p class="stat-value"><?php echo esc_html($circulation_points); ?></p>
+        </div>
+    </div>
     <p><?php echo esc_html(sprintf(__('Chasses gagnées : %d', 'chassesautresor'), $wins)); ?></p>
 </section>


### PR DESCRIPTION
Résumé : Déplace les cartes liées aux points des administrateurs vers les onglets adaptés.

- Vide l'onglet Points pour les administrateurs afin de retirer les cartes spécifiques.
- Ajoute les statistiques Points utilisés/achetés/en circulation dans l'onglet Statistiques.
- Déplace le formulaire de gestion des points dans l'onglet Outils avec des libellés traduits.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ca50079eb48332b0909ce4bc45bc6e