### PR TITLE
Aligner la recherche des tentatives et ajouter un reset

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -27,6 +27,9 @@ Enregistre un contexte de recherche avec :
 - `hidden_fields` : champs cachés ajoutés systématiquement au formulaire.
 - `pagination_params` : liste de paramètres à purger lors d'une nouvelle
   recherche (`tentatives-page`, `page`, etc.).
+- `ui.show_reset_button` : afficher un bouton de réinitialisation lorsque
+  l'utilisateur a déjà saisi une recherche.
+- `ui.reset_label` : personnalise l'intitulé du bouton de réinitialisation.
 
 ### `ca_resolve_search_context(string $key): array`
 
@@ -53,7 +56,7 @@ Génère le formulaire `<form class="table-search">` associé à un contexte :
 - ajoute automatiquement `search[context]`, préserve le paramètre `section` et
   fusionne les `hidden_fields` déclarés.
 - accepte des surcharges (`method`, `action`, `hidden_fields`, `submit_label`,
-  etc.) et insère un nonce si demandé.
+  `show_reset_button`, `reset_label`, etc.) et insère un nonce si demandé.
 - renseigne `data-reset-pagination` pour que le script JS supprime les anciens
   paramètres de pagination.
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -57,6 +57,8 @@ Génère le formulaire `<form class="table-search">` associé à un contexte :
   fusionne les `hidden_fields` déclarés.
 - accepte des surcharges (`method`, `action`, `hidden_fields`, `submit_label`,
   `show_reset_button`, `reset_label`, `data_attributes`, etc.) et insère un nonce si demandé.
+- garantit la présence de la classe de base `table-search` même lorsque des
+  modificateurs (`table-search--inline`, `table-search--compact`, ...) sont fournis.
 - renseigne `data-reset-pagination` pour que le script JS supprime les anciens
   paramètres de pagination.
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -56,7 +56,7 @@ Génère le formulaire `<form class="table-search">` associé à un contexte :
 - ajoute automatiquement `search[context]`, préserve le paramètre `section` et
   fusionne les `hidden_fields` déclarés.
 - accepte des surcharges (`method`, `action`, `hidden_fields`, `submit_label`,
-  `show_reset_button`, `reset_label`, etc.) et insère un nonce si demandé.
+  `show_reset_button`, `reset_label`, `data_attributes`, etc.) et insère un nonce si demandé.
 - renseigne `data-reset-pagination` pour que le script JS supprime les anciens
   paramètres de pagination.
 
@@ -71,6 +71,15 @@ navigateur :
 - déclenche l'événement `tablesearch:submit` (bubbling, annulable) contenant
   `{ form, searchKey, term, actionUrl, resetParams }`. Annuler l'événement
   empêche l'envoi natif du formulaire (intégrations AJAX).
+
+### Intégration AJAX
+
+- Ajouter des attributs `data-ajax-action` et `data-ajax-target` sur le
+  formulaire pour brancher un traitement dynamique.
+- Intercepter `tablesearch:submit` et `tablesearch:reset` pour envoyer la
+  requête avec `fetch()` puis rafraîchir le tableau sans rechargement.
+- Mettre à jour l'URL via `history.replaceState` afin de conserver les
+  paramètres de recherche et de pagination dans l'historique.
 
 ## Exemple minimal
 

--- a/tests/myaccount_tentatives.test.php
+++ b/tests/myaccount_tentatives.test.php
@@ -343,5 +343,6 @@ class MyAccountTentativesTest extends TestCase
         $this->assertStringContainsString('Chasse aux bonbons', $output);
         $this->assertStringNotContainsString('Chasse aux pirates', $output);
         $this->assertStringContainsString('table-search', $output);
+        $this->assertStringContainsString('table-search__reset', $output);
     }
 }

--- a/tests/myaccount_tentatives.test.php
+++ b/tests/myaccount_tentatives.test.php
@@ -147,6 +147,22 @@ if (!function_exists('wp_enqueue_script')) {
     function wp_enqueue_script(...$args): void {}
 }
 
+if (!function_exists('wp_localize_script')) {
+    function wp_localize_script($handle, $object_name, $l10n)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = '', $scheme = 'admin')
+    {
+        $base = 'https://example.com/wp-admin/';
+
+        return $base . ltrim((string) $path, '/');
+    }
+}
+
 if (!function_exists('wp_unslash')) {
     function wp_unslash($value)
     {

--- a/tests/myaccount_tentatives.test.php
+++ b/tests/myaccount_tentatives.test.php
@@ -178,7 +178,11 @@ if (!function_exists('current_user_can')) {
 if (!function_exists('cta_render_search_form')) {
     function cta_render_search_form($key, $overrides = [])
     {
-        return '<form class="table-search" data-search-key="' . esc_attr($key) . '"></form>';
+        return '<form class="table-search" data-search-key="' . esc_attr($key) . '" data-ajax-action="ca_fetch_tentatives" data-ajax-target="#tentatives-table-wrapper">'
+            . '<div class="table-search__controls">'
+            . '<button type="button" class="table-search__reset" data-table-search-reset hidden></button>'
+            . '</div>'
+            . '</form>';
     }
 }
 
@@ -344,5 +348,7 @@ class MyAccountTentativesTest extends TestCase
         $this->assertStringNotContainsString('Chasse aux pirates', $output);
         $this->assertStringContainsString('table-search', $output);
         $this->assertStringContainsString('table-search__reset', $output);
+        $this->assertStringContainsString('data-ajax-action="ca_fetch_tentatives"', $output);
+        $this->assertStringContainsString('id="tentatives-table-wrapper"', $output);
     }
 }

--- a/tests/myaccount_tentatives.test.php
+++ b/tests/myaccount_tentatives.test.php
@@ -362,7 +362,7 @@ class MyAccountTentativesTest extends TestCase
 
         $this->assertStringContainsString('Chasse aux bonbons', $output);
         $this->assertStringNotContainsString('Chasse aux pirates', $output);
-        $this->assertStringContainsString('table-search', $output);
+        $this->assertStringContainsString('class="table-search table-search--inline table-search--compact"', $output);
         $this->assertStringContainsString('table-search__reset', $output);
         $this->assertStringContainsString('data-ajax-action="ca_fetch_tentatives"', $output);
         $this->assertStringContainsString('id="tentatives-table-wrapper"', $output);

--- a/wp-content/themes/chassesautresor/assets/js/core/table-search.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/table-search.js
@@ -104,9 +104,112 @@
     });
   }
 
