### PR TITLE
Ajoute les badges région et thème aux chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -33,6 +33,63 @@
   gap: var(--space-md);
 }
 
+/* 🏷️ Badges région & thèmes */
+.chasse-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xxs);
+}
+
+.chasse-card-badges {
+  margin-top: var(--space-xs);
+}
+
+.chasse-meta-badges {
+  margin: var(--space-sm) 0;
+}
+
+.chasse-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  font-weight: 600;
+  text-decoration: none;
+  background: rgba(var(--color-text-fond-clair-rgb), 0.08);
+  color: var(--color-text-fond-clair);
+  border: 1px solid rgba(var(--color-text-fond-clair-rgb), 0.1);
+  transition: background-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.chasse-badge--region {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-text-fond-clair);
+}
+
+.chasse-badge--theme {
+  background: rgba(255, 215, 0, 0.18);
+  border-color: rgba(255, 215, 0, 0.35);
+  color: var(--color-text-fond-clair);
+}
+
+a.chasse-badge {
+  cursor: pointer;
+}
+
+a.chasse-badge:hover,
+a.chasse-badge:focus-visible {
+  text-decoration: none;
+  box-shadow: 0 0 0 2px rgba(var(--color-text-fond-clair-rgb), 0.15);
+}
+
+a.chasse-badge.chasse-badge--region:hover,
+a.chasse-badge.chasse-badge--region:focus-visible {
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.18);
+}
+
 
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1394,69 +1394,43 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
 }
 
 /**
- * Prépare les informations d'affichage pour une carte de chasse.
+ * Prépare les données d'affichage des termes associés à une chasse.
  *
- * @param int $chasse_id  ID de la chasse.
- * @param int $word_limit Nombre maximum de mots pour le descriptif.
+ * @param int    $chasse_id ID de la chasse.
+ * @param string $taxonomy  Taxonomie ciblée.
  *
- * @return array Tableau associatif prêt pour le template.
-*/
-function chasse_recuperer_regions_infos(int $chasse_id): array
+ * @return array[]
+ */
+function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): array
 {
     if (!function_exists('wp_get_post_terms')) {
-        return [
-            'regions' => [],
-            'region_principale' => null,
-        ];
+        return [];
     }
 
-    $taxonomy = 'chasse_region';
-
-    if (function_exists('get_field_object')) {
-        $field_object = get_field_object('chasse_region', $chasse_id);
-        if (is_array($field_object) && !empty($field_object['taxonomy'])) {
-            $taxonomy = (string) $field_object['taxonomy'];
-        }
+    $terms = wp_get_post_terms($chasse_id, $taxonomy, ['orderby' => 'term_order']);
+    if (is_wp_error($terms) || empty($terms)) {
+        return [];
     }
 
-    if ($taxonomy === '') {
-        return [
-            'regions' => [],
-            'region_principale' => null,
-        ];
-    }
-
-    $terms = wp_get_post_terms(
-        $chasse_id,
-        $taxonomy,
-        [
-            'orderby' => 'term_order',
-            'order'   => 'ASC',
-        ]
-    );
-
-    if (is_wp_error($terms)) {
-        $terms = [];
-    }
-
-    $regions = [];
+    $items = [];
 
     foreach ($terms as $term) {
-        $term_link = function_exists('get_term_link') ? get_term_link($term) : '';
+        $link = '';
+        if (function_exists('get_term_link')) {
+            $link = get_term_link($term);
+            if (is_wp_error($link)) {
+                $link = '';
+            }
+        }
 
-        $link_is_error = function_exists('is_wp_error') && is_wp_error($term_link);
-
-        $regions[] = [
-            'name' => (string) $term->name,
-            'slug' => (string) $term->slug,
-            'link' => !$link_is_error ? (string) $term_link : '',
+        $items[] = [
+            'nom'  => $term->name,
+            'slug' => $term->slug,
+            'lien' => $link,
         ];
     }
 
-    return [
-        'regions' => $regions,
-        'region_principale' => $regions[0] ?? null,
-    ];
+    return $items;
 }
 
 function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit = 300, array $options = []): array
@@ -1546,6 +1520,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     }
 
     $champs = chasse_get_champs($chasse_id);
