### PR TITLE
Remplacer l'icône de validation automatique

### DIFF
--- a/tests/js/chasse-edit.test.js
+++ b/tests/js/chasse-edit.test.js
@@ -1,3 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const automaticIconSvg = fs.readFileSync(
+  path.resolve(__dirname, '../../wp-content/themes/chassesautresor/assets/svg/automatic.svg'),
+  'utf8',
+).trim();
+
+const manualIconSvg = fs.readFileSync(
+  path.resolve(__dirname, '../../wp-content/themes/chassesautresor/assets/svg/hand.svg'),
+  'utf8',
+).trim();
+
 const flush = () => new Promise(resolve =>  setTimeout(resolve, 0));
 const html = `
   <div id="chasse-tab-param">
@@ -309,8 +322,16 @@ describe('chasse-edit UI', () => {
     container.className = 'header-chasse__image';
     container.dataset.modeAutoLabel = 'mode de fin de chasse : automatique';
     container.dataset.modeManuelLabel = 'mode de fin de chasse : manuelle';
-    container.dataset.modeAutoIcon = '<i class="fa-solid fa-bolt"></i>';
-    container.dataset.modeManuelIcon = '<i class="hand"></i>';
+    const automaticWrapper = document.createElement('div');
+    automaticWrapper.innerHTML = automaticIconSvg;
+    const normalizedAutomaticIcon = automaticWrapper.innerHTML.trim();
+
+    const manualWrapper = document.createElement('div');
+    manualWrapper.innerHTML = manualIconSvg;
+    const normalizedManualIcon = manualWrapper.innerHTML.trim();
+
+    container.dataset.modeAutoIcon = automaticIconSvg;
+    container.dataset.modeManuelIcon = manualIconSvg;
     const icone = document.createElement('span');
     icone.className = 'mode-fin-icone';
     container.appendChild(icone);
@@ -319,12 +340,12 @@ describe('chasse-edit UI', () => {
     const toggle = document.getElementById('chasse_mode_fin');
     toggle.checked = true;
     toggle.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(icone.innerHTML).toBe('<i class="hand"></i>');
+    expect(icone.innerHTML.trim()).toBe(normalizedManualIcon);
     expect(icone.getAttribute('title')).toBe('mode de fin de chasse : manuelle');
 
     toggle.checked = false;
     toggle.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(icone.innerHTML).toBe('<i class="fa-solid fa-bolt"></i>');
+    expect(icone.innerHTML.trim()).toBe(normalizedAutomaticIcon);
     expect(icone.getAttribute('title')).toBe('mode de fin de chasse : automatique');
   });
 });

--- a/wp-content/themes/chassesautresor/inc/enigme/reponses.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/reponses.php
@@ -62,11 +62,12 @@ function enigme_get_bonnes_reponses(int $enigme_id): array
         $mode_validation = get_field('enigme_mode_validation', $enigme_id);
         $badge_html      = '';
         if ($mode_validation !== 'aucune') {
-            $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
             if ($mode_validation === 'automatique') {
-                $message = __("Mode de validation de l'énigme automatique. Vous connaîtrez le résultat de votre tentative immédiatement après l'avoir soumise.", 'chassesautresor-com');
+                $icon_html = trim(get_svg_icon('automatic'));
+                $message   = __("Mode de validation de l'énigme automatique. Vous connaîtrez le résultat de votre tentative immédiatement après l'avoir soumise.", 'chassesautresor-com');
             } else {
-                $chasse_id        = function_exists('recuperer_id_chasse_associee') ? (int) recuperer_id_chasse_associee($enigme_id) : 0;
+                $icon_html         = '<i class="fa-solid fa-envelope" aria-hidden="true"></i>';
+                $chasse_id         = function_exists('recuperer_id_chasse_associee') ? (int) recuperer_id_chasse_associee($enigme_id) : 0;
                 $organisateur_id   = $chasse_id ? get_organisateur_from_chasse($chasse_id) : 0;
                 $organisateur_nom  = $organisateur_id ? get_the_title($organisateur_id) : '';
                 $organisateur_lien = $organisateur_id ? get_permalink($organisateur_id) : '#';
@@ -77,9 +78,7 @@ function enigme_get_bonnes_reponses(int $enigme_id): array
             }
             $badge_html = '<button type="button" class="badge-validation" data-tooltip="'
                 . esc_attr($message)
-                . '"><i class="fa-solid '
-                . esc_attr($icon)
-                . '"></i></button>';
+                . '">' . $icon_html . '</button>';
         }
 
         $data  = calculer_contexte_points($user_id, $enigme_id);

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -51,6 +51,8 @@ $mode_fin            = $champs['mode_fin'] ?? 'automatique';
 $title_mode          = $mode_fin === 'automatique'
     ? __('mode de fin de chasse : automatique', 'chassesautresor-com')
     : __('mode de fin de chasse : manuelle', 'chassesautresor-com');
+$mode_auto_icon      = trim(get_svg_icon('automatic'));
+$mode_manual_icon    = trim(get_svg_icon('hand'));
 
 // Dates
 $date_debut_formatee        = formater_date($date_debut);
@@ -161,8 +163,8 @@ if ($edition_active && !$est_complet) {
               data-pts-label="<?= esc_attr__('pts', 'chassesautresor-com'); ?>"
               data-mode-auto-label="<?= esc_attr__('mode de fin de chasse : automatique', 'chassesautresor-com'); ?>"
               data-mode-manuel-label="<?= esc_attr__('mode de fin de chasse : manuelle', 'chassesautresor-com'); ?>"
-              data-mode-auto-icon="<?= esc_attr('<i class="fa-solid fa-bolt"></i>'); ?>"
-              data-mode-manuel-icon="<?= esc_attr(get_svg_icon('hand')); ?>"
+              data-mode-auto-icon="<?= esc_attr($mode_auto_icon); ?>"
+              data-mode-manuel-icon="<?= esc_attr($mode_manual_icon); ?>"
           >
               <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>"
                 data-post-id="<?= esc_attr($chasse_id); ?>">
@@ -184,9 +186,9 @@ if ($edition_active && !$est_complet) {
               <?php endif; ?>
               <span class="mode-fin-icone" title="<?= esc_attr($title_mode); ?>" aria-label="<?= esc_attr($title_mode); ?>">
                 <?php if ($mode_fin === 'automatique') : ?>
-                  <i class="fa-solid fa-bolt"></i>
+                  <?= $mode_auto_icon; ?>
                 <?php else : ?>
-                  <?= get_svg_icon('hand'); ?>
+                  <?= $mode_manual_icon; ?>
                 <?php endif; ?>
               </span>
               <?php if ($image_id) : ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -76,9 +76,9 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 
         <span class="mode-fin-icone" title="<?php echo esc_attr($title_mode); ?>" aria-label="<?php echo esc_attr($title_mode); ?>">
             <?php if ($mode_fin === 'automatique') : ?>
-                <i class="fa-solid fa-bolt"></i>
+                <?= trim(get_svg_icon('automatic')); ?>
             <?php else : ?>
-                <?php echo get_svg_icon('hand'); ?>
+                <?= trim(get_svg_icon('hand')); ?>
             <?php endif; ?>
         </span>
         <?php

--- a/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -227,13 +227,15 @@ if (!function_exists('compter_tentatives_du_jour') || !function_exists('compter_
                     </span>
                   <?php endif; ?>
                   <?php if (in_array($mode_validation, ['automatique', 'manuelle'], true)) :
-                    $icon = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
+                    $icon_html = $mode_validation === 'automatique'
+                      ? trim(get_svg_icon('automatic'))
+                      : '<i class="fa-solid fa-envelope" aria-hidden="true"></i>';
                     $label = $mode_validation === 'automatique'
                       ? esc_html__('Mode de validation : automatique', 'chassesautresor-com')
                       : esc_html__('Mode de validation : manuel', 'chassesautresor-com');
                   ?>
                     <span class="footer-item" title="<?= esc_attr($label); ?>" aria-label="<?= esc_attr($label); ?>">
-                      <i class="fa-solid <?= esc_attr($icon); ?>" aria-hidden="true"></i>
+                      <?= $icon_html; ?>
                     </span>
                   <?php endif; ?>
                 </div>

--- a/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
+++ b/wp-content/themes/chassesautresor/template-parts/enigme/partials/enigme-partial-bloc-reponse.php
@@ -154,10 +154,11 @@ if ($points_manquants <= 0 && !$message_tentatives && $cout > 0) {
 
 $badge_html = '';
 if ($mode_validation !== 'aucune') {
-    $icon       = $mode_validation === 'automatique' ? 'fa-bolt' : 'fa-envelope';
     if ($mode_validation === 'automatique') {
-        $message = __("Mode de validation de l'énigme automatique. Vous connaîtrez le résultat de votre tentative immédiatement après l'avoir soumise.", 'chassesautresor-com');
+        $icon_html = trim(get_svg_icon('automatic'));
+        $message   = __("Mode de validation de l'énigme automatique. Vous connaîtrez le résultat de votre tentative immédiatement après l'avoir soumise.", 'chassesautresor-com');
     } else {
+        $icon_html         = '<i class="fa-solid fa-envelope" aria-hidden="true"></i>';
         $organisateur_id   = get_organisateur_from_chasse($chasse_id);
         $organisateur_nom  = $organisateur_id ? get_the_title($organisateur_id) : '';
         $organisateur_lien = $organisateur_id ? get_permalink($organisateur_id) : '#';
@@ -168,9 +169,7 @@ if ($mode_validation !== 'aucune') {
     }
     $badge_html = '<button type="button" class="badge-validation" data-tooltip="'
         . esc_attr($message)
-        . '"><i class="fa-solid '
-        . esc_attr($icon)
-        . '"></i></button>';
+        . '">' . $icon_html . '</button>';
 }
 
 $nonce = wp_create_nonce('reponse_auto_nonce');


### PR DESCRIPTION
## Résumé
- Remplacement de l’icône d’éclair par le SVG `automatic` pour les badges de validation automatique
- Harmonisation des attributs de données liés au mode automatique et mutualisation des SVG pour les affichages
- Mise à jour des tests Jest pour prendre en compte le nouvel SVG et normaliser les comparaisons

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm test -- chasse-edit`


------
https://chatgpt.com/codex/tasks/task_e_68d02bec2e088332a1f9df35aaf31687