### PR TITLE
Supprimer la section régions sur la page chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -353,59 +353,6 @@
     margin-top: 0.3rem;
 }
 
-.chasse-regions {
-  margin: var(--space-3xl) 0;
-  padding: var(--space-2xl) var(--space-lg);
-  background: rgba(var(--aside-bg-rgb), 0.15);
-  border-radius: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-
-  &__header {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xxs);
-  }
-
-  &__subtitle {
-    margin: 0;
-    color: var(--color-gris-3);
-    font-size: 0.95rem;
-  }
-
-  &__list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-sm);
-  }
-
-  &__item {
-    margin: 0;
-  }
-
-  &__link,
-  &__label {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-xxs);
-    padding: 0.35rem 0.9rem;
-    border-radius: 999px;
-    background: rgba(var(--aside-bg-rgb), 0.35);
-    color: var(--color-text-fond-clair);
-    font-weight: 600;
-    text-decoration: none;
-  }
-
-  &__link:hover,
-  &__link:focus-visible {
-    text-decoration: underline;
-  }
-}
-
 .chasse-description {
   margin-top: var(--space-xl);
   line-height: 1.6;

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -33,8 +33,6 @@ $peut_voir_aside    = $est_engage_chasse
 
 // Récupération centralisée des infos
 $infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
-$regions = $infos_chasse['regions'] ?? [];
-$region_principale = $infos_chasse['region_principale'] ?? null;
 
 // Champs principaux
 $champs = $infos_chasse['champs'];
@@ -269,50 +267,6 @@ if ($peut_voir_aside) {
       'infos_chasse'=> $infos_chasse,
     ]);
     ?>
-
-    <?php if (!empty($regions)) : ?>
-        <?php
-        $region_main_name = '';
-        if (!empty($region_principale) && !empty($region_principale['name'])) {
-            $region_main_name = (string) $region_principale['name'];
-        }
-        ?>
-        <section class="chasse-regions" aria-labelledby="chasse-regions-title">
-            <div class="chasse-regions__header">
-                <h2 id="chasse-regions-title"><?php esc_html_e('Régions de la chasse', 'chassesautresor-com'); ?></h2>
-                <?php if ($region_main_name !== '') : ?>
-                    <p class="chasse-regions__subtitle">
-                        <?php
-                        printf(
-                            esc_html__('Région : %s', 'chassesautresor-com'),
-                            esc_html($region_main_name)
-                        );
-                        ?>
-                    </p>
-                <?php endif; ?>
-            </div>
-            <ul class="chasse-regions__list">
-                <?php foreach ($regions as $region) : ?>
-                    <?php
-                    $region_name = isset($region['name']) ? (string) $region['name'] : '';
-                    if ($region_name === '') {
-                        continue;
-                    }
-                    $region_link = isset($region['link']) ? (string) $region['link'] : '';
-                    ?>
-                    <li class="chasse-regions__item">
-                        <?php if ($region_link !== '') : ?>
-                            <a class="chasse-regions__link" href="<?php echo esc_url($region_link); ?>">
-                                <?php echo esc_html($region_name); ?>
-                            </a>
-                        <?php else : ?>
-                            <span class="chasse-regions__label"><?php echo esc_html($region_name); ?></span>
-                        <?php endif; ?>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        </section>
-    <?php endif; ?>
 
     <!-- 🧩 Liste des énigmes -->
     <section class="chasse-enigmes-wrapper" id="chasse-enigmes-wrapper">


### PR DESCRIPTION
## Résumé
- suppression du bloc d'affichage des régions sur la page chasse
- nettoyage des styles SCSS associés à cette section

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d1073459348332939337fc90754914