+  function getSearchField(form) {
+    if (!(form instanceof HTMLFormElement)) {
+      return null;
+    }
+
+    return form.querySelector('input[type="search"]');
+  }
+
+  function getSearchFieldName(form) {
+    var field = getSearchField(form);
+
+    if (!field || !field.name) {
+      return '';
+    }
+
+    return field.name;
+  }
+
+  function buildResetUrl(form) {
+    var url = buildActionUrl(form, '');
+    var searchParam = getSearchFieldName(form);
+
+    if (searchParam) {
+      url.searchParams.delete(searchParam);
+    }
+
+    url.searchParams.delete('search[context]');
+
+    var hiddenFields = form.querySelectorAll('input[type="hidden"][name]');
+
+    Array.prototype.forEach.call(hiddenFields, function (field) {
+      var name = field.getAttribute('name');
+
+      if (!name || name === 'search[context]' || name === searchParam) {
+        return;
+      }
+
+      var value = field.value;
+
+      if (value === undefined) {
+        return;
+      }
+
+      if (value === '') {
+        url.searchParams.delete(name);
+        return;
+      }
+
+      url.searchParams.set(name, value);
+    });
+
+    return url;
+  }
+
   function getSearchTerm(form) {
     var field = form.querySelector('input[type="search"]');
     return field ? field.value.trim() : '';
+  }
+
+  function handleReset(event) {
+    if (!event.target || typeof event.target.closest !== 'function') {
+      return;
+    }
+
+    var trigger = event.target.closest('[data-table-search-reset]');
+
+    if (!trigger) {
+      return;
+    }
+
+    var form = trigger.closest('form.table-search');
+
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    var field = getSearchField(form);
+
+    if (field) {
+      field.value = '';
+    }
+
+    resetPaginationFields(form);
+
+    var url = buildResetUrl(form);
+    var detail = {
+      form: form,
+      searchKey: form.dataset.searchKey || '',
+      term: '',
+      actionUrl: url,
+      resetParams: getResetParams(form)
+    };
+
+    var customEvent = new CustomEvent('tablesearch:reset', {
+      bubbles: true,
+      cancelable: true,
+      detail: detail
+    });
+
+    if (!form.dispatchEvent(customEvent)) {
+      return;
+    }
+
+    window.location.href = url.toString();
   }
 
   function handleSubmit(event) {
@@ -149,6 +252,10 @@
 
   document.addEventListener('submit', function (event) {
     handleSubmit(event);
+  });
+
+  document.addEventListener('click', function (event) {
+    handleReset(event);
   });
 
   document.addEventListener('DOMContentLoaded', function () {

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -2,8 +2,23 @@
  * Handle AJAX interactions for the Tentatives table search and pager.
  */
 (function () {
-  var SEARCH_ACTION = 'ca_fetch_tentatives';
+  var config = window.caTentativesPager || {};
+  var SEARCH_ACTION =
+    (config && typeof config.action === 'string' && config.action) ||
+    'ca_fetch_tentatives';
   var PAGE_PARAM = 'tentatives-page';
+
+  function getAjaxUrl() {
+    if (config && typeof config.ajaxUrl === 'string' && config.ajaxUrl) {
+      return config.ajaxUrl;
+    }
+
+    if (typeof window.ajaxurl === 'string' && window.ajaxurl) {
+      return window.ajaxurl;
+    }
+
+    return '';
+  }
 
   function getSearchForm() {
     return document.querySelector('form.table-search[data-ajax-action="' + SEARCH_ACTION + '"]');
@@ -243,7 +258,9 @@
 
   function loadTentatives(form, options) {
     var wrapper = getWrapper(form);
-    if (!form || !wrapper || !window.ajaxurl) {
+    var ajaxUrl = getAjaxUrl();
+
+    if (!form || !wrapper || !ajaxUrl) {
       return Promise.resolve();
     }
 
@@ -264,7 +281,7 @@
 
     setLoading(wrapper, true);
 
-    return fetch(window.ajaxurl, {
+    return fetch(ajaxUrl, {
       method: 'POST',
       credentials: 'same-origin',
       headers: {

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -326,6 +326,17 @@
       });
   }
 
+  function isTentativesForm(form) {
+    return (
+      form &&
+      typeof form === 'object' &&
+      typeof form.classList !== 'undefined' &&
+      form.classList.contains('table-search') &&
+      form.dataset &&
+      form.dataset.ajaxAction === SEARCH_ACTION
+    );
+  }
+
   function handleSearchSubmit(event) {
     var detail = event.detail;
     if (!detail || !detail.form) {
@@ -333,7 +344,7 @@
     }
 
     var form = detail.form;
-    if (form.dataset.ajaxAction !== SEARCH_ACTION) {
+    if (!isTentativesForm(form)) {
       return;
     }
 
@@ -348,7 +359,7 @@
     }
 
     var form = detail.form;
-    if (form.dataset.ajaxAction !== SEARCH_ACTION) {
+    if (!isTentativesForm(form)) {
       return;
     }
 
@@ -378,6 +389,51 @@
     loadTentatives(form, { page: page });
   }
 
+  function handleNativeSubmit(event) {
+    var form = event.target;
+
+    if (!isTentativesForm(form)) {
+      return;
+    }
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    event.preventDefault();
+    loadTentatives(form, { page: 1 });
+  }
+
+  function handleNativeReset(event) {
+    var trigger =
+      event.target && typeof event.target.closest === 'function'
+        ? event.target.closest('[data-table-search-reset]')
+        : null;
+
+    if (!trigger) {
+      return;
+    }
+
+    var form = trigger.closest('form.table-search');
+    if (!isTentativesForm(form)) {
+      return;
+    }
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    event.preventDefault();
+
+    var field = getSearchField(form);
+    if (field) {
+      field.value = '';
+    }
+
+    toggleReset(form, false);
+    loadTentatives(form, { page: 1, term: '' });
+  }
+
   function initialise() {
     var form = getSearchForm();
     if (form) {
@@ -388,5 +444,7 @@
   document.addEventListener('tablesearch:submit', handleSearchSubmit);
   document.addEventListener('tablesearch:reset', handleSearchReset);
   document.addEventListener('pager:change', handlePagerChange);
+  document.addEventListener('submit', handleNativeSubmit);
+  document.addEventListener('click', handleNativeReset);
   document.addEventListener('DOMContentLoaded', initialise);
 })();

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -7,6 +7,9 @@
     (config && typeof config.action === 'string' && config.action) ||
     'ca_fetch_tentatives';
   var PAGE_PARAM = 'tentatives-page';
+  var SEARCH_KEY =
+    (config && typeof config.searchKey === 'string' && config.searchKey) ||
+    'tentatives';
   var ERROR_MESSAGE =
     (config && typeof config.errorMessage === 'string' && config.errorMessage) ||
     'Unable to load attempts. Please try again.';
@@ -28,8 +31,95 @@
     return '';
   }
 
+  function matchesTentativesForm(form) {
+    if (
+      !form ||
+      typeof form !== 'object' ||
+      typeof form.classList === 'undefined' ||
+      !form.classList.contains('table-search')
+    ) {
+      return false;
+    }
+
+    var dataset = form.dataset || {};
+
+    if (dataset.ajaxAction === SEARCH_ACTION) {
+      return true;
+    }
+
+    if (dataset.searchKey === SEARCH_KEY) {
+      return true;
+    }
+
+    var searchParam = dataset.searchParameter || '';
+    if (searchParam && searchParam.indexOf('[' + SEARCH_KEY + ']') !== -1) {
+      return true;
+    }
+
+    var contextField = form.querySelector('input[name="search[context]"]');
+    if (contextField && contextField.value === SEARCH_KEY) {
+      return true;
+    }
+
+    return false;
+  }
+
   function getSearchForm() {
-    return document.querySelector('form.table-search[data-ajax-action="' + SEARCH_ACTION + '"]');
+    var selectors = [
+      'form.table-search[data-ajax-action="' + SEARCH_ACTION + '"]',
+      'form.table-search[data-search-key="' + SEARCH_KEY + '"]',
+      'form.table-search[data-search-parameter="search[' + SEARCH_KEY + ']"]'
+    ];
+
+    for (var index = 0; index < selectors.length; index += 1) {
+      var node = document.querySelector(selectors[index]);
+      if (matchesTentativesForm(node)) {
+        return node;
+      }
+    }
+
+    var forms = document.querySelectorAll('form.table-search');
+    for (var i = 0; i < forms.length; i += 1) {
+      if (matchesTentativesForm(forms[i])) {
+        return forms[i];
+      }
+    }
+
+    return null;
+  }
+
+  function getSearchParameter(form) {
+    if (!form) {
+      return '';
+    }
+
+    if (form.dataset && form.dataset.searchParameter) {
+      return form.dataset.searchParameter;
+    }
+
+    var field = getSearchField(form);
+    if (field && field.name) {
+      return field.name;
+    }
+
+    return '';
+  }
+
+  function getSearchKey(form) {
+    if (!form) {
+      return SEARCH_KEY;
+    }
+
+    if (form.dataset && form.dataset.searchKey) {
+      return form.dataset.searchKey;
+    }
+
+    var contextField = form.querySelector('input[name="search[context]"]');
+    if (contextField && contextField.value) {
+      return contextField.value;
+    }
+
+    return SEARCH_KEY;
   }
 
   function getWrapper(form) {
@@ -153,7 +243,7 @@
 
   function buildStateUrl(form, term, page) {
     var url = new URL(window.location.href);
-    var searchParam = form ? form.dataset.searchParameter : '';
+    var searchParam = getSearchParameter(form);
     var contextParam = 'search[context]';
     var hiddenFields = getHiddenFields(form);
     var contextValue = '';
@@ -170,6 +260,8 @@
         url.searchParams.set(contextParam, contextValue);
       } else if (form && form.dataset.searchKey) {
         url.searchParams.set(contextParam, form.dataset.searchKey);
+      } else {
+        url.searchParams.set(contextParam, getSearchKey(form));
       }
     } else {
       if (searchParam) {
@@ -220,14 +312,14 @@
         return;
       }
 
-      if (name === 'search[context]' || (form && name === form.dataset.searchParameter)) {
+      if (name === 'search[context]' || (form && name === getSearchParameter(form))) {
         return;
       }
 
       data.append(name, field.value);
     });
 
-    var searchParam = form ? form.dataset.searchParameter : '';
+    var searchParam = getSearchParameter(form);
     if (searchParam) {
       data.set(searchParam, term);
     }
@@ -237,8 +329,8 @@
       var contextInput = form.querySelector('input[name="search[context]"]');
       if (contextInput && contextInput.value) {
         data.set(contextParam, contextInput.value);
-      } else if (form.dataset.searchKey) {
-        data.set(contextParam, form.dataset.searchKey);
+      } else {
+        data.set(contextParam, getSearchKey(form));
       }
     }
 
@@ -432,15 +524,16 @@
       });
   }
 
-  function isTentativesForm(form) {
-    return (
-      form &&
-      typeof form === 'object' &&
-      typeof form.classList !== 'undefined' &&
-      form.classList.contains('table-search') &&
-      form.dataset &&
-      form.dataset.ajaxAction === SEARCH_ACTION
-    );
+  function isTentativesForm(form, detail) {
+    if (matchesTentativesForm(form)) {
+      return true;
+    }
+
+    if (detail && detail.searchKey && detail.searchKey === SEARCH_KEY) {
+      return true;
+    }
+
+    return false;
   }
 
   function handleSearchSubmit(event) {
@@ -450,7 +543,7 @@
     }
 
     var form = detail.form;
-    if (!isTentativesForm(form)) {
+    if (!isTentativesForm(form, detail)) {
       return;
     }
 
@@ -476,7 +569,7 @@
     }
 
     var form = detail.form;
-    if (!isTentativesForm(form)) {
+    if (!isTentativesForm(form, detail)) {
       return;
     }
 
@@ -599,5 +692,9 @@
   document.addEventListener('tablesearch:submit', handleSearchSubmit);
   document.addEventListener('tablesearch:reset', handleSearchReset);
   document.addEventListener('pager:change', handlePagerChange);
-  document.addEventListener('DOMContentLoaded', initialise);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialise);
+  } else {
+    initialise();
+  }
 })();

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -1,53 +1,375 @@
 /**
- * Handle navigation for the Tentatives table using the default pager.
+ * Handle AJAX interactions for the Tentatives table search and pager.
  */
 (function () {
-  document.addEventListener('pager:change', function (e) {
-    var pager = e.target;
-    if (!pager.classList.contains('tentatives-pager')) {
+  var SEARCH_ACTION = 'ca_fetch_tentatives';
+  var PAGE_PARAM = 'tentatives-page';
+
+  function getSearchForm() {
+    return document.querySelector('form.table-search[data-ajax-action="' + SEARCH_ACTION + '"]');
+  }
+
+  function getWrapper(form) {
+    if (!form) {
+      return null;
+    }
+
+    var target = form.dataset.ajaxTarget;
+    if (target) {
+      try {
+        var node = document.querySelector(target);
+        if (node) {
+          return node;
+        }
+      } catch (error) {
+        // Ignore invalid selector errors.
+      }
+    }
+
+    var scope = form.closest('.myaccount-tentatives');
+    if (scope) {
+      var wrapper = scope.querySelector('.stats-table-wrapper');
+      if (wrapper) {
+        return wrapper;
+      }
+    }
+
+    return null;
+  }
+
+  function getSearchField(form) {
+    if (!form) {
+      return null;
+    }
+
+    return form.querySelector('input[type="search"]');
+  }
+
+  function getSearchValue(form) {
+    var field = getSearchField(form);
+    if (!field) {
+      return '';
+    }
+
+    return field.value.trim();
+  }
+
+  function toggleReset(form, visible) {
+    if (!form) {
       return;
     }
-    var page = e.detail.page || 1;
-    var currentUrl = new URL(window.location.href);
-    var url = new URL(currentUrl.toString());
-    var param = pager.dataset.param || 'page';
-    var section = pager.dataset.section;
-    var searchKey = pager.dataset.searchKey;
 
-    if (typeof section === 'string') {
-      if (section.length) {
-        url.searchParams.set('section', section);
-      } else {
-        url.searchParams.delete('section');
+    var button = form.querySelector('[data-table-search-reset]');
+    if (!button) {
+      return;
+    }
+
+    if (visible) {
+      button.hidden = false;
+      button.disabled = false;
+    } else {
+      button.hidden = true;
+      button.disabled = true;
+    }
+  }
+
+  function setLoading(wrapper, loading) {
+    if (!wrapper) {
+      return;
+    }
+
+    if (loading) {
+      wrapper.classList.add('is-loading');
+      wrapper.setAttribute('aria-busy', 'true');
+    } else {
+      wrapper.classList.remove('is-loading');
+      wrapper.removeAttribute('aria-busy');
+    }
+  }
+
+  function getHiddenFields(form) {
+    if (!form) {
+      return [];
+    }
+
+    return form.querySelectorAll('input[type="hidden"][name]');
+  }
+
+  function buildStateUrl(form, term, page) {
+    var url = new URL(window.location.href);
+    var searchParam = form ? form.dataset.searchParameter : '';
+    var contextParam = 'search[context]';
+    var hiddenFields = getHiddenFields(form);
+    var contextValue = '';
+
+    Array.prototype.forEach.call(hiddenFields, function (field) {
+      if (field.name === contextParam) {
+        contextValue = field.value || '';
       }
+    });
+
+    if (searchParam && term) {
+      url.searchParams.set(searchParam, term);
+      if (contextValue) {
+        url.searchParams.set(contextParam, contextValue);
+      } else if (form && form.dataset.searchKey) {
+        url.searchParams.set(contextParam, form.dataset.searchKey);
+      }
+    } else {
+      if (searchParam) {
+        url.searchParams.delete(searchParam);
+      }
+      url.searchParams.delete(contextParam);
     }
 
     if (page > 1) {
-      url.searchParams.set(param, String(page));
+      url.searchParams.set(PAGE_PARAM, String(page));
     } else {
-      url.searchParams.delete(param);
+      url.searchParams.delete(PAGE_PARAM);
     }
 
-    if (param !== 'page') {
-      url.searchParams.delete('page');
-    }
-
-    if (searchKey) {
-      var searchParam = 'search[' + searchKey + ']';
-      var searchValue = currentUrl.searchParams.get(searchParam);
-      if (searchValue !== null) {
-        url.searchParams.set(searchParam, searchValue);
+    Array.prototype.forEach.call(hiddenFields, function (field) {
+      var name = field.name;
+      if (!name || name === searchParam || name === contextParam) {
+        return;
       }
 
-      var contextParam = 'search[context]';
-      var contextValue = currentUrl.searchParams.get(contextParam);
-      if (contextValue !== null) {
-        url.searchParams.set(contextParam, contextValue);
-      } else if (searchValue !== null) {
-        url.searchParams.set(contextParam, searchKey);
+      if (field.value === '') {
+        url.searchParams.delete(name);
+      } else {
+        url.searchParams.set(name, field.value);
+      }
+    });
+
+    return url;
+  }
+
+  function buildRequestBody(form, wrapper, page, term) {
+    var data = new URLSearchParams();
+    var action = form ? form.dataset.ajaxAction || SEARCH_ACTION : SEARCH_ACTION;
+    data.set('action', action);
+    data.set('page', String(page));
+
+    var perPageAttr = wrapper ? wrapper.getAttribute('data-per-page') : null;
+    var perPage = parseInt(perPageAttr || '10', 10);
+    if (!perPage || perPage < 1) {
+      perPage = 10;
+    }
+    data.set('per_page', String(perPage));
+
+    var hiddenFields = getHiddenFields(form);
+    Array.prototype.forEach.call(hiddenFields, function (field) {
+      var name = field.name;
+      if (!name) {
+        return;
+      }
+
+      if (name === 'search[context]' || (form && name === form.dataset.searchParameter)) {
+        return;
+      }
+
+      data.append(name, field.value);
+    });
+
+    var searchParam = form ? form.dataset.searchParameter : '';
+    if (searchParam) {
+      data.set(searchParam, term);
+    }
+
+    var contextParam = 'search[context]';
+    if (form) {
+      var contextInput = form.querySelector('input[name="search[context]"]');
+      if (contextInput && contextInput.value) {
+        data.set(contextParam, contextInput.value);
+      } else if (form.dataset.searchKey) {
+        data.set(contextParam, form.dataset.searchKey);
       }
     }
 
-    window.location.href = url.toString();
-  });
+    return data;
+  }
+
+  function updatePager(wrapper, html) {
+    if (!wrapper) {
+      return;
+    }
+
+    var current = wrapper.querySelector('.tentatives-pager');
+    if (typeof html === 'string' && html.trim() !== '') {
+      var template = document.createElement('template');
+      template.innerHTML = html.trim();
+      var next = template.content.firstElementChild;
+
+      if (next) {
+        if (current && current.parentNode) {
+          current.parentNode.replaceChild(next, current);
+        } else {
+          var table = wrapper.querySelector('table');
+          if (table) {
+            table.insertAdjacentElement('afterend', next);
+          } else {
+            wrapper.appendChild(next);
+          }
+        }
+      }
+
+      return;
+    }
+
+    if (current && current.parentNode) {
+      current.parentNode.removeChild(current);
+    }
+  }
+
+  function updateTable(wrapper, rowsHtml) {
+    if (!wrapper) {
+      return;
+    }
+
+    var tbody = wrapper.querySelector('tbody');
+    if (tbody) {
+      tbody.innerHTML = typeof rowsHtml === 'string' ? rowsHtml : '';
+    }
+  }
+
+  function updateHistory(form, wrapper, page, term) {
+    if (!window.history || typeof window.history.replaceState !== 'function') {
+      return;
+    }
+
+    var url = buildStateUrl(form, term, page);
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  function loadTentatives(form, options) {
+    var wrapper = getWrapper(form);
+    if (!form || !wrapper || !window.ajaxurl) {
+      return Promise.resolve();
+    }
+
+    var page = options && typeof options.page === 'number' ? options.page : 1;
+    if (page < 1) {
+      page = 1;
+    }
+
+    var term = '';
+    if (options && Object.prototype.hasOwnProperty.call(options, 'term')) {
+      term = String(options.term || '').trim();
+    } else {
+      term = getSearchValue(form);
+    }
+
+    var stateUrl = buildStateUrl(form, term, page);
+    var requestBody = buildRequestBody(form, wrapper, page, term);
+
+    setLoading(wrapper, true);
+
+    return fetch(window.ajaxurl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: requestBody
+    })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        return response.json();
+      })
+      .then(function (payload) {
+        if (!payload || !payload.success) {
+          var message = payload && payload.data && payload.data.message ? payload.data.message : 'Unknown error';
+          throw new Error(message);
+        }
+
+        return payload.data || {};
+      })
+      .then(function (data) {
+        updateTable(wrapper, data.rows || '');
+        updatePager(wrapper, data.pager || '');
+        wrapper.setAttribute('data-page', String(data.page || 1));
+        toggleReset(form, term !== '');
+
+        var field = getSearchField(form);
+        if (field) {
+          field.value = term;
+        }
+
+        updateHistory(form, wrapper, data.page || 1, term);
+      })
+      .catch(function (error) {
+        console.error('Tentatives table update failed', error);
+        window.location.href = stateUrl.toString();
+      })
+      .finally(function () {
+        setLoading(wrapper, false);
+      });
+  }
+
+  function handleSearchSubmit(event) {
+    var detail = event.detail;
+    if (!detail || !detail.form) {
+      return;
+    }
+
+    var form = detail.form;
+    if (form.dataset.ajaxAction !== SEARCH_ACTION) {
+      return;
+    }
+
+    event.preventDefault();
+    loadTentatives(form, { page: 1, term: detail.term || '' });
+  }
+
+  function handleSearchReset(event) {
+    var detail = event.detail;
+    if (!detail || !detail.form) {
+      return;
+    }
+
+    var form = detail.form;
+    if (form.dataset.ajaxAction !== SEARCH_ACTION) {
+      return;
+    }
+
+    event.preventDefault();
+
+    var field = getSearchField(form);
+    if (field) {
+      field.value = '';
+    }
+
+    toggleReset(form, false);
+    loadTentatives(form, { page: 1, term: '' });
+  }
+
+  function handlePagerChange(event) {
+    var pager = event.target;
+    if (!pager || !pager.classList || !pager.classList.contains('tentatives-pager')) {
+      return;
+    }
+
+    var form = getSearchForm();
+    if (!form) {
+      return;
+    }
+
+    var page = event.detail && typeof event.detail.page === 'number' ? event.detail.page : 1;
+    loadTentatives(form, { page: page });
+  }
+
+  function initialise() {
+    var form = getSearchForm();
+    if (form) {
+      toggleReset(form, getSearchValue(form) !== '');
+    }
+  }
+
+  document.addEventListener('tablesearch:submit', handleSearchSubmit);
+  document.addEventListener('tablesearch:reset', handleSearchReset);
+  document.addEventListener('pager:change', handlePagerChange);
+  document.addEventListener('DOMContentLoaded', initialise);
 })();

--- a/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/tentatives-pager.js
@@ -7,6 +7,14 @@
     (config && typeof config.action === 'string' && config.action) ||
     'ca_fetch_tentatives';
   var PAGE_PARAM = 'tentatives-page';
+  var ERROR_MESSAGE =
+    (config && typeof config.errorMessage === 'string' && config.errorMessage) ||
+    'Unable to load attempts. Please try again.';
+  var SUBMIT_STATE_KEY = 'tentativesSubmitSource';
+  var RESET_STATE_KEY = 'tentativesResetSource';
+  var LOADING_STATE_KEY = 'tentativesLoading';
+  var BOUND_STATE_KEY = 'tentativesBound';
+  var activeController = null;
 
   function getAjaxUrl() {
     if (config && typeof config.ajaxUrl === 'string' && config.ajaxUrl) {
@@ -85,6 +93,39 @@
     } else {
       button.hidden = true;
       button.disabled = true;
+    }
+  }
+
+  function setState(form, key, value) {
+    if (!form || !form.dataset) {
+      return;
+    }
+
+    if (value === '' || value === null || typeof value === 'undefined') {
+      delete form.dataset[key];
+      return;
+    }
+
+    form.dataset[key] = value;
+  }
+
+  function getState(form, key) {
+    if (!form || !form.dataset) {
+      return '';
+    }
+
+    return form.dataset[key] || '';
+  }
+
+  function setFormLoading(form, loading) {
+    if (!form || !form.dataset) {
+      return;
+    }
+
+    if (loading) {
+      form.dataset[LOADING_STATE_KEY] = '1';
+    } else {
+      delete form.dataset[LOADING_STATE_KEY];
     }
   }
 
@@ -247,6 +288,44 @@
     }
   }
 
+  function showError(wrapper, message) {
+    if (!wrapper) {
+      return;
+    }
+
+    var tbody = wrapper.querySelector('tbody');
+    if (!tbody) {
+      return;
+    }
+
+    var columns = 0;
+    var headerRow = wrapper.querySelector('thead tr');
+    if (headerRow && headerRow.children) {
+      columns = headerRow.children.length;
+    }
+
+    if (!columns) {
+      var firstRow = tbody.querySelector('tr');
+      if (firstRow && firstRow.children) {
+        columns = firstRow.children.length;
+      }
+    }
+
+    if (!columns) {
+      columns = 1;
+    }
+
+    var row = document.createElement('tr');
+    row.className = 'tentatives-error';
+    var cell = document.createElement('td');
+    cell.colSpan = columns;
+    cell.textContent = message;
+    row.appendChild(cell);
+
+    tbody.innerHTML = '';
+    tbody.appendChild(row);
+  }
+
   function updateHistory(form, wrapper, page, term) {
     if (!window.history || typeof window.history.replaceState !== 'function') {
       return;
@@ -264,6 +343,18 @@
       return Promise.resolve();
     }
 
+    if (activeController && typeof activeController.abort === 'function') {
+      activeController.abort();
+    }
+
+    var controller = null;
+    if (typeof window.AbortController === 'function') {
+      controller = new AbortController();
+      activeController = controller;
+    } else {
+      activeController = null;
+    }
+
     var page = options && typeof options.page === 'number' ? options.page : 1;
     if (page < 1) {
       page = 1;
@@ -276,19 +367,25 @@
       term = getSearchValue(form);
     }
 
-    var stateUrl = buildStateUrl(form, term, page);
     var requestBody = buildRequestBody(form, wrapper, page, term);
 
     setLoading(wrapper, true);
+    setFormLoading(form, true);
 
-    return fetch(ajaxUrl, {
+    var fetchOptions = {
       method: 'POST',
       credentials: 'same-origin',
       headers: {
         'X-Requested-With': 'XMLHttpRequest'
       },
       body: requestBody
-    })
+    };
+
+    if (controller) {
+      fetchOptions.signal = controller.signal;
+    }
+
+    return fetch(ajaxUrl, fetchOptions)
       .then(function (response) {
         if (!response.ok) {
           throw new Error('Network response was not ok');
@@ -318,11 +415,20 @@
         updateHistory(form, wrapper, data.page || 1, term);
       })
       .catch(function (error) {
+        if (controller && error && error.name === 'AbortError') {
+          return;
+        }
+
         console.error('Tentatives table update failed', error);
-        window.location.href = stateUrl.toString();
+        showError(wrapper, ERROR_MESSAGE);
       })
       .finally(function () {
         setLoading(wrapper, false);
+        setFormLoading(form, false);
+
+        if (controller && activeController === controller) {
+          activeController = null;
+        }
       });
   }
 
@@ -349,7 +455,18 @@
     }
 
     event.preventDefault();
-    loadTentatives(form, { page: 1, term: detail.term || '' });
+
+    if (getState(form, SUBMIT_STATE_KEY) === 'native') {
+      return;
+    }
+
+    setState(form, SUBMIT_STATE_KEY, 'custom');
+
+    loadTentatives(form, { page: 1, term: detail.term || '' }).finally(function () {
+      if (getState(form, SUBMIT_STATE_KEY) === 'custom') {
+        setState(form, SUBMIT_STATE_KEY, '');
+      }
+    });
   }
 
   function handleSearchReset(event) {
@@ -365,13 +482,23 @@
 
     event.preventDefault();
 
+    if (getState(form, RESET_STATE_KEY) === 'native') {
+      return;
+    }
+
+    setState(form, RESET_STATE_KEY, 'custom');
+
     var field = getSearchField(form);
     if (field) {
       field.value = '';
     }
 
     toggleReset(form, false);
-    loadTentatives(form, { page: 1, term: '' });
+    loadTentatives(form, { page: 1, term: '' }).finally(function () {
+      if (getState(form, RESET_STATE_KEY) === 'custom') {
+        setState(form, RESET_STATE_KEY, '');
+      }
+    });
   }
 
   function handlePagerChange(event) {
@@ -401,7 +528,14 @@
     }
 
     event.preventDefault();
-    loadTentatives(form, { page: 1 });
+
+    setState(form, SUBMIT_STATE_KEY, 'native');
+
+    loadTentatives(form, { page: 1 }).finally(function () {
+      if (getState(form, SUBMIT_STATE_KEY) === 'native') {
+        setState(form, SUBMIT_STATE_KEY, '');
+      }
+    });
   }
 
   function handleNativeReset(event) {
@@ -425,26 +559,45 @@
 
     event.preventDefault();
 
+    setState(form, RESET_STATE_KEY, 'native');
+
     var field = getSearchField(form);
     if (field) {
       field.value = '';
     }
 
     toggleReset(form, false);
-    loadTentatives(form, { page: 1, term: '' });
+    loadTentatives(form, { page: 1, term: '' }).finally(function () {
+      if (getState(form, RESET_STATE_KEY) === 'native') {
+        setState(form, RESET_STATE_KEY, '');
+      }
+    });
+  }
+
+  function bindNativeEvents(form) {
+    if (!form || !form.dataset) {
+      return;
+    }
+
+    if (form.dataset[BOUND_STATE_KEY] === '1') {
+      return;
+    }
+
+    form.addEventListener('submit', handleNativeSubmit);
+    form.addEventListener('click', handleNativeReset);
+    form.dataset[BOUND_STATE_KEY] = '1';
   }
 
   function initialise() {
     var form = getSearchForm();
     if (form) {
       toggleReset(form, getSearchValue(form) !== '');
+      bindNativeEvents(form);
     }
   }
 
   document.addEventListener('tablesearch:submit', handleSearchSubmit);
   document.addEventListener('tablesearch:reset', handleSearchReset);
   document.addEventListener('pager:change', handlePagerChange);
-  document.addEventListener('submit', handleNativeSubmit);
-  document.addEventListener('click', handleNativeReset);
   document.addEventListener('DOMContentLoaded', initialise);
 })();

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -815,6 +815,16 @@ body.woocommerce h2 {
     flex: 1 1 100%;
 }
 
+.myaccount-tentatives .stats-table-wrapper {
+    position: relative;
+    transition: opacity 0.2s ease;
+}
+
+.myaccount-tentatives .stats-table-wrapper.is-loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
 @media (--bp-mobile) {
     .myaccount-tentatives .table-header {
         gap: var(--space-sm);

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -803,6 +803,29 @@ body.woocommerce h2 {
 }
 
 /* Tentatives table alignment */
+.myaccount-tentatives .table-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-sm);
+}
+
+.myaccount-tentatives .table-header .table-search {
+    flex: 1 1 100%;
+}
+
+@media (--bp-mobile) {
+    .myaccount-tentatives .table-header {
+        gap: var(--space-sm);
+    }
+
+    .myaccount-tentatives .table-header .table-search {
+        flex: 0 1 auto;
+        margin-left: auto;
+    }
+}
+
 .tentatives-table th:nth-child(2),
 .tentatives-table td:nth-child(2),
 .tentatives-table th:nth-child(3),

--- a/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
@@ -63,6 +63,35 @@
     transform: translateY(-1px);
     outline: none;
   }
+
+  &__reset {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-xxs);
+    padding: var(--space-xs) var(--space-md);
+    border-radius: 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background-color: transparent;
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+  }
+
+  &__reset:hover,
+  &__reset:focus {
+    background-color: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.4);
+    color: var(--color-white);
+    outline: none;
+  }
+
+  &__reset:focus-visible {
+    box-shadow: 0 0 0 2px rgba(184, 134, 11, 0.35);
+  }
 }
 
 @media (--bp-mobile) {
@@ -81,6 +110,44 @@
     &__submit {
       align-self: stretch;
       padding: var(--space-xs) var(--space-xl);
+    }
+
+    &__reset {
+      align-self: stretch;
+    }
+  }
+}
+
+.table-search--inline {
+  .table-search__description {
+    grid-column: 1 / -1;
+  }
+
+  @media (--bp-mobile) {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+
+    .table-search__label {
+      margin-bottom: 0;
+    }
+
+    .table-search__controls {
+      justify-content: flex-start;
+      align-items: center;
+      gap: var(--space-xs);
+    }
+  }
+}
+
+.table-search--compact {
+  .table-search__field {
+    max-width: 100%;
+  }
+
+  @media (--bp-mobile) {
+    .table-search__field {
+      flex: 0 1 20rem;
+      max-width: 20rem;
     }
   }
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9559,6 +9559,16 @@ body.woocommerce h2 {
   flex: 1 1 100%;
 }
 
+.myaccount-tentatives .stats-table-wrapper {
+  position: relative;
+  transition: opacity 0.2s ease;
+}
+
+.myaccount-tentatives .stats-table-wrapper.is-loading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 @media (min-width: 600px) {
   .myaccount-tentatives .table-header {
     gap: var(--space-sm);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1412,6 +1412,31 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   transform: translateY(-1px);
   outline: none;
 }
+.table-search__reset {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xxs);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background-color: transparent;
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+.table-search__reset:hover, .table-search__reset:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.4);
+  color: var(--color-white);
+  outline: none;
+}
+.table-search__reset:focus-visible {
+  box-shadow: 0 0 0 2px rgba(184, 134, 11, 0.35);
+}
 
 @media (min-width: 600px) {
   .table-search {
@@ -1428,7 +1453,38 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
     align-self: stretch;
     padding: var(--space-xs) var(--space-xl);
   }
+  .table-search__reset {
+    align-self: stretch;
+  }
 }
