### PR TITLE
Harmoniser l'affichage compact des cartes de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -59,6 +59,7 @@
     flex-direction: column;
     color: inherit;
     text-decoration: none;
+    height: 100%;
   }
 
   .carte-compact__image-wrapper {
@@ -79,15 +80,20 @@
   }
 
   .carte-compact__contenu {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: var(--space-sm);
     padding: var(--space-md);
   }
 
   .carte-compact__titre {
-    margin: 0 0 var(--space-xs);
+    margin: 0;
   }
 
   .carte-compact__meta {
     font-size: 0.875rem;
+    margin-top: auto;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -51,6 +51,9 @@
 
 /* ========== 🃏 Carte compacte ========== */
 .carte-compact {
+  width: 100%;
+  max-width: 300px;
+  margin: 0 auto;
   padding: 0;
   overflow: hidden;
 

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -307,6 +307,10 @@
     cursor: pointer;
 }
 
+.meta-regular .meta-indic--static {
+    cursor: default;
+}
+
 .meta-regular .meta-indic__count {
     font-weight: 600;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -49,6 +49,9 @@
 
 /* ========== 🃏 Carte compacte ========== */
 .carte-compact {
+  width: 100%;
+  max-width: 300px;
+  margin: 0 auto;
   padding: 0;
   overflow: hidden;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -57,6 +57,7 @@
   flex-direction: column;
   color: inherit;
   text-decoration: none;
+  height: 100%;
 }
 .carte-compact .carte-compact__image-wrapper {
   position: relative;
@@ -74,13 +75,18 @@
   left: var(--space-xs);
 }
 .carte-compact .carte-compact__contenu {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: var(--space-sm);
   padding: var(--space-md);
 }
 .carte-compact .carte-compact__titre {
-  margin: 0 0 var(--space-xs);
+  margin: 0;
 }
 .carte-compact .carte-compact__meta {
   font-size: 0.875rem;
+  margin-top: auto;
 }
 
 /* ========== 🆕 Carte format CART ========== */
@@ -1096,6 +1102,10 @@
   color: inherit;
   font: inherit;
   cursor: pointer;
+}
+
+.meta-regular .meta-indic--static {
+  cursor: default;
 }
 
 .meta-regular .meta-indic__count {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -23,27 +23,18 @@ if (empty($infos)) {
         <div class="carte-compact__contenu">
             <h3 class="carte-compact__titre"><?php echo esc_html($infos['titre']); ?></h3>
             <?php echo $infos['lot_html']; ?>
-            <div class="carte-compact__meta meta-row svg-xsmall">
-                <div class="meta-regular">
-                    <?php echo get_svg_icon('enigme'); ?>
-                    <?php
-                    echo esc_html(
-                        sprintf(
-                            _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
-                            $infos['total_enigmes']
-                        )
-                    );
-                    ?> —
-                    <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
-                </div>
-                <div class="meta-etiquette">
-                    <?php echo get_svg_icon('calendar'); ?>
-                    <span class="chasse-date-plage">
-                        <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
-                        <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
-                    </span>
-                </div>
-            </div>
+            <?php
+            get_template_part(
+                'template-parts/chasse/partials/chasse-meta-row',
+                null,
+                array(
+                    'infos'           => $infos,
+                    'wrapper_class'   => 'carte-compact__meta meta-row svg-xsmall',
+                    'display_mode'    => 'buttons',
+                    'use_short_dates' => true,
+                )
+            );
+            ?>
         </div>
     </a>
 </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -30,7 +30,7 @@ if (empty($infos)) {
                 array(
                     'infos'           => $infos,
                     'wrapper_class'   => 'carte-compact__meta meta-row svg-xsmall',
-                    'display_mode'    => 'buttons',
+                    'display_mode'    => 'counts',
                     'use_short_dates' => true,
                 )
             );

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -27,25 +27,18 @@ if (empty($infos)) {
             <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
         </h3>
 
-        <div class="meta-row svg-xsmall">
-            <div class="meta-regular">
-                <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre d\'énigmes', 'chassesautresor-com'); ?>">
-                    <?php echo get_svg_icon('enigme'); ?>
-                    <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['total_enigmes'])); ?></span>
-                </button>
-                <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre de joueurs', 'chassesautresor-com'); ?>">
-                    <?php echo get_svg_icon('participants'); ?>
-                    <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['nb_joueurs'])); ?></span>
-                </button>
-            </div>
-            <div class="meta-etiquette">
-                <?php echo get_svg_icon('calendar'); ?>
-                <span class="chasse-date-plage">
-                    <span class="date-debut"><?php echo esc_html($infos['date_debut_court']); ?></span> –
-                    <span class="date-fin"><?php echo esc_html($infos['date_fin_court']); ?></span>
-                </span>
-            </div>
-        </div>
+        <?php
+        get_template_part(
+            'template-parts/chasse/partials/chasse-meta-row',
+            null,
+            array(
+                'infos'           => $infos,
+                'wrapper_class'   => 'meta-row svg-xsmall',
+                'display_mode'    => 'buttons',
+                'use_short_dates' => true,
+            )
+        );
+        ?>
 
         <?php echo $infos['extrait_html']; ?>
         <?php echo $infos['lot_html']; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-meta-row.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-meta-row.php
