### PR TITLE
Ajoute un badge de connexion sur l’icône de compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -62,6 +62,28 @@ header.site-header {
     padding: 0 7px;
 }
 
+.logged-in .ast-header-account-inner-wrap {
+    position: relative;
+}
+
+.logged-in .ast-header-account-inner-wrap::after {
+    content: "✓";
+    position: absolute;
+    bottom: -2px;
+    right: -2px;
+    display: grid;
+    place-items: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background-color: var(--color-success);
+    color: #fff;
+    font-size: 0.625rem;
+    font-weight: 700;
+    border: 2px solid var(--color-background);
+    pointer-events: none;
+}
+
 @media (--bp-small) {
     header.site-header {
         padding: 0 10px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7907,6 +7907,28 @@ header.site-header {
   padding: 0 7px;
 }
 
+.logged-in .ast-header-account-inner-wrap {
+  position: relative;
+}
+
+.logged-in .ast-header-account-inner-wrap::after {
+  content: "✓";
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  display: grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: var(--color-success);
+  color: #fff;
+  font-size: 0.625rem;
+  font-weight: 700;
+  border: 2px solid var(--color-background);
+  pointer-events: none;
+}
+
 @media (min-width: 480px) {
   header.site-header {
     padding: 0 10px;


### PR DESCRIPTION
## Résumé
Ajout d’un indicateur visuel de connexion sur l’icône de compte de l’entête.

## Changements
- Positionne l’enveloppe de l’icône de compte connectée pour accueillir un badge.
- Dessine un badge circulaire vert avec coche sur l’état connecté dans les styles compilés.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cbbb722c5c8332b02266cda8efdaa4