+    $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
+    $themes = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
+    $region_principale = !empty($regions) ? $regions[0] : null;
     $titre_recompense  = $champs['titre_recompense'];
     $valeur_recompense = $champs['valeur_recompense'];
     $cout_points       = (int) $champs['cout_points'];
@@ -1592,8 +1569,6 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         ? '<span class="badge-statut__icon" aria-hidden="true">' . $badge_infos['icon_html'] . '</span>'
             . '<span class="screen-reader-text">' . esc_html($badge_infos['label']) . '</span>'
         : esc_html($badge_infos['label']);
-
-    $regions_infos = chasse_recuperer_regions_infos($chasse_id);
 
     $enigmes_associees = recuperer_enigmes_associees($chasse_id);
     $total_enigmes     = count($enigmes_associees);
@@ -1740,8 +1715,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'cta_message'       => $cta_message,
         'cta_type'         => $cta_data['type'] ?? '',
         'footer_html'       => $footer_html,
-        'regions'           => $regions_infos['regions'],
-        'region_principale' => $regions_infos['region_principale'],
+        'regions'           => $regions,
+        'themes'            => $themes,
+        'region_principale' => $region_principale,
     ];
 
     if (!empty($progression['resolvables'])) {
@@ -1790,7 +1766,9 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     }
 
     $champs = chasse_get_champs($chasse_id);
-    $regions_infos = chasse_recuperer_regions_infos($chasse_id);
+    $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
+    $themes = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
+    $region_principale = !empty($regions) ? $regions[0] : null;
 
     $description   = get_field('chasse_principale_description', $chasse_id);
     $texte_complet = wp_strip_all_tags($description);
@@ -1856,8 +1834,9 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
         ],
         'statut'            => get_field('chasse_cache_statut', $chasse_id) ?: 'revision',
         'statut_validation' => get_field('chasse_cache_statut_validation', $chasse_id),
-        'regions'           => $regions_infos['regions'],
-        'region_principale' => $regions_infos['region_principale'],
+        'regions'           => $regions,
+        'themes'            => $themes,
+        'region_principale' => $region_principale,
     ];
 
     $cache[$user_id] = $memo[$memo_key];
@@ -1878,6 +1857,25 @@ function chasse_clear_infos_affichage_cache(int $chasse_id): void
     $key = chasse_infos_affichage_cache_key($chasse_id);
     wp_cache_delete($key, 'chasse_affichage');
     delete_transient($key);
+}
+
+function chasse_invalidate_infos_affichage_terms(
+    int $object_id,
+    $terms,
+    $tt_ids,
+    string $taxonomy,
+    $append,
+    $old_tt_ids
+): void {
+    if (!in_array($taxonomy, ['chasse_region', 'theme_chasse'], true)) {
+        return;
+    }
+
+    if (get_post_type($object_id) !== 'chasse') {
+        return;
+    }
+
+    chasse_clear_infos_affichage_cache((int) $object_id);
 }
 
 function chasse_invalidate_infos_affichage_cache(int $post_id, \WP_Post $post, bool $update): void
@@ -1910,23 +1908,4 @@ function chasse_acf_clear_infos_affichage_cache($post_id): void
 add_action('acf/save_post', 'chasse_acf_clear_infos_affichage_cache', 20);
 add_action('save_post', 'chasse_invalidate_infos_affichage_cache', 10, 3);
 add_action('chasse_engagement_created', 'chasse_clear_infos_affichage_cache');
