### PR TITLE
Remplace les stat-badges par des méta-étiquettes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -2084,7 +2084,8 @@ body.panneau-ouvert::before {
 .chasse-stats-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  gap: var(--space-xs);
 }
 
 #chasse-tab-stats > div.edition-panel-body > table > thead > tr:nth-child(2) > th:nth-child(1),

--- a/wp-content/themes/chassesautresor/assets/scss/_general.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_general.scss
@@ -215,16 +215,6 @@ tbody tr:nth-child(even) {
 }
 
 /* ====== Stat tables ====== */
-.stat-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border: 1px solid var(--color-grey-medium);
-  border-radius: 4px;
-  background-color: rgba(255, 255, 255, 0.05);
-  color: var(--color-text-fond-clair);
-  font-size: 0.85rem;
-}
-
 .stats-table thead {
   background-color: rgba(255, 255, 255, 0.06);
   color: var(--color-text-primary);

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -908,11 +908,15 @@ body.woocommerce h2 {
     min-width: 0;
 }
 
-.myaccount-tentatives .table-header__stats .stat-badge {
+.myaccount-tentatives .table-header__stats .meta-etiquette {
     display: inline-flex;
     align-items: center;
     white-space: nowrap;
     line-height: 1.15;
+}
+
+.myaccount-tentatives .table-header__stats .meta-etiquette--success {
+    color: var(--color-success);
 }
 
 .myaccount-tentatives .table-header .table-search {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -5319,7 +5319,8 @@ body.panneau-ouvert::before {
 .chasse-stats-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  gap: var(--space-xs);
 }
 
 #chasse-tab-stats > div.edition-panel-body > table > thead > tr:nth-child(2) > th:nth-child(1),
@@ -7559,16 +7560,6 @@ tbody tr:nth-child(even) {
 }
 
 /* ====== Stat tables ====== */
-.stat-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border: 1px solid var(--color-grey-medium);
-  border-radius: 4px;
-  background-color: rgba(255, 255, 255, 0.05);
-  color: var(--color-text-fond-clair);
-  font-size: 0.85rem;
-}
-
 .stats-table thead {
   background-color: rgba(255, 255, 255, 0.06);
   color: var(--color-text-primary);
@@ -9780,11 +9771,15 @@ body.woocommerce h2 {
   min-width: 0;
 }
 
-.myaccount-tentatives .table-header__stats .stat-badge {
+.myaccount-tentatives .table-header__stats .meta-etiquette {
   display: inline-flex;
   align-items: center;
   white-space: nowrap;
   line-height: 1.15;
+}
+
+.myaccount-tentatives .table-header__stats .meta-etiquette--success {
+  color: var(--color-success);
 }
 
 .myaccount-tentatives .table-header .table-search {

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1448,13 +1448,17 @@ function ca_render_dashboard_tentatives(): void
         <div class="table-header">
             <div class="table-header__stats">
                 <?php if ($view['pending'] > 0) : ?>
-                <span class="stat-badge"><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $view['pending'], 'chassesautresor-com')), $view['pending']); ?></span>
+                <div class="meta-etiquette">
+                    <span><?php printf(esc_html(_n('%d tentative en attente', '%d tentatives en attente', $view['pending'], 'chassesautresor-com')), $view['pending']); ?></span>
+                </div>
                 <?php endif; ?>
-                <span class="stat-badge"><?php printf(esc_html(_n('%d tentative', '%d tentatives', $view['total'], 'chassesautresor-com')), $view['total']); ?></span>
+                <div class="meta-etiquette">
+                    <span><?php printf(esc_html(_n('%d tentative', '%d tentatives', $view['total'], 'chassesautresor-com')), $view['total']); ?></span>
+                </div>
                 <?php if ($view['success'] > 0) : ?>
-                <span class="stat-badge" style="color:var(--color-success);">
-                    <?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $view['success'], 'chassesautresor-com')), $view['success']); ?>
-                </span>
+                <div class="meta-etiquette meta-etiquette--success">
+                    <span><?php printf(esc_html(_n('%d bonne réponse', '%d bonnes rponses', $view['success'], 'chassesautresor-com')), $view['success']); ?></span>
+                </div>
                 <?php endif; ?>
             </div>
             <?php

--- a/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/panneaux/organisateur-edition-statistiques.php
@@ -54,9 +54,15 @@ $points          = organisateur_compter_points_collectes($organisateur_id);
           <div class="chasse-stats-header">
             <h3><?php echo esc_html(get_the_title($chasse_id)); ?></h3>
             <div class="chasse-stats-summary">
-              <span class="stat-badge"><?php echo esc_html($participants . ' participants'); ?></span>
-              <span class="stat-badge"><?php echo esc_html($total_tentatives . ' tentatives'); ?></span>
-              <span class="stat-badge"><?php echo esc_html($total_resolutions . ' bonnes réponses'); ?></span>
+              <div class="meta-etiquette">
+                <span><?php echo esc_html($participants . ' participants'); ?></span>
+              </div>
+              <div class="meta-etiquette">
+                <span><?php echo esc_html($total_tentatives . ' tentatives'); ?></span>
+              </div>
+              <div class="meta-etiquette">
+                <span><?php echo esc_html($total_resolutions . ' bonnes réponses'); ?></span>
+              </div>
             </div>
           </div>
           <?php


### PR DESCRIPTION
## Résumé
- Harmonise les panneaux de statistiques organisateur avec la structure d’étiquette méta.
- Remplace les badges des tentatives par des méta-étiquettes et ajuste les styles SCSS associés.
- Régénère le CSS compilé pour refléter ces adaptations.

## Tests
- npm run build:css
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d0200e4bfc83329a382ab104294094