### PR TITLE
Remplacer l’emoji de localisation sur la page chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -453,7 +453,7 @@ if ($edition_active && !$est_complet) {
               $region_main_link = $region_main['link'] ?? '';
               ?>
               <div class="caracteristique caracteristique-region">
-                <span class="caracteristique-icone" aria-hidden="true">🧭</span>
+                <span class="caracteristique-icone" aria-hidden="true">📍</span>
                 <span class="caracteristique-label"><?= esc_html__('Région', 'chassesautresor-com'); ?></span>
                 <span class="caracteristique-valeur">
                   <?php if ($region_main_link !== '') : ?>


### PR DESCRIPTION
Résumé rapide : Remplacement de l’emoji de région dans le CTA de la chasse.

- Mise à jour de l’emoji affiché pour la région afin de privilégier une icône de localisation.

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d106ed29708332b03b9fa32eae22b9