### PR TITLE
Vérifier la complétude du profil organisateur

### DIFF
--- a/docs/tests-profil-organisateur.md
+++ b/docs/tests-profil-organisateur.md
@@ -17,5 +17,13 @@
 3. Vérifiez que le message d’alerte a disparu et que le CTA indique « Créer mon profil » avec le lien d’origine.
 4. Accédez à `/creer-mon-profil/` et confirmez que la demande est envoyée (mail de confirmation, redirection vers « Devenir organisateur »…).
 
+## Cas 3 : demande de création expirée
+1. Après avoir généré une demande (Cas 2), forcez son expiration en positionnant la métadonnée `organisateur_demande_date` à une valeur antérieure de plus de 48 heures :
+   ```bash
+   wp user meta update <USER_ID> organisateur_demande_date "2023-01-01 00:00:00"
+   ```
+2. Rechargez « Devenir organisateur » et vérifiez qu’un message informe de l’expiration et que le CTA redevient « Créer mon profil ».
+3. Retournez sur `/creer-mon-profil/` et confirmez qu’un nouvel email est envoyé automatiquement et que le message persistant précise que l’ancienne demande avait expiré.
+
 ## Nettoyage
 - Supprimez le message persistant via la mise à jour du profil si nécessaire.

--- a/docs/tests-profil-organisateur.md
+++ b/docs/tests-profil-organisateur.md
@@ -1,0 +1,21 @@
+# Procédure de test – profil organisateur
+
+## Pré-requis
+- Un compte WooCommerce existant.
+- Accès à la page « Devenir organisateur » (`/devenir-organisateur/`).
+
+## Cas 1 : profil utilisateur incomplet
+1. Connectez-vous avec un compte qui n’a pas renseigné tous les champs obligatoires (prénom, nom, nom d’affichage, adresse e-mail…).
+2. Rendez-vous sur « Devenir organisateur ».
+3. Vérifiez que le message d’alerte liste les champs à compléter et que le bouton principal affiche « Compléter mon profil » avec un lien vers l’édition du compte WooCommerce.
+4. Cliquez sur « Créer mon profil » (`/creer-mon-profil/`).
+5. Confirmez que vous êtes redirigé vers l’édition du compte WooCommerce et qu’un message persistant rappelle les champs manquants.
+
+## Cas 2 : profil utilisateur complet
+1. Renseignez tous les champs requis du compte WooCommerce.
+2. Retournez sur « Devenir organisateur ».
+3. Vérifiez que le message d’alerte a disparu et que le CTA indique « Créer mon profil » avec le lien d’origine.
+4. Accédez à `/creer-mon-profil/` et confirmez que la demande est envoyée (mail de confirmation, redirection vers « Devenir organisateur »…).
+
+## Nettoyage
+- Supprimez le message persistant via la mise à jour du profil si nécessaire.

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -696,6 +696,25 @@ function get_cta_devenir_organisateur(?int $user_id = null): array
 
     $roles = (array) $user->roles;
 
