### PR TITLE
Ajuste le fond des stat-badges

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -220,7 +220,7 @@ tbody tr:nth-child(even) {
   padding: 2px 8px;
   border: 1px solid var(--color-grey-medium);
   border-radius: 4px;
-  background-color: var(--color-grey-light);
+  background-color: rgba(255, 255, 255, 0.05);
   color: var(--color-text-fond-clair);
   font-size: 0.85rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -7564,7 +7564,7 @@ tbody tr:nth-child(even) {
   padding: 2px 8px;
   border: 1px solid var(--color-grey-medium);
   border-radius: 4px;
-  background-color: var(--color-grey-light);
+  background-color: rgba(255, 255, 255, 0.05);
   color: var(--color-text-fond-clair);
   font-size: 0.85rem;
 }


### PR DESCRIPTION
Résumé
- Harmonisation du fond des stat-badges avec celui des méta-étiquettes.

Changements notables
- Ajustement de la couleur de fond des stat-badges dans le SCSS.
- Regénération de la feuille de style compilée.

Tests
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d01dbe37b083328f6a9099be9e1581