### PR TITLE
Affiche les badges région et thèmes sur la carte compacte

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -56,20 +56,20 @@ $themes = array_values(array_filter(
                     <div class="chasse-card-badges chasse-badges">
                         <?php if (!empty($region_principale['nom'])) : ?>
                             <?php if (!empty($region_principale['lien'])) : ?>
-                                <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                <a class="meta-etiquette" href="<?php echo esc_url($region_principale['lien']); ?>">
                                     <?php echo esc_html($region_principale['nom']); ?>
                                 </a>
                             <?php else : ?>
-                                <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                                <span class="meta-etiquette"><?php echo esc_html($region_principale['nom']); ?></span>
                             <?php endif; ?>
                         <?php endif; ?>
                         <?php foreach ($themes as $theme) : ?>
                             <?php if (!empty($theme['lien'])) : ?>
-                                <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
+                                <a class="meta-etiquette" href="<?php echo esc_url($theme['lien']); ?>">
                                     <?php echo esc_html($theme['nom']); ?>
                                 </a>
                             <?php else : ?>
-                                <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
+                                <span class="meta-etiquette"><?php echo esc_html($theme['nom']); ?></span>
                             <?php endif; ?>
                         <?php endforeach; ?>
                     </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -40,6 +40,22 @@ $themes = array_values(array_filter(
         return is_array($theme) && !empty($theme['nom']);
     }
 ));
+
+if (empty($region_principale) && function_exists('chasse_preparer_termes_affichage')) {
+    $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
+    if (!empty($regions) && is_array($regions[0])) {
+        $region_principale = $regions[0];
+    }
+}
+
+if (empty($themes) && function_exists('chasse_preparer_termes_affichage')) {
+    $themes = array_values(array_filter(
+        chasse_preparer_termes_affichage($chasse_id, 'theme_chasse'),
+        static function ($theme) {
+            return is_array($theme) && !empty($theme['nom']);
+        }
+    ));
+}
 ?>
 <div class="carte-compact-card">
     <div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
@@ -56,20 +72,20 @@ $themes = array_values(array_filter(
                     <div class="chasse-card-badges chasse-badges">
                         <?php if (!empty($region_principale['nom'])) : ?>
                             <?php if (!empty($region_principale['lien'])) : ?>
-                                <a class="meta-etiquette" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                <a class="meta-etiquette chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
                                     <?php echo esc_html($region_principale['nom']); ?>
                                 </a>
                             <?php else : ?>
-                                <span class="meta-etiquette"><?php echo esc_html($region_principale['nom']); ?></span>
+                                <span class="meta-etiquette chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
                             <?php endif; ?>
                         <?php endif; ?>
                         <?php foreach ($themes as $theme) : ?>
                             <?php if (!empty($theme['lien'])) : ?>
-                                <a class="meta-etiquette" href="<?php echo esc_url($theme['lien']); ?>">
+                                <a class="meta-etiquette chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
                                     <?php echo esc_html($theme['nom']); ?>
                                 </a>
                             <?php else : ?>
-                                <span class="meta-etiquette"><?php echo esc_html($theme['nom']); ?></span>
+                                <span class="meta-etiquette chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
                             <?php endif; ?>
                         <?php endforeach; ?>
                     </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -33,6 +33,13 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 $progression = $infos['progression'] ?? null;
 $resolvables = is_array($progression) ? (int) ($progression['resolvables'] ?? 0) : 0;
 $resolues_validables = isset($infos['resolues_validables']) ? (int) $infos['resolues_validables'] : 0;
+$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
+$themes = array_values(array_filter(
+    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
+    static function ($theme) {
+        return is_array($theme) && !empty($theme['nom']);
+    }
+));
 ?>
 <div class="carte-compact-card">
     <div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
@@ -45,6 +52,28 @@ $resolues_validables = isset($infos['resolues_validables']) ? (int) $infos['reso
             </div>
             <div class="carte-compact__contenu">
                 <h3 class="carte-compact__titre"><?php echo esc_html($infos['titre']); ?></h3>
+                <?php if (!empty($region_principale) || !empty($themes)) : ?>
+                    <div class="chasse-card-badges chasse-badges">
+                        <?php if (!empty($region_principale['nom'])) : ?>
+                            <?php if (!empty($region_principale['lien'])) : ?>
+                                <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
+                                    <?php echo esc_html($region_principale['nom']); ?>
+                                </a>
+                            <?php else : ?>
+                                <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                        <?php foreach ($themes as $theme) : ?>
+                            <?php if (!empty($theme['lien'])) : ?>
+                                <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
+                                    <?php echo esc_html($theme['nom']); ?>
+                                </a>
+                            <?php else : ?>
+                                <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
                 <?php echo $infos['lot_html']; ?>
                 <?php
                 get_template_part(


### PR DESCRIPTION
Ajout de l'affichage des badges de région et de thèmes sur la carte compacte.

- Récupération des métadonnées de région principale et des thèmes associés pour la carte compacte.
- Affichage conditionnel des badges de région et de thèmes avec échappement des valeurs et classes existantes.

**Tests**
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d11eabe8f0833281ba2c21b62904f8