### PR TITLE
Use icon status badges in hunt list

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -503,61 +503,9 @@
   max-height: 350px;
 }
 
-.carte-ligne { 
+.carte-ligne {
   display: flex;
   align-items: stretch;
-
-  .badge-statut--responsive {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--space-xxs);
-    width: 2.5rem;
-    height: 2.5rem;
-  }
-
-  .badge-statut--responsive .badge-statut__icon {
-    display: inline-flex;
-  }
-
-  .badge-statut--responsive .badge-statut__label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-
-  @media (--bp-tablet) {
-    .badge-statut--responsive {
-      width: auto;
-      height: auto;
-      padding: 4px 8px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .badge-statut--responsive .badge-statut__icon {
-      display: none;
-    }
-
-    .badge-statut--responsive .badge-statut__label {
-      position: static;
-      width: auto;
-      height: auto;
-      margin: 0;
-      padding: 0;
-      overflow: visible;
-      clip: auto;
-      white-space: normal;
-      border: 0;
-    }
-  }
 }
 
 .carte-ligne__contenu {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -503,9 +503,61 @@
   max-height: 350px;
 }
 
-.carte-ligne {
+.carte-ligne { 
   display: flex;
   align-items: stretch;
+
+  .badge-statut--responsive {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-xxs);
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .badge-statut--responsive .badge-statut__icon {
+    display: inline-flex;
+  }
+
+  .badge-statut--responsive .badge-statut__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (--bp-tablet) {
+    .badge-statut--responsive {
+      width: auto;
+      height: auto;
+      padding: 4px 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .badge-statut--responsive .badge-statut__icon {
+      display: none;
+    }
+
+    .badge-statut--responsive .badge-statut__label {
+      position: static;
+      width: auto;
+      height: auto;
+      margin: 0;
+      padding: 0;
+      overflow: visible;
+      clip: auto;
+      white-space: normal;
+      border: 0;
+    }
+  }
 }
 
 .carte-ligne__contenu {

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -823,7 +823,7 @@ a.ajout-link:focus-visible {
   }
 }
 
-@media (--bp-tablet) {
+@media (--bp-desktop) {
   .badge-statut--responsive {
     width: auto;
     height: auto;

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -798,6 +798,55 @@ a.ajout-link:focus-visible {
   display: block;
 }
 
+.badge-statut--responsive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xxs);
+  width: 2.5rem;
+  height: 2.5rem;
+
+  .badge-statut__icon {
+    display: inline-flex;
+  }
+
+  .badge-statut__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
+@media (--bp-tablet) {
+  .badge-statut--responsive {
+    width: auto;
+    height: auto;
+    padding: 4px 8px;
+  }
+
+  .badge-statut--responsive .badge-statut__icon {
+    display: none;
+  }
+
+  .badge-statut--responsive .badge-statut__label {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: 0;
+  }
+}
+
 /* Couleurs par statut (alignées sur le nuancier) */
 .badge-statut.statut-en_cours {
   background-color: var(--color-success);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -475,6 +475,52 @@
   display: flex;
   align-items: stretch;
 }
+.carte-ligne .badge-statut--responsive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xxs);
+  width: 2.5rem;
+  height: 2.5rem;
+}
+.carte-ligne .badge-statut--responsive .badge-statut__icon {
+  display: inline-flex;
+}
+.carte-ligne .badge-statut--responsive .badge-statut__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (min-width: 768px) {
+  .carte-ligne .badge-statut--responsive {
+    width: auto;
+    height: auto;
+    padding: 4px 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .carte-ligne .badge-statut--responsive .badge-statut__icon {
+    display: none;
+  }
+  .carte-ligne .badge-statut--responsive .badge-statut__label {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: 0;
+  }
+}
 
 .carte-ligne__contenu {
   padding: var(--space-md) var(--space-2xl);

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2258,7 +2258,7 @@ a.ajout-link:focus-visible {
   border: 0;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .badge-statut--responsive {
     width: auto;
     height: auto;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -475,52 +475,6 @@
   display: flex;
   align-items: stretch;
 }
-.carte-ligne .badge-statut--responsive {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-xxs);
-  width: 2.5rem;
-  height: 2.5rem;
-}
-.carte-ligne .badge-statut--responsive .badge-statut__icon {
-  display: inline-flex;
-}
-.carte-ligne .badge-statut--responsive .badge-statut__label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-@media (min-width: 768px) {
-  .carte-ligne .badge-statut--responsive {
-    width: auto;
-    height: auto;
-    padding: 4px 8px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-  .carte-ligne .badge-statut--responsive .badge-statut__icon {
-    display: none;
-  }
-  .carte-ligne .badge-statut--responsive .badge-statut__label {
-    position: static;
-    width: auto;
-    height: auto;
-    margin: 0;
-    padding: 0;
-    overflow: visible;
-    clip: auto;
-    white-space: normal;
-    border: 0;
-  }
-}
 
 .carte-ligne__contenu {
   padding: var(--space-md) var(--space-2xl);
@@ -2281,6 +2235,50 @@ a.ajout-link:focus-visible {
   display: block;
 }
 
+.badge-statut--responsive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xxs);
+  width: 2.5rem;
+  height: 2.5rem;
+}
+.badge-statut--responsive .badge-statut__icon {
+  display: inline-flex;
+}
+.badge-statut--responsive .badge-statut__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .badge-statut--responsive {
+    width: auto;
+    height: auto;
+    padding: 4px 8px;
+  }
+  .badge-statut--responsive .badge-statut__icon {
+    display: none;
+  }
+  .badge-statut--responsive .badge-statut__label {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: 0;
+  }
+}
 /* Couleurs par statut (alignées sur le nuancier) */
 .badge-statut.statut-en_cours {
   background-color: var(--color-success);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -21,7 +21,16 @@ if (empty($infos)) {
 }
 
 $badge_tooltip = $infos['badge_tooltip'] ?? '';
-$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_icon_html = $infos['statut_icon'] ?? '';
+$badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
+$has_badge_icon = $badge_icon_html !== '';
+$badge_classes = $infos['badge_class'] ?? '';
+
+if ($has_badge_icon) {
+    $badge_classes = trim($badge_classes . ' badge-statut--responsive');
+}
+
+$badge_has_interaction = $has_badge_icon && $badge_tooltip !== '';
 $badge_attributes = '';
 
 if ($badge_has_interaction && $badge_tooltip !== '') {
@@ -35,8 +44,13 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
         <div class="carte-cart__image-wrapper">
-            <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-                <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+            <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+                <?php if ($has_badge_icon) : ?>
+                    <span class="badge-statut__icon" aria-hidden="true">
+                        <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                    </span>
+                <?php endif; ?>
             </span>
             <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-cart__image">
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -28,7 +28,16 @@ if (empty($infos)) {
 }
 
 $badge_tooltip = $infos['badge_tooltip'] ?? '';
-$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_icon_html = $infos['statut_icon'] ?? '';
+$badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
+$has_badge_icon = $badge_icon_html !== '';
+$badge_classes = $infos['badge_class'] ?? '';
+
+if ($has_badge_icon) {
+    $badge_classes = trim($badge_classes . ' badge-statut--responsive');
+}
+
+$badge_has_interaction = $has_badge_icon && $badge_tooltip !== '';
 $badge_attributes = '';
 
 if ($badge_has_interaction && $badge_tooltip !== '') {
@@ -41,9 +50,14 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
-        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>"
+        <span class="badge-statut <?php echo esc_attr($badge_classes); ?>"
             data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-            <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+            <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+            <?php if ($has_badge_icon) : ?>
+                <span class="badge-statut__icon" aria-hidden="true">
+                    <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                </span>
+            <?php endif; ?>
         </span>
         <?php if ((int) $infos['cout_points'] > 0) : ?>
         <span

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -8,7 +8,13 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 $chasse_id = $args['chasse_id'];
 $completion_class = $args['completion_class'] ?? '';
 
-$infos = preparer_infos_affichage_carte_chasse($chasse_id);
+$infos = preparer_infos_affichage_carte_chasse(
+    $chasse_id,
+    300,
+    [
+        'badge_format' => 'icon',
+    ]
+);
 if (empty($infos)) {
     return;
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -8,19 +8,22 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 $chasse_id = $args['chasse_id'];
 $completion_class = $args['completion_class'] ?? '';
 
-$infos = preparer_infos_affichage_carte_chasse(
-    $chasse_id,
-    300,
-    [
-        'badge_format' => 'icon',
-    ]
-);
+$infos = preparer_infos_affichage_carte_chasse($chasse_id);
 if (empty($infos)) {
     return;
 }
 
 $badge_tooltip = $infos['badge_tooltip'] ?? '';
-$badge_has_interaction = !empty($infos['badge_requires_interaction']);
+$badge_icon_html = $infos['statut_icon'] ?? '';
+$badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
+$has_badge_icon = $badge_icon_html !== '';
+$badge_classes = $infos['badge_class'] ?? '';
+
+if ($has_badge_icon) {
+    $badge_classes = trim($badge_classes . ' badge-statut--responsive');
+}
+
+$badge_has_interaction = $has_badge_icon && $badge_tooltip !== '';
 $badge_attributes = '';
 
 if ($badge_has_interaction && $badge_tooltip !== '') {
@@ -34,8 +37,13 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 
 <div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-ligne__image">
-        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-            <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+        <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+            <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+            <?php if ($has_badge_icon) : ?>
+                <span class="badge-statut__icon" aria-hidden="true">
+                    <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                </span>
+            <?php endif; ?>
         </span>
         <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">
     </div>


### PR DESCRIPTION
## Résumé
- bascule les cartes de chasse de la boucle vers le badge de statut au format icône

## Changements notables
- force l'utilisation du format `icon` lors de la préparation des cartes de chasse en liste

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d00de3ffac8332b554c26d9bc34906