### PR TITLE
feat: afficher les régions associées aux chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -88,6 +88,54 @@
   height: 0.75rem;
 }
 
+.badge-region {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(var(--aside-bg-rgb), 0.8);
+  color: var(--color-text-fond-clair);
+  font-weight: 600;
+  font-size: 0.85rem;
+  line-height: 1;
+
+  &__icon {
+    display: inline-flex;
+    width: 0.9rem;
+    height: 0.9rem;
+
+    svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+  }
+
+  &__link,
+  &__label {
+    color: inherit;
+    text-decoration: none;
+    font-weight: inherit;
+  }
+
+  &__link:hover,
+  &__link:focus-visible {
+    text-decoration: underline;
+  }
+
+  &--overlay {
+    position: absolute;
+    left: 10px;
+    bottom: 10px;
+    z-index: 2;
+  }
+
+  &--inline {
+    margin-top: var(--space-xs);
+  }
+}
+
 .header-chasse__image img {
   display: block;
   max-width: 100%;
@@ -289,10 +337,26 @@
     display: flex;
     gap: var(--space-md);
     align-items: center;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    row-gap: var(--space-xs);
     justify-content: flex-start;
     font-size: 93%;
     color: var(--color-gris-3);
+}
+
+.caracteristique-region__link,
+.caracteristique-region__text {
+  color: inherit;
+  font-weight: 600;
+}
+
+.caracteristique-region__link {
+  text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
 }
 
 .meta-regular .meta-indic {
@@ -335,6 +399,59 @@
 .page-chasse-wrapper .chasse-lot .lot-description {
     font-size: 16px;
     margin-top: 0.3rem;
+}
+
+.chasse-regions {
+  margin: var(--space-3xl) 0;
+  padding: var(--space-2xl) var(--space-lg);
+  background: rgba(var(--aside-bg-rgb), 0.15);
+  border-radius: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+  }
+
+  &__subtitle {
+    margin: 0;
+    color: var(--color-gris-3);
+    font-size: 0.95rem;
+  }
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+
+  &__item {
+    margin: 0;
+  }
+
+  &__link,
+  &__label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xxs);
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(var(--aside-bg-rgb), 0.35);
+    color: var(--color-text-fond-clair);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  &__link:hover,
+  &__link:focus-visible {
+    text-decoration: underline;
+  }
 }
 
 .chasse-description {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -88,54 +88,6 @@
   height: 0.75rem;
 }
 
