### PR TITLE
feat: allow icon badges on chasse cards

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1357,12 +1357,27 @@ function rafraichirStatutChasse(postId) {
           if (data.success && data.data?.statut) {
             const statut = data.data.statut;
             const label = data.data.statut_label;
+            const icon = data.data.statut_icon || '';
             const badge = document.querySelector(`.badge-statut[data-post-id="${postId}"]`);
             DEBUG && console.log('🔎 Badge trouvé :', badge);
 
             if (badge) {
-              badge.textContent = label;
-              badge.className = `badge-statut statut-${statut}`;
+              const hadIconFormat = badge.classList.contains('badge-statut--format-icon');
+              let extraClasses = Array.from(badge.classList).filter(
+                cls => cls !== 'badge-statut' && !cls.startsWith('statut-')
+              );
+
+              if (hadIconFormat && !icon.trim()) {
+                extraClasses = extraClasses.filter(cls => cls !== 'badge-statut--format-icon');
+              }
+
+              badge.className = ['badge-statut', `statut-${statut}`, ...extraClasses].join(' ');
+
+              if (hadIconFormat && icon.trim()) {
+                badge.innerHTML = `<span class="badge-statut__icon" aria-hidden="true">${icon}</span><span class="screen-reader-text">${label}</span>`;
+              } else {
+                badge.textContent = label;
+              }
             } else {
               console.warn('❓ Aucun badge-statut trouvé pour postId', postId);
             }

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -725,6 +725,28 @@ a.ajout-link:focus-visible {
   z-index: 1;
 }
 
+.badge-statut--format-icon {
+  padding: var(--space-xxs);
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: none;
+}
+
+.badge-statut__icon {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.badge-statut__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 /* Couleurs par statut (alignées sur le nuancier) */
 .badge-statut.statut-en_cours {
   background-color: var(--color-success);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2106,6 +2106,28 @@ a.ajout-link:focus-visible {
   z-index: 1;
 }
 
+.badge-statut--format-icon {
+  padding: var(--space-xxs);
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: none;
+}
+
+.badge-statut__icon {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.badge-statut__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 /* Couleurs par statut (alignées sur le nuancier) */
 .badge-statut.statut-en_cours {
   background-color: var(--color-success);

--- a/wp-content/themes/chassesautresor/inc/badge-functions.php
+++ b/wp-content/themes/chassesautresor/inc/badge-functions.php
@@ -1,0 +1,74 @@
+<?php
+
+// 🚀 Empêcher l'accès direct au fichier
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('chasse_preparer_badge_statut')) {
+    /**
+     * Prépare les informations d'affichage du badge de statut d'une chasse.
+     *
+     * @param string      $statut            Statut métier principal (revision, en_cours, ...).
+     * @param string|null $statut_validation Statut de validation complémentaire.
+     *
+     * @return array{
+     *     statut: string,
+     *     label: string,
+     *     base_class: string,
+     *     icon_name: string|null,
+     *     icon_html: string
+     * }
+     */
+    function chasse_preparer_badge_statut(string $statut, ?string $statut_validation): array
+    {
+        $statut = $statut !== '' ? $statut : 'revision';
+        $statut_for_class = $statut === 'payante' ? 'en_cours' : $statut;
+
+        $label = '';
+        $icon_name = null;
+        $translate = static function (string $string): string {
+            return function_exists('__') ? __($string, 'chassesautresor-com') : $string;
+        };
+
+        if ($statut === 'revision') {
+            if ($statut_validation === 'creation') {
+                $label = $translate('création');
+                $icon_name = 'add';
+            } elseif ($statut_validation === 'correction' || $statut_validation === 'edition') {
+                $label = $translate('correction');
+                $icon_name = 'edition';
+            } elseif ($statut_validation === 'en_attente') {
+                $label = $translate('en attente');
+                $icon_name = 'pending';
+            } else {
+                $label = $translate('révision');
+                $icon_name = 'edition';
+            }
+        } elseif ($statut_for_class === 'en_cours') {
+            $label = $translate('en cours');
+            $icon_name = 'in_progress';
+        } elseif ($statut === 'a_venir') {
+            $label = $translate('à venir');
+            $icon_name = 'hourglass';
+        } elseif ($statut === 'termine') {
+            $label = $translate('terminée');
+            $icon_name = 'finish';
+        } elseif ($statut === 'en_attente') {
+            $label = $translate('en attente');
+            $icon_name = 'pending';
+        } else {
+            $label = function_exists('__') ? __($statut, 'chassesautresor-com') : $statut;
+        }
+
+        $icon_html = ($icon_name && function_exists('get_svg_icon')) ? get_svg_icon($icon_name) : '';
+
+        return [
+            'statut'     => $statut_for_class,
+            'label'      => $label,
+            'base_class' => 'statut-' . $statut_for_class,
+            'icon_name'  => $icon_name,
+            'icon_html'  => $icon_html,
+        ];
+    }
+}

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1,6 +1,8 @@
 <?php
 defined('ABSPATH') || exit;
 
+require_once __DIR__ . '/badge-functions.php';
+
 
 //
 // 1. 📦 FONCTIONS LIÉES À UNE CHASSE
@@ -1399,11 +1401,18 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
  *
  * @return array Tableau associatif prêt pour le template.
 */
-function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit = 300): array
+function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit = 300, array $options = []): array
 {
     if (get_post_type($chasse_id) !== 'chasse') {
         return [];
     }
+
+    $options = wp_parse_args(
+        $options,
+        [
+            'badge_format' => 'text',
+        ]
+    );
 
     $titre     = get_the_title($chasse_id);
     $permalink = get_permalink($chasse_id);
@@ -1461,29 +1470,18 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
 
     $nb_joueurs       = compter_joueurs_engages_chasse($chasse_id);
     $nb_joueurs_label = formater_nombre_joueurs($nb_joueurs);
-    $badge_class       = 'statut-' . $statut;
-    $statut_label      = '';
+    $badge_infos = chasse_preparer_badge_statut($statut, $statut_validation);
+    $badge_format = ($options['badge_format'] === 'icon' && $badge_infos['icon_html']) ? 'icon' : 'text';
+    $badge_class = $badge_infos['base_class'];
 
-    if ($statut === 'revision') {
-        if ($statut_validation === 'creation') {
-            $statut_label = __('création', 'chassesautresor-com');
-        } elseif ($statut_validation === 'correction') {
-            $statut_label = __('correction', 'chassesautresor-com');
-        } elseif ($statut_validation === 'en_attente') {
-            $statut_label = __('en attente', 'chassesautresor-com');
-        } else {
-            $statut_label = __('révision', 'chassesautresor-com');
-        }
-    } elseif ($statut === 'payante' || $statut === 'en_cours') {
-        $statut_label = __('en cours', 'chassesautresor-com');
-        $badge_class   = 'statut-en_cours';
-    } elseif ($statut === 'a_venir') {
-        $statut_label = __('à venir', 'chassesautresor-com');
-    } elseif ($statut === 'termine') {
-        $statut_label = __('terminée', 'chassesautresor-com');
-    } else {
-        $statut_label = __($statut, 'chassesautresor-com');
+    if ($badge_format === 'icon') {
+        $badge_class .= ' badge-statut--format-icon';
     }
+
+    $badge_content = $badge_format === 'icon'
+        ? '<span class="badge-statut__icon" aria-hidden="true">' . $badge_infos['icon_html'] . '</span>'
+            . '<span class="screen-reader-text">' . esc_html($badge_infos['label']) . '</span>'
+        : esc_html($badge_infos['label']);
 
     $enigmes_associees = recuperer_enigmes_associees($chasse_id);
     $total_enigmes     = count($enigmes_associees);
@@ -1597,9 +1595,13 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'date_fin'          => $date_fin_affichage,
         'date_debut_court'  => $date_debut_court,
         'date_fin_court'    => $date_fin_court,
-        'badge_class'       => $badge_class,
-        'statut_label'      => $statut_label,
-        'classe_statut'     => $badge_class,
+        'badge_class'       => trim($badge_class),
+        'statut_label'      => $badge_infos['label'],
+        'statut_icon'       => $badge_infos['icon_html'],
+        'statut_icon_name'  => $badge_infos['icon_name'],
+        'badge_format'      => $badge_format,
+        'badge_content'     => $badge_content,
+        'classe_statut'     => $badge_infos['base_class'],
         'extrait_html'      => $extrait_html,
         'lot_html'          => $lot_html,
         'cta_html'          => $cta_html,

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -5,6 +5,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/badge-functions.php';
+
 if (!function_exists('enigme_get_bonnes_reponses')) {
     function enigme_get_bonnes_reponses(int $enigme_id): array
     {
@@ -1068,26 +1070,13 @@ function recuperer_statut_chasse()
     }
 
     $statut_str = is_string($statut) ? $statut : '';
-    $statut_label = ucfirst(str_replace('_', ' ', $statut_str));
-    if ($statut_str === 'payante') {
-        $statut_str = 'en_cours';
-        $statut_label = 'en cours';
-    }
-
-    if ($statut_str === 'revision') {
-        $validation = get_field('chasse_cache_statut_validation', $post_id);
-        if ($validation === 'creation') {
-            $statut_label = 'création';
-        } elseif ($validation === 'correction') {
-            $statut_label = 'correction';
-        } elseif ($validation === 'en_attente') {
-            $statut_label = 'en attente';
-        }
-    }
+    $validation = get_field('chasse_cache_statut_validation', $post_id);
+    $badge_infos = chasse_preparer_badge_statut($statut_str, is_string($validation) ? $validation : null);
 
     wp_send_json_success([
-        'statut' => $statut_str,
-        'statut_label' => $statut_label
+        'statut'       => $badge_infos['statut'],
+        'statut_label' => $badge_infos['label'],
+        'statut_icon'  => $badge_infos['icon_html'],
     ]);
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -24,7 +24,7 @@ if (empty($infos)) {
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
         <div class="carte-cart__image-wrapper">
             <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
-                <?php echo esc_html($infos['statut_label']); ?>
+                <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
             </span>
             <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-cart__image">
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -6,7 +6,13 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 }
 
 $chasse_id = (int) $args['chasse_id'];
-$infos     = preparer_infos_affichage_carte_chasse($chasse_id);
+$infos     = preparer_infos_affichage_carte_chasse(
+    $chasse_id,
+    300,
+    [
+        'badge_format' => 'icon',
+    ]
+);
 
 if (empty($infos)) {
     return;
@@ -16,7 +22,7 @@ if (empty($infos)) {
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-compact__lien">
         <div class="carte-compact__image-wrapper">
             <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
-                <?php echo esc_html($infos['statut_label']); ?>
+                <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
             </span>
             <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-compact__image">
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -31,7 +31,7 @@ if (empty($infos)) {
     <div class="carte-wide__image">
         <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>"
             data-post-id="<?php echo esc_attr($chasse_id); ?>">
-            <?php echo esc_html($infos['statut_label']); ?>
+            <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
         </span>
         <?php if ((int) $infos['cout_points'] > 0) : ?>
         <span

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -17,7 +17,7 @@ if (empty($infos)) {
 <div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-ligne__image">
         <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
-            <?php echo esc_html($infos['statut_label']); ?>
+            <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
         </span>
         <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">
     </div>


### PR DESCRIPTION
## Résumé
- mutualisation de la préparation du badge de statut pour fournir label et icône selon l’état métier
- option d’affichage textuel ou icône pour `preparer_infos_affichage_carte_chasse`, utilisée par la carte compacte
- mise à jour du rendu (PHP/JS/CSS) pour intégrer les icônes et rafraîchir correctement les badges

## Détails
- création de `badge-functions.php` pour exposer `chasse_preparer_badge_statut`
- ajout d’un paramètre `badge_format` et d’un contenu pré-rendu dans les infos de carte
- refonte des templates des cartes de chasse pour exploiter le nouveau contenu et activer le format icône sur la version compacte
- ajustement du rafraîchissement JS/AJAX et des styles SCSS/CSS afin de prendre en charge les badges icône

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68cf9fed81b0833283f2f9fc0f54e545