### PR TITLE
Add tentatives search filtering and tests

### DIFF
--- a/tests/myaccount_tentatives.test.php
+++ b/tests/myaccount_tentatives.test.php
@@ -1,0 +1,347 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+if (!function_exists('add_action')) {
+    function add_action(...$args): void {}
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter(...$args): void {}
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value)
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key)
+    {
+        $key = strtolower((string) $key);
+        return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = [])
+    {
+        if (is_array($args)) {
+            return array_merge($defaults, $args);
+        }
+
+        if (is_object($args)) {
+            return array_merge($defaults, get_object_vars($args));
+        }
+
+        parse_str((string) $args, $parsed);
+
+        return array_merge($defaults, $parsed);
+    }
+}
+
+if (!function_exists('_doing_it_wrong')) {
+    function _doing_it_wrong(...$args): void {}
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return (string) $text;
+    }
+}
+
+if (!function_exists('esc_html_e')) {
+    function esc_html_e($text, $domain = 'default')
+    {
+        echo esc_html($text);
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('_n')) {
+    function _n($single, $plural, $number, $domain = 'default')
+    {
+        return (int) $number > 1 ? $plural : $single;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text)
+    {
+        return (string) $text;
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_attr_e')) {
+    function esc_attr_e($text, $domain = 'default')
+    {
+        echo esc_attr($text);
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url)
+    {
+        return (string) $url;
+    }
+}
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in()
+    {
+        return true;
+    }
+}
+
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id()
+    {
+        return 42;
+    }
+}
+
+if (!function_exists('get_stylesheet_directory')) {
+    function get_stylesheet_directory()
+    {
+        $path = realpath(__DIR__ . '/../wp-content/themes/chassesautresor');
+
+        return $path !== false ? $path : __DIR__ . '/../wp-content/themes/chassesautresor';
+    }
+}
+
+if (!function_exists('get_stylesheet_directory_uri')) {
+    function get_stylesheet_directory_uri()
+    {
+        return 'https://example.com/theme';
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script(...$args): void {}
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value)
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('wp_doing_ajax')) {
+    function wp_doing_ajax()
+    {
+        return false;
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value)
+    {
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+}
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($cap = '')
+    {
+        return true;
+    }
+}
+
+if (!function_exists('cta_render_search_form')) {
+    function cta_render_search_form($key, $overrides = [])
+    {
+        return '<form class="table-search" data-search-key="' . esc_attr($key) . '"></form>';
+    }
+}
+
+if (!function_exists('cta_render_proposition_cell')) {
+    function cta_render_proposition_cell($text, $expanded = false, $limit = 39)
+    {
+        return '<td class="proposition-cell">' . esc_html($text) . '</td>';
+    }
+}
+
+if (!function_exists('cta_render_pager')) {
+    function cta_render_pager($current, $total, $class = '', $attributes = [])
+    {
+        return '<nav class="' . esc_attr($class) . '"></nav>';
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($post_id)
+    {
+        return 'https://example.com/post-' . (int) $post_id;
+    }
+}
+
+if (!function_exists('mysql2date')) {
+    function mysql2date($format, $date)
+    {
+        $datetime = date_create($date);
+        if (!$datetime) {
+            return '';
+        }
+
+        return $datetime->format($format);
+    }
+}
+
+class TentativesTestWpdb
+{
+    public string $prefix = 'wp_';
+    public string $posts = 'wp_posts';
+    public string $postmeta = 'wp_postmeta';
+    public string $last_get_results_sql = '';
+
+    public function esc_like($text)
+    {
+        return str_replace(['%', '_'], ['\\%', '\\_'], $text);
+    }
+
+    public function prepare($query, ...$args)
+    {
+        if (count($args) === 1 && is_array($args[0])) {
+            $args = $args[0];
+        }
+
+        $segments = preg_split('/(%s|%d|%f)/', $query, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $result   = '';
+        $index    = 0;
+
+        foreach ($segments as $segment) {
+            if ($segment === '%s') {
+                $value  = $args[$index++] ?? '';
+                $result .= "'" . addslashes((string) $value) . "'";
+            } elseif ($segment === '%d') {
+                $value  = $args[$index++] ?? 0;
+                $result .= (string) (int) $value;
+            } elseif ($segment === '%f') {
+                $value  = $args[$index++] ?? 0.0;
+                $result .= (string) (float) $value;
+            } else {
+                $result .= $segment;
+            }
+        }
+
+        return $result;
+    }
+
+    public function get_var($sql)
+    {
+        if (strpos($sql, "resultat = 'attente'") !== false) {
+            return 1;
+        }
+
+        if (strpos($sql, "resultat = 'bon'") !== false && strpos($sql, 'chasses') === false) {
+            return 2;
+        }
+
+        if (strpos($sql, 'COUNT(*)') !== false && strpos($sql, 'chasses') !== false) {
+            return stripos($sql, 'bonbons') !== false ? 1 : 3;
+        }
+
+        if (strpos($sql, 'COUNT(*)') !== false) {
+            return 3;
+        }
+
+        return 0;
+    }
+
+    public function get_results($sql, $output = OBJECT)
+    {
+        $this->last_get_results_sql = $sql;
+        $rows = [
+            (object) [
+                'ID'             => 1,
+                'enigme_id'      => 10,
+                'date_tentative' => '2024-05-01 10:00:00',
+                'reponse_saisie' => 'Bonbons',
+                'resultat'       => 'bon',
+                'chasse_id'      => 201,
+                'chasse_title'   => 'Chasse aux bonbons',
+                'enigme_title'   => 'Énigme Bonbons',
+            ],
+            (object) [
+                'ID'             => 2,
+                'enigme_id'      => 11,
+                'date_tentative' => '2024-05-02 11:00:00',
+                'reponse_saisie' => 'Pirates',
+                'resultat'       => 'mauvais',
+                'chasse_id'      => 202,
+                'chasse_title'   => 'Chasse aux pirates',
+                'enigme_title'   => 'Énigme Pirates',
+            ],
+        ];
+
+        if (stripos($sql, 'bonbons') !== false) {
+            return [$rows[0]];
+        }
+
+        return $rows;
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/search/registry.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/search/helpers.php';
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/user-functions.php';
+
+class MyAccountTentativesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $wpdb;
+        $wpdb = new TentativesTestWpdb();
+
+        $registry = &ca_get_search_registry_storage();
+        $registry = [];
+
+        $_GET = [];
+    }
+
+    public function test_search_filters_results(): void
+    {
+        global $wpdb;
+
+        $_GET['search'] = [
+            'context'    => 'tentatives',
+            'tentatives' => 'bonbons',
+        ];
+
+        ob_start();
+        ca_render_dashboard_tentatives();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Chasse aux bonbons', $output);
+        $this->assertStringNotContainsString('Chasse aux pirates', $output);
+        $this->assertStringContainsString('table-search', $output);
+    }
+}

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -8,9 +8,11 @@
       return;
     }
     var page = e.detail.page || 1;
-    var url = new URL(window.location.href);
+    var currentUrl = new URL(window.location.href);
+    var url = new URL(currentUrl.toString());
     var param = pager.dataset.param || 'page';
     var section = pager.dataset.section;
+    var searchKey = pager.dataset.searchKey;
 
     if (typeof section === 'string') {
       if (section.length) {
@@ -28,6 +30,22 @@
 
     if (param !== 'page') {
       url.searchParams.delete('page');
+    }
+
+    if (searchKey) {
+      var searchParam = 'search[' + searchKey + ']';
+      var searchValue = currentUrl.searchParams.get(searchParam);
+      if (searchValue !== null) {
+        url.searchParams.set(searchParam, searchValue);
+      }
+
+      var contextParam = 'search[context]';
+      var contextValue = currentUrl.searchParams.get(contextParam);
+      if (contextValue !== null) {
+        url.searchParams.set(contextParam, contextValue);
+      } else if (searchValue !== null) {
+        url.searchParams.set(contextParam, searchKey);
+      }
     }
 
     window.location.href = url.toString();

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1242,6 +1242,10 @@ function ca_render_dashboard_tentatives(): void
         true
     );
 
+    if (function_exists('wp_enqueue_script')) {
+        wp_enqueue_script('table-search');
+    }
+
     global $wpdb;
 
     $table   = $wpdb->prefix . 'enigme_tentatives';
@@ -1258,21 +1262,74 @@ function ca_render_dashboard_tentatives(): void
         $user_id
     ));
 
