### PR TITLE
Ajout d’un héros dynamique sur la page d’accueil

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hero.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hero.js
@@ -1,0 +1,47 @@
+(function () {
+  const onReady = (callback) => {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback);
+    } else {
+      callback();
+    }
+  };
+
+  onReady(() => {
+    const wrapper = document.querySelector('[data-home-hero-wrapper]');
+
+    if (!wrapper) {
+      return;
+    }
+
+    const initialHero = wrapper.querySelector('[data-home-hero="initial"]');
+    const latestHero = wrapper.querySelector('[data-home-hero="latest"]');
+
+    if (!initialHero || !latestHero) {
+      return;
+    }
+
+    const prefersReducedMotion = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+    const delay = 5000;
+
+    initialHero.setAttribute('aria-hidden', 'false');
+    latestHero.setAttribute('aria-hidden', 'true');
+
+    const swapHeroes = () => {
+      initialHero.classList.add('is-home-hero-hidden');
+      initialHero.setAttribute('aria-hidden', 'true');
+
+      latestHero.classList.add('is-home-hero-visible');
+      latestHero.setAttribute('aria-hidden', 'false');
+    };
+
+    if (prefersReducedMotion && prefersReducedMotion.matches) {
+      swapHeroes();
+      return;
+    }
+
+    window.setTimeout(swapHeroes, delay);
+  });
+})();

--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -238,6 +238,101 @@ header.site-header {
   }
 }
 