-.badge-region {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xxs);
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(var(--aside-bg-rgb), 0.8);
-  color: var(--color-text-fond-clair);
-  font-weight: 600;
-  font-size: 0.85rem;
-  line-height: 1;
-
-  &__icon {
-    display: inline-flex;
-    width: 0.9rem;
-    height: 0.9rem;
-
-    svg {
-      width: 100%;
-      height: 100%;
-      display: block;
-    }
-  }
-
-  &__link,
-  &__label {
-    color: inherit;
-    text-decoration: none;
-    font-weight: inherit;
-  }
-
-  &__link:hover,
-  &__link:focus-visible {
-    text-decoration: underline;
-  }
-
-  &--overlay {
-    position: absolute;
-    left: 10px;
-    bottom: 10px;
-    z-index: 2;
-  }
-
-  &--inline {
-    margin-top: var(--space-xs);
-  }
-}
-
 .header-chasse__image img {
   display: block;
   max-width: 100%;

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -611,11 +611,23 @@ a.ajout-link:focus-visible {
   white-space: nowrap;
   font-size: 85%;
 }
+.meta-etiquette a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+.meta-etiquette a:hover,
+.meta-etiquette a:focus-visible {
+  text-decoration: underline;
+}
 .meta-etiquette svg {
   margin-bottom: -5px;
 }
 .meta-etiquette span {
   font-weight: 600;
+}
+.meta-etiquette__value {
+  font-weight: 400;
 }
 .meta-etiquette strong {
   font-weight: 600;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1401,6 +1401,64 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
  *
  * @return array Tableau associatif prêt pour le template.
 */
+function chasse_recuperer_regions_infos(int $chasse_id): array
+{
+    if (!function_exists('wp_get_post_terms')) {
+        return [
+            'regions' => [],
+            'region_principale' => null,
+        ];
+    }
+
+    $taxonomy = 'chasse_region';
+
+    if (function_exists('get_field_object')) {
+        $field_object = get_field_object('chasse_region', $chasse_id);
+        if (is_array($field_object) && !empty($field_object['taxonomy'])) {
+            $taxonomy = (string) $field_object['taxonomy'];
+        }
+    }
+
+    if ($taxonomy === '') {
+        return [
+            'regions' => [],
+            'region_principale' => null,
+        ];
+    }
+
+    $terms = wp_get_post_terms(
+        $chasse_id,
+        $taxonomy,
+        [
+            'orderby' => 'term_order',
+            'order'   => 'ASC',
+        ]
+    );
+
+    if (is_wp_error($terms)) {
+        $terms = [];
+    }
+
+    $regions = [];
+
+    foreach ($terms as $term) {
+        $term_link = function_exists('get_term_link') ? get_term_link($term) : '';
+
+        $link_is_error = function_exists('is_wp_error') && is_wp_error($term_link);
+
+        $regions[] = [
+            'name' => (string) $term->name,
+            'slug' => (string) $term->slug,
+            'link' => !$link_is_error ? (string) $term_link : '',
+        ];
+    }
+
+    return [
+        'regions' => $regions,
+        'region_principale' => $regions[0] ?? null,
+    ];
+}
+
 function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit = 300, array $options = []): array
 {
     if (get_post_type($chasse_id) !== 'chasse') {
@@ -1534,6 +1592,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         ? '<span class="badge-statut__icon" aria-hidden="true">' . $badge_infos['icon_html'] . '</span>'
             . '<span class="screen-reader-text">' . esc_html($badge_infos['label']) . '</span>'
         : esc_html($badge_infos['label']);
+
+    $regions_infos = chasse_recuperer_regions_infos($chasse_id);
 
     $enigmes_associees = recuperer_enigmes_associees($chasse_id);
     $total_enigmes     = count($enigmes_associees);
@@ -1680,6 +1740,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'cta_message'       => $cta_message,
         'cta_type'         => $cta_data['type'] ?? '',
         'footer_html'       => $footer_html,
+        'regions'           => $regions_infos['regions'],
+        'region_principale' => $regions_infos['region_principale'],
     ];
 
     if (!empty($progression['resolvables'])) {
@@ -1728,6 +1790,7 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     }
 
     $champs = chasse_get_champs($chasse_id);
+    $regions_infos = chasse_recuperer_regions_infos($chasse_id);
 
     $description   = get_field('chasse_principale_description', $chasse_id);
     $texte_complet = wp_strip_all_tags($description);
@@ -1793,6 +1856,8 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
         ],
         'statut'            => get_field('chasse_cache_statut', $chasse_id) ?: 'revision',
         'statut_validation' => get_field('chasse_cache_statut_validation', $chasse_id),
+        'regions'           => $regions_infos['regions'],
+        'region_principale' => $regions_infos['region_principale'],
     ];
 
     $cache[$user_id] = $memo[$memo_key];
@@ -1845,3 +1910,23 @@ function chasse_acf_clear_infos_affichage_cache($post_id): void
 add_action('acf/save_post', 'chasse_acf_clear_infos_affichage_cache', 20);
 add_action('save_post', 'chasse_invalidate_infos_affichage_cache', 10, 3);
 add_action('chasse_engagement_created', 'chasse_clear_infos_affichage_cache');
+add_action('set_object_terms', 'chasse_clear_infos_affichage_cache_on_region_terms', 10, 6);
+
+function chasse_clear_infos_affichage_cache_on_region_terms(
+    int $object_id,
+    $terms,
+    $tt_ids,
+    string $taxonomy,
+    bool $append,
+    $old_tt_ids
+): void {
+    if ($taxonomy !== 'chasse_region') {
+        return;
+    }
+
+    if (get_post_type($object_id) !== 'chasse') {
+        return;
+    }
+
+    chasse_clear_infos_affichage_cache($object_id);
+}

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -33,6 +33,8 @@ $peut_voir_aside    = $est_engage_chasse
 
 // Récupération centralisée des infos
 $infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