+    $profile_state = cat_is_user_profile_complete($user_id);
+    if (!$profile_state['complete']) {
+        $profile_url = function_exists('wc_get_account_endpoint_url')
+            ? wc_get_account_endpoint_url('edit-account')
+            : home_url('/mon-compte/edit-account/');
+
+        $message = cat_get_missing_profile_fields_message($profile_state['missing']);
+
+        add_site_message('error', $message, false, 'profil_incomplet_' . $user_id);
+
+        return [
+            'label'    => __('Compléter mon profil', 'chassesautresor-com'),
+            'url'      => $profile_url,
+            'disabled' => false,
+        ];
+    }
+
+    myaccount_remove_persistent_message($user_id, 'profil_incomplet');
+
     if (in_array('administrator', $roles, true)) {
         return [
             'label' => 'Salut Patron',

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -667,6 +667,68 @@ function generer_liste_chasses_hierarchique($organisateur_id) {
 // 🎯 CTA PAGE "DEVENIR ORGANISATEUR"
 // ==================================================
 /**
+ * Remove any pending organiser request metadata for the given user.
+ *
+ * @param int $user_id Target user identifier.
+ *
+ * @return void
+ */
+function cat_clear_organisateur_request(int $user_id): void
+{
+    delete_user_meta($user_id, 'organisateur_demande_token');
+    delete_user_meta($user_id, 'organisateur_demande_date');
+}
+
+/**
+ * Retrieve the status of the organiser creation request for a user.
+ *
+ * @param int $user_id Target user identifier.
+ *
+ * @return array{token:?string,expired:bool,expires_at?:int} Request status payload.
+ */
+function cat_get_organisateur_request_status(int $user_id): array
+{
+    $token = (string) get_user_meta($user_id, 'organisateur_demande_token', true);
+
+    if ($token === '') {
+        return [
+            'token'   => null,
+            'expired' => false,
+        ];
+    }
+
+    $date = get_user_meta($user_id, 'organisateur_demande_date', true);
+    $timestamp = $date ? strtotime((string) $date) : false;
+
+    if (!$timestamp) {
+        cat_clear_organisateur_request($user_id);
+
+        return [
+            'token'   => null,
+            'expired' => false,
+        ];
+    }
+
+    $expires_at = $timestamp + 2 * DAY_IN_SECONDS;
+    $now        = (int) current_time('timestamp');
+
+    if ($now > $expires_at) {
+        cat_clear_organisateur_request($user_id);
+
+        return [
+            'token'   => null,
+            'expired' => true,
+        ];
+    }
+
+    return [
+        'token'      => $token,
+        'expired'    => false,
+        'expires_at' => $expires_at,
+    ];
+}
+
+/**
  * Retourne le libellé et l'URL du bouton d'appel à l'action
  * présent sur la page "Devenir organisateur".
  *
@@ -713,6 +775,7 @@ function get_cta_devenir_organisateur(?int $user_id = null): array
         ];
     }
 
+    remove_site_message('profil_incomplet_' . $user_id);
     myaccount_remove_persistent_message($user_id, 'profil_incomplet');
 
     if (in_array('administrator', $roles, true)) {
@@ -723,8 +786,19 @@ function get_cta_devenir_organisateur(?int $user_id = null): array
         ];
     }
 
+    $request_status = cat_get_organisateur_request_status($user_id);
+
+    if ($request_status['expired']) {
+        add_site_message(
+            'info',
+            __('Votre précédente demande de création de profil a expiré. Vous pouvez en envoyer une nouvelle.', 'chassesautresor-com'),
+            false,
+            'profil_expire_' . $user_id
+        );
+    }
+
     // Demande d'inscription non confirmée
-    if (get_user_meta($user_id, 'organisateur_demande_token', true)) {
+    if (!empty($request_status['token'])) {
         return [
             'label' => "Renvoyer l'email de confirmation",
             'url'   => home_url('/creer-mon-profil/?resend=1'),

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -329,6 +329,115 @@ function ca_profile_endpoint_title($title)
 add_filter('woocommerce_endpoint_edit-account_title', 'ca_profile_endpoint_title');
 
 // ==================================================
+// 👤 USER PROFILE UTILITIES
+// ==================================================
+/**
+ * Check whether the mandatory WooCommerce account fields are filled in.
+ *
+ * @param int $user_id Target user identifier.
+ *
+ * @return array{complete:bool,missing:array<int,string>} Tuple containing the completion status and the list of missing field labels.
+ */
+function cat_is_user_profile_complete(int $user_id): array
+{
+    $user = get_userdata($user_id);
+
+    if (!$user) {
+        return [
+            'complete' => false,
+            'missing'  => [__('Profil utilisateur introuvable', 'chassesautresor-com')],
+        ];
+    }
+
+    $default_fields = [
+        'first_name'   => [
+            'label'  => __('Prénom', 'chassesautresor-com'),
+            'source' => 'meta',
+        ],
+        'last_name'    => [
+            'label'  => __('Nom', 'chassesautresor-com'),
+            'source' => 'meta',
+        ],
+        'display_name' => [
+            'label'  => __('Nom d’affichage', 'chassesautresor-com'),
+            'source' => 'property',
+        ],
+        'user_email'   => [
+            'label'  => __('Adresse e-mail', 'chassesautresor-com'),
+            'source' => 'property',
+        ],
+    ];
+
+    /** @var array<string, array{label:string,source?:string,callback?:callable}|string> $required_fields */
+    $required_fields = apply_filters('cat_required_user_profile_fields', $default_fields, $user_id, $user);
+
+    $missing = [];
+
+    foreach ($required_fields as $field_key => $config) {
+        if (is_string($config)) {
+            $config = [
+                'label'  => $config,
+                'source' => 'meta',
+            ];
+        }
+
+        if (empty($config['label'])) {
+            continue;
+        }
+
+        $label = (string) $config['label'];
+
+        $value = null;
+        if (!empty($config['callback']) && is_callable($config['callback'])) {
+            $value = call_user_func($config['callback'], $user_id, $user, $field_key, $config);
+        } elseif (($config['source'] ?? 'meta') === 'property') {
+            $value = $user->{$field_key} ?? '';
+        } else {
+            $value = get_user_meta($user_id, $field_key, true);
+        }
+
+        if (is_scalar($value) || $value === null) {
+            $value = trim((string) $value);
+        } elseif (is_array($value)) {
+            $value = implode('', array_map('trim', array_map('strval', $value)));
+        } else {
+            $value = '';
+        }
+
+        if ($value === '') {
+            $missing[] = $label;
+        }
+    }
+
+    return [
+        'complete' => $missing === [],
+        'missing'  => $missing,
+    ];
+}
+
+/**
+ * Build a translated message listing missing profile fields.
+ *
+ * @param array<int, string> $missing_fields Missing field labels.
+ *
+ * @return string
+ */
+function cat_get_missing_profile_fields_message(array $missing_fields): string
+{
+    if ($missing_fields === []) {
+        return __('Veuillez compléter votre profil utilisateur.', 'chassesautresor-com');
+    }
+
+    $fields_list = wp_sprintf_l('%l', $missing_fields);
+
+    return sprintf(
+        /* translators: %s: comma-separated list of missing profile fields */
+        __('Veuillez compléter votre profil utilisateur : %s.', 'chassesautresor-com'),
+        $fields_list
+    );
+}
+
+// ==================================================
 // 📣 IMPORTANT MESSAGES
 // ==================================================
 /**

--- a/wp-content/themes/chassesautresor/templates/page-creer-profil.php
+++ b/wp-content/themes/chassesautresor/templates/page-creer-profil.php
@@ -13,6 +13,32 @@ if (!is_user_logged_in()) {
 }
 
 $current_user_id = get_current_user_id();
+$profile_state = cat_is_user_profile_complete($current_user_id);
+
+if (!$profile_state['complete']) {
+    $message = cat_get_missing_profile_fields_message($profile_state['missing']);
+
+    myaccount_add_persistent_message(
+        $current_user_id,
+        'profil_incomplet',
+        $message,
+        'error',
+        false,
+        0,
+        false,
+        null,
+        get_user_locale($current_user_id)
+    );
+
+    $redirect_url = function_exists('wc_get_account_endpoint_url')
+        ? wc_get_account_endpoint_url('edit-account')
+        : home_url('/mon-compte/edit-account/');
+
+    wp_safe_redirect($redirect_url);
+    exit;
+}
+
+myaccount_remove_persistent_message($current_user_id, 'profil_incomplet');
 $verification_message = __(
     'Un email de confirmation vous a été envoyé. '
     . "Cliquez sur le lien qu'il contient pour valider la création de votre profil organisateur.",

--- a/wp-content/themes/chassesautresor/templates/page-creer-profil.php
+++ b/wp-content/themes/chassesautresor/templates/page-creer-profil.php
@@ -39,11 +39,20 @@ if (!$profile_state['complete']) {
 }
 
 myaccount_remove_persistent_message($current_user_id, 'profil_incomplet');
+$request_status = cat_get_organisateur_request_status($current_user_id);
 $verification_message = __(
     'Un email de confirmation vous a été envoyé. '
     . "Cliquez sur le lien qu'il contient pour valider la création de votre profil organisateur.",
     'chassesautresor-com'
 );
+
+if ($request_status['expired']) {
+    $verification_message = sprintf(
+        '%s %s',
+        __('Votre précédente demande avait expiré.', 'chassesautresor-com'),
+        $verification_message
+    );
+}
 
 // 2. Si un profil existe déjà, on n'effectue plus de redirection automatique
 // vers l'espace organisateur. Le bouton principal se charge de guider
@@ -69,8 +78,7 @@ if (isset($_GET['resend'])) {
     exit;
 }
 
-$token = get_user_meta($current_user_id, 'organisateur_demande_token', true);
-if ($token) {
+if (!empty($request_status['token'])) {
     myaccount_add_persistent_message(
         $current_user_id,
         'profil_verification',


### PR DESCRIPTION
## Résumé
- ajoute un helper pour vérifier les champs obligatoires du profil utilisateur et générer un message dédié
- adapte le CTA « Devenir organisateur » pour inciter à compléter le profil et informer des champs manquants
- bloque l’accès à la création tant que le profil est incomplet et documente la procédure de test manuel

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0e38a185c8332af09391a9e8cc577