### PR TITLE
Ajuste le lien de déconnexion du menu Mon Compte

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -86,7 +86,12 @@
 }
 
 .dashboard-nav-link.logout {
-    font-size: 0.75rem;
+    display: inline-flex;
+    align-self: flex-start;
+    gap: 0;
+    padding: 8px;
+    font-size: 0.875rem;
+    width: auto;
 }
 
 .dashboard-nav-heading {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8902,7 +8902,12 @@ footer .site-footer-primary-section-3 {
 }
 
 .dashboard-nav-link.logout {
-  font-size: 0.75rem;
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 0;
+  padding: 8px;
+  font-size: 0.875rem;
+  width: auto;
 }
 
 .dashboard-nav-heading {

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -98,9 +98,13 @@ get_header();
                 echo '</a>';
             }
             ?>
-            <a href="<?php echo esc_url(wc_logout_url()); ?>" class="dashboard-nav-link logout">
-                <i class="fas fa-sign-out-alt"></i>
-                <span><?php esc_html_e('Déconnexion', 'chassesautresor-com'); ?></span>
+            <a
+                href="<?php echo esc_url(wc_logout_url()); ?>"
+                class="dashboard-nav-link logout"
+                aria-label="<?php esc_attr_e('Déconnexion', 'chassesautresor-com'); ?>"
+                title="<?php esc_attr_e('Déconnexion', 'chassesautresor-com'); ?>"
+            >
+                <i class="fas fa-sign-out-alt" aria-hidden="true"></i>
             </a>
         </nav>
         <?php if (current_user_can('administrator')) : ?>


### PR DESCRIPTION
Ajuste l'affichage du lien de déconnexion dans le menu latéral Mon Compte.

- Supprime le libellé textuel au profit d'une icône accessible pour le lien de déconnexion.
- Réduit la zone cliquable de l'action de déconnexion grâce à des styles spécifiques.

**Testing**
- ✅ `npm run build:css`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0181771e4833293fbcf0281fa2e4d