+.table-search--inline .table-search__description {
+  grid-column: 1/-1;
+}
+@media (min-width: 600px) {
+  .table-search--inline {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+  }
+  .table-search--inline .table-search__label {
+    margin-bottom: 0;
+  }
+  .table-search--inline .table-search__controls {
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+}
+
+.table-search--compact .table-search__field {
+  max-width: 100%;
+}
+@media (min-width: 600px) {
+  .table-search--compact .table-search__field {
+    flex: 0 1 20rem;
+    max-width: 20rem;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation: none !important;
@@ -9491,6 +9547,27 @@ body.woocommerce h2 {
 }
 
 /* Tentatives table alignment */
+.myaccount-tentatives .table-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.myaccount-tentatives .table-header .table-search {
+  flex: 1 1 100%;
+}
+
+@media (min-width: 600px) {
+  .myaccount-tentatives .table-header {
+    gap: var(--space-sm);
+  }
+  .myaccount-tentatives .table-header .table-search {
+    flex: 0 1 auto;
+    margin-left: auto;
+  }
+}
 .tentatives-table th:nth-child(2),
 .tentatives-table td:nth-child(2),
 .tentatives-table th:nth-child(3),

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -53,6 +53,7 @@ function cta_render_search_form(string $key, array $overrides = []): string
         'show_reset_button'  => $ui['show_reset_button'] ?? false,
         'pagination_params'  => $context['pagination_params'] ?? [],
         'description'        => $ui['description'] ?? '',
+        'data_attributes'    => [],
     ];
 
     $config = array_merge($defaults, $overrides);
@@ -120,12 +121,41 @@ function cta_render_search_form(string $key, array $overrides = []): string
     $form_attrs .= sprintf(' data-search-key="%s"', esc_attr($context['key'] ?? $key));
     $form_attrs .= sprintf(' data-search-parameter="%s"', esc_attr($input_name));
 
+    $data_attributes = [];
+    $used_data_keys  = [
+        'search-key',
+        'search-parameter',
+    ];
+
     if ($show_reset) {
-        $form_attrs .= ' data-has-reset="1"';
+        $form_attrs     .= ' data-has-reset="1"';
+        $used_data_keys[] = 'has-reset';
     }
 
     if (!empty($pagination_params)) {
-        $form_attrs .= sprintf(' data-reset-pagination="%s"', esc_attr(implode(',', $pagination_params)));
+        $form_attrs     .= sprintf(' data-reset-pagination="%s"', esc_attr(implode(',', $pagination_params)));
+        $used_data_keys[] = 'reset-pagination';
+    }
+
+    if (is_array($config['data_attributes'])) {
+        foreach ($config['data_attributes'] as $data_key => $data_value) {
+            $sanitized = strtolower((string) $data_key);
+            $sanitized = preg_replace('/[^a-z0-9_-]+/', '', $sanitized);
+
+            if ('' === $sanitized) {
+                continue;
+            }
+
+            if (in_array($sanitized, $used_data_keys, true)) {
+                continue;
+            }
+
+            $data_attributes[$sanitized] = (string) $data_value;
+        }
+    }
+
+    foreach ($data_attributes as $data_key => $data_value) {
+        $form_attrs .= sprintf(' data-%s="%s"', esc_attr($data_key), esc_attr($data_value));
     }
 
     $form_attrs .= ' role="search"';
@@ -179,8 +209,8 @@ function cta_render_search_form(string $key, array $overrides = []): string
             <button type="submit" class="table-search__submit">
                 <span class="table-search__submit-text"><?php echo esc_html($submit); ?></span>
             </button>
-            <?php if ($show_reset && '' !== $search_value) : ?>
-            <button type="button" class="table-search__reset" data-table-search-reset>
+            <?php if ($show_reset) : ?>
+            <button type="button" class="table-search__reset" data-table-search-reset<?php echo '' === $search_value ? ' hidden' : ''; ?>>
                 <span class="table-search__reset-text"><?php echo esc_html($reset_label); ?></span>
             </button>
             <?php endif; ?>

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -39,18 +39,20 @@ function cta_render_search_form(string $key, array $overrides = []): string
     $form_id   = $overrides['id'] ?? sprintf('table-search-%s', $parameter);
 
     $defaults = [
-        'class'             => 'table-search',
-        'method'            => 'get',
-        'action'            => '',
-        'label'             => $ui['label'] ?? '',
-        'placeholder'       => $ui['placeholder'] ?? '',
-        'value'             => null,
-        'hidden_fields'     => [],
-        'nonce_action'      => $ui['nonce_action'] ?? '',
-        'nonce_name'        => $ui['nonce_name'] ?? 'nonce',
-        'submit_label'      => $ui['submit_label'] ?? esc_html__('Rechercher', 'chassesautresor-com'),
-        'pagination_params' => $context['pagination_params'] ?? [],
-        'description'       => $ui['description'] ?? '',
+        'class'              => 'table-search',
+        'method'             => 'get',
+        'action'             => '',
+        'label'              => $ui['label'] ?? '',
+        'placeholder'        => $ui['placeholder'] ?? '',
+        'value'              => null,
+        'hidden_fields'      => [],
+        'nonce_action'       => $ui['nonce_action'] ?? '',
+        'nonce_name'         => $ui['nonce_name'] ?? 'nonce',
+        'submit_label'       => $ui['submit_label'] ?? esc_html__('Rechercher', 'chassesautresor-com'),
+        'reset_label'        => $ui['reset_label'] ?? esc_html__('Réinitialiser', 'chassesautresor-com'),
+        'show_reset_button'  => $ui['show_reset_button'] ?? false,
+        'pagination_params'  => $context['pagination_params'] ?? [],
+        'description'        => $ui['description'] ?? '',
     ];
 
     $config = array_merge($defaults, $overrides);
@@ -104,6 +106,8 @@ function cta_render_search_form(string $key, array $overrides = []): string
     $label       = (string) $config['label'];
     $desc        = (string) $config['description'];
     $submit      = (string) $config['submit_label'];
+    $reset_label = (string) $config['reset_label'];
+    $show_reset  = (bool) $config['show_reset_button'];
 
     $form_attrs = sprintf(' method="%s"', esc_attr($method));
 
@@ -114,6 +118,11 @@ function cta_render_search_form(string $key, array $overrides = []): string
     $form_attrs .= sprintf(' class="%s"', esc_attr($form_classes));
     $form_attrs .= sprintf(' id="%s"', esc_attr($form_id));
     $form_attrs .= sprintf(' data-search-key="%s"', esc_attr($context['key'] ?? $key));
+    $form_attrs .= sprintf(' data-search-parameter="%s"', esc_attr($input_name));
+
+    if ($show_reset) {
+        $form_attrs .= ' data-has-reset="1"';
+    }
 
     if (!empty($pagination_params)) {
         $form_attrs .= sprintf(' data-reset-pagination="%s"', esc_attr(implode(',', $pagination_params)));
@@ -170,6 +179,11 @@ function cta_render_search_form(string $key, array $overrides = []): string
             <button type="submit" class="table-search__submit">
                 <span class="table-search__submit-text"><?php echo esc_html($submit); ?></span>
             </button>
+            <?php if ($show_reset && '' !== $search_value) : ?>
+            <button type="button" class="table-search__reset" data-table-search-reset>
+                <span class="table-search__reset-text"><?php echo esc_html($reset_label); ?></span>
+            </button>
+            <?php endif; ?>
         </div>
 
         <?php

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -64,11 +64,19 @@ function cta_render_search_form(string $key, array $overrides = []): string
     }
 
     $form_classes = trim((string) $config['class']);
-    if ('' === $form_classes) {
-        $form_classes = 'table-search';
-    } elseif (false === strpos($form_classes, 'table-search')) {
-        $form_classes = trim('table-search ' . $form_classes);
+    $class_tokens = preg_split('/\s+/', $form_classes);
+    $class_tokens = array_filter(
+        is_array($class_tokens) ? $class_tokens : [],
+        static function ($class_name): bool {
+            return is_string($class_name) && '' !== $class_name;
+        }
+    );
+
+    if (!in_array('table-search', $class_tokens, true)) {
+        array_unshift($class_tokens, 'table-search');
     }
+
+    $form_classes = implode(' ', array_unique($class_tokens));
 
     $search_value = $config['value'];
     if (null === $search_value) {

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1417,6 +1417,15 @@ function ca_render_dashboard_tentatives(): void
         true
     );
 
+    wp_localize_script(
+        'tentatives-pager',
+        'caTentativesPager',
+        [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'action'  => 'ca_fetch_tentatives',
+        ]
+    );
+
     if (function_exists('wp_enqueue_script')) {
         wp_enqueue_script('table-search');
     }

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1345,7 +1345,12 @@ function ca_render_dashboard_tentatives(): void
                 <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $success, 'chassesautresor-com')), $success); ?>
             </span>
             <?php endif; ?>
