### PR TITLE
Add search to homepage hunts filters

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -23,13 +23,18 @@ Enregistre un contexte de recherche avec :
   ou tableau de configuration).
 - `count_callback` : callable optionnel pour calculer le nombre de résultats.
 - `ui` : métadonnées d'interface (`label`, `placeholder`, `submit_label`,
-  `capability`, `nonce_action`, `nonce_name`, `hidden_fields`, `description`).
+  `submit_icon`, `submit_icon_only`, `capability`, `nonce_action`,
+  `nonce_name`, `hidden_fields`, `description`).
 - `hidden_fields` : champs cachés ajoutés systématiquement au formulaire.
 - `pagination_params` : liste de paramètres à purger lors d'une nouvelle
   recherche (`tentatives-page`, `page`, etc.).
 - `ui.show_reset_button` : afficher un bouton de réinitialisation lorsque
   l'utilisateur a déjà saisi une recherche.
 - `ui.reset_label` : personnalise l'intitulé du bouton de réinitialisation.
+
+> ℹ️ **Interface standard** : pour reproduire l'affichage utilisé sur les
+> listes front-office (loupe seule dans le bouton), associer toujours
+> `submit_icon` à `search` et activer `submit_icon_only`.
 
 ### `ca_resolve_search_context(string $key): array`
 
@@ -93,6 +98,8 @@ ca_register_search_context('tentatives', [
     'ui' => [
         'label'       => __('Rechercher une tentative', 'chassesautresor-com'),
         'placeholder' => __('Texte, joueur, ...', 'chassesautresor-com'),
+        'submit_icon' => 'search',
+        'submit_icon_only' => true,
     ],
     'pagination_params' => ['tentatives-page'],
 ]);

--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -22,6 +22,7 @@
   const labels = localized.labels && typeof localized.labels === 'object' ? localized.labels : {};
   const errorLabel = typeof labels.error === 'string' ? labels.error : '';
   const resetLabel = typeof labels.reset === 'string' ? labels.reset : '';
+  const emptyLabel = typeof labels.empty === 'string' ? labels.empty : '';
 
   if (!endpoint) {
     return;
@@ -32,6 +33,10 @@
   const countElement = form.querySelector('[data-home-hunts-count]') || root.querySelector('[data-home-hunts-count]');
   const feedbackElement = root.querySelector('[data-home-hunts-feedback]');
   const resetButton = form.querySelector('[data-home-hunts-reset]');
+  const filtersWrapper = form.closest('.home-hunts__filters') || form;
+  const searchForm = filtersWrapper ? filtersWrapper.querySelector('form[data-home-hunts-search]') : null;
+  const searchInput = searchForm ? searchForm.querySelector('input[type="search"]') : null;
+  const searchResetButton = searchForm ? searchForm.querySelector('[data-table-search-reset]') : null;
 
   if (countElement && !countElement.dataset.template) {
     countElement.dataset.template = countElement.textContent || '';
@@ -121,6 +126,61 @@
     feedbackElement.classList.add('home-hunts__feedback--error');
   }
 
+  function toggleSearchReset(visible) {
+    if (!searchResetButton) {
+      return;
+    }
+
+    if (visible) {
+      searchResetButton.hidden = false;
+      searchResetButton.disabled = false;
+    } else {
+      searchResetButton.hidden = true;
+      searchResetButton.disabled = true;
+    }
+  }
+
+  function getSearchTerm() {
+    if (!searchInput) {
+      return '';
+    }
+
+    return searchInput.value.trim();
+  }
+
+  function setSearchTerm(value) {
+    if (!searchInput) {
+      return;
+    }
+
+    const normalized = typeof value === 'string' ? value.trim() : '';
+
+    if (searchInput.value !== normalized) {
+      searchInput.value = normalized;
+    }
+
+    toggleSearchReset(normalized.length > 0);
+  }
+
+  function resetSearchTerm() {
+    setSearchTerm('');
+  }
+
+  function showEmptyMessage(message) {
+    if (!feedbackElement) {
+      return;
+    }
+
+    const finalMessage = typeof message === 'string' && message.length > 0 ? message : emptyLabel;
+
+    if (!finalMessage) {
+      return;
+    }
+
+    feedbackElement.textContent = finalMessage;
+    feedbackElement.classList.remove('home-hunts__feedback--error');
+  }
+
   function formatCountLabel(countValue) {
     const template = defaultTemplate;
 
@@ -154,11 +214,14 @@
   }
 
   function clearHunts() {
-    let node = form.nextSibling;
+    const startNode = filtersWrapper ? filtersWrapper.nextSibling : form.nextSibling;
+    let node = startNode;
 
     while (node && node !== feedbackElement) {
       const next = node.nextSibling;
-      node.parentNode.removeChild(node);
+      if (node.parentNode) {
+        node.parentNode.removeChild(node);
+      }
       node = next;
     }
   }
@@ -350,6 +413,8 @@
       data.append('cost[]', '');
     }
 
