### PR TITLE
Réactiver le motif de fond sur toutes les mises en page Astra

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -122,10 +122,34 @@ h3, .entry-content h3 {
 
 /* ========== 🎨 ÉLÉMENTS HTML NATIFS ========== */
 
-body {
+body,
+body.ast-plain-container,
+body.ast-page-builder-template,
+body.ast-separate-container {
   font-family: 'Poppins', sans-serif;
   color: var(--color-text-primary);
   background-color: var(--color-background); /* Bleu nuit (fond global) */
+  --site-background-overlay: linear-gradient(135deg, rgba(6, 12, 33, 0.9), rgba(18, 27, 55, 0.82));
+  --site-background-pattern-size: 320px;
+  --site-background-overlay-blend-mode: overlay;
+  --site-background-pattern-blend-mode: soft-light;
+  background-image: var(--site-background-overlay), url("../assets/svg/pattern-puzzle.svg");
+  background-repeat: no-repeat, repeat;
+  background-position: center;
+  background-size: cover, var(--site-background-pattern-size);
+  background-blend-mode: var(--site-background-overlay-blend-mode), var(--site-background-pattern-blend-mode);
+}
+
+body > #page,
+body > #page > #content,
+body > #page > #content > .ast-container {
+  background: transparent;
+}
+
+body.woocommerce-account {
+  --site-background-overlay: linear-gradient(145deg, rgba(9, 14, 38, 0.82), rgba(32, 24, 58, 0.76));
+  --site-background-pattern-size: 220px;
+  --site-background-pattern-blend-mode: multiply;
 }
 p {
     margin-bottom: var(--space-0);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7178,10 +7178,34 @@ h3, .entry-content h3 {
   }
 }
 /* ========== 🎨 ÉLÉMENTS HTML NATIFS ========== */
-body {
+body,
+body.ast-plain-container,
+body.ast-page-builder-template,
+body.ast-separate-container {
   font-family: "Poppins", sans-serif;
   color: var(--color-text-primary);
   background-color: var(--color-background); /* Bleu nuit (fond global) */
+  --site-background-overlay: linear-gradient(135deg, rgba(6, 12, 33, 0.9), rgba(18, 27, 55, 0.82));
+  --site-background-pattern-size: 320px;
+  --site-background-overlay-blend-mode: overlay;
+  --site-background-pattern-blend-mode: soft-light;
+  background-image: var(--site-background-overlay), url("../assets/svg/pattern-puzzle.svg");
+  background-repeat: no-repeat, repeat;
+  background-position: center;
+  background-size: cover, var(--site-background-pattern-size);
+  background-blend-mode: var(--site-background-overlay-blend-mode), var(--site-background-pattern-blend-mode);
+}
+
+body > #page,
+body > #page > #content,
+body > #page > #content > .ast-container {
+  background: transparent;
+}
+
+body.woocommerce-account {
+  --site-background-overlay: linear-gradient(145deg, rgba(9, 14, 38, 0.82), rgba(32, 24, 58, 0.76));
+  --site-background-pattern-size: 220px;
+  --site-background-pattern-blend-mode: multiply;
 }
 
 p {


### PR DESCRIPTION
## Résumé
- Rétablit le motif puzzle sur le `<body>` en définissant les variables de superposition et de fusion pour toutes les variantes de layout Astra.
- Force la transparence des conteneurs Astra afin que le fond du site reste visible.
- Adapte les variables du motif pour la page « Mon compte » avant de recompiler la feuille de style du thème.

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68ce867b6b6483329a6626d90ba49d11