-    if ($total <= 0) {
-        return;
+    ca_register_search_context('tentatives', [
+        'fields' => [
+            'sql' => [
+                'p.post_title',
+                't.reponse_saisie',
+                'chasses.post_title',
+            ],
+        ],
+        'ui' => [
+            'label'       => __('Rechercher une tentative', 'chassesautresor-com'),
+            'placeholder' => __('Chasse, énigme ou réponse...', 'chassesautresor-com'),
+        ],
+        'pagination_params' => ['tentatives-page'],
+    ]);
+
+    $search_term = ca_get_search_term('tentatives');
+
+    $per_page = 10;
+    $page     = max(1, (int) ($_GET['tentatives-page'] ?? 1));
+
+    $base_from = sprintf(
+        " FROM %s t
+        INNER JOIN %s p ON t.enigme_id = p.ID
+        LEFT JOIN (
+            SELECT pm.post_id,
+                   MAX(
+                       CAST(
+                           SUBSTRING_INDEX(
+                               SUBSTRING_INDEX(pm.meta_value, ';', 2),
+                               ':',
+                               -1
+                           ) AS UNSIGNED
+                       )
+                   ) AS chasse_id
+            FROM %s pm
+            WHERE pm.meta_key IN ('chasse_associee', 'enigme_chasse_associee')
+            GROUP BY pm.post_id
+        ) AS chasse_meta ON chasse_meta.post_id = t.enigme_id
+        LEFT JOIN %s chasses ON chasses.ID = chasse_meta.chasse_id",
+        $table,
+        $wpdb->posts,
+        $wpdb->postmeta,
+        $wpdb->posts
+    );
+
+    $where_clause = ' WHERE t.user_id = %d';
+
+    $count_sql = "SELECT COUNT(*){$base_from}{$where_clause}";
+    $count_sql = ca_apply_search_filters('tentatives', $count_sql, $search_term);
+    $filtered_total = (int) $wpdb->get_var($wpdb->prepare($count_sql, $user_id));
+
+    $pages = $filtered_total > 0 ? (int) ceil($filtered_total / $per_page) : 0;
+    if ($pages > 0 && $page > $pages) {
+        $page = $pages;
+    } elseif ($pages === 0) {
+        $page = 1;
     }
 
-    $per_page   = 10;
-    $page       = max(1, (int) ($_GET['tentatives-page'] ?? 1));
-    $offset     = ($page - 1) * $per_page;
-    $tentatives = $wpdb->get_results($wpdb->prepare(
-        "SELECT t.*, p.post_title FROM {$table} t JOIN {$wpdb->posts} p ON t.enigme_id = p.ID WHERE t.user_id = %d ORDER BY t.date_tentative DESC LIMIT %d OFFSET %d",
-        $user_id,
-        $per_page,
-        $offset
-    ));
+    $offset = ($page - 1) * $per_page;
 
-    $pages = (int) ceil($total / $per_page);
+    $select_sql = "SELECT t.*, p.post_title AS enigme_title, COALESCE(chasse_meta.chasse_id, 0) AS chasse_id, chasses.post_title AS chasse_title{$base_from}{$where_clause}";
+    $select_sql = ca_apply_search_filters('tentatives', $select_sql, $search_term);
+    $select_sql .= ' ORDER BY t.date_tentative DESC LIMIT %d OFFSET %d';
+    $tentatives = $wpdb->get_results($wpdb->prepare($select_sql, $user_id, $per_page, $offset));
+
+    $no_results_message = $search_term !== ''
+        ? __('Aucune tentative ne correspond à votre recherche.', 'chassesautresor-com')
+        : __('Vous n\'avez pas encore enregistré de tentative.', 'chassesautresor-com');
 
     ob_start();
     ?>
@@ -1288,6 +1345,7 @@ function ca_render_dashboard_tentatives(): void
                 <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $success, 'chassesautresor-com')), $success); ?>
             </span>
             <?php endif; ?>
