### PR TITLE
Documenter le champ ACF chasse_region

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -1,7 +1,7 @@
 🔹 Groupe : paramètre de la chasse
 🆔 ID : 27
 🔑 Key : group_67b58c51b9a49
-📦 Champs trouvés : 21
+📦 Champs trouvés : 22
 
 — chasse_principale_image —
 Type : image
@@ -162,6 +162,18 @@ Type : true_false
 Label : chasse_cache_has_indices
 Instructions : (vide)
 Requis : non
+----------------------------------------
+
+— chasse_region —
+Type : taxonomy
+Label : chasse_region
+Instructions : (vide)
+Requis : non
+Taxonomie : chasse_region
+Mode de sélection : select (simple)
+Retour : objet (WP_Term)
+Load Terms : oui
+Save Terms : oui
 ----------------------------------------
 
 🔹 Groupe : Paramètres de l’énigme

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -372,6 +372,7 @@ Groupe : paramètre de la chasse
 * chasse_cache_statut_validation (select)
 * chasse_cache_statut (select)
 * chasse_cache_complet (true_false)
+* chasse_region (taxonomy) — référence la taxonomie des régions de chasse
 
 CPT : enigme
 Groupe : Paramètres de l’énigme


### PR DESCRIPTION
## Résumé
- Documente le nouveau champ ACF de région pour le CPT chasse
- Actualise l'aperçu global des champs pour inclure la taxonomie de région

## Changements notables
- Ajout du détail du champ `chasse_region` (taxonomie cible, mode de sélection, synchronisation des termes)
- Mise à jour de la liste des champs du CPT chasse pour référencer la taxonomie des régions

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0ea1aff148332bb29cd7afb62e936