### PR TITLE
Ajustement du ratio des images des cartes compactes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -152,24 +152,26 @@
 
   .carte-cart__image-wrapper {
     position: relative;
-  }
-
-  .carte-cart__image {
     width: 100%;
-    height: auto;
     aspect-ratio: var(--carte-cart-aspect-ratio, 4 / 3);
-    object-fit: cover;
-    display: block;
-    object-position: center;
-  }
+    overflow: hidden;
 
-  @media not all and (--bp-desktop) {
-    .carte-cart__image {
+    @media not all and (--bp-desktop) {
       aspect-ratio: var(
         --carte-cart-compact-aspect-ratio,
         var(--carte-cart-aspect-ratio, 4 / 3)
       );
     }
+  }
+
+  .carte-cart__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    object-position: center;
+    position: absolute;
+    inset: 0;
   }
 
   .badge-statut {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -153,14 +153,41 @@
   .carte-cart__image-wrapper {
     position: relative;
     width: 100%;
-    aspect-ratio: var(--carte-cart-aspect-ratio, 4 / 3);
     overflow: hidden;
+    --carte-cart-effective-aspect: var(
+      --carte-cart-aspect-ratio,
+      4 / 3
+    );
+    --carte-cart-effective-padding: var(
+      --carte-cart-padding,
+      75%
+    );
+    aspect-ratio: var(--carte-cart-effective-aspect, 4 / 3);
+
+    &::before {
+      content: "";
+      display: block;
+      width: 100%;
+      padding-top: var(--carte-cart-effective-padding, 75%);
+    }
 
     @media not all and (--bp-desktop) {
-      aspect-ratio: var(
+      --carte-cart-effective-aspect: var(
         --carte-cart-compact-aspect-ratio,
         var(--carte-cart-aspect-ratio, 4 / 3)
       );
+      --carte-cart-effective-padding: var(
+        --carte-cart-compact-padding,
+        var(--carte-cart-padding, 75%)
+      );
+    }
+  }
+
+  @supports (aspect-ratio: 1 / 1) {
+    .carte-cart__image-wrapper::before {
+      display: none;
+      content: none;
+      padding-top: 0;
     }
   }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -156,7 +156,8 @@
 
   .carte-cart__image {
     width: 100%;
-    aspect-ratio: 4 / 3;
+    height: auto;
+    aspect-ratio: var(--carte-cart-aspect-ratio, 4 / 3);
     object-fit: cover;
     display: block;
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -155,12 +155,12 @@
     width: 100%;
     overflow: hidden;
     --carte-cart-effective-aspect: var(
-      --carte-cart-aspect-ratio,
-      4 / 3
+      --carte-cart-compact-aspect-ratio,
+      var(--carte-cart-aspect-ratio, 4 / 3)
     );
     --carte-cart-effective-padding: var(
-      --carte-cart-padding,
-      75%
+      --carte-cart-compact-padding,
+      var(--carte-cart-padding, 75%)
     );
     aspect-ratio: var(--carte-cart-effective-aspect, 4 / 3);
 
@@ -171,14 +171,14 @@
       padding-top: var(--carte-cart-effective-padding, 75%);
     }
 
-    @media not all and (--bp-desktop) {
+    @media (--bp-desktop) {
       --carte-cart-effective-aspect: var(
-        --carte-cart-compact-aspect-ratio,
-        var(--carte-cart-aspect-ratio, 4 / 3)
+        --carte-cart-aspect-ratio,
+        4 / 3
       );
       --carte-cart-effective-padding: var(
-        --carte-cart-compact-padding,
-        var(--carte-cart-padding, 75%)
+        --carte-cart-padding,
+        75%
       );
     }
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -160,6 +160,16 @@
     aspect-ratio: var(--carte-cart-aspect-ratio, 4 / 3);
     object-fit: cover;
     display: block;
+    object-position: center;
+  }
+
+  @media not all and (--bp-desktop) {
+    .carte-cart__image {
+      aspect-ratio: var(
+        --carte-cart-compact-aspect-ratio,
+        var(--carte-cart-aspect-ratio, 4 / 3)
+      );
+    }
   }
 
   .badge-statut {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -154,6 +154,8 @@
     position: relative;
     width: 100%;
     overflow: hidden;
+    --carte-cart-compact-aspect-ratio: 4 / 3;
+    --carte-cart-compact-padding: 75%;
     --carte-cart-effective-aspect: var(
       --carte-cart-compact-aspect-ratio,
       var(--carte-cart-aspect-ratio, 4 / 3)

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -143,21 +143,25 @@
 }
 .carte-cart .carte-cart__image-wrapper {
   position: relative;
+  width: 100%;
+  aspect-ratio: var(--carte-cart-aspect-ratio, 4/3);
+  overflow: hidden;
+}
+@media not all and (min-width: 1024px) {
+  .carte-cart .carte-cart__image-wrapper {
+    aspect-ratio: var(--carte-cart-compact-aspect-ratio, var(--carte-cart-aspect-ratio, 4/3));
+  }
 }
 .carte-cart .carte-cart__image {
   width: 100%;
-  height: auto;
-  aspect-ratio: var(--carte-cart-aspect-ratio, 4/3);
+  height: 100%;
   -o-object-fit: cover;
      object-fit: cover;
   display: block;
   -o-object-position: center;
      object-position: center;
-}
-@media not all and (min-width: 1024px) {
-  .carte-cart .carte-cart__image {
-    aspect-ratio: var(--carte-cart-compact-aspect-ratio, var(--carte-cart-aspect-ratio, 4/3));
-  }
+  position: absolute;
+  inset: 0;
 }
 .carte-cart .badge-statut {
   position: absolute;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -145,6 +145,8 @@
   position: relative;
   width: 100%;
   overflow: hidden;
+  --carte-cart-compact-aspect-ratio: 4 / 3;
+  --carte-cart-compact-padding: 75%;
   --carte-cart-effective-aspect: var(
     --carte-cart-compact-aspect-ratio,
     var(--carte-cart-aspect-ratio, 4 / 3)

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -146,7 +146,8 @@
 }
 .carte-cart .carte-cart__image {
   width: 100%;
-  aspect-ratio: 4/3;
+  height: auto;
+  aspect-ratio: var(--carte-cart-aspect-ratio, 4/3);
   -o-object-fit: cover;
      object-fit: cover;
   display: block;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -144,12 +144,40 @@
 .carte-cart .carte-cart__image-wrapper {
   position: relative;
   width: 100%;
-  aspect-ratio: var(--carte-cart-aspect-ratio, 4/3);
   overflow: hidden;
+  --carte-cart-effective-aspect: var(
+    --carte-cart-aspect-ratio,
+    4 / 3
+  );
+  --carte-cart-effective-padding: var(
+    --carte-cart-padding,
+    75%
+  );
+  aspect-ratio: var(--carte-cart-effective-aspect, 4/3);
+}
+.carte-cart .carte-cart__image-wrapper::before {
+  content: "";
+  display: block;
+  width: 100%;
+  padding-top: var(--carte-cart-effective-padding, 75%);
 }
 @media not all and (min-width: 1024px) {
   .carte-cart .carte-cart__image-wrapper {
-    aspect-ratio: var(--carte-cart-compact-aspect-ratio, var(--carte-cart-aspect-ratio, 4/3));
+    --carte-cart-effective-aspect: var(
+      --carte-cart-compact-aspect-ratio,
+      var(--carte-cart-aspect-ratio, 4 / 3)
+    );
+    --carte-cart-effective-padding: var(
+      --carte-cart-compact-padding,
+      var(--carte-cart-padding, 75%)
+    );
+  }
+}
+@supports (aspect-ratio: 1/1) {
+  .carte-cart .carte-cart__image-wrapper::before {
+    display: none;
+    content: none;
+    padding-top: 0;
   }
 }
 .carte-cart .carte-cart__image {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -151,6 +151,13 @@
   -o-object-fit: cover;
      object-fit: cover;
   display: block;
+  -o-object-position: center;
+     object-position: center;
+}
+@media not all and (min-width: 1024px) {
+  .carte-cart .carte-cart__image {
+    aspect-ratio: var(--carte-cart-compact-aspect-ratio, var(--carte-cart-aspect-ratio, 4/3));
+  }
 }
 .carte-cart .badge-statut {
   position: absolute;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -146,12 +146,12 @@
   width: 100%;
   overflow: hidden;
   --carte-cart-effective-aspect: var(
-    --carte-cart-aspect-ratio,
-    4 / 3
+    --carte-cart-compact-aspect-ratio,
+    var(--carte-cart-aspect-ratio, 4 / 3)
   );
   --carte-cart-effective-padding: var(
-    --carte-cart-padding,
-    75%
+    --carte-cart-compact-padding,
+    var(--carte-cart-padding, 75%)
   );
   aspect-ratio: var(--carte-cart-effective-aspect, 4/3);
 }
@@ -161,15 +161,15 @@
   width: 100%;
   padding-top: var(--carte-cart-effective-padding, 75%);
 }
-@media not all and (min-width: 1024px) {
+@media (min-width: 1024px) {
   .carte-cart .carte-cart__image-wrapper {
     --carte-cart-effective-aspect: var(
-      --carte-cart-compact-aspect-ratio,
-      var(--carte-cart-aspect-ratio, 4 / 3)
+      --carte-cart-aspect-ratio,
+      4 / 3
     );
     --carte-cart-effective-padding: var(
-      --carte-cart-compact-padding,
-      var(--carte-cart-padding, 75%)
+      --carte-cart-padding,
+      75%
     );
   }
 }

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1425,16 +1425,41 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $image_data = get_field('chasse_principale_image', $chasse_id);
     $image_id = 0;
     $image = '';
+    $image_width = 0;
+    $image_height = 0;
+
     if (is_array($image_data) && !empty($image_data['sizes']['medium'])) {
         $image_id = $image_data['ID'] ?? 0;
         $image = $image_data['sizes']['medium'];
+
+        if (!empty($image_data['sizes']['medium-width']) && !empty($image_data['sizes']['medium-height'])) {
+            $image_width  = (int) $image_data['sizes']['medium-width'];
+            $image_height = (int) $image_data['sizes']['medium-height'];
+        } elseif (!empty($image_data['width']) && !empty($image_data['height'])) {
+            $image_width  = (int) $image_data['width'];
+            $image_height = (int) $image_data['height'];
+        }
     } elseif ($image_data) {
         $image_id = is_array($image_data) ? ($image_data['ID'] ?? 0) : (int) $image_data;
         $image = $image_id ? wp_get_attachment_image_url($image_id, 'medium') : '';
     }
+
     if (!$image) {
         $image_id = get_post_thumbnail_id($chasse_id);
         $image = $image_id ? wp_get_attachment_image_url($image_id, 'medium') : '';
+    }
+
+    if ((!$image_width || !$image_height) && $image_id) {
+        $image_src = wp_get_attachment_image_src($image_id, 'medium');
+        if (is_array($image_src)) {
+            $image_width  = (int) $image_src[1];
+            $image_height = (int) $image_src[2];
+        }
+    }
+
+    $image_ratio = '';
+    if ($image_width > 0 && $image_height > 0) {
+        $image_ratio = $image_width . ' / ' . $image_height;
     }
 
     $champs = chasse_get_champs($chasse_id);
@@ -1602,6 +1627,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'permalink'         => $permalink,
         'image_id'          => $image_id,
         'image'             => $image,
+        'image_ratio'       => $image_ratio,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs'        => $nb_joueurs,
         'nb_joueurs_label'  => $nb_joueurs_label,

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1427,34 +1427,48 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $image = '';
     $image_width = 0;
     $image_height = 0;
+    $image_size = 'medium_large';
 
-    if (is_array($image_data) && !empty($image_data['sizes']['medium'])) {
-        $image_id = $image_data['ID'] ?? 0;
-        $image = $image_data['sizes']['medium'];
-
-        if (!empty($image_data['sizes']['medium-width']) && !empty($image_data['sizes']['medium-height'])) {
-            $image_width  = (int) $image_data['sizes']['medium-width'];
-            $image_height = (int) $image_data['sizes']['medium-height'];
-        } elseif (!empty($image_data['width']) && !empty($image_data['height'])) {
-            $image_width  = (int) $image_data['width'];
-            $image_height = (int) $image_data['height'];
+    if (is_array($image_data)) {
+        if (!empty($image_data['ID'])) {
+            $image_id = (int) $image_data['ID'];
+        } elseif (!empty($image_data['id'])) {
+            $image_id = (int) $image_data['id'];
         }
-    } elseif ($image_data) {
-        $image_id = is_array($image_data) ? ($image_data['ID'] ?? 0) : (int) $image_data;
-        $image = $image_id ? wp_get_attachment_image_url($image_id, 'medium') : '';
+    } elseif (!empty($image_data)) {
+        $image_id = (int) $image_data;
     }
 
-    if (!$image) {
+    if (!$image_id) {
         $image_id = get_post_thumbnail_id($chasse_id);
-        $image = $image_id ? wp_get_attachment_image_url($image_id, 'medium') : '';
     }
 
-    if ((!$image_width || !$image_height) && $image_id) {
-        $image_src = wp_get_attachment_image_src($image_id, 'medium');
-        if (is_array($image_src)) {
-            $image_width  = (int) $image_src[1];
+    if ($image_id) {
+        $preferred_sizes = ['medium_large', 'large', 'medium', 'full'];
+
+        foreach ($preferred_sizes as $size_candidate) {
+            $image_src = wp_get_attachment_image_src($image_id, $size_candidate);
+
+            if (!is_array($image_src) || empty($image_src[0])) {
+                continue;
+            }
+
+            $image = $image_src[0];
+            $image_width = (int) $image_src[1];
             $image_height = (int) $image_src[2];
+            $image_size = $size_candidate;
+
+            break;
         }
+
+        if ($image === '') {
+            $image = wp_get_attachment_url($image_id) ?: '';
+            $image_size = 'full';
+        }
+    } elseif (is_array($image_data) && !empty($image_data['url'])) {
+        $image = (string) $image_data['url'];
+    } elseif (is_string($image_data) && $image_data !== '') {
+        $image = $image_data;
     }
 
     $image_ratio = '';
@@ -1628,6 +1642,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'image_id'          => $image_id,
         'image'             => $image,
         'image_ratio'       => $image_ratio,
+        'image_size'        => $image_size,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs'        => $nb_joueurs,
         'nb_joueurs_label'  => $nb_joueurs_label,

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1480,12 +1480,12 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         $image_ratio = $image_width . ' / ' . $image_height;
 
         $ratio_value = $image_width / $image_height;
-        $min_ratio   = 3 / 4;
+        $min_ratio   = 4 / 3;
         $max_ratio   = 16 / 9;
         $compact_ratio_value = $ratio_value;
 
         if ($ratio_value < $min_ratio) {
-            $image_compact_ratio = '3 / 4';
+            $image_compact_ratio = '4 / 3';
             $compact_ratio_value = $min_ratio;
         } elseif ($ratio_value > $max_ratio) {
             $image_compact_ratio = '16 / 9';

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1472,8 +1472,22 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     }
 
     $image_ratio = '';
+    $image_compact_ratio = '';
+
     if ($image_width > 0 && $image_height > 0) {
         $image_ratio = $image_width . ' / ' . $image_height;
+
+        $ratio_value = $image_width / $image_height;
+        $min_ratio   = 3 / 4;
+        $max_ratio   = 16 / 9;
+
+        if ($ratio_value < $min_ratio) {
+            $image_compact_ratio = '3 / 4';
+        } elseif ($ratio_value > $max_ratio) {
+            $image_compact_ratio = '16 / 9';
+        } else {
+            $image_compact_ratio = $image_ratio;
+        }
     }
 
     $champs = chasse_get_champs($chasse_id);
@@ -1642,6 +1656,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'image_id'          => $image_id,
         'image'             => $image,
         'image_ratio'       => $image_ratio,
+        'image_compact_ratio' => $image_compact_ratio,
         'image_size'        => $image_size,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs'        => $nb_joueurs,

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1473,6 +1473,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
 
     $image_ratio = '';
     $image_compact_ratio = '';
+    $image_ratio_padding = '';
+    $image_compact_ratio_padding = '';
 
     if ($image_width > 0 && $image_height > 0) {
         $image_ratio = $image_width . ' / ' . $image_height;
@@ -1480,13 +1482,32 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         $ratio_value = $image_width / $image_height;
         $min_ratio   = 3 / 4;
         $max_ratio   = 16 / 9;
+        $compact_ratio_value = $ratio_value;
 
         if ($ratio_value < $min_ratio) {
             $image_compact_ratio = '3 / 4';
+            $compact_ratio_value = $min_ratio;
         } elseif ($ratio_value > $max_ratio) {
             $image_compact_ratio = '16 / 9';
+            $compact_ratio_value = $max_ratio;
         } else {
             $image_compact_ratio = $image_ratio;
+        }
+
+        if ($ratio_value > 0) {
+            $ratio_padding_value = 100 / $ratio_value;
+            $image_ratio_padding = rtrim(rtrim(sprintf('%.6F', $ratio_padding_value), '0'), '.');
+            if ($image_ratio_padding !== '') {
+                $image_ratio_padding .= '%';
+            }
+        }
+
+        if ($compact_ratio_value > 0) {
+            $compact_padding_value = 100 / $compact_ratio_value;
+            $image_compact_ratio_padding = rtrim(rtrim(sprintf('%.6F', $compact_padding_value), '0'), '.');
+            if ($image_compact_ratio_padding !== '') {
+                $image_compact_ratio_padding .= '%';
+            }
         }
     }
 
@@ -1657,6 +1678,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'image'             => $image,
         'image_ratio'       => $image_ratio,
         'image_compact_ratio' => $image_compact_ratio,
+        'image_ratio_padding' => $image_ratio_padding,
+        'image_compact_ratio_padding' => $image_compact_ratio_padding,
         'image_size'        => $image_size,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs'        => $nb_joueurs,

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1472,41 +1472,17 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     }
 
     $image_ratio = '';
-    $image_compact_ratio = '';
     $image_ratio_padding = '';
-    $image_compact_ratio_padding = '';
 
     if ($image_width > 0 && $image_height > 0) {
         $image_ratio = $image_width . ' / ' . $image_height;
 
         $ratio_value = $image_width / $image_height;
-        $min_ratio   = 4 / 3;
-        $max_ratio   = 16 / 9;
-        $compact_ratio_value = $ratio_value;
-
-        if ($ratio_value < $min_ratio) {
-            $image_compact_ratio = '4 / 3';
-            $compact_ratio_value = $min_ratio;
-        } elseif ($ratio_value > $max_ratio) {
-            $image_compact_ratio = '16 / 9';
-            $compact_ratio_value = $max_ratio;
-        } else {
-            $image_compact_ratio = $image_ratio;
-        }
-
         if ($ratio_value > 0) {
             $ratio_padding_value = 100 / $ratio_value;
             $image_ratio_padding = rtrim(rtrim(sprintf('%.6F', $ratio_padding_value), '0'), '.');
             if ($image_ratio_padding !== '') {
                 $image_ratio_padding .= '%';
-            }
-        }
-
-        if ($compact_ratio_value > 0) {
-            $compact_padding_value = 100 / $compact_ratio_value;
-            $image_compact_ratio_padding = rtrim(rtrim(sprintf('%.6F', $compact_padding_value), '0'), '.');
-            if ($image_compact_ratio_padding !== '') {
-                $image_compact_ratio_padding .= '%';
             }
         }
     }
@@ -1677,9 +1653,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'image_id'          => $image_id,
         'image'             => $image,
         'image_ratio'       => $image_ratio,
-        'image_compact_ratio' => $image_compact_ratio,
         'image_ratio_padding' => $image_ratio_padding,
-        'image_compact_ratio_padding' => $image_compact_ratio_padding,
         'image_size'        => $image_size,
         'total_enigmes'     => $total_enigmes,
         'nb_joueurs'        => $nb_joueurs,

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -28,6 +28,8 @@ $badge_classes = $infos['badge_class'] ?? '';
 $image_size = $infos['image_size'] ?? 'medium_large';
 $image_ratio = $infos['image_ratio'] ?? '';
 $image_compact_ratio = $infos['image_compact_ratio'] ?? '';
+$image_ratio_padding = $infos['image_ratio_padding'] ?? '';
+$image_compact_ratio_padding = $infos['image_compact_ratio_padding'] ?? '';
 $wrapper_style = '';
 
 if ($image_ratio !== '' || $image_compact_ratio !== '') {
@@ -39,6 +41,14 @@ if ($image_ratio !== '' || $image_compact_ratio !== '') {
 
     if ($image_compact_ratio !== '') {
         $style_parts[] = '--carte-cart-compact-aspect-ratio:' . $image_compact_ratio;
+    }
+
+    if ($image_ratio_padding !== '') {
+        $style_parts[] = '--carte-cart-padding:' . $image_ratio_padding;
+    }
+
+    if ($image_compact_ratio_padding !== '') {
+        $style_parts[] = '--carte-cart-compact-padding:' . $image_compact_ratio_padding;
     }
 
     if (!empty($style_parts)) {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -25,8 +25,18 @@ $badge_icon_html = $infos['statut_icon'] ?? '';
 $badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
 $has_badge_icon = $badge_icon_html !== '';
 $badge_classes = $infos['badge_class'] ?? '';
+$image_size = $infos['image_size'] ?? 'medium_large';
 $image_ratio = $infos['image_ratio'] ?? '';
-$image_style = $image_ratio !== '' ? '--carte-cart-aspect-ratio:' . $image_ratio . ';' : '';
+$image_style = '';
+
+if ($image_ratio !== '') {
+    $style_parts = [
+        '--carte-cart-aspect-ratio:' . $image_ratio,
+        'aspect-ratio:' . $image_ratio,
+    ];
+
+    $image_style = implode(';', $style_parts) . ';';
+}
 $image_html = '';
 
 if (!empty($infos['image_id'])) {
@@ -34,6 +44,7 @@ if (!empty($infos['image_id'])) {
         'class'   => 'carte-cart__image',
         'alt'     => $infos['titre'],
         'loading' => 'lazy',
+        'sizes'   => '(max-width: 320px) 100vw, 300px',
     ];
 
     if ($image_style !== '') {
@@ -42,7 +53,7 @@ if (!empty($infos['image_id'])) {
 
     $image_html = wp_get_attachment_image(
         (int) $infos['image_id'],
-        'medium',
+        $image_size,
         false,
         $image_attributes
     );

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -27,28 +27,18 @@ $has_badge_icon = $badge_icon_html !== '';
 $badge_classes = $infos['badge_class'] ?? '';
 $image_size = $infos['image_size'] ?? 'medium_large';
 $image_ratio = $infos['image_ratio'] ?? '';
-$image_compact_ratio = $infos['image_compact_ratio'] ?? '';
 $image_ratio_padding = $infos['image_ratio_padding'] ?? '';
-$image_compact_ratio_padding = $infos['image_compact_ratio_padding'] ?? '';
 $wrapper_style = '';
 
-if ($image_ratio !== '' || $image_compact_ratio !== '') {
+if ($image_ratio !== '') {
     $style_parts = [];
 
     if ($image_ratio !== '') {
         $style_parts[] = '--carte-cart-aspect-ratio:' . $image_ratio;
     }
 
-    if ($image_compact_ratio !== '') {
-        $style_parts[] = '--carte-cart-compact-aspect-ratio:' . $image_compact_ratio;
-    }
-
     if ($image_ratio_padding !== '') {
         $style_parts[] = '--carte-cart-padding:' . $image_ratio_padding;
-    }
-
-    if ($image_compact_ratio_padding !== '') {
-        $style_parts[] = '--carte-cart-compact-padding:' . $image_compact_ratio_padding;
     }
 
     if (!empty($style_parts)) {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -25,6 +25,38 @@ $badge_icon_html = $infos['statut_icon'] ?? '';
 $badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
 $has_badge_icon = $badge_icon_html !== '';
 $badge_classes = $infos['badge_class'] ?? '';
+$image_ratio = $infos['image_ratio'] ?? '';
+$image_style = $image_ratio !== '' ? '--carte-cart-aspect-ratio:' . $image_ratio . ';' : '';
+$image_html = '';
+
+if (!empty($infos['image_id'])) {
+    $image_attributes = [
+        'class'   => 'carte-cart__image',
+        'alt'     => $infos['titre'],
+        'loading' => 'lazy',
+    ];
+
+    if ($image_style !== '') {
+        $image_attributes['style'] = $image_style;
+    }
+
+    $image_html = wp_get_attachment_image(
+        (int) $infos['image_id'],
+        'medium',
+        false,
+        $image_attributes
+    );
+}
+
+if ($image_html === '') {
+    $style_attribute = $image_style !== '' ? ' style="' . esc_attr($image_style) . '"' : '';
+    $image_html = sprintf(
+        '<img src="%1$s" alt="%2$s" class="carte-cart__image" loading="lazy"%3$s>',
+        esc_url($infos['image']),
+        esc_attr($infos['titre']),
+        $style_attribute
+    );
+}
 
 if ($has_badge_icon) {
     $badge_classes = trim($badge_classes . ' badge-statut--responsive');
@@ -52,7 +84,7 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                     </span>
                 <?php endif; ?>
             </span>
-            <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-cart__image">
+            <?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé ci-dessus. ?>
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -28,7 +28,7 @@ $badge_classes = $infos['badge_class'] ?? '';
 $image_size = $infos['image_size'] ?? 'medium_large';
 $image_ratio = $infos['image_ratio'] ?? '';
 $image_compact_ratio = $infos['image_compact_ratio'] ?? '';
-$image_style = '';
+$wrapper_style = '';
 
 if ($image_ratio !== '' || $image_compact_ratio !== '') {
     $style_parts = [];
@@ -42,9 +42,15 @@ if ($image_ratio !== '' || $image_compact_ratio !== '') {
     }
 
     if (!empty($style_parts)) {
-        $image_style = implode(';', $style_parts) . ';';
+        $wrapper_style = implode(';', $style_parts) . ';';
     }
 }
+$wrapper_attributes = 'class="carte-cart__image-wrapper"';
+
+if ($wrapper_style !== '') {
+    $wrapper_attributes .= ' style="' . esc_attr($wrapper_style) . '"';
+}
+
 $image_html = '';
 
 if (!empty($infos['image_id'])) {
@@ -55,10 +61,6 @@ if (!empty($infos['image_id'])) {
         'sizes'   => '(max-width: 320px) 100vw, 300px',
     ];
 
-    if ($image_style !== '') {
-        $image_attributes['style'] = $image_style;
-    }
-
     $image_html = wp_get_attachment_image(
         (int) $infos['image_id'],
         $image_size,
@@ -68,12 +70,10 @@ if (!empty($infos['image_id'])) {
 }
 
 if ($image_html === '') {
-    $style_attribute = $image_style !== '' ? ' style="' . esc_attr($image_style) . '"' : '';
     $image_html = sprintf(
-        '<img src="%1$s" alt="%2$s" class="carte-cart__image" loading="lazy"%3$s>',
+        '<img src="%1$s" alt="%2$s" class="carte-cart__image" loading="lazy">',
         esc_url($infos['image']),
-        esc_attr($infos['titre']),
-        $style_attribute
+        esc_attr($infos['titre'])
     );
 }
 
@@ -94,7 +94,7 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
-        <div class="carte-cart__image-wrapper">
+        <div <?php echo $wrapper_attributes; ?>>
             <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
                 <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
                 <?php if ($has_badge_icon) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -27,15 +27,23 @@ $has_badge_icon = $badge_icon_html !== '';
 $badge_classes = $infos['badge_class'] ?? '';
 $image_size = $infos['image_size'] ?? 'medium_large';
 $image_ratio = $infos['image_ratio'] ?? '';
+$image_compact_ratio = $infos['image_compact_ratio'] ?? '';
 $image_style = '';
 
-if ($image_ratio !== '') {
-    $style_parts = [
-        '--carte-cart-aspect-ratio:' . $image_ratio,
-        'aspect-ratio:' . $image_ratio,
-    ];
+if ($image_ratio !== '' || $image_compact_ratio !== '') {
+    $style_parts = [];
 
-    $image_style = implode(';', $style_parts) . ';';
+    if ($image_ratio !== '') {
+        $style_parts[] = '--carte-cart-aspect-ratio:' . $image_ratio;
+    }
+
+    if ($image_compact_ratio !== '') {
+        $style_parts[] = '--carte-cart-compact-aspect-ratio:' . $image_compact_ratio;
+    }
+
+    if (!empty($style_parts)) {
+        $image_style = implode(';', $style_parts) . ';';
+    }
 }
 $image_html = '';
 


### PR DESCRIPTION
Corrige l'affichage des images compactes en respectant le ratio source.

- Calcule et transmet le ratio de l'image medium d'une chasse aux gabarits front.
- Utilise `wp_get_attachment_image` et un style inline pour appliquer ce ratio dans la carte compacte.
- Met à jour les styles compilés pour tenir compte de l'aspect dynamique.

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0215e8e288332bad07122f42a536d