### PR TITLE
Améliorer la transition du héros d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hero.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hero.js
@@ -26,8 +26,22 @@
       : null;
     const delay = 5000;
 
+    const updateWrapperHeight = () => {
+      window.requestAnimationFrame(() => {
+        const visibleHero = wrapper.querySelector('[data-home-hero][aria-hidden="false"]');
+
+        if (!visibleHero) {
+          return;
+        }
+
+        wrapper.style.height = `${visibleHero.offsetHeight}px`;
+      });
+    };
+
     initialHero.setAttribute('aria-hidden', 'false');
     latestHero.setAttribute('aria-hidden', 'true');
+
+    updateWrapperHeight();
 
     const swapHeroes = () => {
       initialHero.classList.add('is-home-hero-hidden');
@@ -35,12 +49,17 @@
 
       latestHero.classList.add('is-home-hero-visible');
       latestHero.setAttribute('aria-hidden', 'false');
+
+      updateWrapperHeight();
     };
 
     if (prefersReducedMotion && prefersReducedMotion.matches) {
       swapHeroes();
       return;
     }
+
+    window.addEventListener('resize', updateWrapperHeight);
+    window.addEventListener('load', updateWrapperHeight);
 
     window.setTimeout(swapHeroes, delay);
   });

--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -242,6 +242,11 @@ header.site-header {
   position: relative;
   display: grid;
   overflow: hidden;
+  min-height: 220px;
+}
+
+.has-hero .homepage-hero-wrapper + #content {
+  padding-top: 0;
 }
 
 .homepage-hero-wrapper [data-home-hero] {
@@ -319,12 +324,28 @@ header.site-header {
     font-size: 1.1rem;
     max-width: 760px;
   }
+
+  .homepage-hero-wrapper {
+    min-height: 280px;
+  }
+
+  .has-hero .homepage-hero-wrapper + #content {
+    padding-top: 0;
+  }
 }
 
 @media (--bp-tablet) {
   .hero-description {
     font-size: 1.2rem;
     max-width: 840px;
+  }
+
+  .homepage-hero-wrapper {
+    min-height: 475px;
+  }
+
+  .has-hero .homepage-hero-wrapper + #content {
+    padding-top: 0;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_layout.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_layout.scss
@@ -240,33 +240,34 @@ header.site-header {
 
 .homepage-hero-wrapper {
   position: relative;
+  display: grid;
+  overflow: hidden;
 }
 
 .homepage-hero-wrapper [data-home-hero] {
-  transition: opacity 0.6s ease;
+  grid-area: 1 / 1;
+  transition: transform 0.9s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
 }
 
 .homepage-hero-wrapper [data-home-hero="initial"] {
-  opacity: 1;
+  transform: translateY(0);
   pointer-events: auto;
 }
 
 .homepage-hero-wrapper [data-home-hero="initial"].is-home-hero-hidden {
-  opacity: 0;
-  visibility: hidden;
+  transform: translateY(-100%);
   pointer-events: none;
 }
 
 .homepage-hero-wrapper [data-home-hero="latest"] {
-  opacity: 0;
-  visibility: hidden;
+  transform: translateY(100%);
   pointer-events: none;
   z-index: 9;
 }
 
 .homepage-hero-wrapper [data-home-hero="latest"].is-home-hero-visible {
-  opacity: 1;
-  visibility: visible;
+  transform: translateY(0);
   pointer-events: auto;
   z-index: 11;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8483,33 +8483,34 @@ header.site-header {
 }
 .homepage-hero-wrapper {
   position: relative;
+  display: grid;
+  overflow: hidden;
 }
 
 .homepage-hero-wrapper [data-home-hero] {
-  transition: opacity 0.6s ease;
+  grid-area: 1/1;
+  transition: transform 0.9s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
 }
 
 .homepage-hero-wrapper [data-home-hero=initial] {
-  opacity: 1;
+  transform: translateY(0);
   pointer-events: auto;
 }
 
 .homepage-hero-wrapper [data-home-hero=initial].is-home-hero-hidden {
-  opacity: 0;
-  visibility: hidden;
+  transform: translateY(-100%);
   pointer-events: none;
 }
 
 .homepage-hero-wrapper [data-home-hero=latest] {
-  opacity: 0;
-  visibility: hidden;
+  transform: translateY(100%);
   pointer-events: none;
   z-index: 9;
 }
 
 .homepage-hero-wrapper [data-home-hero=latest].is-home-hero-visible {
-  opacity: 1;
-  visibility: visible;
+  transform: translateY(0);
   pointer-events: auto;
   z-index: 11;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8485,6 +8485,11 @@ header.site-header {
   position: relative;
   display: grid;
   overflow: hidden;
+  min-height: 220px;
+}
+
+.has-hero .homepage-hero-wrapper + #content {
+  padding-top: 0;
 }
 
 .homepage-hero-wrapper [data-home-hero] {
@@ -8561,11 +8566,23 @@ header.site-header {
     font-size: 1.1rem;
     max-width: 760px;
   }
+  .homepage-hero-wrapper {
+    min-height: 280px;
+  }
+  .has-hero .homepage-hero-wrapper + #content {
+    padding-top: 0;
+  }
 }
 @media (min-width: 768px) {
   .hero-description {
     font-size: 1.2rem;
     max-width: 840px;
+  }
+  .homepage-hero-wrapper {
+    min-height: 475px;
+  }
+  .has-hero .homepage-hero-wrapper + #content {
+    padding-top: 0;
   }
 }
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Résumé
- Remplace la disparition brutale par une animation verticale fluide entre les deux héros de la page d'accueil.
- Ajuste le script pour maintenir la hauteur du conteneur pendant et après la transition.
- Recompile la feuille de styles du thème avec la nouvelle animation.

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0418dc3a083328ef006954288e472