### PR TITLE
Add AJAX filtering for homepage hunts

### DIFF
--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -13,6 +13,7 @@ if (is_user_logged_in() && function_exists('render_points_history_table')) {
 get_header();
 
 $home_filters = ca_home_filter_chasse_ids([]);
+$filters_nonce = wp_create_nonce('ca-filter-chasses');
 
 $chasse_ids             = $home_filters['ids'];
 $normalized_filters     = $home_filters['filters_normalises'] ?? [];
@@ -94,7 +95,11 @@ $after_items_markup = '<div class="home-hunts__feedback" data-home-hunts-feedbac
     <main id="home-page">
         <section class="chasses">
             <div class="conteneur">
-                <div class="liste-chasses" data-home-hunts="true">
+                <div
+                    class="liste-chasses"
+                    data-home-hunts="true"
+                    data-nonce="<?php echo esc_attr($filters_nonce); ?>"
+                >
                     <?php
                     get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [
                         'chasse_ids' => $chasse_ids,

--- a/wp-content/themes/chassesautresor/inc/homepage-filters.php
+++ b/wp-content/themes/chassesautresor/inc/homepage-filters.php
@@ -131,3 +131,68 @@ function ca_home_filter_chasse_ids(array $args): array
         ],
     ];
 }
+
+/**
+ * AJAX endpoint returning filtered hunts list markup.
+ */
+function ca_ajax_filter_chasses(): void
+{
+    check_ajax_referer('ca-filter-chasses', 'nonce');
+
+    $status_whitelist = ['tous', 'en_cours', 'a_venir', 'termine'];
+    $cost_whitelist   = ['gratuit', 'points'];
+
+    $raw_request = wp_unslash($_POST);
+
+    $filters = [];
+
+    if (isset($raw_request['status']) && is_string($raw_request['status'])) {
+        $status = sanitize_text_field($raw_request['status']);
+        if (in_array($status, $status_whitelist, true)) {
+            $filters['statut'] = $status;
+        }
+    }
+
+    if (array_key_exists('cost', $raw_request)) {
+        $raw_cost = $raw_request['cost'];
+
+        if (is_string($raw_cost)) {
+            $raw_cost = [$raw_cost];
+        }
+
+        if (is_array($raw_cost)) {
+            $raw_cost = array_map('strval', $raw_cost);
+            $filtered_cost = array_values(array_intersect($cost_whitelist, $raw_cost));
+            $filters['cout'] = $filtered_cost;
+        }
+    }
+
+    $filter_results = ca_home_filter_chasse_ids($filters);
+
+    if (!is_array($filter_results) || !isset($filter_results['ids'])) {
+        wp_send_json_error([
+            'message' => __('Impossible de charger les chasses.', 'chassesautresor-com'),
+        ]);
+    }
+
+    $chasse_ids = is_array($filter_results['ids']) ? array_map('intval', $filter_results['ids']) : [];
+
+    ob_start();
+    get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [
+        'chasse_ids'  => $chasse_ids,
+        'show_header' => false,
+        'grid_class'  => 'organisateur-chasses-grid',
+        'before_items' => '',
+        'after_items'  => '',
+    ]);
+    $html = (string) ob_get_clean();
+
+    wp_send_json_success([
+        'html'  => $html,
+        'total' => (int) ($filter_results['total'] ?? count($chasse_ids)),
+        'nonce' => wp_create_nonce('ca-filter-chasses'),
+    ]);
+}
+
+add_action('wp_ajax_ca_filter_chasses', 'ca_ajax_filter_chasses');
+add_action('wp_ajax_nopriv_ca_filter_chasses', 'ca_ajax_filter_chasses');


### PR DESCRIPTION
Résumé :
- Ajout d'un point d'entrée AJAX pour filtrer dynamiquement les chasses de la page d'accueil.
- Exposition du nonce initial de filtrage côté front pour sécuriser les requêtes JavaScript.

Changes :
- Crée la fonction `ca_ajax_filter_chasses()` qui valide les paramètres, génère le HTML des cartes et renvoie les totaux.
- Enregistre les hooks AJAX publics/privés pour le filtrage des chasses.
- Ajoute l'attribut `data-nonce` sur le conteneur des chasses avec un nonce généré côté serveur.

Testing :
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0e28e18dc83328677e31f26e5471c