### PR TITLE
Supprime le motif de fond du body

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -122,10 +122,11 @@ h3, .entry-content h3 {
 
 /* ========== 🎨 ÉLÉMENTS HTML NATIFS ========== */
 
-body {
+body,
+body[class*="ast-"] {
   font-family: 'Poppins', sans-serif;
   color: var(--color-text-primary);
-  background-color: var(--color-background); /* Bleu nuit (fond global) */
+  background-color: var(--color-background); /* Fond neutre sans motif */
 }
 p {
     margin-bottom: var(--space-0);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7178,10 +7178,11 @@ h3, .entry-content h3 {
   }
 }
 /* ========== 🎨 ÉLÉMENTS HTML NATIFS ========== */
-body {
+body,
+body[class*=ast-] {
   font-family: "Poppins", sans-serif;
   color: var(--color-text-primary);
-  background-color: var(--color-background); /* Bleu nuit (fond global) */
+  background-color: var(--color-background); /* Fond neutre sans motif */
 }
 
 p {


### PR DESCRIPTION
Résumé : Nettoie le style global du thème pour ne conserver qu'un fond neutre.

* Aligne le sélecteur `body` et ses variantes Astra sur une couleur de fond unifiée sans motif.
* Regénère la feuille `dist/style.css` afin d'appliquer ce fond neutre dans la version compilée.

## Tests
* `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68ceb4ead998833288e271d2d3697d38