+    data.append('search', getSearchTerm());
+
     return data;
   }
 
@@ -360,6 +425,14 @@
 
     if (payload.filters && typeof payload.filters === 'object') {
       updateAvailableFilters(payload.filters);
+
+      if (payload.filters.normalized && typeof payload.filters.normalized === 'object') {
+        const normalizedSearch = payload.filters.normalized.search;
+
+        if (typeof normalizedSearch === 'string') {
+          setSearchTerm(normalizedSearch);
+        }
+      }
     }
 
     if (typeof payload.html === 'string') {
@@ -368,8 +441,14 @@
       replaceHunts('');
     }
 
-    if (typeof payload.total === 'number') {
-      updateCount(payload.total);
+    const totalValue = typeof payload.total === 'number' ? payload.total : null;
+
+    if (totalValue !== null) {
+      updateCount(totalValue);
+
+      if (totalValue === 0) {
+        showEmptyMessage(payload.message);
+      }
     } else {
       updateCount(null);
     }
@@ -494,6 +573,8 @@
         checkbox.checked = checkbox.dataset.defaultChecked === 'true';
       }
     });
+
+    resetSearchTerm();
   }
 
   function onResetClick(event) {
@@ -504,10 +585,50 @@
     submitFilters();
   }
 
+  function onSearchSubmit(event) {
+    if (!searchForm || event.target !== searchForm) {
+      return;
+    }
+
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+
+    const term = event.detail && typeof event.detail.term === 'string' ? event.detail.term : getSearchTerm();
+    setSearchTerm(term);
+    submitFilters();
+  }
+
+  function onSearchReset(event) {
+    if (!searchForm || event.target !== searchForm) {
+      return;
+    }
+
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+
+    resetSearchTerm();
+    submitFilters();
+  }
+
   form.addEventListener('change', onFiltersChange);
   form.addEventListener('input', onFiltersChange);
 
   if (resetButton) {
     resetButton.addEventListener('click', onResetClick);
   }
+
+  if (searchForm) {
+    searchForm.addEventListener('tablesearch:submit', onSearchSubmit);
+    searchForm.addEventListener('tablesearch:reset', onSearchReset);
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      toggleSearchReset(getSearchTerm() !== '');
+    });
+  }
+
+  toggleSearchReset(getSearchTerm() !== '');
 })();

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -52,6 +52,21 @@ body.accueil-fullscreen {
     transform: translateY(-2px);
 }
 
+.home-hunts__filters-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    width: 100%;
+}
+
+.home-hunts__filters-search {
+    width: 100%;
+}
+
+.home-hunts__filters-search .table-search {
+    width: 100%;
+}
+
 .home-hunts-filters label,
 .home-hunts__filters label,
 .home-hunts-filters legend,