@@ -1,0 +1,71 @@
+<?php
+defined('ABSPATH') || exit;
+
+$infos = $args['infos'] ?? [];
+if (empty($infos) || !is_array($infos)) {
+    return;
+}
+
+$wrapper_class   = trim((string) ($args['wrapper_class'] ?? 'meta-row svg-xsmall'));
+$display_mode    = $args['display_mode'] ?? 'buttons';
+$use_short_dates = !empty($args['use_short_dates']);
+
+$tooltip_enigmes = $args['tooltip_enigmes'] ?? __('nombre d\'énigmes', 'chassesautresor-com');
+$tooltip_joueurs = $args['tooltip_joueurs'] ?? __('nombre de joueurs', 'chassesautresor-com');
+
+$date_debut_key = $use_short_dates ? 'date_debut_court' : 'date_debut';
+$date_fin_key   = $use_short_dates ? 'date_fin_court' : 'date_fin';
+
+$nombre_enigmes        = isset($infos['total_enigmes']) ? (int) $infos['total_enigmes'] : 0;
+$nombre_enigmes_format = number_format_i18n($nombre_enigmes);
+$nombre_joueurs        = isset($infos['nb_joueurs']) ? (int) $infos['nb_joueurs'] : 0;
+$nombre_joueurs_format = number_format_i18n($nombre_joueurs);
+
+$label_enigmes = sprintf(
+    _n('%s énigme', '%s énigmes', $nombre_enigmes === 1 ? 1 : $nombre_enigmes, 'chassesautresor-com'),
+    $nombre_enigmes_format
+);
+$label_joueurs = $infos['nb_joueurs_label'] ?? sprintf(
+    _n('%s joueur', '%s joueurs', $nombre_joueurs === 1 ? 1 : $nombre_joueurs, 'chassesautresor-com'),
+    $nombre_joueurs_format
+);
+
+$date_debut = isset($infos[$date_debut_key]) ? (string) $infos[$date_debut_key] : '';
+$date_fin   = isset($infos[$date_fin_key]) ? (string) $infos[$date_fin_key] : '';
+?>
+<div class="<?php echo esc_attr($wrapper_class); ?>">
+    <div class="meta-regular">
+        <?php if ($display_mode === 'text') : ?>
+            <?php echo get_svg_icon('enigme'); ?>
+            <?php echo esc_html($label_enigmes); ?>
+            &mdash;
+            <?php echo get_svg_icon('participants'); ?>
+            <?php echo esc_html($label_joueurs); ?>
+        <?php else : ?>
+            <button
+                type="button"
+                class="meta-indic"
+                data-tap="<?php echo esc_attr($tooltip_enigmes); ?>"
+            >
+                <?php echo get_svg_icon('enigme'); ?>
+                <span class="meta-indic__count"><?php echo esc_html($nombre_enigmes_format); ?></span>
+            </button>
+            <button
+                type="button"
+                class="meta-indic"
+                data-tap="<?php echo esc_attr($tooltip_joueurs); ?>"
+            >
+                <?php echo get_svg_icon('participants'); ?>
+                <span class="meta-indic__count"><?php echo esc_html($nombre_joueurs_format); ?></span>
+            </button>
+        <?php endif; ?>
+    </div>
+    <div class="meta-etiquette">
+        <?php echo get_svg_icon('calendar'); ?>
+        <span class="chasse-date-plage">
+            <span class="date-debut"><?php echo esc_html($date_debut); ?></span>
+            &ndash;
+            <span class="date-fin"><?php echo esc_html($date_fin); ?></span>
+        </span>
+    </div>
+</div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-meta-row.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/partials/chasse-meta-row.php
@@ -41,6 +41,23 @@ $date_fin   = isset($infos[$date_fin_key]) ? (string) $infos[$date_fin_key] : ''
             &mdash;
             <?php echo get_svg_icon('participants'); ?>
             <?php echo esc_html($label_joueurs); ?>
+        <?php elseif ($display_mode === 'counts') : ?>
+            <span
+                class="meta-indic meta-indic--static"
+                title="<?php echo esc_attr($label_enigmes); ?>"
+                aria-label="<?php echo esc_attr($label_enigmes); ?>"
+            >
+                <?php echo get_svg_icon('enigme'); ?>
+                <span class="meta-indic__count"><?php echo esc_html($nombre_enigmes_format); ?></span>
+            </span>
+            <span
+                class="meta-indic meta-indic--static"
+                title="<?php echo esc_attr($label_joueurs); ?>"
+                aria-label="<?php echo esc_attr($label_joueurs); ?>"
+            >
+                <?php echo get_svg_icon('participants'); ?>
+                <span class="meta-indic__count"><?php echo esc_html($nombre_joueurs_format); ?></span>
+            </span>
         <?php else : ?>
             <button
                 type="button"


### PR DESCRIPTION
Résumé : Harmonisation de l'affichage compact des cartes de chasse.

- Factorisation de l'affichage des métadonnées via un gabarit commun.
- Alignement des cartes compactes sur l'interface standard (icônes seules et dates courtes).

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ca6169b8948332ad1dcd441366c639