+.homepage-hero-wrapper {
+  position: relative;
+}
+
+.homepage-hero-wrapper [data-home-hero] {
+  transition: opacity 0.6s ease;
+}
+
+.homepage-hero-wrapper [data-home-hero="initial"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.homepage-hero-wrapper [data-home-hero="initial"].is-home-hero-hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.homepage-hero-wrapper [data-home-hero="latest"] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 9;
+}
+
+.homepage-hero-wrapper [data-home-hero="latest"].is-home-hero-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  z-index: 11;
+}
+
+.hero-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-xs);
+}
+
+.hero-description {
+  font-size: 1rem;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-md);
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  max-width: 680px;
+}
+
+.hero-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.hero-cta form {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hero-cta__message {
+  color: var(--color-text-primary);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+@media (--bp-small) {
+  .hero-eyebrow {
+    font-size: 0.85rem;
+    letter-spacing: 0.16em;
+  }
+
+  .hero-description {
+    font-size: 1.1rem;
+    max-width: 760px;
+  }
+}
+
+@media (--bp-tablet) {
+  .hero-description {
+    font-size: 1.2rem;
+    max-width: 840px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .homepage-hero-wrapper [data-home-hero] {
+    transition: none;
+  }
+}
+
 
 /* ==================================================
    📄 CONTENU

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8439,6 +8439,97 @@ header.site-header {
     padding-top: 475px;
   }
 }
+.homepage-hero-wrapper {
+  position: relative;
+}
+
+.homepage-hero-wrapper [data-home-hero] {
+  transition: opacity 0.6s ease;
+}
+
+.homepage-hero-wrapper [data-home-hero=initial] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.homepage-hero-wrapper [data-home-hero=initial].is-home-hero-hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.homepage-hero-wrapper [data-home-hero=latest] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 9;
+}
+
+.homepage-hero-wrapper [data-home-hero=latest].is-home-hero-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  z-index: 11;
+}
+
+.hero-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-xs);
+}
+
+.hero-description {
+  font-size: 1rem;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-md);
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  max-width: 680px;
+}
+
+.hero-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.hero-cta form {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hero-cta__message {
+  color: var(--color-text-primary);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+@media (min-width: 480px) {
+  .hero-eyebrow {
+    font-size: 0.85rem;
+    letter-spacing: 0.16em;
+  }
+  .hero-description {
+    font-size: 1.1rem;
+    max-width: 760px;
+  }
+}
+@media (min-width: 768px) {
+  .hero-description {
+    font-size: 1.2rem;
+    max-width: 840px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .homepage-hero-wrapper [data-home-hero] {
+    transition: none;
+  }
+}
 /* ==================================================
    📄 CONTENU
    ================================================== */

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -344,6 +344,16 @@ add_action('wp_enqueue_scripts', function () {
     );
     wp_set_script_translations('help-modal', 'chassesautresor-com');
 
+    if (is_front_page()) {
+        wp_enqueue_script(
+            'home-hero',
+            $script_dir . 'home-hero.js',
+            [],
+            filemtime($theme_path . '/assets/js/home-hero.js'),
+            true
+        );
+    }
+
     if (is_account_page() && is_user_logged_in()) {
         wp_enqueue_script(
             'myaccount',

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -96,12 +96,100 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
             esc_html__( 'chasses au trésor', 'chassesautresor-com' )
         );
 
-        get_header_fallback([
-            'titre'      => $titre,
-            'sous_titre' => '',
-            'image_fond' => $image_url,
-            'logo_id'    => 475,
-        ]);
+        ob_start();
+        get_header_fallback(
+            [
+                'titre'      => $titre,
+                'sous_titre' => '',
+                'image_fond' => $image_url,
+                'logo_id'    => 475,
+            ]
+        );
+        $fallback_markup = ob_get_clean();
+
+        if ( $fallback_markup ) {
+            $fallback_markup = preg_replace(
+                '/<section(\s+)class="([^\"]*\bbandeau-hero\b[^\"]*)"/',
+                '<section$1class="$2" data-home-hero="initial"',
+                $fallback_markup,
+                1
+            );
+        }
+
+        $latest_hero_markup = '';
+
+        $latest_chasse_query = new WP_Query(
+            [
+                'post_type'      => 'chasse',
+                'post_status'    => 'publish',
+                'posts_per_page' => 1,
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'meta_query'     => [
+                    [
+                        'key'   => 'chasse_cache_statut_validation',
+                        'value' => 'valide',
+                    ],
+                ],
+                'fields'         => 'ids',
+            ]
+        );
+
+        if ( $latest_chasse_query->have_posts() && function_exists( 'generer_cta_chasse' ) ) {
+            $latest_chasse_id = (int) $latest_chasse_query->posts[0];
+            $raw_description  = get_field( 'chasse_principale_description', $latest_chasse_id );
+
+            if ( ! $raw_description ) {
+                $raw_description = get_the_excerpt( $latest_chasse_id );
+            }
+
+            $description = $raw_description
+                ? wp_trim_words( wp_strip_all_tags( (string) $raw_description ), 75, '…' )
+                : '';
+
+            $image_fond = get_the_post_thumbnail_url( $latest_chasse_id, 'chasse-fiche' );
+
+            if ( ! $image_fond ) {
+                $image_fond = get_the_post_thumbnail_url( $latest_chasse_id, 'full' );
+            }
+
+            $cta_data = generer_cta_chasse( $latest_chasse_id, get_current_user_id() );
+
+            ob_start();
+            get_template_part(
+                'template-parts/headers/front-page-latest-hero',
+                null,
+                [
+                    'chasse_id'   => $latest_chasse_id,
+                    'titre'       => get_the_title( $latest_chasse_id ),
+                    'image_fond'  => $image_fond,
+                    'description' => $description,
+                    'cta_html'    => $cta_data['cta_html'] ?? '',
+                    'cta_message' => $cta_data['cta_message'] ?? '',
+                ]
+            );
+            $latest_hero_markup = ob_get_clean();
+        }
+
+        wp_reset_postdata();
+
+        if ( $fallback_markup || $latest_hero_markup ) {
+            echo '<div class="homepage-hero-wrapper" data-home-hero-wrapper>';
+
+            if ( $fallback_markup ) {
+                echo '<div class="homepage-hero homepage-hero--initial" data-home-hero-initial>';
+                echo $fallback_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                echo '</div>';
+            }
+
+            if ( $latest_hero_markup ) {
+                echo '<div class="homepage-hero homepage-hero--latest" data-home-hero-latest>';
+                echo $latest_hero_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                echo '</div>';
+            }
+
+            echo '</div>';
+        }
     } elseif ( is_page() && ! is_user_account_area() ) {
         $image_id  = get_post_thumbnail_id();
         $image_url = $image_id ? imagify_get_webp_url( wp_get_attachment_image_url( $image_id, 'full' ) ) : '';

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -147,10 +147,35 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
                 ? wp_trim_words( wp_strip_all_tags( (string) $raw_description ), 75, '…' )
                 : '';
 
-            $image_fond = get_the_post_thumbnail_url( $latest_chasse_id, 'chasse-fiche' );
+            $image_fond = '';
+            $image_data = get_field( 'chasse_principale_image', $latest_chasse_id );
+
+            if ( is_array( $image_data ) ) {
+                if ( ! empty( $image_data['sizes']['chasse-fiche'] ) ) {
+                    $image_fond = (string) $image_data['sizes']['chasse-fiche'];
+                } elseif ( ! empty( $image_data['ID'] ) ) {
+                    $image_fond = (string) wp_get_attachment_image_url( (int) $image_data['ID'], 'chasse-fiche' );
+                } elseif ( ! empty( $image_data['url'] ) ) {
+                    $image_fond = (string) $image_data['url'];
+                }
+            } elseif ( ! empty( $image_data ) ) {
+                $image_fond = (string) wp_get_attachment_image_url( (int) $image_data, 'chasse-fiche' );
+            }
+
+            if ( ! $image_fond ) {
+                $image_fond = get_the_post_thumbnail_url( $latest_chasse_id, 'chasse-fiche' );
+            }
 
             if ( ! $image_fond ) {
                 $image_fond = get_the_post_thumbnail_url( $latest_chasse_id, 'full' );
+            }
+
+            if ( $image_fond && function_exists( 'imagify_get_webp_url' ) ) {
+                $webp_url = imagify_get_webp_url( $image_fond );
+
+                if ( $webp_url ) {
+                    $image_fond = $webp_url;
+                }
             }
 
             $cta_data = generer_cta_chasse( $latest_chasse_id, get_current_user_id() );

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -115,10 +115,68 @@ add_filter('admin_body_class', 'ajouter_classes_roles_admin');
  * 🖼️ Convertit une URL d'image vers son équivalent WebP.
  *
  * @param string|null $image_url URL de l'image source.
- * @return string URL en .webp ou vide si URL invalide.
+ * @return string URL en .webp (si disponible) ou URL originale.
  */
 function imagify_get_webp_url($image_url) {
-    return $image_url ? preg_replace('/\.(jpg|jpeg|png)$/i', '.webp', $image_url) : '';
+    if (empty($image_url)) {
+        return '';
+    }
+
+    $parsed_path = parse_url($image_url, PHP_URL_PATH);
+
+    if (!is_string($parsed_path)) {
+        return $image_url;
+    }
+
+    $extension = strtolower(pathinfo($parsed_path, PATHINFO_EXTENSION));
+    $supported_extensions = ['jpg', 'jpeg', 'png'];
+
+    if (!in_array($extension, $supported_extensions, true)) {
+        return $image_url;
+    }
+
+    $webp_url = preg_replace('/\.(jpg|jpeg|png)$/i', '.webp', $image_url);
+
+    if (!$webp_url || $webp_url === $image_url) {
+        return $image_url;
+    }
+
+    if (!function_exists('wp_get_upload_dir')) {
+        return $image_url;
+    }
+
+    $upload_dir = wp_get_upload_dir();
+    $baseurl = $upload_dir['baseurl'] ?? '';
+    $basedir = $upload_dir['basedir'] ?? '';
+
+    if (!$baseurl || !$basedir) {
+        return $image_url;
+    }
+
+    $base_variants = [$baseurl];
+
+    if (strpos($baseurl, 'https://') === 0) {
+        $base_variants[] = 'http://' . substr($baseurl, 8);
+    } elseif (strpos($baseurl, 'http://') === 0) {
+        $base_variants[] = 'https://' . substr($baseurl, 7);
+    }
+
+    foreach ($base_variants as $base_variant) {
+        if (0 !== strpos($webp_url, $base_variant)) {
+            continue;
+        }
+
+        $relative_path = ltrim(substr($webp_url, strlen($base_variant)), '/');
+        $file_path = rtrim($basedir, '/\\') . '/' . str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $relative_path);
+
+        if (file_exists($file_path)) {
+            return $webp_url;
+        }
+
+        break;
+    }
+
+    return $image_url;
 }
 
 

--- a/wp-content/themes/chassesautresor/template-parts/headers/front-page-latest-hero.php
+++ b/wp-content/themes/chassesautresor/template-parts/headers/front-page-latest-hero.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Hero section highlighting the latest validated hunt on the homepage.
+ */
+
+defined('ABSPATH') || exit;
+
+if (!isset($args['chasse_id'])) {
+    return;
+}
+
+$chasse_id   = (int) $args['chasse_id'];
+$titre       = isset($args['titre']) ? sanitize_text_field($args['titre']) : get_the_title($chasse_id);
+$image_fond  = isset($args['image_fond']) ? esc_url($args['image_fond']) : get_the_post_thumbnail_url($chasse_id, 'chasse-fiche');
+$description = isset($args['description']) ? sanitize_text_field($args['description']) : '';
+$cta_html    = $args['cta_html'] ?? '';
+$cta_message = $args['cta_message'] ?? '';
+?>
+<section class="bandeau-hero bandeau-hero--latest-chasse" data-home-hero="latest" aria-hidden="true">
+  <div class="hero-overlay"<?php if ($image_fond) : ?> style="background-image: url('<?php echo esc_url($image_fond); ?>');"<?php endif; ?>>
+    <div class="contenu-hero">
+      <p class="hero-eyebrow"><?php esc_html_e('Dernière chasse validée', 'chassesautresor-com'); ?></p>
+      <h2 class="hero-title"><?php echo esc_html($titre); ?></h2>
+      <?php if ($description) : ?>
+        <p class="hero-description"><?php echo esc_html($description); ?></p>
+      <?php endif; ?>
+      <div class="hero-cta">
+        <?php if (!empty($cta_html)) : ?>
+          <?php echo $cta_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        <?php endif; ?>
+        <?php if (!empty($cta_message)) : ?>
+          <div class="hero-cta__message"><?php echo wp_kses_post($cta_message); ?></div>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Mise à jour du héros d’accueil pour présenter automatiquement la dernière chasse validée.

## Changements
- Capture du héros historique puis affichage différé d’un nouveau héros consacré à la dernière chasse validée avec récupération du CTA adapté.
- Création d’un template dédié, des styles associés et d’un script JS pour orchestrer la transition douce entre les deux blocs.
- Ajout de l’enqueue conditionnel du nouveau script côté front.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d02a4f0c7083328d86a2d4ff8258ed