### PR TITLE
Centraliser la logique de filtrage des chasses d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -12,36 +12,17 @@ if (is_user_logged_in() && function_exists('render_points_history_table')) {
 
 get_header();
 
-$query = new WP_Query([
-    'post_type'      => 'chasse',
-    'post_status'    => 'publish',
-    'meta_query'     => [
-        [
-            'key'   => 'chasse_cache_statut_validation',
-            'value' => 'valide',
-        ],
-    ],
-    'fields'         => 'ids',
-    'posts_per_page' => -1,
-]);
+$home_filters = ca_home_filter_chasse_ids([]);
 
-$chasse_ids = $query->posts;
-
-$user_id = get_current_user_id();
-$filtered_chasse_ids = $chasse_ids;
-
-if (function_exists('chasse_est_visible_pour_utilisateur')) {
-    $filtered_chasse_ids = array_values(array_filter(
-        $filtered_chasse_ids,
-        static function ($chasse_id) use ($user_id) {
-            return chasse_est_visible_pour_utilisateur((int) $chasse_id, $user_id);
-        }
-    ));
-}
-
-$default_status_filter = 'tous';
-$default_cost_filters  = ['gratuit', 'points'];
-$initial_results_count = count($filtered_chasse_ids);
+$chasse_ids             = $home_filters['ids'];
+$normalized_filters     = $home_filters['filters_normalises'] ?? [];
+$default_status_filter  = is_string($normalized_filters['statut'] ?? null)
+    ? $normalized_filters['statut']
+    : 'tous';
+$default_cost_filters   = is_array($normalized_filters['cout'] ?? null)
+    ? $normalized_filters['cout']
+    : ['gratuit', 'points'];
+$initial_results_count  = (int) ($home_filters['total'] ?? count($chasse_ids));
 
 $status_options = [
     'tous'     => __('Tous les statuts', 'chassesautresor-com'),
@@ -107,8 +88,6 @@ ob_start();
 $before_items_markup = ob_get_clean();
 
 $after_items_markup = '<div class="home-hunts__feedback" data-home-hunts-feedback aria-live="polite"></div>';
-
-$chasse_ids = $filtered_chasse_ids;
 ?>
 
 <div id="primary" class="content-area">

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -581,6 +581,7 @@ require_once $inc_path . 'table.php';
 require_once $inc_path . 'search/registry.php';
 require_once $inc_path . 'search/helpers.php';
 require_once $inc_path . 'search/form.php';
+require_once $inc_path . 'homepage-filters.php';
 
 require_once $inc_path . 'edition/edition-core.php';
 require_once $inc_path . 'edition/edition-organisateur.php';

--- a/wp-content/themes/chassesautresor/inc/homepage-filters.php
+++ b/wp-content/themes/chassesautresor/inc/homepage-filters.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Homepage filters utilities.
+ */
+
+defined('ABSPATH') || exit();
+
+/**
+ * Retrieves hunt identifiers for the homepage according to optional filters.
+ *
+ * Filters accept the following values:
+ * - statut: "tous", "en_cours", "a_venir", "termine".
+ *   The "en_cours" filter groups hunts whose "chasse_cache_statut" is either "en_cours" or "payante".
+ * - cout: array of "gratuit" and/or "points". Omit to keep both values by default.
+ *   A hunt is considered "gratuit" when both "chasse_infos_cout_points" and "nb_enigmes_payantes" are equal to 0.
+ *
+ * @param array{statut?:string, cout?:string|string[]}|array $args Raw filters coming from the frontend.
+ *
+ * @return array{ids:int[], total:int, filters_normalises:array{statut:string, cout:string[]}}
+ */
+function ca_home_filter_chasse_ids(array $args): array
+{
+    $status_whitelist = ['tous', 'en_cours', 'a_venir', 'termine'];
+    $cost_whitelist   = ['gratuit', 'points'];
+
+    $default_filters = [
+        'statut' => 'tous',
+        'cout'   => $cost_whitelist,
+    ];
+
+    $normalized_status = $default_filters['statut'];
+    if (isset($args['statut']) && is_string($args['statut']) && in_array($args['statut'], $status_whitelist, true)) {
+        $normalized_status = $args['statut'];
+    }
+
+    $cost_filter_provided = array_key_exists('cout', $args);
+    $raw_cost_values      = $args['cout'] ?? $default_filters['cout'];
+
+    if (is_string($raw_cost_values)) {
+        $raw_cost_values = [$raw_cost_values];
+    }
+
+    if (!is_array($raw_cost_values)) {
+        $raw_cost_values = [];
+    }
+
+    $raw_cost_values = array_map('strval', $raw_cost_values);
+    $normalized_cost = array_values(array_intersect($cost_whitelist, $raw_cost_values));
+
+    if (!$cost_filter_provided) {
+        $normalized_cost = $default_filters['cout'];
+    }
+
+    $query = new WP_Query([
+        'post_type'      => 'chasse',
+        'post_status'    => 'publish',
+        'meta_query'     => [
+            [
+                'key'   => 'chasse_cache_statut_validation',
+                'value' => 'valide',
+            ],
+        ],
+        'fields'         => 'ids',
+        'posts_per_page' => -1,
+    ]);
+
+    $chasse_ids = is_array($query->posts) ? array_map('intval', $query->posts) : [];
+    wp_reset_postdata();
+
+    $user_id = (int) get_current_user_id();
+
+    if (function_exists('chasse_est_visible_pour_utilisateur')) {
+        $chasse_ids = array_values(array_filter(
+            $chasse_ids,
+            static function (int $chasse_id) use ($user_id): bool {
+                return chasse_est_visible_pour_utilisateur($chasse_id, $user_id);
+            }
+        ));
+    }
+
+    $status_map = [
+        'en_cours' => ['en_cours', 'payante'],
+        'a_venir'  => ['a_venir'],
+        'termine'  => ['termine'],
+    ];
+
+    $filtered_ids = [];
+
+    foreach ($chasse_ids as $chasse_id) {
+        $infos_chasse = function_exists('preparer_infos_affichage_chasse')
+            ? preparer_infos_affichage_chasse($chasse_id, $user_id)
+            : [];
+
+        $statut_metier = $infos_chasse['statut'] ?? get_field('chasse_cache_statut', $chasse_id);
+
+        if (
+            'tous' !== $normalized_status
+            && !in_array($statut_metier, $status_map[$normalized_status] ?? [], true)
+        ) {
+            continue;
+        }
+
+        $cout_points        = (int) ($infos_chasse['champs']['cout_points'] ?? get_field('chasse_infos_cout_points', $chasse_id));
+        $nb_enigmes_payantes = (int) ($infos_chasse['nb_enigmes_payantes'] ?? 0);
+
+        $is_free = ($cout_points <= 0) && ($nb_enigmes_payantes <= 0);
+
+        if ($cost_filter_provided) {
+            if (empty($normalized_cost)) {
+                continue;
+            }
+
+            if ($is_free && !in_array('gratuit', $normalized_cost, true)) {
+                continue;
+            }
+
+            if (!$is_free && !in_array('points', $normalized_cost, true)) {
+                continue;
+            }
+        }
+
+        $filtered_ids[] = $chasse_id;
+    }
+
+    return [
+        'ids'                => $filtered_ids,
+        'total'              => count($filtered_ids),
+        'filters_normalises' => [
+            'statut' => $normalized_status,
+            'cout'   => $normalized_cost,
+        ],
+    ];
+}


### PR DESCRIPTION
## Résumé
- Centralise la requête et le filtrage des chasses d'accueil dans un utilitaire dédié qui normalise les paramètres et respecte les droits d'accès.
- Adapte la page d'accueil pour consommer la nouvelle fonction et récupérer les valeurs par défaut des filtres à partir des données normalisées.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0d8a7cbe48332a4226737f6b528ba