### PR TITLE
Limit homepage filters to available options

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -204,6 +204,124 @@
     return Array.from(form.querySelectorAll('[data-home-hunts-checkbox]'));
   }
 
+  function updateStatusOptions(availableStatuses, normalizedStatus) {
+    const select = getStatusControl();
+
+    if (!select) {
+      return;
+    }
+
+    const options = Array.from(select.options || []);
+    const hasAvailableData = availableStatuses && typeof availableStatuses === 'object';
+    const availableValues = new Set();
+
+    if (hasAvailableData) {
+      Object.keys(availableStatuses).forEach((value) => {
+        const count = Number(availableStatuses[value]);
+        if (Number.isFinite(count) && count > 0) {
+          availableValues.add(String(value));
+        }
+      });
+    }
+
+    if (hasAvailableData) {
+      options.forEach((option) => {
+        const value = option.value;
+
+        if (value === 'tous') {
+          option.hidden = false;
+          option.disabled = false;
+          return;
+        }
+
+        const isAvailable = availableValues.has(value);
+        option.hidden = !isAvailable;
+        option.disabled = !isAvailable;
+      });
+    }
+
+    let desiredValue = typeof normalizedStatus === 'string' ? normalizedStatus : select.value;
+    const optionExists = options.some((option) => option.value === desiredValue);
+
+    if (!optionExists) {
+      desiredValue = 'tous';
+    }
+
+    if (hasAvailableData && desiredValue !== 'tous' && !availableValues.has(desiredValue)) {
+      const fallbackOption = options.find((option) => option.value !== 'tous' && !option.hidden);
+      desiredValue = fallbackOption ? fallbackOption.value : 'tous';
+    }
+
+    if (select.value !== desiredValue) {
+      select.value = desiredValue;
+    }
+  }
+
+  function updateCostOptions(availableCosts, normalizedCosts) {
+    const checkboxes = getCostControls();
+
+    if (checkboxes.length === 0) {
+      return;
+    }
+
+    const hasAvailableData = availableCosts && typeof availableCosts === 'object';
+    const normalizedValues = Array.isArray(normalizedCosts)
+      ? new Set(normalizedCosts.map((value) => String(value)))
+      : null;
+
+    checkboxes.forEach((checkbox) => {
+      const value = checkbox.value;
+      const wrapper = checkbox.closest('.home-hunts__filters-checkbox');
+
+      if (hasAvailableData) {
+        const count = Number(availableCosts[value]);
+        const isAvailable = Number.isFinite(count) && count > 0;
+
+        if (wrapper) {
+          wrapper.hidden = !isAvailable;
+          if (isAvailable) {
+            wrapper.removeAttribute('aria-hidden');
+          } else {
+            wrapper.setAttribute('aria-hidden', 'true');
+          }
+        } else if (!isAvailable) {
+          checkbox.hidden = true;
+        } else {
+          checkbox.hidden = false;
+        }
+
+        checkbox.disabled = !isAvailable;
+
+        if (!isAvailable) {
+          checkbox.checked = false;
+          return;
+        }
+
+        checkbox.hidden = false;
+      }
+
+      if (normalizedValues) {
+        checkbox.checked = normalizedValues.has(value);
+      }
+    });
+  }
+
+  function updateAvailableFilters(filtersPayload) {
+    if (!filtersPayload || typeof filtersPayload !== 'object') {
+      return;
+    }
+
+    const availableFilters = filtersPayload.available && typeof filtersPayload.available === 'object'
+      ? filtersPayload.available
+      : {};
+    const normalizedFilters = filtersPayload.normalized && typeof filtersPayload.normalized === 'object'
+      ? filtersPayload.normalized
+      : {};
+
+    updateStatusOptions(availableFilters.statut || null, normalizedFilters.statut);
+    updateCostOptions(availableFilters.cout || null, normalizedFilters.cout || null);
+  }
+
   function buildFormData() {
     const data = new FormData();
 
@@ -238,6 +356,10 @@
   function handleSuccess(payload) {
     if (!payload || typeof payload !== 'object') {
       throw new Error('Invalid response');
+    }
+
+    if (payload.filters && typeof payload.filters === 'object') {
+      updateAvailableFilters(payload.filters);
     }
 
     if (typeof payload.html === 'string') {

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -25,11 +25,63 @@ $default_cost_filters   = is_array($normalized_filters['cout'] ?? null)
     : ['gratuit', 'points'];
 $initial_results_count  = (int) ($home_filters['total'] ?? count($chasse_ids));
 
+$available_filters = [];
+if (isset($home_filters['available_filters']) && is_array($home_filters['available_filters'])) {
+    $available_filters = $home_filters['available_filters'];
+}
+
+$available_status_counts = [];
+if (isset($available_filters['statut']) && is_array($available_filters['statut'])) {
+    foreach ($available_filters['statut'] as $status_value => $count) {
+        $available_status_counts[$status_value] = (int) $count;
+    }
+}
+
+$available_cost_counts = [];
+if (isset($available_filters['cout']) && is_array($available_filters['cout'])) {
+    foreach ($available_filters['cout'] as $cost_value => $count) {
+        $available_cost_counts[$cost_value] = (int) $count;
+    }
+}
+
+if ('tous' !== $default_status_filter) {
+    $status_available_count = $available_status_counts[$default_status_filter] ?? 0;
+    if ($status_available_count <= 0) {
+        $default_status_filter = 'tous';
+    }
+}
+
+$available_cost_values = [];
+foreach ($available_cost_counts as $cost_value => $count) {
+    if ($count > 0) {
+        $available_cost_values[] = $cost_value;
+    }
+}
+
+$available_cost_values = array_values(array_unique($available_cost_values));
+
+$default_cost_filters = array_values(array_intersect($default_cost_filters, $available_cost_values));
+
+if (empty($default_cost_filters) && !empty($available_cost_values)) {
+    $default_cost_filters = $available_cost_values;
+}
+
 $status_options = [
     'tous'     => __('Tous les statuts', 'chassesautresor-com'),
     'en_cours' => __('En cours', 'chassesautresor-com'),
     'a_venir'  => __('À venir', 'chassesautresor-com'),
     'termine'  => __('Terminées', 'chassesautresor-com'),
+];
+
+$cost_options = [
+    'gratuit' => [
+        'label' => __('Gratuit', 'chassesautresor-com'),
+        'id'    => 'home-hunts-cost-free',
+    ],
+    'points'  => [
+        'label' => __('Points', 'chassesautresor-com'),
+        'id'    => 'home-hunts-cost-points',
+    ],
 ];
 
 $results_label = sprintf(
@@ -49,7 +101,16 @@ ob_start();
             data-default-value="<?php echo esc_attr($default_status_filter); ?>"
         >
             <?php foreach ($status_options as $status_value => $status_label) : ?>
-                <option value="<?php echo esc_attr($status_value); ?>"<?php echo selected($default_status_filter, $status_value, false); ?>>
+                <?php
+                $status_count = $available_status_counts[$status_value] ?? 0;
+                $status_is_available = ('tous' === $status_value) || ($status_count > 0);
+                ?>
+                <option
+                    value="<?php echo esc_attr($status_value); ?>"
+                    data-home-hunts-status-option="<?php echo esc_attr($status_value); ?>"
+                    <?php echo selected($default_status_filter, $status_value, false); ?>
+                    <?php if (!$status_is_available) : ?>hidden disabled<?php endif; ?>
+                >
                     <?php echo esc_html($status_label); ?>
                 </option>
             <?php endforeach; ?>
@@ -57,28 +118,29 @@ ob_start();
     </div>
     <fieldset class="home-hunts__filters-group home-hunts__filters-group--cost" data-home-hunts-cost-group>
         <legend><?php echo esc_html(__('Coût', 'chassesautresor-com')); ?></legend>
-        <div class="home-hunts__filters-checkbox">
-            <input
-                type="checkbox"
-                id="home-hunts-cost-free"
-                name="home-hunts-cost[]"
-                value="gratuit"
-                data-home-hunts-checkbox="gratuit"
-                data-default-checked="true"<?php echo checked(in_array('gratuit', $default_cost_filters, true), true, false); ?>
-            />
-            <label for="home-hunts-cost-free"><?php echo esc_html(__('Gratuit', 'chassesautresor-com')); ?></label>
-        </div>
-        <div class="home-hunts__filters-checkbox">
-            <input
-                type="checkbox"
-                id="home-hunts-cost-points"
-                name="home-hunts-cost[]"
-                value="points"
-                data-home-hunts-checkbox="points"
-                data-default-checked="true"<?php echo checked(in_array('points', $default_cost_filters, true), true, false); ?>
-            />
-            <label for="home-hunts-cost-points"><?php echo esc_html(__('Points', 'chassesautresor-com')); ?></label>
-        </div>
+        <?php foreach ($cost_options as $cost_value => $cost_option) : ?>
+            <?php
+            $is_cost_available = in_array($cost_value, $available_cost_values, true);
+            $is_cost_checked  = in_array($cost_value, $default_cost_filters, true);
+            $cost_input_id    = $cost_option['id'] ?? ('home-hunts-cost-' . $cost_value);
+            ?>
+            <div
+                class="home-hunts__filters-checkbox"
+                data-home-hunts-cost-option="<?php echo esc_attr($cost_value); ?>"<?php echo $is_cost_available ? '' : ' hidden'; ?>
+            >
+                <input
+                    type="checkbox"
+                    id="<?php echo esc_attr($cost_input_id); ?>"
+                    name="home-hunts-cost[]"
+                    value="<?php echo esc_attr($cost_value); ?>"
+                    data-home-hunts-checkbox="<?php echo esc_attr($cost_value); ?>"
+                    data-default-checked="<?php echo $is_cost_checked ? 'true' : 'false'; ?>"
+                    <?php echo checked($is_cost_checked, true, false); ?>
+                    <?php echo disabled($is_cost_available, false, false); ?>
+                />
+                <label for="<?php echo esc_attr($cost_input_id); ?>"><?php echo esc_html($cost_option['label'] ?? ''); ?></label>
+            </div>
+        <?php endforeach; ?>
     </fieldset>
     <div class="home-hunts__filters-actions">
         <button type="reset" class="home-hunts__filters-reset" data-home-hunts-reset><?php echo esc_html(__('Réinitialiser', 'chassesautresor-com')); ?></button>

--- a/wp-content/themes/chassesautresor/inc/homepage-filters.php
+++ b/wp-content/themes/chassesautresor/inc/homepage-filters.php
@@ -16,7 +16,15 @@ defined('ABSPATH') || exit();
  *
  * @param array{statut?:string, cout?:string|string[]}|array $args Raw filters coming from the frontend.
  *
- * @return array{ids:int[], total:int, filters_normalises:array{statut:string, cout:string[]}}
+ * @return array{
+ *     ids:int[],
+ *     total:int,
+ *     filters_normalises:array{statut:string, cout:string[]},
+ *     available_filters:array{
+ *         statut:array<string,int>,
+ *         cout:array<string,int>
+ *     }
+ * }
  */
 function ca_home_filter_chasse_ids(array $args): array
 {
@@ -84,7 +92,7 @@ function ca_home_filter_chasse_ids(array $args): array
         'termine'  => ['termine'],
     ];
 
-    $filtered_ids = [];
+    $hunts_data = [];
 
     foreach ($chasse_ids as $chasse_id) {
         $infos_chasse = function_exists('preparer_infos_affichage_chasse')
@@ -92,34 +100,95 @@ function ca_home_filter_chasse_ids(array $args): array
             : [];
 
         $statut_metier = $infos_chasse['statut'] ?? get_field('chasse_cache_statut', $chasse_id);
-
-        if (
-            'tous' !== $normalized_status
-            && !in_array($statut_metier, $status_map[$normalized_status] ?? [], true)
-        ) {
-            continue;
-        }
-
-        $cout_points        = (int) ($infos_chasse['champs']['cout_points'] ?? get_field('chasse_infos_cout_points', $chasse_id));
+        $cout_points = (int) ($infos_chasse['champs']['cout_points'] ?? get_field('chasse_infos_cout_points', $chasse_id));
         $nb_enigmes_payantes = (int) ($infos_chasse['nb_enigmes_payantes'] ?? 0);
 
         $is_free = ($cout_points <= 0) && ($nb_enigmes_payantes <= 0);
+        $cost_key = $is_free ? 'gratuit' : 'points';
+
+        $hunts_data[] = [
+            'id'     => (int) $chasse_id,
+            'status' => is_string($statut_metier) ? $statut_metier : '',
+            'cost'   => $cost_key,
+        ];
+    }
+
+    $filtered_ids = [];
+
+    foreach ($hunts_data as $hunt) {
+        if ('tous' !== $normalized_status) {
+            $allowed_statuses = $status_map[$normalized_status] ?? [];
+
+            if (empty($allowed_statuses) || !in_array($hunt['status'], $allowed_statuses, true)) {
+                continue;
+            }
+        }
 
         if ($cost_filter_provided) {
             if (empty($normalized_cost)) {
                 continue;
             }
 
-            if ($is_free && !in_array('gratuit', $normalized_cost, true)) {
+            if ('gratuit' === $hunt['cost'] && !in_array('gratuit', $normalized_cost, true)) {
                 continue;
             }
 
-            if (!$is_free && !in_array('points', $normalized_cost, true)) {
+            if ('points' === $hunt['cost'] && !in_array('points', $normalized_cost, true)) {
                 continue;
             }
         }
 
-        $filtered_ids[] = $chasse_id;
+        $filtered_ids[] = $hunt['id'];
+    }
+
+    $allowed_costs_for_status = $cost_filter_provided ? $normalized_cost : $cost_whitelist;
+
+    if ($cost_filter_provided && empty($normalized_cost)) {
+        $allowed_costs_for_status = [];
+    }
+
+    $status_counts = [
+        'tous'     => 0,
+        'en_cours' => 0,
+        'a_venir'  => 0,
+        'termine'  => 0,
+    ];
+
+    foreach ($hunts_data as $hunt) {
+        if (!in_array($hunt['cost'], $allowed_costs_for_status, true)) {
+            continue;
+        }
+
+        $status_counts['tous']++;
+
+        foreach ($status_map as $status_filter => $expected_statuses) {
+            if (in_array($hunt['status'], $expected_statuses, true)) {
+                $status_counts[$status_filter]++;
+            }
+        }
+    }
+
+    $cost_counts = [
+        'gratuit' => 0,
+        'points'  => 0,
+    ];
+
+    $allowed_statuses_for_cost = null;
+
+    if ('tous' !== $normalized_status) {
+        $allowed_statuses_for_cost = $status_map[$normalized_status] ?? [];
+    }
+
+    foreach ($hunts_data as $hunt) {
+        if (is_array($allowed_statuses_for_cost)) {
+            if (empty($allowed_statuses_for_cost) || !in_array($hunt['status'], $allowed_statuses_for_cost, true)) {
+                continue;
+            }
+        }
+
+        if (array_key_exists($hunt['cost'], $cost_counts)) {
+            $cost_counts[$hunt['cost']]++;
+        }
     }
 
     return [
@@ -128,6 +197,10 @@ function ca_home_filter_chasse_ids(array $args): array
         'filters_normalises' => [
             'statut' => $normalized_status,
             'cout'   => $normalized_cost,
+        ],
+        'available_filters'  => [
+            'statut' => $status_counts,
+            'cout'   => $cost_counts,
         ],
     ];
 }
@@ -187,10 +260,24 @@ function ca_ajax_filter_chasses(): void
     ]);
     $html = (string) ob_get_clean();
 
+    $available_filters = [];
+    if (isset($filter_results['available_filters']) && is_array($filter_results['available_filters'])) {
+        $available_filters = $filter_results['available_filters'];
+    }
+
+    $normalized_filters = [];
+    if (isset($filter_results['filters_normalises']) && is_array($filter_results['filters_normalises'])) {
+        $normalized_filters = $filter_results['filters_normalises'];
+    }
+
     wp_send_json_success([
-        'html'  => $html,
-        'total' => (int) ($filter_results['total'] ?? count($chasse_ids)),
-        'nonce' => wp_create_nonce('ca-filter-chasses'),
+        'html'     => $html,
+        'total'    => (int) ($filter_results['total'] ?? count($chasse_ids)),
+        'nonce'    => wp_create_nonce('ca-filter-chasses'),
+        'filters'  => [
+            'available'  => $available_filters,
+            'normalized' => $normalized_filters,
+        ],
     ]);
 }
 


### PR DESCRIPTION
Mise à jour pour limiter les filtres de la page d'accueil aux options réellement disponibles.

- Ajout du calcul des statuts et coûts disponibles côté serveur et envoi de ces informations dans l'API AJAX.
- Ajustement du template de la page d'accueil pour masquer les options sans résultats et conserver des valeurs par défaut cohérentes.
- Mise à jour du script des filtres pour appliquer dynamiquement la disponibilité des options après chaque réponse AJAX.

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0e9c6c9188332adbaf2353e592be7