### PR TITLE
Stop uppercasing headings on account pages

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -19,6 +19,12 @@
     color: var(--color-text-primary);
 }
 
+.myaccount-layout h1,
+.myaccount-layout h2,
+.myaccount-layout h3 {
+    text-transform: none;
+}
+
 .myaccount-sidebar {
     width: 280px;
     border-right: 1px solid rgba(255, 255, 255, 0.1);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8705,6 +8705,12 @@ footer .site-footer-primary-section-3 {
   color: var(--color-text-primary);
 }
 
+.myaccount-layout h1,
+.myaccount-layout h2,
+.myaccount-layout h3 {
+  text-transform: none;
+}
+
 .myaccount-sidebar {
   width: 280px;
   border-right: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
Supprime la capitalisation forcée des titres dans l'espace Mon Compte.

- Supprime la transformation en majuscules des h1, h2 et h3 sous `.myaccount-layout` dans le SCSS.
- Regénère la feuille de styles compilée afin d'inclure la nouvelle règle CSS.

**Tests**
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cf7dab3d588332abd1605ce90fa554