### PR TITLE
Fix homepage hero CTA link

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -180,6 +180,16 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
 
             $cta_data = generer_cta_chasse( $latest_chasse_id, get_current_user_id() );
 
+            if ( ( $cta_data['type'] ?? '' ) === 'engage' ) {
+                $cta_data['cta_html'] = sprintf(
+                    '<a href="%s" class="bouton-secondaire">%s</a>',
+                    esc_url( get_permalink( $latest_chasse_id ) . '#chasse-enigmes-wrapper' ),
+                    esc_html__( 'Voir mes énigmes', 'chassesautresor-com' )
+                );
+            }
+
+            $cta_data['cta_message'] = '';
+
             ob_start();
             get_template_part(
                 'template-parts/headers/front-page-latest-hero',


### PR DESCRIPTION
## Résumé
- corrige le CTA de la chasse à la une pour qu'il pointe vers la fiche chasse
- masque les messages d'état du CTA sur le héros d'accueil

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0cdcb1b808332b471b5209b3dd123