@@ -183,6 +198,24 @@ body.accueil-fullscreen {
         flex-direction: row;
         flex-wrap: wrap;
         align-items: flex-end;
+    }
+
+    .home-hunts__filters-form {
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        flex: 1 1 600px;
+    }
+
+    .home-hunts__filters-search {
+        flex: 0 0 auto;
+        display: flex;
+        justify-content: flex-end;
+        margin-left: auto;
+    }
+
+    .home-hunts__filters-search .table-search {
+        max-width: 360px;
     }
 
     .home-hunts__filters-group {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8268,6 +8268,21 @@ body.accueil-fullscreen {
   transform: translateY(-2px);
 }
 
+.home-hunts__filters-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  width: 100%;
+}
+
+.home-hunts__filters-search {
+  width: 100%;
+}
+
+.home-hunts__filters-search .table-search {
+  width: 100%;
+}
+
 .home-hunts-filters label,
 .home-hunts__filters label,
 .home-hunts-filters legend,
@@ -8397,6 +8412,21 @@ body.accueil-fullscreen {
     flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-end;
+  }
+  .home-hunts__filters-form {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    flex: 1 1 600px;
+  }
+  .home-hunts__filters-search {
+    flex: 0 0 auto;
+    display: flex;
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+  .home-hunts__filters-search .table-search {
+    max-width: 360px;
   }
   .home-hunts__filters-group {
     flex: 1 1 220px;

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -162,6 +162,7 @@ ob_start();
             'label'             => '',
             'placeholder'       => __('Rechercher une chasse', 'chassesautresor-com'),
             'submit_icon'       => 'search',
+            'submit_icon_only'  => true,
             'show_reset_button' => true,
             'data_attributes'   => [
                 'home-hunts-search' => '1',

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -12,7 +12,10 @@ if (is_user_logged_in() && function_exists('render_points_history_table')) {
 
 get_header();
 
-$home_filters = ca_home_filter_chasse_ids([]);
+$search_term  = ca_get_search_term('home-hunts');
+$home_filters = ca_home_filter_chasse_ids([
+    'search' => $search_term,
+]);
 $filters_nonce = wp_create_nonce('ca-filter-chasses');
 
 $chasse_ids             = $home_filters['ids'];
@@ -91,66 +94,94 @@ $results_label = sprintf(
 
 ob_start();
 ?>
-<form class="home-hunts__filters" data-home-hunts-filters aria-label="<?php echo esc_attr(__('Filtrer les chasses', 'chassesautresor-com')); ?>">
-    <div class="home-hunts__filters-group home-hunts__filters-group--status">
-        <label for="home-hunts-status"><?php echo esc_html(__('Statut', 'chassesautresor-com')); ?></label>
-        <select
-            id="home-hunts-status"
-            name="home-hunts-status"
-            data-home-hunts-select="statut"
-            data-default-value="<?php echo esc_attr($default_status_filter); ?>"
-        >
-            <?php foreach ($status_options as $status_value => $status_label) : ?>
-                <?php
-                $status_count = $available_status_counts[$status_value] ?? 0;
-                $status_is_available = ('tous' === $status_value) || ($status_count > 0);
-                ?>
-                <option
-                    value="<?php echo esc_attr($status_value); ?>"
-                    data-home-hunts-status-option="<?php echo esc_attr($status_value); ?>"
-                    <?php echo selected($default_status_filter, $status_value, false); ?>
-                    <?php if (!$status_is_available) : ?>hidden disabled<?php endif; ?>
-                >
-                    <?php echo esc_html($status_label); ?>
-                </option>
-            <?php endforeach; ?>
-        </select>
-    </div>
-    <fieldset class="home-hunts__filters-group home-hunts__filters-group--cost" data-home-hunts-cost-group>
-        <legend><?php echo esc_html(__('Coût', 'chassesautresor-com')); ?></legend>
-        <?php foreach ($cost_options as $cost_value => $cost_option) : ?>
-            <?php
-            $is_cost_available = in_array($cost_value, $available_cost_values, true);
-            $is_cost_checked  = in_array($cost_value, $default_cost_filters, true);
-            $cost_input_id    = $cost_option['id'] ?? ('home-hunts-cost-' . $cost_value);
-            ?>
-            <div
-                class="home-hunts__filters-checkbox"
-                data-home-hunts-cost-option="<?php echo esc_attr($cost_value); ?>"<?php echo $is_cost_available ? '' : ' hidden'; ?>
+<div class="home-hunts__filters">
+    <form
+        class="home-hunts__filters-form"
+        data-home-hunts-filters
+        aria-label="<?php echo esc_attr(__('Filtrer les chasses', 'chassesautresor-com')); ?>"
+    >
+        <div class="home-hunts__filters-group home-hunts__filters-group--status">
+            <label for="home-hunts-status"><?php echo esc_html(__('Statut', 'chassesautresor-com')); ?></label>
+            <select
+                id="home-hunts-status"
+                name="home-hunts-status"
+                data-home-hunts-select="statut"
+                data-default-value="<?php echo esc_attr($default_status_filter); ?>"
             >
-                <input
-                    type="checkbox"
-                    id="<?php echo esc_attr($cost_input_id); ?>"
-                    name="home-hunts-cost[]"
-                    value="<?php echo esc_attr($cost_value); ?>"
-                    data-home-hunts-checkbox="<?php echo esc_attr($cost_value); ?>"
-                    data-default-checked="<?php echo $is_cost_checked ? 'true' : 'false'; ?>"
-                    <?php echo checked($is_cost_checked, true, false); ?>
-                    <?php echo disabled($is_cost_available, false, false); ?>
-                />
-                <label for="<?php echo esc_attr($cost_input_id); ?>"><?php echo esc_html($cost_option['label'] ?? ''); ?></label>
-            </div>
-        <?php endforeach; ?>
-    </fieldset>
-    <div class="home-hunts__filters-actions">
-        <button type="reset" class="home-hunts__filters-reset" data-home-hunts-reset><?php echo esc_html(__('Réinitialiser', 'chassesautresor-com')); ?></button>
-        <span class="home-hunts__filters-count" data-home-hunts-count data-default-count="<?php echo esc_attr($initial_results_count); ?>"><?php echo esc_html($results_label); ?></span>
+                <?php foreach ($status_options as $status_value => $status_label) : ?>
+                    <?php
+                    $status_count = $available_status_counts[$status_value] ?? 0;
+                    $status_is_available = ('tous' === $status_value) || ($status_count > 0);
+                    ?>
+                    <option
+                        value="<?php echo esc_attr($status_value); ?>"
+                        data-home-hunts-status-option="<?php echo esc_attr($status_value); ?>"
+                        <?php echo selected($default_status_filter, $status_value, false); ?>
+                        <?php if (!$status_is_available) : ?>hidden disabled<?php endif; ?>
+                    >
+                        <?php echo esc_html($status_label); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <fieldset class="home-hunts__filters-group home-hunts__filters-group--cost" data-home-hunts-cost-group>
+            <legend><?php echo esc_html(__('Coût', 'chassesautresor-com')); ?></legend>
+            <?php foreach ($cost_options as $cost_value => $cost_option) : ?>
+                <?php
+                $is_cost_available = in_array($cost_value, $available_cost_values, true);
+                $is_cost_checked  = in_array($cost_value, $default_cost_filters, true);
+                $cost_input_id    = $cost_option['id'] ?? ('home-hunts-cost-' . $cost_value);
+                ?>
+                <div
+                    class="home-hunts__filters-checkbox"
+                    data-home-hunts-cost-option="<?php echo esc_attr($cost_value); ?>"<?php echo $is_cost_available ? '' : ' hidden'; ?>
+                >
+                    <input
+                        type="checkbox"
+                        id="<?php echo esc_attr($cost_input_id); ?>"
+                        name="home-hunts-cost[]"
+                        value="<?php echo esc_attr($cost_value); ?>"
+                        data-home-hunts-checkbox="<?php echo esc_attr($cost_value); ?>"
+                        data-default-checked="<?php echo $is_cost_checked ? 'true' : 'false'; ?>"
+                        <?php echo checked($is_cost_checked, true, false); ?>
+                        <?php echo disabled($is_cost_available, false, false); ?>
+                    />
+                    <label for="<?php echo esc_attr($cost_input_id); ?>"><?php echo esc_html($cost_option['label'] ?? ''); ?></label>
+                </div>
+            <?php endforeach; ?>
+        </fieldset>
+        <div class="home-hunts__filters-actions">
+            <button type="reset" class="home-hunts__filters-reset" data-home-hunts-reset><?php echo esc_html(__('Réinitialiser', 'chassesautresor-com')); ?></button>
+            <span class="home-hunts__filters-count" data-home-hunts-count data-default-count="<?php echo esc_attr($initial_results_count); ?>"><?php echo esc_html($results_label); ?></span>
+        </div>
+    </form>
+    <div class="home-hunts__filters-search">
+        <?php
+        echo cta_render_search_form('home-hunts', [
+            'class'             => 'table-search--inline table-search--compact',
+            'label'             => '',
+            'placeholder'       => __('Rechercher une chasse', 'chassesautresor-com'),
+            'submit_icon'       => 'search',
+            'show_reset_button' => true,
+            'data_attributes'   => [
+                'home-hunts-search' => '1',
+            ],
+        ]);
+        ?>
     </div>
-</form>
+</div>
 <?php
 $before_items_markup = ob_get_clean();
 
-$after_items_markup = '<div class="home-hunts__feedback" data-home-hunts-feedback aria-live="polite"></div>';
+$initial_feedback_message = '';
+if ($initial_results_count <= 0 && !empty($home_filters['message'])) {
+    $initial_feedback_message = esc_html((string) $home_filters['message']);
+}
+
+$after_items_markup = sprintf(
+    '<div class="home-hunts__feedback" data-home-hunts-feedback aria-live="polite">%s</div>',
+    $initial_feedback_message
+);
 ?>
 
 <div id="primary" class="content-area">

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -87,6 +87,31 @@ function cta_handle_language() {
 add_action( 'init', 'cta_handle_language' );
 
 /**
+ * Registers the search context used on the homepage hunts listing.
+ *
+ * @return void
+ */
+function ca_register_home_hunts_search_context(): void {
+    ca_register_search_context('home-hunts', [
+        'fields' => [
+            'sql' => [
+                'p.post_title',
+                'pm_short_description.meta_value',
+                'organisateur.post_title',
+            ],
+        ],
+        'ui' => [
+            'label'             => __('Rechercher une chasse', 'chassesautresor-com'),
+            'placeholder'       => __('Rechercher une chasse', 'chassesautresor-com'),
+            'submit_icon'       => 'search',
+            'show_reset_button' => true,
+            'no_results_message' => __('Aucune chasse trouvée', 'chassesautresor-com'),
+        ],
+    ]);
+}
+add_action('init', 'ca_register_home_hunts_search_context');
+
+/**
  * Redirects non-logged-in users requesting `/mon-compte` to the login page.
  *
  * @return void
@@ -361,6 +386,12 @@ add_action('wp_enqueue_scripts', function () {
             true
         );
 
+        $home_hunts_context = ca_resolve_search_context('home-hunts');
+        $home_hunts_ui      = is_array($home_hunts_context['ui'] ?? null) ? $home_hunts_context['ui'] : [];
+        $no_results_label   = isset($home_hunts_ui['no_results_message']) && $home_hunts_ui['no_results_message'] !== ''
+            ? (string) $home_hunts_ui['no_results_message']
+            : __('Aucune chasse trouvée', 'chassesautresor-com');
+
         wp_localize_script(
             'home-hunts-filters',
             'homeHuntsFilters',
@@ -370,6 +401,7 @@ add_action('wp_enqueue_scripts', function () {
                 'labels'  => [
                     'error' => __('Impossible de charger les chasses.', 'chassesautresor-com'),
                     'reset' => __('Réinitialiser', 'chassesautresor-com'),
+                    'empty' => $no_results_label,
                 ],
             ]
         );

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -104,6 +104,7 @@ function ca_register_home_hunts_search_context(): void {
             'label'             => __('Rechercher une chasse', 'chassesautresor-com'),
             'placeholder'       => __('Rechercher une chasse', 'chassesautresor-com'),
             'submit_icon'       => 'search',
+            'submit_icon_only'  => true,
             'show_reset_button' => true,
             'no_results_message' => __('Aucune chasse trouvée', 'chassesautresor-com'),
         ],

--- a/wp-content/themes/chassesautresor/inc/homepage-filters.php
+++ b/wp-content/themes/chassesautresor/inc/homepage-filters.php
@@ -14,16 +14,17 @@ defined('ABSPATH') || exit();
  * - cout: array of "gratuit" and/or "points". Omit to keep both values by default.
  *   A hunt is considered "gratuit" when both "chasse_infos_cout_points" and "nb_enigmes_payantes" are equal to 0.
  *
- * @param array{statut?:string, cout?:string|string[]}|array $args Raw filters coming from the frontend.
+ * @param array{statut?:string, cout?:string|string[], search?:string}|array $args Raw filters coming from the frontend.
  *
  * @return array{
  *     ids:int[],
  *     total:int,
- *     filters_normalises:array{statut:string, cout:string[]},
+ *     filters_normalises:array{statut:string, cout:string[], search:string},
  *     available_filters:array{
  *         statut:array<string,int>,
  *         cout:array<string,int>
- *     }
+ *     },
+ *     message?:string
  * }
  */
 function ca_home_filter_chasse_ids(array $args): array
@@ -35,6 +36,40 @@ function ca_home_filter_chasse_ids(array $args): array
         'statut' => 'tous',
         'cout'   => $cost_whitelist,
     ];
+
+    $raw_search = '';
+    if (array_key_exists('search', $args)) {
+        $raw_search = $args['search'];
+        if (is_array($raw_search)) {
+            $raw_search = reset($raw_search);
+        }
+    }
+
+    $raw_search = is_scalar($raw_search) ? (string) $raw_search : '';
+    $search_term = trim($raw_search);
+    $sanitized_search_term = sanitize_text_field($search_term);
+
+    $to_lowercase = static function (string $value): string {
+        return function_exists('mb_strtolower') ? mb_strtolower($value) : strtolower($value);
+    };
+
+    $normalize_text = static function ($value) use ($to_lowercase): string {
+        if (!is_string($value) || '' === $value) {
+            return '';
+        }
+
+        $sanitized = wp_strip_all_tags($value);
+
+        if (function_exists('remove_accents')) {
+            $sanitized = remove_accents($sanitized);
+        }
+
+        $sanitized = $to_lowercase($sanitized);
+
+        return trim($sanitized);
+    };
+
+    $normalized_search_term = $normalize_text($search_term);
 
     $normalized_status = $default_filters['statut'];
     if (isset($args['statut']) && is_string($args['statut']) && in_array($args['statut'], $status_whitelist, true)) {
@@ -106,16 +141,74 @@ function ca_home_filter_chasse_ids(array $args): array
         $is_free = ($cout_points <= 0) && ($nb_enigmes_payantes <= 0);
         $cost_key = $is_free ? 'gratuit' : 'points';
 
+        $title = get_the_title($chasse_id);
+        $post_excerpt = get_post_field('post_excerpt', $chasse_id);
+        $description_field = get_field('chasse_principale_description', $chasse_id);
+        $description_segments = [];
+
+        if (is_string($post_excerpt) && '' !== trim($post_excerpt)) {
+            $description_segments[] = $post_excerpt;
+        }
+
+        if (is_string($description_field) && '' !== trim($description_field)) {
+            $description_segments[] = $description_field;
+        }
+
+        $description_text = trim(implode(' ', $description_segments));
+
+        $organizer_name = '';
+        if (function_exists('get_organisateur_from_chasse')) {
+            $organizer_id = get_organisateur_from_chasse($chasse_id);
+            if ($organizer_id) {
+                $organizer_title = get_the_title($organizer_id);
+                if (is_string($organizer_title)) {
+                    $organizer_name = $organizer_title;
+                }
+            }
+        }
+
         $hunts_data[] = [
             'id'     => (int) $chasse_id,
             'status' => is_string($statut_metier) ? $statut_metier : '',
             'cost'   => $cost_key,
+            'title'  => is_string($title) ? $title : '',
+            'description' => $description_text,
+            'organizer'   => $organizer_name,
         ];
+    }
+
+    $search_filtered_hunts = $hunts_data;
+
+    if ('' !== $normalized_search_term) {
+        $search_filtered_hunts = array_values(array_filter(
+            $hunts_data,
+            static function (array $hunt) use ($normalize_text, $normalized_search_term): bool {
+                $haystacks = [
+                    $hunt['title'] ?? '',
+                    $hunt['description'] ?? '',
+                    $hunt['organizer'] ?? '',
+                ];
+
+                foreach ($haystacks as $haystack) {
+                    $normalized_value = $normalize_text((string) $haystack);
+
+                    if ('' === $normalized_value) {
+                        continue;
+                    }
+
+                    if (false !== strpos($normalized_value, $normalized_search_term)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        ));
     }
 
     $filtered_ids = [];
 
-    foreach ($hunts_data as $hunt) {
+    foreach ($search_filtered_hunts as $hunt) {
         if ('tous' !== $normalized_status) {
             $allowed_statuses = $status_map[$normalized_status] ?? [];
 
@@ -154,7 +247,7 @@ function ca_home_filter_chasse_ids(array $args): array
         'termine'  => 0,
     ];
 
-    foreach ($hunts_data as $hunt) {
+    foreach ($search_filtered_hunts as $hunt) {
         if (!in_array($hunt['cost'], $allowed_costs_for_status, true)) {
             continue;
         }
@@ -179,7 +272,7 @@ function ca_home_filter_chasse_ids(array $args): array
         $allowed_statuses_for_cost = $status_map[$normalized_status] ?? [];
     }
 
-    foreach ($hunts_data as $hunt) {
+    foreach ($search_filtered_hunts as $hunt) {
         if (is_array($allowed_statuses_for_cost)) {
             if (empty($allowed_statuses_for_cost) || !in_array($hunt['status'], $allowed_statuses_for_cost, true)) {
                 continue;
@@ -191,17 +284,24 @@ function ca_home_filter_chasse_ids(array $args): array
         }
     }
 
+    $results_message = '';
+    if (count($filtered_ids) <= 0) {
+        $results_message = __('Aucune chasse trouvée', 'chassesautresor-com');
+    }
+
     return [
         'ids'                => $filtered_ids,
         'total'              => count($filtered_ids),
         'filters_normalises' => [
             'statut' => $normalized_status,
             'cout'   => $normalized_cost,
+            'search' => $sanitized_search_term,
         ],
         'available_filters'  => [
             'statut' => $status_counts,
             'cout'   => $cost_counts,
         ],
+        'message'            => $results_message,
     ];
 }
 
@@ -240,6 +340,10 @@ function ca_ajax_filter_chasses(): void
         }
     }
 
+    if (array_key_exists('search', $raw_request)) {
+        $filters['search'] = sanitize_text_field((string) $raw_request['search']);
+    }
+
     $filter_results = ca_home_filter_chasse_ids($filters);
 
     if (!is_array($filter_results) || !isset($filter_results['ids'])) {
@@ -270,6 +374,11 @@ function ca_ajax_filter_chasses(): void
         $normalized_filters = $filter_results['filters_normalises'];
     }
 
+    $response_message = '';
+    if (!empty($filter_results['message']) && is_string($filter_results['message'])) {
+        $response_message = $filter_results['message'];
+    }
+
     wp_send_json_success([
         'html'     => $html,
         'total'    => (int) ($filter_results['total'] ?? count($chasse_ids)),
@@ -278,6 +387,7 @@ function ca_ajax_filter_chasses(): void
             'available'  => $available_filters,
             'normalized' => $normalized_filters,
         ],
+        'message'  => $response_message,
     ]);
 }
 

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -69,6 +69,7 @@ function cta_render_search_form(string $key, array $overrides = []): string
         'nonce_name'         => $ui['nonce_name'] ?? 'nonce',
         'submit_label'       => $ui['submit_label'] ?? esc_html__('Rechercher', 'chassesautresor-com'),
         'submit_icon'        => $ui['submit_icon'] ?? '',
+        // Garder `submit_icon_only` à true garantit un bouton visuellement réduit à l'icône.
         'submit_icon_only'   => $ui['submit_icon_only'] ?? false,
         'reset_label'        => $ui['reset_label'] ?? esc_html__('Réinitialiser', 'chassesautresor-com'),
         'show_reset_button'  => $ui['show_reset_button'] ?? false,

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -3306,6 +3306,14 @@ msgstr "View hunt solution"
 msgid "Réinitialiser"
 msgstr "Reset"
 
+#: wp-content/themes/chassesautresor/front-page.php
+msgid "Rechercher une chasse"
+msgstr "Search for a hunt"
+
+#: wp-content/themes/chassesautresor/inc/homepage-filters.php
+msgid "Aucune chasse trouvée"
+msgstr "No hunts found"
+
 #: inc/user-functions.php:1444
 msgid "Unable to load attempts. Please try again."
 msgstr "Unable to load attempts. Please try again."

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -3268,6 +3268,14 @@ msgstr "Voir la solution de la chasse"
 msgid "Réinitialiser"
 msgstr "Réinitialiser"
 
+#: wp-content/themes/chassesautresor/front-page.php
+msgid "Rechercher une chasse"
+msgstr "Rechercher une chasse"
+
+#: wp-content/themes/chassesautresor/inc/homepage-filters.php
+msgid "Aucune chasse trouvée"
+msgstr "Aucune chasse trouvée"
+
 #: inc/user-functions.php:1444
 msgid "Unable to load attempts. Please try again."
 msgstr "Impossible de charger les tentatives. Veuillez réessayer."


### PR DESCRIPTION
## Résumé
- Ajout d’un champ de recherche pour les chasses sur la page d’accueil avec inscription du contexte associé
- Adaptation du filtrage PHP/JS pour transmettre le terme saisi, gérer la réinitialisation et afficher un message en absence de résultats
- Ajustements de style et de traduction pour intégrer le formulaire et son libellé au thème

## Changements notables
- Ajout du formulaire de recherche dans `front-page.php` et enregistrement du contexte de recherche dans `functions.php`
- Mise à jour de `inc/homepage-filters.php` pour filtrer sur le titre, la description et l’organisateur, et retourner un message lorsqu’aucune chasse n’est trouvée
- Évolution du script `home-hunts-filters.js` pour gérer les événements de recherche, transmettre le terme côté AJAX et traiter les messages de retour
- Ajustement des styles SCSS/CSS du bloc de filtres et ajout des traductions FR/EN correspondantes

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d107425f608332b85982416f2f2254