### PR TITLE
style: improve header account icon contrast

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -32,6 +32,14 @@
 
 /* ========== 🎯 HEADER TOP BAR ========== */
 
+:is(#ast-desktop-header, #ast-mobile-header) .ast-header-account-link.ast-header-account-type-icon {
+    color: var(--color-contrast-low, #f9fafb);
+}
+
+body.logged-in :is(#ast-desktop-header, #ast-mobile-header) .ast-header-account-link.ast-header-account-type-icon {
+    color: var(--color-success, #22c55e);
+}
+
 .site-above-header-wrap {
     background-color: rgba(0, 0, 0, 0.2);
     width: 100%;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7870,6 +7870,14 @@ body.accueil-fullscreen {
    📐 LAYOUT – STRUCTURE GÉNÉRALE DES PAGES
    ========================================================== */
 /* ========== 🎯 HEADER TOP BAR ========== */
+:is(#ast-desktop-header, #ast-mobile-header) .ast-header-account-link.ast-header-account-type-icon {
+  color: var(--color-contrast-low, #f9fafb);
+}
+
+body.logged-in :is(#ast-desktop-header, #ast-mobile-header) .ast-header-account-link.ast-header-account-type-icon {
+  color: var(--color-success, #22c55e);
+}
+
 .site-above-header-wrap {
   background-color: rgba(0, 0, 0, 0.2);
   width: 100%;


### PR DESCRIPTION
Mise à jour de la couleur des icônes de compte pour garantir un contraste correct sur fonds sombres.

- Adoption d'une teinte claire par défaut pour l'icône de compte dans les en-têtes desktop et mobile.
- Priorisation du vert de succès pour l'état connecté afin d'écraser les styles dynamiques d'Astra.
- Recompilation de la feuille `style.css` avec la nouvelle règle.

**Testing**
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cc03ee4d588332be9573f2565b8691