+            <?php echo cta_render_search_form('tentatives'); ?>
         </div>
         <div class="stats-table-wrapper" data-per-page="<?php echo esc_attr($per_page); ?>">
             <table class="stats-table tentatives-table">
@@ -1301,40 +1359,51 @@ function ca_render_dashboard_tentatives(): void
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($tentatives as $tent) : ?>
-                    <tr>
-                        <?php $chasse_id = (int) recuperer_id_chasse_associee($tent->enigme_id); ?>
-                        <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
-                        <td>
-                            <?php if ($chasse_id) : ?>
-                            <a href="<?php echo esc_url(get_permalink($chasse_id)); ?>">
-                                <?php echo esc_html(get_the_title($chasse_id)); ?>
-                            </a>
-                            <?php else : ?>
-                            &mdash;
-                            <?php endif; ?>
-                        </td>
-                        <td><?php echo esc_html($tent->post_title); ?></td>
-                        <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? ''); ?>
-                        <?php
-                        $result = $tent->resultat;
-                        $class  = 'etiquette-error';
-                        if ($result === 'bon') {
-                            $class = 'etiquette-success';
-                        } elseif ($result === 'attente') {
-                            $class = 'etiquette-pending';
-                        }
-                        ?>
-                        <td>
-                            <span class="etiquette <?php echo esc_attr($class); ?>">
-                                <?php echo esc_html__($result, 'chassesautresor-com'); ?>
-                            </span>
-                        </td>
+                    <?php if ($filtered_total <= 0 || empty($tentatives)) : ?>
+                    <tr class="tentatives-empty">
+                        <td colspan="5"><?php echo esc_html($no_results_message); ?></td>
                     </tr>
