### PR TITLE
Améliore la recherche des tentatives

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
@@ -156,6 +156,10 @@
     grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
 
+    &.table-search--no-label {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
     .table-search__label {
       margin-bottom: 0;
     }

--- a/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
@@ -46,6 +46,10 @@
 
   &__submit {
     align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-xxs);
     padding: var(--space-xs) var(--space-lg);
     border: none;
     border-radius: 0.5rem;
@@ -55,6 +59,27 @@
     font-size: 0.9375rem;
     cursor: pointer;
     transition: background-color var(--transition-fast), transform var(--transition-fast);
+  }
+
+  &__submit-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+      fill: currentColor;
+    }
+  }
+
+  &__submit--icon-only {
+    padding: var(--space-xs);
+    min-width: 2.75rem;
+    min-height: 2.75rem;
   }
 
   &__submit:hover,
@@ -110,6 +135,10 @@
     &__submit {
       align-self: stretch;
       padding: var(--space-xs) var(--space-xl);
+    }
+
+    &__submit--icon-only {
+      padding: var(--space-xs);
     }
 
     &__reset {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1520,6 +1520,9 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
     grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
   }
+  .table-search--inline.table-search--no-label {
+    grid-template-columns: minmax(0, 1fr);
+  }
   .table-search--inline .table-search__label {
     margin-bottom: 0;
   }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1427,6 +1427,10 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
 }
 .table-search__submit {
   align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xxs);
   padding: var(--space-xs) var(--space-lg);
   border: none;
   border-radius: 0.5rem;
@@ -1436,6 +1440,24 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   font-size: 0.9375rem;
   cursor: pointer;
   transition: background-color var(--transition-fast), transform var(--transition-fast);
+}
+.table-search__submit-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+.table-search__submit-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+.table-search__submit--icon-only {
+  padding: var(--space-xs);
+  min-width: 2.75rem;
+  min-height: 2.75rem;
 }
 .table-search__submit:hover, .table-search__submit:focus {
   background-color: var(--color-background-button-hover);
@@ -1482,6 +1504,9 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   .table-search__submit {
     align-self: stretch;
     padding: var(--space-xs) var(--space-xl);
+  }
+  .table-search__submit--icon-only {
+    padding: var(--space-xs);
   }
   .table-search__reset {
     align-self: stretch;

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -8,6 +8,25 @@
 defined('ABSPATH') || exit;
 
 /**
+ * Returns the SVG markup for supported submit icons.
+ *
+ * @param string $icon Identifier of the icon to render.
+ *
+ * @return string
+ */
+function cta_get_table_search_submit_icon_markup(string $icon): string
+{
+    switch ($icon) {
+        case 'search':
+            return '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+                . '<path fill="currentColor" d="M10.5 3a7.5 7.5 0 015.88 12.04l4.79 4.79-1.42 1.42-4.79-4.79A7.5 7.5 0 1110.5 3zm0 2a5.5 5.5 0 100 11 5.5 5.5 0 000-11z" />'
+                . '</svg>';
+        default:
+            return '';
+    }
+}
+
+/**
  * Renders the HTML markup for a table search form.
  *
  * @param string $key       Context identifier.
@@ -49,6 +68,8 @@ function cta_render_search_form(string $key, array $overrides = []): string
         'nonce_action'       => $ui['nonce_action'] ?? '',
         'nonce_name'         => $ui['nonce_name'] ?? 'nonce',
         'submit_label'       => $ui['submit_label'] ?? esc_html__('Rechercher', 'chassesautresor-com'),
+        'submit_icon'        => $ui['submit_icon'] ?? '',
+        'submit_icon_only'   => $ui['submit_icon_only'] ?? false,
         'reset_label'        => $ui['reset_label'] ?? esc_html__('Réinitialiser', 'chassesautresor-com'),
         'show_reset_button'  => $ui['show_reset_button'] ?? false,
         'pagination_params'  => $context['pagination_params'] ?? [],
@@ -115,8 +136,27 @@ function cta_render_search_form(string $key, array $overrides = []): string
     $label       = (string) $config['label'];
     $desc        = (string) $config['description'];
     $submit      = (string) $config['submit_label'];
+    $submit_icon = (string) $config['submit_icon'];
     $reset_label = (string) $config['reset_label'];
     $show_reset  = (bool) $config['show_reset_button'];
+
+    $icon_markup = '';
+    if ('' !== $submit_icon) {
+        $icon_markup = cta_get_table_search_submit_icon_markup($submit_icon);
+    }
+
+    $has_icon   = '' !== $icon_markup;
+    $icon_only  = $has_icon && !empty($config['submit_icon_only']);
+    $submit_cls = 'table-search__submit';
+
+    $submit_text = $submit;
+    if ('' === $submit_text && $icon_only) {
+        $submit_text = __('Rechercher', 'chassesautresor-com');
+    }
+
+    if ($icon_only) {
+        $submit_cls .= ' table-search__submit--icon-only';
+    }
 
     $form_attrs = sprintf(' method="%s"', esc_attr($method));
 
@@ -214,8 +254,17 @@ function cta_render_search_form(string $key, array $overrides = []): string
 
         <div class="table-search__controls">
             <input<?php echo $input_html; ?> />
-            <button type="submit" class="table-search__submit">
-                <span class="table-search__submit-text"><?php echo esc_html($submit); ?></span>
+            <button type="submit" class="<?php echo esc_attr($submit_cls); ?>">
+                <?php if ($has_icon) : ?>
+                <span class="table-search__submit-icon" aria-hidden="true">
+                    <?php echo $icon_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </span>
+                <?php endif; ?>
+                <?php if ('' !== $submit_text) : ?>
+                <span class="table-search__submit-text<?php echo $icon_only ? ' screen-reader-text' : ''; ?>">
+                    <?php echo esc_html($submit_text); ?>
+                </span>
+                <?php endif; ?>
             </button>
             <?php if ($show_reset) : ?>
             <button type="button" class="table-search__reset" data-table-search-reset<?php echo '' === $search_value ? ' hidden' : ''; ?>>

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -97,6 +97,10 @@ function cta_render_search_form(string $key, array $overrides = []): string
         array_unshift($class_tokens, 'table-search');
     }
 
+    if ('' === trim((string) ($config['label'] ?? ''))) {
+        $class_tokens[] = 'table-search--no-label';
+    }
+
     $form_classes = implode(' ', array_unique($class_tokens));
 
     $search_value = $config['value'];

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1224,7 +1224,9 @@ function ca_register_tentatives_search_context(): void
         ],
         'ui' => [
             'label'       => __('Rechercher une tentative', 'chassesautresor-com'),
-            'placeholder' => __('Chasse, énigme ou réponse...', 'chassesautresor-com'),
+            'placeholder' => __('Que recherchez-vous ?', 'chassesautresor-com'),
+            'submit_icon' => 'search',
+            'submit_icon_only' => true,
         ],
         'pagination_params' => ['tentatives-page'],
     ]);


### PR DESCRIPTION
Résumé: Améliore l'expérience de recherche du tableau des tentatives sur Mon Compte.

- Ajoute la prise en charge d'une icône de soumission dans le formulaire de recherche des tableaux et l'applique aux tentatives.
- Remplace l'espace réservé des tentatives par « Que recherchez-vous ? » pour mieux guider l'utilisateur.
- Met à jour les styles Sass/CSS pour afficher correctement un bouton de recherche avec loupe.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d01e405220833284052d6261a4791c