-            <?php echo cta_render_search_form('tentatives'); ?>
+            <?php
+            echo cta_render_search_form('tentatives', [
+                'class'             => 'table-search--inline table-search--compact',
+                'show_reset_button' => true,
+            ]);
+            ?>
         </div>
         <div class="stats-table-wrapper" data-per-page="<?php echo esc_attr($per_page); ?>">
             <table class="stats-table tentatives-table">

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1208,6 +1208,181 @@ function ca_ajax_get_engaged_hunts(): void
 add_action('wp_ajax_ca_get_engaged_hunts', 'ca_ajax_get_engaged_hunts');
 
 /**
+ * Register the search context used for the tentatives table.
+ *
+ * @return void
+ */
+function ca_register_tentatives_search_context(): void
+{
+    ca_register_search_context('tentatives', [
+        'fields' => [
+            'sql' => [
+                'p.post_title',
+                't.reponse_saisie',
+                'chasses.post_title',
+            ],
+        ],
+        'ui' => [
+            'label'       => __('Rechercher une tentative', 'chassesautresor-com'),
+            'placeholder' => __('Chasse, énigme ou réponse...', 'chassesautresor-com'),
+        ],
+        'pagination_params' => ['tentatives-page'],
+    ]);
+}
+
+/**
+ * Builds the dataset required to render the tentatives table for a user.
+ *
+ * @param int $user_id  Target user identifier.
+ * @param int $page     Requested page number.
+ * @param int $per_page Number of rows per page.
+ *
+ * @return array<string, mixed>
+ */
+function ca_get_tentatives_view_model(int $user_id, int $page = 1, int $per_page = 10): array
+{
+    global $wpdb;
+
+    $table     = $wpdb->prefix . 'enigme_tentatives';
+    $per_page  = max(1, $per_page);
+    $page      = max(1, $page);
+    $search    = ca_get_search_term('tentatives');
+    $pending   = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND resultat = 'attente' AND traitee = 0",
+        $user_id
+    ));
+    $total     = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$table} WHERE user_id = %d",
+        $user_id
+    ));
+    $success   = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND resultat = 'bon'",
+        $user_id
+    ));
+
+    $base_from = sprintf(
+        " FROM %s t
+        INNER JOIN %s p ON t.enigme_id = p.ID
+        LEFT JOIN (
+            SELECT pm.post_id,
+                   MAX(
+                       CAST(
+                           SUBSTRING_INDEX(
+                               SUBSTRING_INDEX(pm.meta_value, ';', 2),
+                               ':',
+                               -1
+                           ) AS UNSIGNED
+                       )
+                   ) AS chasse_id
+            FROM %s pm
+            WHERE pm.meta_key IN ('chasse_associee', 'enigme_chasse_associee')
+            GROUP BY pm.post_id
+        ) AS chasse_meta ON chasse_meta.post_id = t.enigme_id
+        LEFT JOIN %s chasses ON chasses.ID = chasse_meta.chasse_id",
+        $table,
+        $wpdb->posts,
+        $wpdb->postmeta,
+        $wpdb->posts
+    );
+
+    $where_clause   = ' WHERE t.user_id = %d';
+    $count_sql      = "SELECT COUNT(*){$base_from}{$where_clause}";
+    $count_sql      = ca_apply_search_filters('tentatives', $count_sql, $search);
+    $filtered_total = (int) $wpdb->get_var($wpdb->prepare($count_sql, $user_id));
+
+    $pages = $filtered_total > 0 ? (int) ceil($filtered_total / $per_page) : 0;
+    if ($pages > 0 && $page > $pages) {
+        $page = $pages;
+    } elseif (0 === $pages) {
+        $page = 1;
+    }
+
+    $offset     = ($page - 1) * $per_page;
+    $select_sql = "SELECT t.*, p.post_title AS enigme_title, COALESCE(chasse_meta.chasse_id, 0) AS chasse_id, chasses.post_title AS chasse_title{$base_from}{$where_clause}";
+    $select_sql = ca_apply_search_filters('tentatives', $select_sql, $search);
+    $select_sql .= ' ORDER BY t.date_tentative DESC LIMIT %d OFFSET %d';
+    $results     = $wpdb->get_results($wpdb->prepare($select_sql, $user_id, $per_page, $offset));
+
+    $message = $search !== ''
+        ? __('Aucune tentative ne correspond à votre recherche.', 'chassesautresor-com')
+        : __('Vous n\'avez pas encore enregistré de tentative.', 'chassesautresor-com');
+
+    return [
+        'pending'            => $pending,
+        'total'              => $total,
+        'success'            => $success,
+        'search_term'        => $search,
+        'page'               => $page,
+        'pages'              => $pages,
+        'per_page'           => $per_page,
+        'filtered_total'     => $filtered_total,
+        'tentatives'         => is_array($results) ? $results : [],
+        'no_results_message' => $message,
+    ];
+}
+
+/**
+ * Renders the table rows for the tentatives table.
+ *
+ * @param array  $tentatives        Tentative rows.
+ * @param int    $filtered_total    Number of filtered rows.
+ * @param string $no_results_message Message displayed when there are no rows.
+ *
+ * @return string
+ */
+function ca_render_tentatives_rows(array $tentatives, int $filtered_total, string $no_results_message): string
+{
+    ob_start();
+
+    if ($filtered_total <= 0 || empty($tentatives)) {
+        ?>
+        <tr class="tentatives-empty">
+            <td colspan="5"><?php echo esc_html($no_results_message); ?></td>
+        </tr>
+        <?php
+    } else {
+        foreach ($tentatives as $tent) {
+            $chasse_id    = isset($tent->chasse_id) ? (int) $tent->chasse_id : 0;
+            $chasse_title = isset($tent->chasse_title) ? (string) $tent->chasse_title : '';
+            ?>
+            <tr>
+                <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
+                <td>
+                    <?php if ($chasse_id > 0 && $chasse_title !== '') : ?>
+                    <a href="<?php echo esc_url(get_permalink($chasse_id)); ?>">
+                        <?php echo esc_html($chasse_title); ?>
+                    </a>
+                    <?php elseif ($chasse_title !== '') : ?>
+                    <?php echo esc_html($chasse_title); ?>
+                    <?php else : ?>
+                    &mdash;
+                    <?php endif; ?>
+                </td>
+                <td><?php echo esc_html($tent->enigme_title ?? ''); ?></td>
+                <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? ''); ?>
+                <?php
+                $result = $tent->resultat;
+                $class  = 'etiquette-error';
+                if ($result === 'bon') {
+                    $class = 'etiquette-success';
+                } elseif ($result === 'attente') {
+                    $class = 'etiquette-pending';
+                }
+                ?>
+                <td>
+                    <span class="etiquette <?php echo esc_attr($class); ?>">
+                        <?php echo esc_html__($result, 'chassesautresor-com'); ?>
+                    </span>
+                </td>
+            </tr>
+            <?php
+        }
+    }
+
+    return trim((string) ob_get_clean());
+}
+
+/**
  * Display the Tentatives table on the My Account dashboard.
  *
  * @return void
@@ -1246,113 +1421,44 @@ function ca_render_dashboard_tentatives(): void
         wp_enqueue_script('table-search');
     }
 
-    global $wpdb;
-
-    $table   = $wpdb->prefix . 'enigme_tentatives';
-    $pending = (int) $wpdb->get_var($wpdb->prepare(
-        "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND resultat = 'attente' AND traitee = 0",
-        $user_id
-    ));
-    $total   = (int) $wpdb->get_var($wpdb->prepare(
-        "SELECT COUNT(*) FROM {$table} WHERE user_id = %d",
-        $user_id
-    ));
-    $success = (int) $wpdb->get_var($wpdb->prepare(
-        "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND resultat = 'bon'",
-        $user_id
-    ));
-
-    ca_register_search_context('tentatives', [
-        'fields' => [
-            'sql' => [
-                'p.post_title',
-                't.reponse_saisie',
-                'chasses.post_title',
-            ],
-        ],
-        'ui' => [
-            'label'       => __('Rechercher une tentative', 'chassesautresor-com'),
-            'placeholder' => __('Chasse, énigme ou réponse...', 'chassesautresor-com'),
-        ],
-        'pagination_params' => ['tentatives-page'],
-    ]);
-
-    $search_term = ca_get_search_term('tentatives');
+    ca_register_tentatives_search_context();
 
     $per_page = 10;
     $page     = max(1, (int) ($_GET['tentatives-page'] ?? 1));
 
-    $base_from = sprintf(
-        " FROM %s t
-        INNER JOIN %s p ON t.enigme_id = p.ID
-        LEFT JOIN (
-            SELECT pm.post_id,
-                   MAX(
-                       CAST(
-                           SUBSTRING_INDEX(
-                               SUBSTRING_INDEX(pm.meta_value, ';', 2),
-                               ':',
-                               -1
-                           ) AS UNSIGNED
-                       )
-                   ) AS chasse_id
-            FROM %s pm
-            WHERE pm.meta_key IN ('chasse_associee', 'enigme_chasse_associee')
-            GROUP BY pm.post_id
-        ) AS chasse_meta ON chasse_meta.post_id = t.enigme_id
-        LEFT JOIN %s chasses ON chasses.ID = chasse_meta.chasse_id",
-        $table,
-        $wpdb->posts,
-        $wpdb->postmeta,
-        $wpdb->posts
-    );
-
-    $where_clause = ' WHERE t.user_id = %d';
-
-    $count_sql = "SELECT COUNT(*){$base_from}{$where_clause}";
-    $count_sql = ca_apply_search_filters('tentatives', $count_sql, $search_term);
-    $filtered_total = (int) $wpdb->get_var($wpdb->prepare($count_sql, $user_id));
-
-    $pages = $filtered_total > 0 ? (int) ceil($filtered_total / $per_page) : 0;
-    if ($pages > 0 && $page > $pages) {
-        $page = $pages;
-    } elseif ($pages === 0) {
-        $page = 1;
-    }
-
-    $offset = ($page - 1) * $per_page;
-
-    $select_sql = "SELECT t.*, p.post_title AS enigme_title, COALESCE(chasse_meta.chasse_id, 0) AS chasse_id, chasses.post_title AS chasse_title{$base_from}{$where_clause}";
-    $select_sql = ca_apply_search_filters('tentatives', $select_sql, $search_term);
-    $select_sql .= ' ORDER BY t.date_tentative DESC LIMIT %d OFFSET %d';
-    $tentatives = $wpdb->get_results($wpdb->prepare($select_sql, $user_id, $per_page, $offset));
-
-    $no_results_message = $search_term !== ''
-        ? __('Aucune tentative ne correspond à votre recherche.', 'chassesautresor-com')
-        : __('Vous n\'avez pas encore enregistré de tentative.', 'chassesautresor-com');
+    $view = ca_get_tentatives_view_model($user_id, $page, $per_page);
 
     ob_start();
     ?>
     <section class="myaccount-tentatives">
         <h2><?php esc_html_e('Tentatives', 'chassesautresor-com'); ?></h2>
         <div class="table-header">
-            <?php if ($pending > 0) : ?>
-            <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $pending, 'chassesautresor-com')), $pending); ?></span>
+            <?php if ($view['pending'] > 0) : ?>
+            <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $view['pending'], 'chassesautresor-com')), $view['pending']); ?></span>
             <?php endif; ?>
-            <span class="stat-badge"><?php printf(esc_html(_n('%d tentative', '%d tentatives', $total, 'chassesautresor-com')), $total); ?></span>
-            <?php if ($success > 0) : ?>
+            <span class="stat-badge"><?php printf(esc_html(_n('%d tentative', '%d tentatives', $view['total'], 'chassesautresor-com')), $view['total']); ?></span>
+            <?php if ($view['success'] > 0) : ?>
             <span class="stat-badge" style="color:var(--color-success);">
-                <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $success, 'chassesautresor-com')), $success); ?>
+                <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $view['success'], 'chassesautresor-com')), $view['success']); ?>
             </span>
             <?php endif; ?>
             <?php
             echo cta_render_search_form('tentatives', [
                 'class'             => 'table-search--inline table-search--compact',
                 'show_reset_button' => true,
+                'data_attributes'   => [
+                    'ajax-action' => 'ca_fetch_tentatives',
+                    'ajax-target' => '#tentatives-table-wrapper',
+                ],
             ]);
             ?>
         </div>
-        <div class="stats-table-wrapper" data-per-page="<?php echo esc_attr($per_page); ?>">
+        <div
+            id="tentatives-table-wrapper"
+            class="stats-table-wrapper"
+            data-per-page="<?php echo esc_attr($view['per_page']); ?>"
+            data-page="<?php echo esc_attr($view['page']); ?>"
+        >
             <table class="stats-table tentatives-table">
                 <thead>
                     <tr>
@@ -1364,51 +1470,10 @@ function ca_render_dashboard_tentatives(): void
                     </tr>
                 </thead>
                 <tbody>
-                    <?php if ($filtered_total <= 0 || empty($tentatives)) : ?>
-                    <tr class="tentatives-empty">
-                        <td colspan="5"><?php echo esc_html($no_results_message); ?></td>
-                    </tr>
-                    <?php else : ?>
-                        <?php foreach ($tentatives as $tent) : ?>
-                        <?php
-                        $chasse_id    = isset($tent->chasse_id) ? (int) $tent->chasse_id : 0;
-                        $chasse_title = isset($tent->chasse_title) ? (string) $tent->chasse_title : '';
-                        ?>
-                        <tr>
-                            <td><?php echo esc_html(mysql2date('d/m/Y H:i', $tent->date_tentative)); ?></td>
-                            <td>
-                                <?php if ($chasse_id > 0 && $chasse_title !== '') : ?>
-                                <a href="<?php echo esc_url(get_permalink($chasse_id)); ?>">
-                                    <?php echo esc_html($chasse_title); ?>
-                                </a>
-                                <?php elseif ($chasse_title !== '') : ?>
-                                <?php echo esc_html($chasse_title); ?>
-                                <?php else : ?>
-                                &mdash;
-                                <?php endif; ?>
-                            </td>
-                            <td><?php echo esc_html($tent->enigme_title ?? ''); ?></td>
-                            <?php echo cta_render_proposition_cell($tent->reponse_saisie ?? ''); ?>
-                            <?php
-                            $result = $tent->resultat;
-                            $class  = 'etiquette-error';
-                            if ($result === 'bon') {
-                                $class = 'etiquette-success';
-                            } elseif ($result === 'attente') {
-                                $class = 'etiquette-pending';
-                            }
-                            ?>
-                            <td>
-                                <span class="etiquette <?php echo esc_attr($class); ?>">
-                                    <?php echo esc_html__($result, 'chassesautresor-com'); ?>
-                                </span>
-                            </td>
-                        </tr>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
+                    <?php echo ca_render_tentatives_rows($view['tentatives'], $view['filtered_total'], $view['no_results_message']); ?>
                 </tbody>
             </table>
-            <?php echo cta_render_pager($page, $pages, 'tentatives-pager', ['data-param' => 'tentatives-page', 'data-section' => '', 'data-search-key' => 'tentatives']); ?>
+            <?php echo cta_render_pager($view['page'], $view['pages'], 'tentatives-pager', ['data-param' => 'tentatives-page', 'data-section' => '', 'data-search-key' => 'tentatives']); ?>
         </div>
     </section>
     <?php
@@ -1416,8 +1481,53 @@ function ca_render_dashboard_tentatives(): void
 }
 add_action('woocommerce_account_dashboard', 'ca_render_dashboard_tentatives', 20);
 
-// ==================================================
-// 📡 AJAX ADMIN SECTIONS
+/**
+ * Handle AJAX refreshes for the tentatives table.
+ *
+ * @return void
+ */
+function ca_ajax_fetch_tentatives(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor-com')], 403);
+    }
+
+    $user_id = (int) get_current_user_id();
+    if ($user_id <= 0) {
+        wp_send_json_error(['message' => __('Unauthorized', 'chassesautresor-com')], 403);
+    }
+
+    ca_register_tentatives_search_context();
+
+    $page     = isset($_POST['page']) ? (int) $_POST['page'] : 1;
+    $per_page = isset($_POST['per_page']) ? (int) $_POST['per_page'] : 10;
+
+    $page     = max(1, $page);
+    $per_page = max(1, $per_page);
+
+    $view = ca_get_tentatives_view_model($user_id, $page, $per_page);
+
+    $rows  = ca_render_tentatives_rows($view['tentatives'], $view['filtered_total'], $view['no_results_message']);
+    $pager = cta_render_pager(
+        $view['page'],
+        $view['pages'],
+        'tentatives-pager',
+        ['data-param' => 'tentatives-page', 'data-section' => '', 'data-search-key' => 'tentatives']
+    );
+
+    wp_send_json_success([
+        'rows'             => $rows,
+        'pager'            => $pager,
+        'page'             => $view['page'],
+        'pages'            => $view['pages'],
+        'per_page'         => $view['per_page'],
+        'search_term'      => $view['search_term'],
+        'filtered_total'   => $view['filtered_total'],
+        'no_results_text'  => $view['no_results_message'],
+    ]);
+}
+add_action('wp_ajax_ca_fetch_tentatives', 'ca_ajax_fetch_tentatives');
+add_action('wp_ajax_nopriv_ca_fetch_tentatives', 'ca_ajax_fetch_tentatives');
 // ==================================================
 /**
  * Load My Account sections via AJAX.

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1423,6 +1423,10 @@ function ca_render_dashboard_tentatives(): void
         [
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'action'  => 'ca_fetch_tentatives',
+            'errorMessage' => esc_html__(
+                'Unable to load attempts. Please try again.',
+                'chassesautresor-com'
+            ),
         ]
     );
 

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -3024,3 +3024,7 @@ msgstr ""
 #: template-parts/enigme/partials/enigme-partial-solution.php:32
 msgid "Voir la solution de la chasse"
 msgstr ""
+
+#: inc/search/form.php:52
+msgid "Réinitialiser"
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -3028,3 +3028,7 @@ msgstr ""
 #: inc/search/form.php:52
 msgid "Réinitialiser"
 msgstr ""
+
+#: inc/user-functions.php:1444
+msgid "Unable to load attempts. Please try again."
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3305,3 +3305,7 @@ msgstr "View hunt solution"
 #: inc/search/form.php:52
 msgid "Réinitialiser"
 msgstr "Reset"
+
+#: inc/user-functions.php:1444
+msgid "Unable to load attempts. Please try again."
+msgstr "Unable to load attempts. Please try again."

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3301,3 +3301,7 @@ msgstr "View solutions"
 #: template-parts/enigme/partials/enigme-partial-solution.php:32
 msgid "Voir la solution de la chasse"
 msgstr "View hunt solution"
+
+#: inc/search/form.php:52
+msgid "Réinitialiser"
+msgstr "Reset"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3267,3 +3267,7 @@ msgstr "Voir la solution de la chasse"
 #: inc/search/form.php:52
 msgid "Réinitialiser"
 msgstr "Réinitialiser"
+
+#: inc/user-functions.php:1444
+msgid "Unable to load attempts. Please try again."
+msgstr "Impossible de charger les tentatives. Veuillez réessayer."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3263,3 +3263,7 @@ msgstr "Voir les solutions"
 #: template-parts/enigme/partials/enigme-partial-solution.php:32
 msgid "Voir la solution de la chasse"
 msgstr "Voir la solution de la chasse"
+
+#: inc/search/form.php:52
+msgid "Réinitialiser"
+msgstr "Réinitialiser"


### PR DESCRIPTION
Résumé : amélioration de la recherche des tentatives sur la page « Mon compte ».

Changements notables
- Ajout d'une option de bouton de réinitialisation et d'attributs de données au gabarit de formulaire de recherche.
- Mise à jour de la page « Mon compte » pour afficher un formulaire de recherche compact, aligné avec les badges, et prise en charge du nouveau bouton.
- Rafraîchissement des styles, du script de recherche, de la documentation et des tests pour couvrir la nouvelle interaction.

Tests
- ✅ `npm run build:css`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cf9fbee4ec8332b983f44ec890db35