### PR TITLE
Ajoute un tooltip pour les badges de statut

### DIFF
--- a/tests/ChasseCorrectionBadgeTest.php
+++ b/tests/ChasseCorrectionBadgeTest.php
@@ -52,5 +52,6 @@ class ChasseCorrectionBadgeTest extends TestCase
         $_POST['post_id'] = 123;
         recuperer_statut_chasse();
         $this->assertSame('correction', $json_success_data['statut_label']);
+        $this->assertSame('correction', $json_success_data['statut_tooltip']);
     }
 }

--- a/wp-content/themes/chassesautresor/assets/js/badge-statut-tooltips.js
+++ b/wp-content/themes/chassesautresor/assets/js/badge-statut-tooltips.js
@@ -1,0 +1,101 @@
+(function () {
+  const ready = (callback) => {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback);
+    } else {
+      callback();
+    }
+  };
+
+  ready(() => {
+    const badges = Array.from(document.querySelectorAll('.badge-statut[data-tooltip]'));
+    if (!badges.length) {
+      return;
+    }
+
+    const hideAll = () => {
+      badges.forEach(badge => badge.removeAttribute('data-tooltip-visible'));
+    };
+
+    document.addEventListener('click', (event) => {
+      if (!event.target.closest('.badge-statut[data-tooltip]')) {
+        hideAll();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        hideAll();
+      }
+    });
+
+    badges.forEach((badge) => {
+      const showTooltip = (event) => {
+        if (badge.dataset.tooltipVisible === 'true') {
+          return;
+        }
+
+        hideAll();
+        badge.setAttribute('data-tooltip-visible', 'true');
+
+        if (event) {
+          if (event.type === 'keydown' && event.key === ' ') {
+            event.preventDefault();
+          }
+
+          if (event.type !== 'keydown') {
+            event.preventDefault();
+          }
+
+          event.stopPropagation();
+        }
+      };
+
+      const hideTooltip = () => {
+        badge.removeAttribute('data-tooltip-visible');
+      };
+
+      badge.addEventListener('click', (event) => {
+        if (badge.dataset.tooltipVisible === 'true') {
+          hideTooltip();
+          return;
+        }
+
+        showTooltip(event);
+      });
+
+      badge.addEventListener('touchstart', (event) => {
+        if (badge.dataset.tooltipVisible === 'true') {
+          return;
+        }
+
+        showTooltip(event);
+      }, { passive: false });
+
+      badge.addEventListener('blur', hideTooltip);
+
+      badge.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          hideTooltip();
+          return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+          if (badge.dataset.tooltipVisible === 'true') {
+            if (event.key === ' ') {
+              event.preventDefault();
+            }
+            hideTooltip();
+            const parentLink = badge.closest('a');
+            if (parentLink) {
+              parentLink.click();
+            }
+            return;
+          }
+
+          showTooltip(event);
+        }
+      });
+    });
+  });
+})();

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -1358,25 +1358,52 @@ function rafraichirStatutChasse(postId) {
             const statut = data.data.statut;
             const label = data.data.statut_label;
             const icon = data.data.statut_icon || '';
+            const tooltip = data.data.statut_tooltip || label || '';
+            const wantsIconFormat = icon.trim().length > 0;
             const badge = document.querySelector(`.badge-statut[data-post-id="${postId}"]`);
             DEBUG && console.log('🔎 Badge trouvé :', badge);
 
             if (badge) {
-              const hadIconFormat = badge.classList.contains('badge-statut--format-icon');
               let extraClasses = Array.from(badge.classList).filter(
                 cls => cls !== 'badge-statut' && !cls.startsWith('statut-')
               );
 
-              if (hadIconFormat && !icon.trim()) {
+              if (wantsIconFormat && !extraClasses.includes('badge-statut--format-icon')) {
+                extraClasses.push('badge-statut--format-icon');
+              }
+
+              if (!wantsIconFormat) {
                 extraClasses = extraClasses.filter(cls => cls !== 'badge-statut--format-icon');
               }
 
               badge.className = ['badge-statut', `statut-${statut}`, ...extraClasses].join(' ');
 
-              if (hadIconFormat && icon.trim()) {
+              if (wantsIconFormat) {
                 badge.innerHTML = `<span class="badge-statut__icon" aria-hidden="true">${icon}</span><span class="screen-reader-text">${label}</span>`;
+                if (tooltip) {
+                  badge.dataset.tooltip = tooltip;
+                  badge.setAttribute('title', tooltip);
+                  badge.setAttribute('aria-label', tooltip);
+                } else {
+                  badge.removeAttribute('data-tooltip');
+                  badge.removeAttribute('title');
+                  badge.removeAttribute('aria-label');
+                }
+                badge.setAttribute('role', 'img');
+                badge.setAttribute('tabindex', '0');
               } else {
                 badge.textContent = label;
+                if (tooltip) {
+                  badge.setAttribute('aria-label', tooltip);
+                  badge.setAttribute('title', tooltip);
+                } else {
+                  badge.removeAttribute('aria-label');
+                  badge.removeAttribute('title');
+                }
+                badge.removeAttribute('role');
+                badge.removeAttribute('data-tooltip');
+                badge.removeAttribute('data-tooltip-visible');
+                badge.removeAttribute('tabindex');
               }
             } else {
               console.warn('❓ Aucun badge-statut trouvé pour postId', postId);

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -725,6 +725,57 @@ a.ajout-link:focus-visible {
   z-index: 1;
 }
 
+.badge-statut[data-tooltip] {
+  cursor: help;
+}
+
+.badge-statut[data-tooltip]::before,
+.badge-statut[data-tooltip]::after {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.badge-statut[data-tooltip]::after {
+  content: attr(data-tooltip);
+  top: calc(100% + var(--space-xs));
+  left: 50%;
+  transform: translate(-50%, -8px);
+  background: rgba(var(--color-text-fond-clair-rgb), 0.95);
+  color: var(--color-text-primary);
+  padding: var(--space-xxs) var(--space-xs);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  white-space: normal;
+  text-align: center;
+  max-width: 220px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.25);
+  z-index: 5;
+}
+
+.badge-statut[data-tooltip]::before {
+  content: '';
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translate(-50%, -6px);
+  border: 6px solid transparent;
+  border-bottom-width: 0;
+  border-top-color: rgba(var(--color-text-fond-clair-rgb), 0.95);
+  z-index: 5;
+}
+
+.badge-statut[data-tooltip]:hover::before,
+.badge-statut[data-tooltip]:hover::after,
+.badge-statut[data-tooltip]:focus-visible::before,
+.badge-statut[data-tooltip]:focus-visible::after,
+.badge-statut[data-tooltip][data-tooltip-visible="true"]::before,
+.badge-statut[data-tooltip][data-tooltip-visible="true"]::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .badge-statut--format-icon {
   padding: var(--space-xxs);
   width: 2.5rem;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2106,6 +2106,57 @@ a.ajout-link:focus-visible {
   z-index: 1;
 }
 
+.badge-statut[data-tooltip] {
+  cursor: help;
+}
+
+.badge-statut[data-tooltip]::before,
+.badge-statut[data-tooltip]::after {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.badge-statut[data-tooltip]::after {
+  content: attr(data-tooltip);
+  top: calc(100% + var(--space-xs));
+  left: 50%;
+  transform: translate(-50%, -8px);
+  background: rgba(var(--color-text-fond-clair-rgb), 0.95);
+  color: var(--color-text-primary);
+  padding: var(--space-xxs) var(--space-xs);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  white-space: normal;
+  text-align: center;
+  max-width: 220px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.25);
+  z-index: 5;
+}
+
+.badge-statut[data-tooltip]::before {
+  content: "";
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translate(-50%, -6px);
+  border: 6px solid transparent;
+  border-bottom-width: 0;
+  border-top-color: rgba(var(--color-text-fond-clair-rgb), 0.95);
+  z-index: 5;
+}
+
+.badge-statut[data-tooltip]:hover::before,
+.badge-statut[data-tooltip]:hover::after,
+.badge-statut[data-tooltip]:focus-visible::before,
+.badge-statut[data-tooltip]:focus-visible::after,
+.badge-statut[data-tooltip][data-tooltip-visible=true]::before,
+.badge-statut[data-tooltip][data-tooltip-visible=true]::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .badge-statut--format-icon {
   padding: var(--space-xxs);
   width: 2.5rem;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1473,6 +1473,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $badge_infos = chasse_preparer_badge_statut($statut, $statut_validation);
     $badge_format = ($options['badge_format'] === 'icon' && $badge_infos['icon_html']) ? 'icon' : 'text';
     $badge_class = $badge_infos['base_class'];
+    $badge_tooltip = $badge_infos['label'];
+    $badge_requires_interaction = ($badge_format === 'icon' && $badge_tooltip !== '');
 
     if ($badge_format === 'icon') {
         $badge_class .= ' badge-statut--format-icon';
@@ -1601,6 +1603,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'statut_icon_name'  => $badge_infos['icon_name'],
         'badge_format'      => $badge_format,
         'badge_content'     => $badge_content,
+        'badge_tooltip'     => $badge_tooltip,
+        'badge_requires_interaction' => $badge_requires_interaction,
         'classe_statut'     => $badge_infos['base_class'],
         'extrait_html'      => $extrait_html,
         'lot_html'          => $lot_html,

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -139,6 +139,13 @@ function charger_scripts_personnalises() {
         true
     );
     wp_enqueue_script(
+        'badge-statut-tooltips',
+        $theme_dir . 'badge-statut-tooltips.js',
+        [],
+        filemtime(get_stylesheet_directory() . '/assets/js/badge-statut-tooltips.js'),
+        true
+    );
+    wp_enqueue_script(
         'meta-tap-info',
         $theme_dir . 'meta-tap-info.js',
         [],

--- a/wp-content/themes/chassesautresor/inc/statut-functions.php
+++ b/wp-content/themes/chassesautresor/inc/statut-functions.php
@@ -1077,6 +1077,7 @@ function recuperer_statut_chasse()
         'statut'       => $badge_infos['statut'],
         'statut_label' => $badge_infos['label'],
         'statut_icon'  => $badge_infos['icon_html'],
+        'statut_tooltip' => $badge_infos['label'],
     ]);
 }
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -19,11 +19,23 @@ $infos           = preparer_infos_affichage_carte_chasse($chasse_id);
 if (empty($infos)) {
     return;
 }
+
+$badge_tooltip = $infos['badge_tooltip'] ?? '';
+$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_attributes = '';
+
+if ($badge_has_interaction && $badge_tooltip !== '') {
+    $tooltip_attr = esc_attr($badge_tooltip);
+    $badge_attributes .= ' aria-label="' . $tooltip_attr . '"';
+    $badge_attributes .= ' title="' . $tooltip_attr . '"';
+    $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
+    $badge_attributes .= ' role="img" tabindex="0"';
+}
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
         <div class="carte-cart__image-wrapper">
-            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
                 <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
             </span>
             <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-cart__image">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -17,11 +17,23 @@ $infos     = preparer_infos_affichage_carte_chasse(
 if (empty($infos)) {
     return;
 }
+
+$badge_tooltip = $infos['badge_tooltip'] ?? '';
+$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_attributes = '';
+
+if ($badge_has_interaction && $badge_tooltip !== '') {
+    $tooltip_attr = esc_attr($badge_tooltip);
+    $badge_attributes .= ' aria-label="' . $tooltip_attr . '"';
+    $badge_attributes .= ' title="' . $tooltip_attr . '"';
+    $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
+    $badge_attributes .= ' role="img" tabindex="0"';
+}
 ?>
 <div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-compact__lien">
         <div class="carte-compact__image-wrapper">
-            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
                 <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
             </span>
             <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-compact__image">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -26,11 +26,23 @@ if ($orga_id) {
 if (empty($infos)) {
     return;
 }
+
+$badge_tooltip = $infos['badge_tooltip'] ?? '';
+$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_attributes = '';
+
+if ($badge_has_interaction && $badge_tooltip !== '') {
+    $tooltip_attr = esc_attr($badge_tooltip);
+    $badge_attributes .= ' aria-label="' . $tooltip_attr . '"';
+    $badge_attributes .= ' title="' . $tooltip_attr . '"';
+    $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
+    $badge_attributes .= ' role="img" tabindex="0"';
+}
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
         <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>"
-            data-post-id="<?php echo esc_attr($chasse_id); ?>">
+            data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
             <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
         </span>
         <?php if ((int) $infos['cout_points'] > 0) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -12,11 +12,23 @@ $infos = preparer_infos_affichage_carte_chasse($chasse_id);
 if (empty($infos)) {
     return;
 }
+
+$badge_tooltip = $infos['badge_tooltip'] ?? '';
+$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_attributes = '';
+
+if ($badge_has_interaction && $badge_tooltip !== '') {
+    $tooltip_attr = esc_attr($badge_tooltip);
+    $badge_attributes .= ' aria-label="' . $tooltip_attr . '"';
+    $badge_attributes .= ' title="' . $tooltip_attr . '"';
+    $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
+    $badge_attributes .= ' role="img" tabindex="0"';
+}
 ?>
 
 <div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-ligne__image">
-        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>">
+        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
             <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
         </span>
         <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">


### PR DESCRIPTION
Résumé: Ajout d'une aide contextuelle sur les badges de statut des cartes chasse.

- Prépare et transmet le libellé de statut aux gabarits afin d'afficher une infobulle sur les cartes compactes.
- Ajoute le style et un script front-end pour gérer le survol/le tap des badges, y compris lors des mises à jour dynamiques.
- Étend la réponse AJAX et les tests afin d'exposer le libellé utilisé dans le tooltip.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d009fd9ed08332b9710d223426940e