### PR TITLE
Remove continue shopping button from empty mini cart

### DIFF
--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -253,6 +253,62 @@ function cta_account_icon_by_state( $default ) {
 add_filter( 'astra_get_option_header-account-icon-type', 'cta_account_icon_by_state' );
 
 /**
+ * Removes the "Continue Shopping" button from Astra's flyout cart when empty.
+ *
+ * @return void
+ */
+add_action(
+    'wp',
+    static function (): void {
+        if ( ! class_exists( 'Astra_Woocommerce' ) || ! function_exists( 'WC' ) ) {
+            return;
+        }
+
+        remove_action(
+            'woocommerce_after_mini_cart',
+            [ Astra_Woocommerce::get_instance(), 'astra_update_flyout_cart_layout' ]
+        );
+
+        add_action(
+            'woocommerce_after_mini_cart',
+            static function (): void {
+                if ( ! function_exists( 'WC' ) ) {
+                    return;
+                }
+
+                $cart = WC()->cart;
+
+                if ( ! $cart || ! $cart->is_empty() ) {
+                    return;
+                }
+
+                /**
+                 * Preserve Astra's extensibility hooks around the empty mini-cart.
+                 */
+                do_action( 'astra_empty_cart_before' );
+
+                $message = apply_filters(
+                    'astra_mini_cart_empty_msg',
+                    __( 'No products in the cart.', 'chassesautresor-com' )
+                );
+                ?>
+                <div class="ast-mini-cart-empty">
+                    <div class="ast-mini-cart-message">
+                        <p class="woocommerce-mini-cart__empty-message">
+                            <?php echo esc_html( $message ); ?>
+                        </p>
+                    </div>
+                    <?php do_action( 'astra_empty_cart_content' ); ?>
+                </div>
+                <?php
+                do_action( 'astra_empty_cart_after' );
+            }
+        );
+    },
+    5
+);
+
+/**
  * Chargement des styles du thème parent et enfant avec prise en charge d'Astra.
  */
 add_action('wp_enqueue_scripts', function () {

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -67,6 +67,10 @@ msgstr ""
 msgid "Change language"
 msgstr ""
 
+#: functions.php:292
+msgid "No products in the cart."
+msgstr ""
+
 #: inc/admin-functions.php:40
 msgid "⛔ Accès refusé."
 msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -47,6 +47,10 @@ msgstr "English"
 msgid "Change language"
 msgstr "Change language"
 
+#: functions.php:292
+msgid "No products in the cart."
+msgstr "No products in the cart."
+
 #: inc/admin-functions.php:40
 msgid "⛔ Accès refusé."
 msgstr "Access denied."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -47,6 +47,10 @@ msgstr "Anglais"
 msgid "Change language"
 msgstr "Changer de langue"
 
+#: functions.php:292
+msgid "No products in the cart."
+msgstr "Aucun article dans le panier."
+
 #: inc/admin-functions.php:40
 msgid "⛔ Accès refusé."
 msgstr "⛔ Accès refusé."


### PR DESCRIPTION
Supprime le bouton « Continuer les achats » lorsque le mini-panier Astra est vide.

- Remplace le rendu par défaut du mini-panier vide pour retirer le bouton tout en conservant les hooks Astra.
- Ajoute la chaîne de traduction « No products in the cart. » dans les fichiers POT et PO du thème enfant.

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68cf711b8e0c8332985cc98b72bf2ad0