+$regions = $infos_chasse['regions'] ?? [];
+$region_principale = $infos_chasse['region_principale'] ?? null;
 
 // Champs principaux
 $champs = $infos_chasse['champs'];
@@ -267,6 +269,50 @@ if ($peut_voir_aside) {
       'infos_chasse'=> $infos_chasse,
     ]);
     ?>
+
+    <?php if (!empty($regions)) : ?>
+        <?php
+        $region_main_name = '';
+        if (!empty($region_principale) && !empty($region_principale['name'])) {
+            $region_main_name = (string) $region_principale['name'];
+        }
+        ?>
+        <section class="chasse-regions" aria-labelledby="chasse-regions-title">
+            <div class="chasse-regions__header">
+                <h2 id="chasse-regions-title"><?php esc_html_e('Régions de la chasse', 'chassesautresor-com'); ?></h2>
+                <?php if ($region_main_name !== '') : ?>
+                    <p class="chasse-regions__subtitle">
+                        <?php
+                        printf(
+                            esc_html__('Région principale : %s', 'chassesautresor-com'),
+                            esc_html($region_main_name)
+                        );
+                        ?>
+                    </p>
+                <?php endif; ?>
+            </div>
+            <ul class="chasse-regions__list">
+                <?php foreach ($regions as $region) : ?>
+                    <?php
+                    $region_name = isset($region['name']) ? (string) $region['name'] : '';
+                    if ($region_name === '') {
+                        continue;
+                    }
+                    $region_link = isset($region['link']) ? (string) $region['link'] : '';
+                    ?>
+                    <li class="chasse-regions__item">
+                        <?php if ($region_link !== '') : ?>
+                            <a class="chasse-regions__link" href="<?php echo esc_url($region_link); ?>">
+                                <?php echo esc_html($region_name); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-regions__label"><?php echo esc_html($region_name); ?></span>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </section>
+    <?php endif; ?>
 
     <!-- 🧩 Liste des énigmes -->
     <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -284,7 +284,7 @@ if ($peut_voir_aside) {
                     <p class="chasse-regions__subtitle">
                         <?php
                         printf(
-                            esc_html__('Région principale : %s', 'chassesautresor-com'),
+                            esc_html__('Région : %s', 'chassesautresor-com'),
                             esc_html($region_main_name)
                         );
                         ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -454,7 +454,7 @@ if ($edition_active && !$est_complet) {
               ?>
               <div class="caracteristique caracteristique-region">
                 <span class="caracteristique-icone" aria-hidden="true">🧭</span>
-                <span class="caracteristique-label"><?= esc_html__('Région principale', 'chassesautresor-com'); ?></span>
+                <span class="caracteristique-label"><?= esc_html__('Région', 'chassesautresor-com'); ?></span>
                 <span class="caracteristique-valeur">
                   <?php if ($region_main_link !== '') : ?>
                     <a class="caracteristique-region__link" href="<?= esc_url($region_main_link); ?>"><?= esc_html($region_main_name); ?></a>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -446,6 +446,25 @@ if ($edition_active && !$est_complet) {
               </span>
             </div>
 
+            <?php if (!empty($infos_chasse['region_principale']) && !empty($infos_chasse['region_principale']['name'])) : ?>
+              <?php
+              $region_main = $infos_chasse['region_principale'];
+              $region_main_name = (string) $region_main['name'];
+              $region_main_link = $region_main['link'] ?? '';
+              ?>
+              <div class="caracteristique caracteristique-region">
+                <span class="caracteristique-icone" aria-hidden="true">🧭</span>
+                <span class="caracteristique-label"><?= esc_html__('Région principale', 'chassesautresor-com'); ?></span>
+                <span class="caracteristique-valeur">
+                  <?php if ($region_main_link !== '') : ?>
+                    <a class="caracteristique-region__link" href="<?= esc_url($region_main_link); ?>"><?= esc_html($region_main_name); ?></a>
+                  <?php else : ?>
+                    <span class="caracteristique-region__text"><?= esc_html($region_main_name); ?></span>
+                  <?php endif; ?>
+                </span>
+              </div>
+            <?php endif; ?>
+
             <?php if ($top_avances['nb'] > 0 && $top_avances['enigmes'] > 0) : ?>
               <?php
               $txt_top = sprintf(

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -128,7 +128,7 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
             $region_link = $region_principale['link'] ?? '';
             ?>
             <div class="meta-etiquette meta-etiquette--region">
-                <span class="meta-etiquette__label"><?php esc_html_e('Région principale :', 'chassesautresor-com'); ?></span>
+                <span class="meta-etiquette__label"><?php esc_html_e('Région :', 'chassesautresor-com'); ?></span>
                 <?php if ($region_link !== '') : ?>
                     <a class="meta-etiquette__link" href="<?php echo esc_url($region_link); ?>">
                         <?php echo esc_html($region_name); ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -108,18 +108,6 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
-            <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
-                <?php
-                $region_name = (string) $region_principale['name'];
-                $region_label = sprintf(__('Région principale : %s', 'chassesautresor-com'), $region_name);
-                ?>
-                <span class="badge-region badge-region--inline" aria-label="<?php echo esc_attr($region_label); ?>">
-                    <span class="badge-region__icon" aria-hidden="true">
-                        <?php echo get_svg_icon('compass-rose'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                    </span>
-                    <span class="badge-region__label" aria-hidden="true"><?php echo esc_html($region_name); ?></span>
-                </span>
-            <?php endif; ?>
             <?php echo $infos['lot_html']; ?>
         </div>
     </a>
@@ -134,6 +122,22 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                 <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['nb_joueurs'])); ?></span>
             </button>
         </div>
+        <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
+            <?php
+            $region_name = (string) $region_principale['name'];
+            $region_link = $region_principale['link'] ?? '';
+            ?>
+            <div class="meta-etiquette meta-etiquette--region">
+                <span class="meta-etiquette__label"><?php esc_html_e('Région principale :', 'chassesautresor-com'); ?></span>
+                <?php if ($region_link !== '') : ?>
+                    <a class="meta-etiquette__link" href="<?php echo esc_url($region_link); ?>">
+                        <?php echo esc_html($region_name); ?>
+                    </a>
+                <?php else : ?>
+                    <span class="meta-etiquette__value"><?php echo esc_html($region_name); ?></span>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
         <div class="meta-etiquette">
             <?php echo get_svg_icon('calendar'); ?>
             <span class="chasse-date-plage">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -15,6 +15,7 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 $chasse_id       = (int) $args['chasse_id'];
 $completion_class = $args['completion_class'] ?? '';
 $infos           = preparer_infos_affichage_carte_chasse($chasse_id);
+$region_principale = $infos['region_principale'] ?? null;
 
 if (empty($infos)) {
     return;
@@ -107,6 +108,18 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
+            <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
+                <?php
+                $region_name = (string) $region_principale['name'];
+                $region_label = sprintf(__('Région principale : %s', 'chassesautresor-com'), $region_name);
+                ?>
+                <span class="badge-region badge-region--inline" aria-label="<?php echo esc_attr($region_label); ?>">
+                    <span class="badge-region__icon" aria-hidden="true">
+                        <?php echo get_svg_icon('compass-rose'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                    </span>
+                    <span class="badge-region__label" aria-hidden="true"><?php echo esc_html($region_name); ?></span>
+                </span>
+            <?php endif; ?>
             <?php echo $infos['lot_html']; ?>
         </div>
     </a>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -10,6 +10,7 @@ $completion_class = $args['completion_class'] ?? '';
 $word_limit      = isset($args['word_limit']) ? (int) $args['word_limit'] : 300;
 $infos           = preparer_infos_affichage_carte_chasse($chasse_id, $word_limit);
 $mode_fin        = $infos['mode_fin'] ?? 'automatique';
+$region_principale = $infos['region_principale'] ?? null;
 $title_mode      = $mode_fin === 'automatique'
     ? esc_html__('mode de fin de chasse : automatique', 'chassesautresor-com')
     : esc_html__('mode de fin de chasse : manuelle', 'chassesautresor-com');
@@ -59,6 +60,26 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                 </span>
             <?php endif; ?>
         </span>
+        <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
+        <?php
+            $region_name = (string) $region_principale['name'];
+            $region_label = sprintf(__('Région principale : %s', 'chassesautresor-com'), $region_name);
+            $region_link = $region_principale['link'] ?? '';
+        ?>
+        <span class="badge-region badge-region--overlay" aria-label="<?php echo esc_attr($region_label); ?>">
+            <span class="badge-region__icon" aria-hidden="true">
+                <?php echo get_svg_icon('compass-rose'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </span>
+            <?php if ($region_link !== '') : ?>
+                <a class="badge-region__link" href="<?php echo esc_url($region_link); ?>">
+                    <?php echo esc_html($region_name); ?>
+                </a>
+            <?php else : ?>
+                <span class="badge-region__label"><?php echo esc_html($region_name); ?></span>
+            <?php endif; ?>
+        </span>
+        <?php endif; ?>
+
         <?php if ((int) $infos['cout_points'] > 0) : ?>
         <span
             class="badge-cout"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -60,26 +60,6 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                 </span>
             <?php endif; ?>
         </span>
-        <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
-        <?php
-            $region_name = (string) $region_principale['name'];
-            $region_label = sprintf(__('Région principale : %s', 'chassesautresor-com'), $region_name);
-            $region_link = $region_principale['link'] ?? '';
-        ?>
-        <span class="badge-region badge-region--overlay" aria-label="<?php echo esc_attr($region_label); ?>">
-            <span class="badge-region__icon" aria-hidden="true">
-                <?php echo get_svg_icon('compass-rose'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-            </span>
-            <?php if ($region_link !== '') : ?>
-                <a class="badge-region__link" href="<?php echo esc_url($region_link); ?>">
-                    <?php echo esc_html($region_name); ?>
-                </a>
-            <?php else : ?>
-                <span class="badge-region__label"><?php echo esc_html($region_name); ?></span>
-            <?php endif; ?>
-        </span>
-        <?php endif; ?>
-
         <?php if ((int) $infos['cout_points'] > 0) : ?>
         <span
             class="badge-cout"
@@ -148,6 +128,22 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                     ?> —
                     <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
                 </div>
+                <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
+                    <?php
+                    $region_name = (string) $region_principale['name'];
+                    $region_link = $region_principale['link'] ?? '';
+                    ?>
+                    <div class="meta-etiquette meta-etiquette--region">
+                        <span class="meta-etiquette__label"><?php esc_html_e('Région principale :', 'chassesautresor-com'); ?></span>
+                        <?php if ($region_link !== '') : ?>
+                            <a class="meta-etiquette__link" href="<?php echo esc_url($region_link); ?>">
+                                <?php echo esc_html($region_name); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="meta-etiquette__value"><?php echo esc_html($region_name); ?></span>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
                 <div class="meta-etiquette">
                     <?php echo get_svg_icon('calendar'); ?>
                     <span class="chasse-date-plage">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -134,7 +134,7 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                     $region_link = $region_principale['link'] ?? '';
                     ?>
                     <div class="meta-etiquette meta-etiquette--region">
-                        <span class="meta-etiquette__label"><?php esc_html_e('Région principale :', 'chassesautresor-com'); ?></span>
+                        <span class="meta-etiquette__label"><?php esc_html_e('Région :', 'chassesautresor-com'); ?></span>
                         <?php if ($region_link !== '') : ?>
                             <a class="meta-etiquette__link" href="<?php echo esc_url($region_link); ?>">
                                 <?php echo esc_html($region_name); ?>


### PR DESCRIPTION
## Résumé
- ajoute la récupération des régions associées aux chasses et étend l’invalidation du cache lors des mises à jour de taxonomie
- affiche la région principale sur les cartes chasse et ajoute une section dédiée sur la fiche de chasse
- met à jour les styles pour les nouveaux badges et listes de régions

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d0ebe49bf88332ab75a8914f6764b5