-                    <?php endforeach; ?>
+                    <?php else : ?>
+                        <?php foreach ($tentatives as $tent) : ?>
+                        <?php
+                        $chasse_id    = isset($tent->chasse_id) ? (int) $tent->chasse_id : 0;
+                        $chasse_title = isset($tent->chasse_title) ? (string) $tent->chasse_title : '';
+                        ?>
+                        <tr>
+                            <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
+                            <td>
+                                <?php if ($chasse_id > 0 && $chasse_title !== '') : ?>
+                                <a href="<?php echo esc_url(get_permalink($chasse_id)); ?>">
+                                    <?php echo esc_html($chasse_title); ?>
+                                </a>
+                                <?php elseif ($chasse_title !== '') : ?>
+                                <?php echo esc_html($chasse_title); ?>
+                                <?php else : ?>
+                                &mdash;
+                                <?php endif; ?>
+                            </td>
+                            <td><?php echo esc_html($tent->enigme_title ?? ''); ?></td>
+                            <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? ''); ?>
+                            <?php
+                            $result = $tent->resultat;
+                            $class  = 'etiquette-error';
+                            if ($result === 'bon') {
+                                $class = 'etiquette-success';
+                            } elseif ($result === 'attente') {
+                                $class = 'etiquette-pending';
+                            }
+                            ?>
+                            <td>
+                                <span class="etiquette <?php echo esc_attr($class); ?>">
+                                    <?php echo esc_html__($result, 'chassesautresor-com'); ?>
+                                </span>
+                            </td>
+                        </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
                 </tbody>
             </table>
-            <?php echo cta_render_pager($page, $pages, 'tentatives-pager', ['data-param' => 'tentatives-page', 'data-section' => '']); ?>
+            <?php echo cta_render_pager($page, $pages, 'tentatives-pager', ['data-param' => 'tentatives-page', 'data-section' => '', 'data-search-key' => 'tentatives']); ?>
         </div>
     </section>
     <?php


### PR DESCRIPTION
## Résumé
- ajoute le contexte de recherche des tentatives et filtre les requêtes SQL associées
- insère le formulaire de recherche, gère l’état vide et conserve le paramètre côté pager
- couvre la fonctionnalité via un test d’intégration

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cf7a1c88ec8332922f6ceee116b7ff