### PR TITLE
Ajoute la date de dernière connexion dans l'en-tête Mon compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -153,6 +153,18 @@
     color: var(--color-text-primary);
 }
 
+.myaccount-last-active {
+    margin-left: auto;
+    margin-bottom: 0;
+    font-size: 0.875rem;
+    color: rgba(255, 255, 255, 0.7);
+    text-align: right;
+
+    .meta-label {
+        font-weight: 600;
+    }
+}
+
 .myaccount-content {
     flex: 1;
     overflow-y: auto;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8762,6 +8762,17 @@ footer .site-footer-primary-section-3 {
   color: var(--color-text-primary);
 }
 
+.myaccount-last-active {
+  margin-left: auto;
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: right;
+}
+.myaccount-last-active .meta-label {
+  font-weight: 600;
+}
+
 .myaccount-content {
   flex: 1;
   overflow-y: auto;

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -23,12 +23,20 @@ if (!empty($_SERVER['REQUEST_URI'])) {
 if ($current_user->ID) {
     $last_active_raw = get_user_meta($current_user->ID, 'wc_last_active', true);
     if ($last_active_raw) {
-        $last_active_timestamp = strtotime($last_active_raw);
-        if ($last_active_timestamp) {
+        if (is_numeric($last_active_raw)) {
+            $last_active_timestamp = absint($last_active_raw);
+        } else {
+            $last_active_timestamp = strtotime($last_active_raw);
+        }
+
+        if (!empty($last_active_timestamp)) {
+            $locale = function_exists('determine_locale') ? determine_locale() : get_locale();
+            $date_format = strpos($locale, 'fr_') === 0 ? 'd/m/Y' : 'n/j/Y';
+
             if (function_exists('wp_date')) {
-                $last_active_formatted = wp_date(get_option('date_format'), $last_active_timestamp);
+                $last_active_formatted = wp_date($date_format, $last_active_timestamp);
             } else {
-                $last_active_formatted = date_i18n(get_option('date_format'), $last_active_timestamp);
+                $last_active_formatted = date_i18n($date_format, $last_active_timestamp);
             }
         }
     }

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -10,13 +10,28 @@
 
 defined('ABSPATH') || exit;
 
-$content_template = $GLOBALS['myaccount_content_template'] ?? null;
-$current_user     = wp_get_current_user();
-$display_name     = $current_user->ID ? $current_user->display_name : get_bloginfo('name');
-$show_nav         = is_user_logged_in();
-$current_path     = '';
+$content_template      = $GLOBALS['myaccount_content_template'] ?? null;
+$current_user          = wp_get_current_user();
+$display_name          = $current_user->ID ? $current_user->display_name : get_bloginfo('name');
+$show_nav              = is_user_logged_in();
+$current_path          = '';
+$last_active_formatted = '';
 if (!empty($_SERVER['REQUEST_URI'])) {
     $current_path = trim(parse_url(wp_unslash($_SERVER['REQUEST_URI']), PHP_URL_PATH), '/');
+}
+
+if ($current_user->ID) {
+    $last_active_raw = get_user_meta($current_user->ID, 'wc_last_active', true);
+    if ($last_active_raw) {
+        $last_active_timestamp = strtotime($last_active_raw);
+        if ($last_active_timestamp) {
+            if (function_exists('wp_date')) {
+                $last_active_formatted = wp_date(get_option('date_format'), $last_active_timestamp);
+            } else {
+                $last_active_formatted = date_i18n(get_option('date_format'), $last_active_timestamp);
+            }
+        }
+    }
 }
 
 get_header();
@@ -190,7 +205,12 @@ get_header();
                 <?php
             endif;
             ?>
-            <!-- TODO: header content -->
+            <?php if ($last_active_formatted) : ?>
+                <p class="myaccount-last-active">
+                    <span class="meta-label"><?php esc_html_e('Dernière connexion :', 'chassesautresor-com'); ?></span>
+                    <span class="meta-value"><?php echo esc_html($last_active_formatted); ?></span>
+                </p>
+            <?php endif; ?>
         </header>
         <main class="myaccount-content">
             <?php


### PR DESCRIPTION
Ajout de l'affichage de la dernière connexion sur l'en-tête Mon compte.

- Lecture de la méta `wc_last_active` et présentation conditionnelle dans le header.
- Styles SCSS dédiés et recompilation du CSS distribué pour positionner l'information à droite.

**Testing**
- ✅ `npm run build:css`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cf6f41c1008332a5a6260bfe4c4c9e