### PR TITLE
Harmonise tentatives heading on account dashboard

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1277,7 +1277,7 @@ function ca_render_dashboard_tentatives(): void
     ob_start();
     ?>
     <section class="myaccount-tentatives">
-        <h3><?php esc_html_e('Tentatives', 'chassesautresor-com'); ?></h3>
+        <h2><?php esc_html_e('Tentatives', 'chassesautresor-com'); ?></h2>
         <div class="table-header">
             <?php if ($pending > 0) : ?>
             <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $pending, 'chassesautresor-com')), $pending); ?></span>


### PR DESCRIPTION
## Résumé
- Harmonise le titre de la section "Tentatives" en le passant en H2 sur l'accueil Mon Compte.

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68cf7d72514c8332a637c30c5452d677