### PR TITLE
Optimisation de l'en-tête du tableau des tentatives

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -811,8 +811,17 @@ body.woocommerce h2 {
     margin-bottom: var(--space-sm);
 }
 
+.myaccount-tentatives .table-header__stats {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-xs);
+    min-width: 0;
+}
+
 .myaccount-tentatives .table-header .table-search {
     flex: 1 1 100%;
+    min-width: 0;
 }
 
 .myaccount-tentatives .stats-table-wrapper {
@@ -827,6 +836,12 @@ body.woocommerce h2 {
 
 @media (--bp-mobile) {
     .myaccount-tentatives .table-header {
+        flex-wrap: nowrap;
+        gap: var(--space-sm);
+    }
+
+    .myaccount-tentatives .table-header__stats {
+        flex: 1 1 auto;
         gap: var(--space-sm);
     }
 
@@ -834,6 +849,43 @@ body.woocommerce h2 {
         flex: 0 1 auto;
         margin-left: auto;
     }
+}
+
+.myaccount-tentatives .table-search__reset {
+    position: relative;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background-color: rgba(255, 255, 255, 0.08);
+    color: var(--color-text-primary);
+    flex-shrink: 0;
+}
+
+.myaccount-tentatives .table-search__reset::before {
+    content: "\21BB";
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.myaccount-tentatives .table-search__reset:hover,
+.myaccount-tentatives .table-search__reset:focus {
+    background-color: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.5);
+    color: var(--color-white);
+}
+
+.myaccount-tentatives .table-search__reset-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .tentatives-table th:nth-child(2),

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -809,6 +809,7 @@ body.woocommerce h2 {
     align-items: center;
     gap: var(--space-xs);
     margin-bottom: var(--space-sm);
+    width: 100%;
 }
 
 .myaccount-tentatives .table-header__stats {
@@ -829,6 +830,7 @@ body.woocommerce h2 {
 .myaccount-tentatives .table-header .table-search {
     flex: 1 1 100%;
     min-width: 0;
+    margin-left: auto;
 }
 
 .myaccount-tentatives .table-search__field {
@@ -879,7 +881,9 @@ body.woocommerce h2 {
     }
 
     .myaccount-tentatives .table-header .table-search {
-        flex: 0 1 auto;
+        flex: 0 1 24rem;
+        width: 100%;
+        max-width: 24rem;
         margin-left: auto;
     }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -819,9 +819,42 @@ body.woocommerce h2 {
     min-width: 0;
 }
 
+.myaccount-tentatives .table-header__stats .stat-badge {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    line-height: 1.15;
+}
+
 .myaccount-tentatives .table-header .table-search {
     flex: 1 1 100%;
     min-width: 0;
+}
+
+.myaccount-tentatives .table-search__field {
+    background-color: rgba(255, 255, 255, 0.95);
+    color: var(--color-text-fond-clair);
+    border-color: rgba(11, 19, 43, 0.25);
+}
+
+.myaccount-tentatives .table-search__field::placeholder {
+    color: rgba(28, 28, 28, 0.55);
+}
+
+.myaccount-tentatives .table-search__field:focus {
+    border-color: rgba(225, 169, 95, 0.75);
+    box-shadow: 0 0 0 2px rgba(225, 169, 95, 0.35);
+}
+
+.myaccount-tentatives .table-search__submit {
+    background-color: var(--color-secondary);
+    color: var(--color-background-dark);
+}
+
+.myaccount-tentatives .table-search__submit:hover,
+.myaccount-tentatives .table-search__submit:focus {
+    background-color: var(--color-primary-dark);
+    color: var(--color-background-dark);
 }
 
 .myaccount-tentatives .stats-table-wrapper {
@@ -853,27 +886,30 @@ body.woocommerce h2 {
 
 .myaccount-tentatives .table-search__reset {
     position: relative;
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 2rem;
+    height: 2rem;
     padding: 0;
-    border-radius: 50%;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    background-color: rgba(255, 255, 255, 0.08);
+    border: none;
+    background-color: transparent;
     color: var(--color-text-primary);
     flex-shrink: 0;
 }
 
 .myaccount-tentatives .table-search__reset::before {
-    content: "\21BB";
-    font-size: 1.25rem;
+    content: "\00D7";
+    font-size: 1.125rem;
     line-height: 1;
 }
 
 .myaccount-tentatives .table-search__reset:hover,
 .myaccount-tentatives .table-search__reset:focus {
-    background-color: rgba(255, 255, 255, 0.12);
-    border-color: rgba(255, 255, 255, 0.5);
     color: var(--color-white);
+}
+
+.myaccount-tentatives .table-search__reset:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(225, 169, 95, 0.65);
+    border-radius: 999px;
 }
 
 .myaccount-tentatives .table-search__reset-text {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9628,8 +9628,17 @@ body.woocommerce h2 {
   margin-bottom: var(--space-sm);
 }
 
+.myaccount-tentatives .table-header__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+}
+
 .myaccount-tentatives .table-header .table-search {
   flex: 1 1 100%;
+  min-width: 0;
 }
 
 .myaccount-tentatives .stats-table-wrapper {
@@ -9644,6 +9653,11 @@ body.woocommerce h2 {
 
 @media (min-width: 600px) {
   .myaccount-tentatives .table-header {
+    flex-wrap: nowrap;
+    gap: var(--space-sm);
+  }
+  .myaccount-tentatives .table-header__stats {
+    flex: 1 1 auto;
     gap: var(--space-sm);
   }
   .myaccount-tentatives .table-header .table-search {
@@ -9651,6 +9665,43 @@ body.woocommerce h2 {
     margin-left: auto;
   }
 }
+.myaccount-tentatives .table-search__reset {
+  position: relative;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background-color: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-primary);
+  flex-shrink: 0;
+}
+
+.myaccount-tentatives .table-search__reset::before {
+  content: "↻";
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.myaccount-tentatives .table-search__reset:hover,
+.myaccount-tentatives .table-search__reset:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.5);
+  color: var(--color-white);
+}
+
+.myaccount-tentatives .table-search__reset-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .tentatives-table th:nth-child(2),
 .tentatives-table td:nth-child(2),
 .tentatives-table th:nth-child(3),

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9626,6 +9626,7 @@ body.woocommerce h2 {
   align-items: center;
   gap: var(--space-xs);
   margin-bottom: var(--space-sm);
+  width: 100%;
 }
 
 .myaccount-tentatives .table-header__stats {
@@ -9646,6 +9647,7 @@ body.woocommerce h2 {
 .myaccount-tentatives .table-header .table-search {
   flex: 1 1 100%;
   min-width: 0;
+  margin-left: auto;
 }
 
 .myaccount-tentatives .table-search__field {
@@ -9698,7 +9700,9 @@ body.woocommerce h2 {
     gap: var(--space-sm);
   }
   .myaccount-tentatives .table-header .table-search {
-    flex: 0 1 auto;
+    flex: 0 1 24rem;
+    width: 100%;
+    max-width: 24rem;
     margin-left: auto;
   }
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9636,9 +9636,46 @@ body.woocommerce h2 {
   min-width: 0;
 }
 
+.myaccount-tentatives .table-header__stats .stat-badge {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1.15;
+}
+
 .myaccount-tentatives .table-header .table-search {
   flex: 1 1 100%;
   min-width: 0;
+}
+
+.myaccount-tentatives .table-search__field {
+  background-color: rgba(255, 255, 255, 0.95);
+  color: var(--color-text-fond-clair);
+  border-color: rgba(11, 19, 43, 0.25);
+}
+
+.myaccount-tentatives .table-search__field::-moz-placeholder {
+  color: rgba(28, 28, 28, 0.55);
+}
+
+.myaccount-tentatives .table-search__field::placeholder {
+  color: rgba(28, 28, 28, 0.55);
+}
+
+.myaccount-tentatives .table-search__field:focus {
+  border-color: rgba(225, 169, 95, 0.75);
+  box-shadow: 0 0 0 2px rgba(225, 169, 95, 0.35);
+}
+
+.myaccount-tentatives .table-search__submit {
+  background-color: var(--color-secondary);
+  color: var(--color-background-dark);
+}
+
+.myaccount-tentatives .table-search__submit:hover,
+.myaccount-tentatives .table-search__submit:focus {
+  background-color: var(--color-primary-dark);
+  color: var(--color-background-dark);
 }
 
 .myaccount-tentatives .stats-table-wrapper {
@@ -9667,27 +9704,30 @@ body.woocommerce h2 {
 }
 .myaccount-tentatives .table-search__reset {
   position: relative;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2rem;
+  height: 2rem;
   padding: 0;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  background-color: rgba(255, 255, 255, 0.08);
+  border: none;
+  background-color: transparent;
   color: var(--color-text-primary);
   flex-shrink: 0;
 }
 
 .myaccount-tentatives .table-search__reset::before {
-  content: "↻";
-  font-size: 1.25rem;
+  content: "×";
+  font-size: 1.125rem;
   line-height: 1;
 }
 
 .myaccount-tentatives .table-search__reset:hover,
 .myaccount-tentatives .table-search__reset:focus {
-  background-color: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.5);
   color: var(--color-white);
+}
+
+.myaccount-tentatives .table-search__reset:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(225, 169, 95, 0.65);
+  border-radius: 999px;
 }
 
 .myaccount-tentatives .table-search__reset-text {

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1446,18 +1446,21 @@ function ca_render_dashboard_tentatives(): void
     <section class="myaccount-tentatives">
         <h2><?php esc_html_e('Tentatives', 'chassesautresor-com'); ?></h2>
         <div class="table-header">
-            <?php if ($view['pending'] > 0) : ?>
-            <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $view['pending'], 'chassesautresor-com')), $view['pending']); ?></span>
-            <?php endif; ?>
-            <span class="stat-badge"><?php printf(esc_html(_n('%d tentative', '%d tentatives', $view['total'], 'chassesautresor-com')), $view['total']); ?></span>
-            <?php if ($view['success'] > 0) : ?>
-            <span class="stat-badge" style="color:var(--color-success);">
-                <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $view['success'], 'chassesautresor-com')), $view['success']); ?>
-            </span>
-            <?php endif; ?>
+            <div class="table-header__stats">
+                <?php if ($view['pending'] > 0) : ?>
+                <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $view['pending'], 'chassesautresor-com')), $view['pending']); ?></span>
+                <?php endif; ?>
+                <span class="stat-badge"><?php printf(esc_html(_n('%d tentative', '%d tentatives', $view['total'], 'chassesautresor-com')), $view['total']); ?></span>
+                <?php if ($view['success'] > 0) : ?>
+                <span class="stat-badge" style="color:var(--color-success);">
+                    <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $view['success'], 'chassesautresor-com')), $view['success']); ?>
+                </span>
+                <?php endif; ?>
+            </div>
             <?php
             echo cta_render_search_form('tentatives', [
                 'class'             => 'table-search--inline table-search--compact',
+                'label'             => '',
                 'show_reset_button' => true,
                 'data_attributes'   => [
                     'ajax-action' => 'ca_fetch_tentatives',


### PR DESCRIPTION
Résumé : Harmonisation de la présentation du tableau des tentatives dans l'espace client.

- Regroupe les badges statistiques et le formulaire de recherche sur une même ligne et supprime le libellé redondant du champ.
- Met à jour les styles du tableau pour l'affichage responsive des badges et transforme le bouton de réinitialisation en icône accessible.
- Recompile la feuille de styles distribuée avec ces ajustements.

**Testing**
- npm run build:css
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d0117043848332ad2e9752c346fc09