### PR TITLE
Align edit account legend color with labels

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -150,6 +150,7 @@ label {
 
 .edition-panel label,
 .edit-account label,
+.edit-account legend,
 .stats-filtres label {
     color: var(--color-editor-text-muted);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7414,6 +7414,7 @@ label {
 
 .edition-panel label,
 .edit-account label,
+.edit-account legend,
 .stats-filtres label {
   color: var(--color-editor-text-muted);
 }


### PR DESCRIPTION
Résumé: Harmonisation de la couleur du champ legend sur la page de modification du compte.

- Aligné la couleur du texte des éléments `<legend>` du formulaire d'édition de compte sur celle des labels existants.
- Recompilé la feuille de style distribuée après la mise à jour SCSS.

**Testing**
- ✅ `npm run build:css`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d015ed53ac8332aeb69e717b8d6bdb