### PR TITLE
Expose les badges de région et de thème pour les chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -33,6 +33,63 @@
   gap: var(--space-md);
 }
 
+/* 🏷️ Badges région & thèmes */
+.chasse-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xxs);
+}
+
+.chasse-card-badges {
+  margin-top: var(--space-xs);
+}
+
+.chasse-meta-badges {
+  margin: var(--space-sm) 0;
+}
+
+.chasse-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  font-weight: 600;
+  text-decoration: none;
+  background: rgba(var(--color-text-fond-clair-rgb), 0.08);
+  color: var(--color-text-fond-clair);
+  border: 1px solid rgba(var(--color-text-fond-clair-rgb), 0.1);
+  transition: background-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.chasse-badge--region {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-text-fond-clair);
+}
+
+.chasse-badge--theme {
+  background: rgba(255, 215, 0, 0.18);
+  border-color: rgba(255, 215, 0, 0.35);
+  color: var(--color-text-fond-clair);
+}
+
+a.chasse-badge {
+  cursor: pointer;
+}
+
+a.chasse-badge:hover,
+a.chasse-badge:focus-visible {
+  text-decoration: none;
+  box-shadow: 0 0 0 2px rgba(var(--color-text-fond-clair-rgb), 0.15);
+}
+
+a.chasse-badge.chasse-badge--region:hover,
+a.chasse-badge.chasse-badge--region:focus-visible {
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.18);
+}
+
 
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1394,6 +1394,46 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
 }
 
 /**
+ * Prépare les données d'affichage des termes associés à une chasse.
+ *
+ * @param int    $chasse_id ID de la chasse.
+ * @param string $taxonomy  Taxonomie ciblée.
+ *
+ * @return array[]
+ */
+function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): array
+{
+    if (!function_exists('wp_get_post_terms')) {
+        return [];
+    }
+
+    $terms = wp_get_post_terms($chasse_id, $taxonomy, ['orderby' => 'term_order']);
+    if (is_wp_error($terms) || empty($terms)) {
+        return [];
+    }
+
+    $items = [];
+
+    foreach ($terms as $term) {
+        $link = '';
+        if (function_exists('get_term_link')) {
+            $link = get_term_link($term);
+            if (is_wp_error($link)) {
+                $link = '';
+            }
+        }
+
+        $items[] = [
+            'nom'  => $term->name,
+            'slug' => $term->slug,
+            'lien' => $link,
+        ];
+    }
+
+    return $items;
+}
+
+/**
  * Prépare les informations d'affichage pour une carte de chasse.
  *
  * @param int $chasse_id  ID de la chasse.
@@ -1488,6 +1528,10 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     }
 
     $champs = chasse_get_champs($chasse_id);
+
+    $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
+    $themes  = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
+    $region_principale = !empty($regions) ? $regions[0] : null;
     $titre_recompense  = $champs['titre_recompense'];
     $valeur_recompense = $champs['valeur_recompense'];
     $cout_points       = (int) $champs['cout_points'];
@@ -1680,6 +1724,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'cta_message'       => $cta_message,
         'cta_type'         => $cta_data['type'] ?? '',
         'footer_html'       => $footer_html,
+        'regions'           => $regions,
+        'themes'            => $themes,
+        'region_principale' => $region_principale,
     ];
 
     if (!empty($progression['resolvables'])) {
@@ -1728,6 +1775,10 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     }
 
     $champs = chasse_get_champs($chasse_id);
+
+    $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
+    $themes  = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
+    $region_principale = !empty($regions) ? $regions[0] : null;
 
     $description   = get_field('chasse_principale_description', $chasse_id);
     $texte_complet = wp_strip_all_tags($description);
@@ -1793,6 +1844,9 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
         ],
         'statut'            => get_field('chasse_cache_statut', $chasse_id) ?: 'revision',
         'statut_validation' => get_field('chasse_cache_statut_validation', $chasse_id),
+        'regions'           => $regions,
+        'themes'            => $themes,
+        'region_principale' => $region_principale,
     ];
 
     $cache[$user_id] = $memo[$memo_key];
@@ -1813,6 +1867,19 @@ function chasse_clear_infos_affichage_cache(int $chasse_id): void
     $key = chasse_infos_affichage_cache_key($chasse_id);
     wp_cache_delete($key, 'chasse_affichage');
     delete_transient($key);
+}
+
+function chasse_invalidate_infos_affichage_terms(int $object_id, $terms, $tt_ids, string $taxonomy, $append, $old_tt_ids): void
+{
+    if (!in_array($taxonomy, ['chasse_region', 'theme_chasse'], true)) {
+        return;
+    }
+
+    if (get_post_type($object_id) !== 'chasse') {
+        return;
+    }
+
+    chasse_clear_infos_affichage_cache((int) $object_id);
 }
 
 function chasse_invalidate_infos_affichage_cache(int $post_id, \WP_Post $post, bool $update): void
@@ -1845,3 +1912,4 @@ function chasse_acf_clear_infos_affichage_cache($post_id): void
 add_action('acf/save_post', 'chasse_acf_clear_infos_affichage_cache', 20);
 add_action('save_post', 'chasse_invalidate_infos_affichage_cache', 10, 3);
 add_action('chasse_engagement_created', 'chasse_clear_infos_affichage_cache');
+add_action('set_object_terms', 'chasse_invalidate_infos_affichage_terms', 10, 6);

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -34,6 +34,14 @@ $peut_voir_aside    = $est_engage_chasse
 // Récupération centralisée des infos
 $infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
 
+$region_principale = is_array($infos_chasse['region_principale'] ?? null) ? $infos_chasse['region_principale'] : null;
+$themes_badges = array_values(array_filter(
+    is_array($infos_chasse['themes'] ?? null) ? $infos_chasse['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
+
 // Champs principaux
 $champs = $infos_chasse['champs'];
 $lot = $champs['lot'];
@@ -258,6 +266,29 @@ if ($peut_voir_aside) {
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>
+    <?php endif; ?>
+
+    <?php if (!empty($region_principale) || !empty($themes_badges)) : ?>
+        <div class="chasse-meta-badges chasse-badges">
+            <?php if (!empty($region_principale['nom'])) : ?>
+                <?php if (!empty($region_principale['lien'])) : ?>
+                    <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                        <?php echo esc_html($region_principale['nom']); ?>
+                    </a>
+                <?php else : ?>
+                    <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                <?php endif; ?>
+            <?php endif; ?>
+            <?php foreach ($themes_badges as $theme_badge) : ?>
+                <?php if (!empty($theme_badge['lien'])) : ?>
+                    <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme_badge['lien']); ?>">
+                        <?php echo esc_html($theme_badge['nom']); ?>
+                    </a>
+                <?php else : ?>
+                    <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme_badge['nom']); ?></span>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        </div>
     <?php endif; ?>
 
     <!-- 📦 Fiche complète (images + méta + actions) -->

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -91,6 +91,14 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
     $badge_attributes .= ' role="img" tabindex="0"';
 }
+
+$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
+$themes = array_values(array_filter(
+    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
@@ -107,6 +115,28 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
+            <?php if (!empty($region_principale) || !empty($themes)) : ?>
+                <div class="chasse-card-badges chasse-badges">
+                    <?php if (!empty($region_principale['nom'])) : ?>
+                        <?php if (!empty($region_principale['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                <?php echo esc_html($region_principale['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                    <?php foreach ($themes as $theme) : ?>
+                        <?php if (!empty($theme['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
+                                <?php echo esc_html($theme['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
             <?php echo $infos['lot_html']; ?>
         </div>
     </a>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -47,6 +47,14 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
     $badge_attributes .= ' role="img" tabindex="0"';
 }
+
+$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
+$themes = array_values(array_filter(
+    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
@@ -111,6 +119,28 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
             <h3 class="carte-wide__titre">
                 <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
             </h3>
+            <?php if (!empty($region_principale) || !empty($themes)) : ?>
+                <div class="chasse-card-badges chasse-badges">
+                    <?php if (!empty($region_principale['nom'])) : ?>
+                        <?php if (!empty($region_principale['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                <?php echo esc_html($region_principale['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                    <?php foreach ($themes as $theme) : ?>
+                        <?php if (!empty($theme['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
+                                <?php echo esc_html($theme['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
         </div>
 
         <div class="carte-wide__content">


### PR DESCRIPTION
## Résumé
- ajoute la récupération des taxonomies `chasse_region` et `theme_chasse` dans les helpers d’affichage, avec prise en compte du cache
- étend l’invalidation du cache d’affichage lorsque les termes ciblés sont modifiés
- affiche les badges de région et de thèmes sur les cartes et la fiche chasse, avec un style dédié

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d104b161108332aa2aa8eb61e924c2