-add_action('set_object_terms', 'chasse_clear_infos_affichage_cache_on_region_terms', 10, 6);
-
-function chasse_clear_infos_affichage_cache_on_region_terms(
-    int $object_id,
-    $terms,
-    $tt_ids,
-    string $taxonomy,
-    bool $append,
-    $old_tt_ids
-): void {
-    if ($taxonomy !== 'chasse_region') {
-        return;
-    }
-
-    if (get_post_type($object_id) !== 'chasse') {
-        return;
-    }
-
-    chasse_clear_infos_affichage_cache($object_id);
-}
+add_action('set_object_terms', 'chasse_invalidate_infos_affichage_terms', 10, 6);

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -33,6 +33,13 @@ $peut_voir_aside    = $est_engage_chasse
 
 // Récupération centralisée des infos
 $infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
+$region_principale = is_array($infos_chasse['region_principale'] ?? null) ? $infos_chasse['region_principale'] : null;
+$themes_badges = array_values(array_filter(
+    is_array($infos_chasse['themes'] ?? null) ? $infos_chasse['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
 
 // Champs principaux
 $champs = $infos_chasse['champs'];
@@ -258,6 +265,29 @@ if ($peut_voir_aside) {
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>
+    <?php endif; ?>
+
+    <?php if (!empty($region_principale) || !empty($themes_badges)) : ?>
+        <div class="chasse-meta-badges chasse-badges">
+            <?php if (!empty($region_principale['nom'])) : ?>
+                <?php if (!empty($region_principale['lien'])) : ?>
+                    <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                        <?php echo esc_html($region_principale['nom']); ?>
+                    </a>
+                <?php else : ?>
+                    <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                <?php endif; ?>
+            <?php endif; ?>
+            <?php foreach ($themes_badges as $theme_badge) : ?>
+                <?php if (!empty($theme_badge['lien'])) : ?>
+                    <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme_badge['lien']); ?>">
+                        <?php echo esc_html($theme_badge['nom']); ?>
+                    </a>
+                <?php else : ?>
+                    <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme_badge['nom']); ?></span>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        </div>
     <?php endif; ?>
 
     <!-- 📦 Fiche complète (images + méta + actions) -->

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -446,11 +446,11 @@ if ($edition_active && !$est_complet) {
               </span>
             </div>
 
-            <?php if (!empty($infos_chasse['region_principale']) && !empty($infos_chasse['region_principale']['name'])) : ?>
+            <?php if (!empty($infos_chasse['region_principale']) && !empty($infos_chasse['region_principale']['nom'])) : ?>
               <?php
               $region_main = $infos_chasse['region_principale'];
-              $region_main_name = (string) $region_main['name'];
-              $region_main_link = $region_main['link'] ?? '';
+              $region_main_name = (string) $region_main['nom'];
+              $region_main_link = $region_main['lien'] ?? '';
               ?>
               <div class="caracteristique caracteristique-region">
                 <span class="caracteristique-icone" aria-hidden="true">📍</span>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -15,7 +15,6 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 $chasse_id       = (int) $args['chasse_id'];
 $completion_class = $args['completion_class'] ?? '';
 $infos           = preparer_infos_affichage_carte_chasse($chasse_id);
-$region_principale = $infos['region_principale'] ?? null;
 
 if (empty($infos)) {
     return;
@@ -92,6 +91,14 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
     $badge_attributes .= ' role="img" tabindex="0"';
 }
+
+$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
+$themes = array_values(array_filter(
+    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
@@ -108,6 +115,28 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
+            <?php if (!empty($region_principale) || !empty($themes)) : ?>
+                <div class="chasse-card-badges chasse-badges">
+                    <?php if (!empty($region_principale['nom'])) : ?>
+                        <?php if (!empty($region_principale['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                <?php echo esc_html($region_principale['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                    <?php foreach ($themes as $theme) : ?>
+                        <?php if (!empty($theme['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
+                                <?php echo esc_html($theme['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
             <?php echo $infos['lot_html']; ?>
         </div>
     </a>
@@ -122,22 +151,6 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                 <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['nb_joueurs'])); ?></span>
             </button>
         </div>
-        <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
-            <?php
-            $region_name = (string) $region_principale['name'];
-            $region_link = $region_principale['link'] ?? '';
-            ?>
-            <div class="meta-etiquette meta-etiquette--region">
-                <span class="meta-etiquette__label"><?php esc_html_e('Région :', 'chassesautresor-com'); ?></span>
-                <?php if ($region_link !== '') : ?>
-                    <a class="meta-etiquette__link" href="<?php echo esc_url($region_link); ?>">
-                        <?php echo esc_html($region_name); ?>
-                    </a>
-                <?php else : ?>
-                    <span class="meta-etiquette__value"><?php echo esc_html($region_name); ?></span>
-                <?php endif; ?>
-            </div>
-        <?php endif; ?>
         <div class="meta-etiquette">
             <?php echo get_svg_icon('calendar'); ?>
             <span class="chasse-date-plage">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -10,7 +10,6 @@ $completion_class = $args['completion_class'] ?? '';
 $word_limit      = isset($args['word_limit']) ? (int) $args['word_limit'] : 300;
 $infos           = preparer_infos_affichage_carte_chasse($chasse_id, $word_limit);
 $mode_fin        = $infos['mode_fin'] ?? 'automatique';
-$region_principale = $infos['region_principale'] ?? null;
 $title_mode      = $mode_fin === 'automatique'
     ? esc_html__('mode de fin de chasse : automatique', 'chassesautresor-com')
     : esc_html__('mode de fin de chasse : manuelle', 'chassesautresor-com');
@@ -48,6 +47,14 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' data-tooltip="' . $tooltip_attr . '"';
     $badge_attributes .= ' role="img" tabindex="0"';
 }
+
+$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
+$themes = array_values(array_filter(
+    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
@@ -112,6 +119,28 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
             <h3 class="carte-wide__titre">
                 <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
             </h3>
+            <?php if (!empty($region_principale) || !empty($themes)) : ?>
+                <div class="chasse-card-badges chasse-badges">
+                    <?php if (!empty($region_principale['nom'])) : ?>
+                        <?php if (!empty($region_principale['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                <?php echo esc_html($region_principale['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                    <?php foreach ($themes as $theme) : ?>
+                        <?php if (!empty($theme['lien'])) : ?>
+                            <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
+                                <?php echo esc_html($theme['nom']); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
         </div>
 
         <div class="carte-wide__content">
@@ -128,22 +157,6 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                     ?> —
                     <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
                 </div>
-                <?php if (!empty($region_principale) && !empty($region_principale['name'])) : ?>
-                    <?php
-                    $region_name = (string) $region_principale['name'];
-                    $region_link = $region_principale['link'] ?? '';
-                    ?>
-                    <div class="meta-etiquette meta-etiquette--region">
-                        <span class="meta-etiquette__label"><?php esc_html_e('Région :', 'chassesautresor-com'); ?></span>
-                        <?php if ($region_link !== '') : ?>
-                            <a class="meta-etiquette__link" href="<?php echo esc_url($region_link); ?>">
-                                <?php echo esc_html($region_name); ?>
-                            </a>
-                        <?php else : ?>
-                            <span class="meta-etiquette__value"><?php echo esc_html($region_name); ?></span>
-                        <?php endif; ?>
-                    </div>
-                <?php endif; ?>
                 <div class="meta-etiquette">
                     <?php echo get_svg_icon('calendar'); ?>
                     <span class="chasse-date-plage">


### PR DESCRIPTION
## Résumé
- ajoute un utilitaire pour préparer les termes de région et de thème associés aux chasses
- affiche les badges région et thème sur les cartes de chasse et sur la fiche détaillée
- stylise les nouveaux badges pour une présentation cohérente

## Tests
- composer install
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d11a305e9c833291d8ffa54c2da975