### PR TITLE
Améliore le contraste des tableaux de statistiques

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -224,6 +224,11 @@ tbody tr:nth-child(even) {
   font-size: 0.85rem;
 }
 
+.stats-table thead {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--color-text-primary);
+}
+
 .stats-table th,
 .stats-table td {
   padding: 8px 12px;
@@ -232,11 +237,15 @@ tbody tr:nth-child(even) {
 }
 
 .stats-table th {
-  background-color: rgba(0, 0, 0, 0.08);
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 .stats-table tbody tr:nth-child(odd) {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.stats-table tbody tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.02);
 }
 
 .stats-table-wrapper {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7288,6 +7288,11 @@ tbody tr:nth-child(even) {
   font-size: 0.85rem;
 }
 
+.stats-table thead {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--color-text-primary);
+}
+
 .stats-table th,
 .stats-table td {
   padding: 8px 12px;
@@ -7296,11 +7301,15 @@ tbody tr:nth-child(even) {
 }
 
 .stats-table th {
-  background-color: rgba(0, 0, 0, 0.08);
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 .stats-table tbody tr:nth-child(odd) {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.stats-table tbody tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.02);
 }
 
 .stats-table-wrapper {


### PR DESCRIPTION
Résumé : Amélioration du contraste des tableaux statistiques sur l'espace Mon Compte.

- Met à jour le style SCSS des tableaux de statistiques pour éclaircir l'en-tête et le texte.
- Regénère la feuille de style compilée avec les nouvelles couleurs de contraste.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cf6c64d990833289d0c963b49b7446