### PR TITLE
Affichage du tableau des tentatives sur la page d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -5,9 +5,18 @@
 
 defined('ABSPATH') || exit;
 
-$points_history = '';
-if (is_user_logged_in() && function_exists('render_points_history_table')) {
-    $points_history = render_points_history_table((int) get_current_user_id());
+$points_history   = '';
+$tentatives_table = '';
+if (is_user_logged_in()) {
+    $user_id = (int) get_current_user_id();
+
+    if (function_exists('render_points_history_table')) {
+        $points_history = render_points_history_table($user_id);
+    }
+
+    if (function_exists('ca_get_tentatives_table')) {
+        $tentatives_table = ca_get_tentatives_table($user_id);
+    }
 }
 
 get_header();
@@ -47,6 +56,13 @@ $chasse_ids = $query->posts;
             <section class="points-history">
                 <div class="conteneur">
                     <?php echo $points_history; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </div>
+            </section>
+        <?php endif; ?>
+        <?php if ($tentatives_table) : ?>
+            <section class="tentatives-history">
+                <div class="conteneur">
+                    <?php echo $tentatives_table; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                 </div>
             </section>
         <?php endif; ?>

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1017,19 +1017,19 @@ function ca_render_dashboard_engaged_hunts(): void
 add_action('woocommerce_account_dashboard', 'ca_render_dashboard_engaged_hunts', 10);
 
 /**
- * Display the Tentatives table on the My Account dashboard.
+ * Retrieve the Tentatives table markup for a specific user.
  *
- * @return void
+ * The function also ensures the required pagination scripts are enqueued so the
+ * result can be rendered from any template, including the homepage.
+ *
+ * @param int $user_id The identifier of the user whose attempts must be displayed.
+ *
+ * @return string The rendered HTML of the Tentatives table, or an empty string when no data is available.
  */
-function ca_render_dashboard_tentatives(): void
+function ca_get_tentatives_table(int $user_id): string
 {
-    if (!is_user_logged_in()) {
-        return;
-    }
-
-    $user_id = (int) get_current_user_id();
     if ($user_id <= 0) {
-        return;
+        return '';
     }
 
     $dir = get_stylesheet_directory();
@@ -1068,7 +1068,7 @@ function ca_render_dashboard_tentatives(): void
     ));
 
     if ($total <= 0) {
-        return;
+        return '';
     }
 
     $per_page   = 10;
@@ -1147,9 +1147,28 @@ function ca_render_dashboard_tentatives(): void
         </div>
     </section>
     <?php
-    echo ob_get_clean();
+    return (string) ob_get_clean();
 }
-add_action('woocommerce_account_dashboard', 'ca_render_dashboard_tentatives', 20);
+
+/**
+ * Display the Tentatives table on the My Account dashboard.
+ *
+ * @return void
+ */
+function ca_render_dashboard_tentatives(): void
+{
+    if (!is_user_logged_in()) {
+        return;
+    }
+
+    $table = ca_get_tentatives_table((int) get_current_user_id());
+
+    if ($table === '') {
+        return;
+    }
+
+    echo $table;
+}
 
 // ==================================================
 // 📡 AJAX ADMIN SECTIONS


### PR DESCRIPTION
Affiche le tableau des tentatives sur la page d'accueil tout en factorisant sa génération.

- Extrait la génération du tableau de tentatives dans `ca_get_tentatives_table()` et supprime l'accrochage WooCommerce.
- Prépare la page d'accueil pour récupérer le rendu et l'afficher dans une nouvelle section.
- Garantit l'enfilement des scripts de pagination pour le tableau sur la page d'accueil.

**Testing**
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cbb8d6be448332aa0550e02b3cd914