### PR TITLE
Enhance WooCommerce address add button styling

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -445,19 +445,18 @@
     }
 
     .woocommerce-Address-action--add {
-        width: 3.25rem;
-        height: 3.25rem;
         padding: 0;
-        border-radius: 50%;
+        min-width: 2.5rem;
+        min-height: 2.5rem;
+        border-radius: 999px;
         background-color: var(--color-titre-enigme);
         color: var(--color-background);
-        font-size: 2rem;
+        font-size: 1.5rem;
         font-weight: 700;
         line-height: 1;
 
         &:hover,
         &:focus-visible {
-            transform: scale(1.05);
             box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
         }
     }
@@ -470,9 +469,9 @@
 @media (--bp-tablet) {
     .woocommerce-account {
         .woocommerce-Address-action--add {
-            width: 3.5rem;
-            height: 3.5rem;
-            font-size: 2.25rem;
+            min-width: 2.75rem;
+            min-height: 2.75rem;
+            font-size: 1.75rem;
         }
     }
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -408,6 +408,77 @@
 
 
 /* ==========================================================
+📌 Adresses
+========================================================== */
+.woocommerce-account {
+    .woocommerce-Address-title {
+        display: flex;
+        align-items: center;
+        gap: var(--space-md);
+        margin-bottom: var(--space-md);
+
+        h2 {
+            margin: 0;
+        }
+    }
+
+    .woocommerce-Address-action {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: 999px;
+        font-weight: 600;
+        text-decoration: none;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+
+        &:focus-visible {
+            outline: 2px solid var(--color-titre-enigme);
+            outline-offset: 2px;
+        }
+    }
+
+    .woocommerce-Address-action--edit {
+        color: var(--color-titre-enigme);
+    }
+
+    .woocommerce-Address-action--add {
+        width: 3.25rem;
+        height: 3.25rem;
+        padding: 0;
+        border-radius: 50%;
+        background-color: var(--color-titre-enigme);
+        color: var(--color-background);
+        font-size: 2rem;
+        font-weight: 700;
+        line-height: 1;
+
+        &:hover,
+        &:focus-visible {
+            transform: scale(1.05);
+            box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+        }
+    }
+
+    .woocommerce-Address-actionIcon {
+        line-height: 1;
+    }
+}
+
+@media (--bp-tablet) {
+    .woocommerce-account {
+        .woocommerce-Address-action--add {
+            width: 3.5rem;
+            height: 3.5rem;
+            font-size: 2.25rem;
+        }
+    }
+}
+
+
+/* ==========================================================
 📌 Contenu Principal
 ========================================================== */
 .dashboard-content {

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -440,6 +440,19 @@
         }
     }
 
+    .addresses {
+        .title {
+            .woocommerce-Address-action {
+                float: none;
+                padding: 0.5rem 0.75rem;
+            }
+
+            .woocommerce-Address-action.woocommerce-Address-action--add {
+                padding: 0;
+            }
+        }
+    }
+
     .woocommerce-Address-action--edit {
         color: var(--color-titre-enigme);
     }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9245,6 +9245,13 @@ footer .site-footer-primary-section-3 {
   outline: 2px solid var(--color-titre-enigme);
   outline-offset: 2px;
 }
