### PR TITLE
Documente le champ ACF de thème de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
+++ b/wp-content/themes/chassesautresor/notices/champs-acf-liste.md
@@ -1,7 +1,7 @@
 🔹 Groupe : paramètre de la chasse
 🆔 ID : 27
 🔑 Key : group_67b58c51b9a49
-📦 Champs trouvés : 22
+📦 Champs trouvés : 23
 
 — chasse_principale_image —
 Type : image
@@ -171,6 +171,18 @@ Instructions : (vide)
 Requis : non
 Taxonomie : chasse_region
 Mode de sélection : select (simple)
+Retour : objet (WP_Term)
+Load Terms : oui
+Save Terms : oui
+----------------------------------------
+
+— chasse_theme —
+Type : taxonomy
+Label : chasse_theme
+Instructions : (vide)
+Requis : non
+Taxonomie : theme_chasse
+Mode de sélection : select (multiple)
 Retour : objet (WP_Term)
 Load Terms : oui
 Save Terms : oui

--- a/wp-content/themes/chassesautresor/notices/global.md
+++ b/wp-content/themes/chassesautresor/notices/global.md
@@ -373,6 +373,7 @@ Groupe : paramètre de la chasse
 * chasse_cache_statut (select)
 * chasse_cache_complet (true_false)
 * chasse_region (taxonomy) — référence la taxonomie des régions de chasse
+* chasse_theme (taxonomy) — référence la taxonomie des thèmes de chasse
 
 CPT : enigme
 Groupe : Paramètres de l’énigme


### PR DESCRIPTION
Résumé : Mise à jour de la documentation ACF pour inclure le champ de thème de chasse.

- Ajuste le compteur de champs du groupe « paramètre de la chasse ».
- Documente le champ taxonomy `chasse_theme` avec ses options.
- Référence la nouvelle taxonomy dans la fiche globale du CPT chasse.

## Tests
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d1036868c08332bc05e05b3bd1b44a