+.woocommerce-account .addresses .title .woocommerce-Address-action {
+  float: none;
+  padding: 0.5rem 0.75rem;
+}
+.woocommerce-account .addresses .title .woocommerce-Address-action.woocommerce-Address-action--add {
+  padding: 0;
+}
 .woocommerce-account .woocommerce-Address-action--edit {
   color: var(--color-titre-enigme);
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9249,18 +9249,17 @@ footer .site-footer-primary-section-3 {
   color: var(--color-titre-enigme);
 }
 .woocommerce-account .woocommerce-Address-action--add {
-  width: 3.25rem;
-  height: 3.25rem;
   padding: 0;
-  border-radius: 50%;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  border-radius: 999px;
   background-color: var(--color-titre-enigme);
   color: var(--color-background);
-  font-size: 2rem;
+  font-size: 1.5rem;
   font-weight: 700;
   line-height: 1;
 }
 .woocommerce-account .woocommerce-Address-action--add:hover, .woocommerce-account .woocommerce-Address-action--add:focus-visible {
-  transform: scale(1.05);
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
 }
 .woocommerce-account .woocommerce-Address-actionIcon {
@@ -9269,9 +9268,9 @@ footer .site-footer-primary-section-3 {
 
 @media (min-width: 768px) {
   .woocommerce-account .woocommerce-Address-action--add {
-    width: 3.5rem;
-    height: 3.5rem;
-    font-size: 2.25rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    font-size: 1.75rem;
   }
 }
 /* ==========================================================

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9218,6 +9218,63 @@ footer .site-footer-primary-section-3 {
   }
 }
 /* ==========================================================
+📌 Adresses
+========================================================== */
+.woocommerce-account .woocommerce-Address-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+.woocommerce-account .woocommerce-Address-title h2 {
+  margin: 0;
+}
+.woocommerce-account .woocommerce-Address-action {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+.woocommerce-account .woocommerce-Address-action:focus-visible {
+  outline: 2px solid var(--color-titre-enigme);
+  outline-offset: 2px;
+}
+.woocommerce-account .woocommerce-Address-action--edit {
+  color: var(--color-titre-enigme);
+}
+.woocommerce-account .woocommerce-Address-action--add {
+  width: 3.25rem;
+  height: 3.25rem;
+  padding: 0;
+  border-radius: 50%;
+  background-color: var(--color-titre-enigme);
+  color: var(--color-background);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+.woocommerce-account .woocommerce-Address-action--add:hover, .woocommerce-account .woocommerce-Address-action--add:focus-visible {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+}
+.woocommerce-account .woocommerce-Address-actionIcon {
+  line-height: 1;
+}
+
+@media (min-width: 768px) {
+  .woocommerce-account .woocommerce-Address-action--add {
+    width: 3.5rem;
+    height: 3.5rem;
+    font-size: 2.25rem;
+  }
+}
+/* ==========================================================
 📌 Contenu Principal
 ========================================================== */
 .dashboard-content {

--- a/wp-content/themes/chassesautresor/woocommerce/myaccount/my-address.php
+++ b/wp-content/themes/chassesautresor/woocommerce/myaccount/my-address.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * My Addresses
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-address.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 9.3.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$customer_id = get_current_user_id();
+
+if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) {
+    $get_addresses = apply_filters(
+        'woocommerce_my_account_get_addresses',
+        array(
+            'billing'  => __( 'Billing address', 'woocommerce' ),
+            'shipping' => __( 'Shipping address', 'woocommerce' ),
+        ),
+        $customer_id
+    );
+} else {
+    $get_addresses = apply_filters(
+        'woocommerce_my_account_get_addresses',
+        array(
+            'billing' => __( 'Billing address', 'woocommerce' ),
+        ),
+        $customer_id
+    );
+}
+
+$oldcol = 1;
+$col    = 1;
+?>
+
+<p>
+    <?php echo apply_filters( 'woocommerce_my_account_my_address_description', esc_html__( 'The following addresses will be used on the checkout page by default.', 'woocommerce' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+</p>
+
+<?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
+    <div class="u-columns woocommerce-Addresses col2-set addresses">
+<?php endif; ?>
+
+<?php foreach ( $get_addresses as $name => $address_title ) : ?>
+    <?php
+    $address         = wc_get_account_formatted_address( $name );
+    $col             = $col * -1;
+    $oldcol          = $oldcol * -1;
+    $action_classes  = array(
+        'woocommerce-Address-action',
+        'edit',
+        $address ? 'woocommerce-Address-action--edit' : 'woocommerce-Address-action--add',
+    );
+    ?>
+
+    <div class="u-column<?php echo $col < 0 ? 1 : 2; ?> col-<?php echo $oldcol < 0 ? 1 : 2; ?> woocommerce-Address">
+        <header class="woocommerce-Address-title title">
+            <h2><?php echo esc_html( $address_title ); ?></h2>
+            <a href="<?php echo esc_url( wc_get_endpoint_url( 'edit-address', $name ) ); ?>" class="<?php echo esc_attr( implode( ' ', array_filter( $action_classes ) ) ); ?>">
+                <?php if ( $address ) : ?>
+                    <?php
+                    printf(
+                        /* translators: %s: Address title */
+                        esc_html__( 'Edit %s', 'woocommerce' ),
+                        esc_html( $address_title )
+                    );
+                    ?>
+                <?php else : ?>
+                    <span aria-hidden="true" class="woocommerce-Address-actionIcon">+</span>
+                    <span class="screen-reader-text">
+                        <?php
+                        printf(
+                            /* translators: %s: Address title */
+                            esc_html__( 'Add %s', 'woocommerce' ),
+                            esc_html( $address_title )
+                        );
+                        ?>
+                    </span>
+                <?php endif; ?>
+            </a>
+        </header>
+        <address>
+            <?php
+            echo $address ? wp_kses_post( $address ) : esc_html_e( 'You have not set up this type of address yet.', 'woocommerce' );
+
+            /**
+             * Used to output content after core address fields.
+             *
+             * @param string $name Address type.
+             * @since 8.7.0
+             */
+            do_action( 'woocommerce_my_account_after_my_address', $name );
+            ?>
+        </address>
+    </div>
+
+<?php endforeach; ?>
+
+<?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
+    </div>
+    <?php
+endif;


### PR DESCRIPTION
Ajout d'un bouton d'ajout stylisé pour les adresses du compte WooCommerce.

- Surcharge du template `my-address.php` pour remplacer le lien d'ajout par un bouton circulaire accessible.
- Ajout des styles SCSS associés et recompilation du CSS distribué.

**Testing**
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d01651019883328d1acc3e3cc845e3