### PR TITLE
Réorganise les filtres d'accueil et harmonise les boutons de réinitialisation

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -34,7 +34,8 @@
   const feedbackElement = root.querySelector('[data-home-hunts-feedback]');
   const resetButton = form.querySelector('[data-home-hunts-reset]');
   const filtersWrapper = form.closest('.home-hunts__filters') || form;
-  const searchForm = filtersWrapper ? filtersWrapper.querySelector('form[data-home-hunts-search]') : null;
+  const searchForm = root.querySelector('form[data-home-hunts-search]')
+    || (filtersWrapper ? filtersWrapper.querySelector('form[data-home-hunts-search]') : null);
   const searchInput = searchForm ? searchForm.querySelector('input[type="search"]') : null;
   const searchResetButton = searchForm ? searchForm.querySelector('[data-table-search-reset]') : null;
 

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -30,8 +30,16 @@ body.accueil-fullscreen {
     padding-top: 500px;
 }
 
+.home-hunts__toolbar {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+}
+
 .home-hunts-filters,
-.home-hunts__filters {
+.home-hunts__filters,
+.home-hunts__search {
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -47,7 +55,8 @@ body.accueil-fullscreen {
 }
 
 .home-hunts-filters:focus-within,
-.home-hunts__filters:focus-within {
+.home-hunts__filters:focus-within,
+.home-hunts__search:focus-within {
     box-shadow: 0 22px 40px rgba(var(--color-black-rgb), 0.45);
     transform: translateY(-2px);
 }
@@ -59,18 +68,20 @@ body.accueil-fullscreen {
     width: 100%;
 }
 
-.home-hunts__filters-search {
-    width: 100%;
+.home-hunts__search {
+    align-self: stretch;
 }
 
-.home-hunts__filters-search .table-search {
+.home-hunts__search .table-search {
     width: 100%;
 }
 
 .home-hunts-filters label,
 .home-hunts__filters label,
+.home-hunts__search label,
 .home-hunts-filters legend,
-.home-hunts__filters legend {
+.home-hunts__filters legend,
+.home-hunts__search legend {
     display: block;
     font-size: 0.875rem;
     font-weight: 600;
@@ -138,15 +149,13 @@ body.accueil-fullscreen {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: var(--space-xxs);
-    padding: 0.6rem 1.25rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
     border-radius: 999px;
     border: 1px solid rgba(255, 255, 255, 0.25);
     background: rgba(255, 255, 255, 0.08);
     color: var(--color-white);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
     transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
 }
 
@@ -156,6 +165,21 @@ body.accueil-fullscreen {
     border-color: rgba(255, 255, 255, 0.35);
     transform: translateY(-1px);
     outline: none;
+}
+
+.home-hunts__filters-reset-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.home-hunts__filters-reset-icon svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
 }
 
 .home-hunts__filters-reset:disabled,
@@ -186,36 +210,32 @@ body.accueil-fullscreen {
         align-items: center;
         justify-content: flex-end;
     }
-
-    .home-hunts__filters-reset {
-        width: auto;
-    }
 }
 
 @media (--bp-desktop) {
-    .home-hunts-filters,
-    .home-hunts__filters {
+    .home-hunts__toolbar {
         flex-direction: row;
-        flex-wrap: wrap;
-        align-items: flex-end;
+        align-items: stretch;
+    }
+
+    .home-hunts__filters {
+        flex: 1 1 auto;
+    }
+
+    .home-hunts__search {
+        flex: 0 1 360px;
+    }
+
+    .home-hunts__search .table-search {
+        max-width: 360px;
+        margin-left: auto;
     }
 
     .home-hunts__filters-form {
         flex-direction: row;
         flex-wrap: wrap;
         align-items: flex-end;
-        flex: 1 1 600px;
-    }
-
-    .home-hunts__filters-search {
-        flex: 0 0 auto;
-        display: flex;
-        justify-content: flex-end;
-        margin-left: auto;
-    }
-
-    .home-hunts__filters-search .table-search {
-        max-width: 360px;
+        flex: 1 1 auto;
     }
 
     .home-hunts__filters-group {
@@ -247,6 +267,7 @@ body.accueil-fullscreen {
 }
 
 .home-hunts--loading .home-hunts__filters,
+.home-hunts--loading .home-hunts__search,
 .home-hunts--loading .organisateur-chasse,
 .home-hunts--loading .home-hunts__feedback {
     opacity: 0.65;
@@ -256,6 +277,10 @@ body.accueil-fullscreen {
 .home-hunts--loading .home-hunts__filters,
 .home-hunts--loading .home-hunts__filters select,
 .home-hunts--loading .home-hunts__filters input,
-.home-hunts--loading .home-hunts__filters button {
+.home-hunts--loading .home-hunts__filters button,
+.home-hunts--loading .home-hunts__search,
+.home-hunts--loading .home-hunts__search select,
+.home-hunts--loading .home-hunts__search input,
+.home-hunts--loading .home-hunts__search button {
     cursor: progress;
 }

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -219,16 +219,21 @@ body.accueil-fullscreen {
     }
 
     .home-hunts__filters {
-        flex: 1 1 auto;
+        flex: 1 1 60%;
+        max-width: 52rem;
+        min-width: 0;
     }
 
     .home-hunts__search {
-        flex: 0 1 360px;
+        flex: 1 1 40%;
+        max-width: 34rem;
+        min-width: 0;
+        margin-left: auto;
     }
 
     .home-hunts__search .table-search {
-        max-width: 360px;
-        margin-left: auto;
+        max-width: none;
+        margin-left: 0;
     }
 
     .home-hunts__filters-form {

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -997,6 +997,10 @@ body.woocommerce h2 {
     line-height: 1;
 }
 
+.myaccount-tentatives .table-search__reset-icon {
+    display: none;
+}
+
 .myaccount-tentatives .table-search__reset:hover,
 .myaccount-tentatives .table-search__reset:focus {
     color: var(--color-white);
@@ -1008,17 +1012,7 @@ body.woocommerce h2 {
     border-radius: 999px;
 }
 
-.myaccount-tentatives .table-search__reset-text {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
+
 
 .tentatives-table th:nth-child(2),
 .tentatives-table td:nth-child(2),

--- a/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
@@ -94,28 +94,43 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: var(--space-xxs);
-    padding: var(--space-xs) var(--space-md);
-    border-radius: 0.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    border-radius: 999px;
     border: 1px solid rgba(255, 255, 255, 0.25);
-    background-color: transparent;
+    background-color: rgba(255, 255, 255, 0.08);
     color: var(--color-text-primary);
-    font-size: 0.875rem;
-    font-weight: 600;
     cursor: pointer;
-    transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+    transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
   }
 
   &__reset:hover,
   &__reset:focus {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(255, 255, 255, 0.16);
     border-color: rgba(255, 255, 255, 0.4);
     color: var(--color-white);
+    transform: translateY(-1px);
     outline: none;
   }
 
   &__reset:focus-visible {
     box-shadow: 0 0 0 2px rgba(184, 134, 11, 0.35);
+  }
+
+  &__reset-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  &__reset-icon svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
   }
 }
 
@@ -142,7 +157,7 @@
     }
 
     &__reset {
-      align-self: stretch;
+      align-self: center;
     }
   }
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -922,6 +922,63 @@
   gap: var(--space-md);
 }
 
+/* 🏷️ Badges région & thèmes */
+.chasse-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xxs);
+}
+
+.chasse-card-badges {
+  margin-top: var(--space-xs);
+}
+
+.chasse-meta-badges {
+  margin: var(--space-sm) 0;
+}
+
+.chasse-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  font-weight: 600;
+  text-decoration: none;
+  background: rgba(var(--color-text-fond-clair-rgb), 0.08);
+  color: var(--color-text-fond-clair);
+  border: 1px solid rgba(var(--color-text-fond-clair-rgb), 0.1);
+  transition: background-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.chasse-badge--region {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-text-fond-clair);
+}
+
+.chasse-badge--theme {
+  background: rgba(255, 215, 0, 0.18);
+  border-color: rgba(255, 215, 0, 0.35);
+  color: var(--color-text-fond-clair);
+}
+
+a.chasse-badge {
+  cursor: pointer;
+}
+
+a.chasse-badge:hover,
+a.chasse-badge:focus-visible {
+  text-decoration: none;
+  box-shadow: 0 0 0 2px rgba(var(--color-text-fond-clair-rgb), 0.15);
+}
+
+a.chasse-badge.chasse-badge--region:hover,
+a.chasse-badge.chasse-badge--region:focus-visible {
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.18);
+}
+
 /* ========== 🖼️ COLONNE IMAGE DE LA CHASSE ========== */
 .champ-chasse.champ-img {
   flex: 0 0 auto;
@@ -1166,10 +1223,24 @@
   display: flex;
   gap: var(--space-md);
   align-items: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  row-gap: var(--space-xs);
   justify-content: flex-start;
   font-size: 93%;
   color: var(--color-gris-3);
+}
+
+.caracteristique-region__link,
+.caracteristique-region__text {
+  color: inherit;
+  font-weight: 600;
+}
+
+.caracteristique-region__link {
+  text-decoration: none;
+}
+.caracteristique-region__link:hover, .caracteristique-region__link:focus-visible {
+  text-decoration: underline;
 }
 
 .meta-regular .meta-indic {
@@ -1511,25 +1582,38 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-xxs);
-  padding: var(--space-xs) var(--space-md);
-  border-radius: 0.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.25);
-  background-color: transparent;
+  background-color: rgba(255, 255, 255, 0.08);
   color: var(--color-text-primary);
-  font-size: 0.875rem;
-  font-weight: 600;
   cursor: pointer;
-  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
 }
 .table-search__reset:hover, .table-search__reset:focus {
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(255, 255, 255, 0.16);
   border-color: rgba(255, 255, 255, 0.4);
   color: var(--color-white);
+  transform: translateY(-1px);
   outline: none;
 }
 .table-search__reset:focus-visible {
   box-shadow: 0 0 0 2px rgba(184, 134, 11, 0.35);
+}
+.table-search__reset-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+.table-search__reset-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
 }
 
 @media (min-width: 600px) {
@@ -1551,7 +1635,7 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
     padding: var(--space-xs);
   }
   .table-search__reset {
-    align-self: stretch;
+    align-self: center;
   }
 }
 .table-search--inline .table-search__description {
@@ -2154,12 +2238,27 @@ a.ajout-link:focus-visible {
   font-size: 85%;
 }
 
+.meta-etiquette a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.meta-etiquette a:hover,
+.meta-etiquette a:focus-visible {
+  text-decoration: underline;
+}
+
 .meta-etiquette svg {
   margin-bottom: -5px;
 }
 
 .meta-etiquette span {
   font-weight: 600;
+}
+
+.meta-etiquette__value {
+  font-weight: 400;
 }
 
 .meta-etiquette strong {
@@ -8246,8 +8345,16 @@ body.accueil-fullscreen {
   padding-top: 500px;
 }
 
+.home-hunts__toolbar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
 .home-hunts-filters,
-.home-hunts__filters {
+.home-hunts__filters,
+.home-hunts__search {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -8263,7 +8370,8 @@ body.accueil-fullscreen {
 }
 
 .home-hunts-filters:focus-within,
-.home-hunts__filters:focus-within {
+.home-hunts__filters:focus-within,
+.home-hunts__search:focus-within {
   box-shadow: 0 22px 40px rgba(var(--color-black-rgb), 0.45);
   transform: translateY(-2px);
 }
@@ -8275,18 +8383,20 @@ body.accueil-fullscreen {
   width: 100%;
 }
 
-.home-hunts__filters-search {
-  width: 100%;
+.home-hunts__search {
+  align-self: stretch;
 }
 
-.home-hunts__filters-search .table-search {
+.home-hunts__search .table-search {
   width: 100%;
 }
 
 .home-hunts-filters label,
 .home-hunts__filters label,
+.home-hunts__search label,
 .home-hunts-filters legend,
-.home-hunts__filters legend {
+.home-hunts__filters legend,
+.home-hunts__search legend {
   display: block;
   font-size: 0.875rem;
   font-weight: 600;
@@ -8354,15 +8464,13 @@ body.accueil-fullscreen {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-xxs);
-  padding: 0.6rem 1.25rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.25);
   background: rgba(255, 255, 255, 0.08);
   color: var(--color-white);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
 }
 
@@ -8372,6 +8480,21 @@ body.accueil-fullscreen {
   border-color: rgba(255, 255, 255, 0.35);
   transform: translateY(-1px);
   outline: none;
+}
+
+.home-hunts__filters-reset-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.home-hunts__filters-reset-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
 }
 
 .home-hunts__filters-reset:disabled,
@@ -8402,31 +8525,27 @@ body.accueil-fullscreen {
     align-items: center;
     justify-content: flex-end;
   }
-  .home-hunts__filters-reset {
-    width: auto;
-  }
 }
 @media (min-width: 1024px) {
-  .home-hunts-filters,
-  .home-hunts__filters {
+  .home-hunts__toolbar {
     flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-end;
+    align-items: stretch;
+  }
+  .home-hunts__filters {
+    flex: 1 1 auto;
+  }
+  .home-hunts__search {
+    flex: 0 1 360px;
+  }
+  .home-hunts__search .table-search {
+    max-width: 360px;
+    margin-left: auto;
   }
   .home-hunts__filters-form {
     flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-end;
-    flex: 1 1 600px;
-  }
-  .home-hunts__filters-search {
-    flex: 0 0 auto;
-    display: flex;
-    justify-content: flex-end;
-    margin-left: auto;
-  }
-  .home-hunts__filters-search .table-search {
-    max-width: 360px;
+    flex: 1 1 auto;
   }
   .home-hunts__filters-group {
     flex: 1 1 220px;
@@ -8454,6 +8573,7 @@ body.accueil-fullscreen {
 }
 
 .home-hunts--loading .home-hunts__filters,
+.home-hunts--loading .home-hunts__search,
 .home-hunts--loading .organisateur-chasse,
 .home-hunts--loading .home-hunts__feedback {
   opacity: 0.65;
@@ -8463,7 +8583,11 @@ body.accueil-fullscreen {
 .home-hunts--loading .home-hunts__filters,
 .home-hunts--loading .home-hunts__filters select,
 .home-hunts--loading .home-hunts__filters input,
-.home-hunts--loading .home-hunts__filters button {
+.home-hunts--loading .home-hunts__filters button,
+.home-hunts--loading .home-hunts__search,
+.home-hunts--loading .home-hunts__search select,
+.home-hunts--loading .home-hunts__search input,
+.home-hunts--loading .home-hunts__search button {
   cursor: progress;
 }
 
@@ -10261,6 +10385,10 @@ body.woocommerce h2 {
   line-height: 1;
 }
 
+.myaccount-tentatives .table-search__reset-icon {
+  display: none;
+}
+
 .myaccount-tentatives .table-search__reset:hover,
 .myaccount-tentatives .table-search__reset:focus {
   color: var(--color-white);
@@ -10270,18 +10398,6 @@ body.woocommerce h2 {
   outline: none;
   box-shadow: 0 0 0 2px rgba(225, 169, 95, 0.65);
   border-radius: 999px;
-}
-
-.myaccount-tentatives .table-search__reset-text {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 .tentatives-table th:nth-child(2),

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8532,14 +8532,19 @@ body.accueil-fullscreen {
     align-items: stretch;
   }
   .home-hunts__filters {
-    flex: 1 1 auto;
+    flex: 1 1 60%;
+    max-width: 52rem;
+    min-width: 0;
   }
   .home-hunts__search {
-    flex: 0 1 360px;
+    flex: 1 1 40%;
+    max-width: 34rem;
+    min-width: 0;
+    margin-left: auto;
   }
   .home-hunts__search .table-search {
-    max-width: 360px;
-    margin-left: auto;
+    max-width: none;
+    margin-left: 0;
   }
   .home-hunts__filters-form {
     flex-direction: row;

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -92,73 +92,91 @@ $results_label = sprintf(
     $initial_results_count
 );
 
+$filters_reset_label = __('Réinitialiser les filtres', 'chassesautresor-com');
+$reset_icon_markup   = function_exists('cta_get_reset_icon_markup')
+    ? cta_get_reset_icon_markup()
+    : '';
+
 ob_start();
 ?>
-<div class="home-hunts__filters">
-    <form
-        class="home-hunts__filters-form"
-        data-home-hunts-filters
-        aria-label="<?php echo esc_attr(__('Filtrer les chasses', 'chassesautresor-com')); ?>"
-    >
-        <div class="home-hunts__filters-group home-hunts__filters-group--status">
-            <label for="home-hunts-status"><?php echo esc_html(__('Statut', 'chassesautresor-com')); ?></label>
-            <select
-                id="home-hunts-status"
-                name="home-hunts-status"
-                data-home-hunts-select="statut"
-                data-default-value="<?php echo esc_attr($default_status_filter); ?>"
-            >
-                <?php foreach ($status_options as $status_value => $status_label) : ?>
-                    <?php
-                    $status_count = $available_status_counts[$status_value] ?? 0;
-                    $status_is_available = ('tous' === $status_value) || ($status_count > 0);
-                    ?>
-                    <option
-                        value="<?php echo esc_attr($status_value); ?>"
-                        data-home-hunts-status-option="<?php echo esc_attr($status_value); ?>"
-                        <?php echo selected($default_status_filter, $status_value, false); ?>
-                        <?php if (!$status_is_available) : ?>hidden disabled<?php endif; ?>
-                    >
-                        <?php echo esc_html($status_label); ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-        </div>
-        <fieldset class="home-hunts__filters-group home-hunts__filters-group--cost" data-home-hunts-cost-group>
-            <legend><?php echo esc_html(__('Coût', 'chassesautresor-com')); ?></legend>
-            <?php foreach ($cost_options as $cost_value => $cost_option) : ?>
-                <?php
-                $is_cost_available = in_array($cost_value, $available_cost_values, true);
-                $is_cost_checked  = in_array($cost_value, $default_cost_filters, true);
-                $cost_input_id    = $cost_option['id'] ?? ('home-hunts-cost-' . $cost_value);
-                ?>
-                <div
-                    class="home-hunts__filters-checkbox"
-                    data-home-hunts-cost-option="<?php echo esc_attr($cost_value); ?>"<?php echo $is_cost_available ? '' : ' hidden'; ?>
+<div class="home-hunts__toolbar">
+    <div class="home-hunts__filters">
+        <form
+            class="home-hunts__filters-form"
+            data-home-hunts-filters
+            aria-label="<?php echo esc_attr(__('Filtrer les chasses', 'chassesautresor-com')); ?>"
+        >
+            <div class="home-hunts__filters-group home-hunts__filters-group--status">
+                <label for="home-hunts-status"><?php echo esc_html(__('Statut', 'chassesautresor-com')); ?></label>
+                <select
+                    id="home-hunts-status"
+                    name="home-hunts-status"
+                    data-home-hunts-select="statut"
+                    data-default-value="<?php echo esc_attr($default_status_filter); ?>"
                 >
-                    <input
-                        type="checkbox"
-                        id="<?php echo esc_attr($cost_input_id); ?>"
-                        name="home-hunts-cost[]"
-                        value="<?php echo esc_attr($cost_value); ?>"
-                        data-home-hunts-checkbox="<?php echo esc_attr($cost_value); ?>"
-                        data-default-checked="<?php echo $is_cost_checked ? 'true' : 'false'; ?>"
-                        <?php echo checked($is_cost_checked, true, false); ?>
-                        <?php echo disabled($is_cost_available, false, false); ?>
-                    />
-                    <label for="<?php echo esc_attr($cost_input_id); ?>"><?php echo esc_html($cost_option['label'] ?? ''); ?></label>
-                </div>
-            <?php endforeach; ?>
-        </fieldset>
-        <div class="home-hunts__filters-actions">
-            <button type="reset" class="home-hunts__filters-reset" data-home-hunts-reset><?php echo esc_html(__('Réinitialiser', 'chassesautresor-com')); ?></button>
-            <span class="home-hunts__filters-count" data-home-hunts-count data-default-count="<?php echo esc_attr($initial_results_count); ?>"><?php echo esc_html($results_label); ?></span>
-        </div>
-    </form>
-    <div class="home-hunts__filters-search">
+                    <?php foreach ($status_options as $status_value => $status_label) : ?>
+                        <?php
+                        $status_count        = $available_status_counts[$status_value] ?? 0;
+                        $status_is_available = ('tous' === $status_value) || ($status_count > 0);
+                        ?>
+                        <option
+                            value="<?php echo esc_attr($status_value); ?>"
+                            data-home-hunts-status-option="<?php echo esc_attr($status_value); ?>"
+                            <?php echo selected($default_status_filter, $status_value, false); ?>
+                            <?php if (!$status_is_available) : ?>hidden disabled<?php endif; ?>
+                        >
+                            <?php echo esc_html($status_label); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <fieldset class="home-hunts__filters-group home-hunts__filters-group--cost" data-home-hunts-cost-group>
+                <legend><?php echo esc_html(__('Coût', 'chassesautresor-com')); ?></legend>
+                <?php foreach ($cost_options as $cost_value => $cost_option) : ?>
+                    <?php
+                    $is_cost_available = in_array($cost_value, $available_cost_values, true);
+                    $is_cost_checked  = in_array($cost_value, $default_cost_filters, true);
+                    $cost_input_id    = $cost_option['id'] ?? ('home-hunts-cost-' . $cost_value);
+                    ?>
+                    <div
+                        class="home-hunts__filters-checkbox"
+                        data-home-hunts-cost-option="<?php echo esc_attr($cost_value); ?>"<?php echo $is_cost_available ? '' : ' hidden'; ?>
+                    >
+                        <input
+                            type="checkbox"
+                            id="<?php echo esc_attr($cost_input_id); ?>"
+                            name="home-hunts-cost[]"
+                            value="<?php echo esc_attr($cost_value); ?>"
+                            data-home-hunts-checkbox="<?php echo esc_attr($cost_value); ?>"
+                            data-default-checked="<?php echo $is_cost_checked ? 'true' : 'false'; ?>"
+                            <?php echo checked($is_cost_checked, true, false); ?>
+                            <?php echo disabled($is_cost_available, false, false); ?>
+                        />
+                        <label for="<?php echo esc_attr($cost_input_id); ?>"><?php echo esc_html($cost_option['label'] ?? ''); ?></label>
+                    </div>
+                <?php endforeach; ?>
+            </fieldset>
+            <div class="home-hunts__filters-actions">
+                <button
+                    type="reset"
+                    class="home-hunts__filters-reset"
+                    data-home-hunts-reset
+                    aria-label="<?php echo esc_attr($filters_reset_label); ?>"
+                >
+                    <?php if ($reset_icon_markup) : ?>
+                        <span class="home-hunts__filters-reset-icon" aria-hidden="true">
+                            <?php echo $reset_icon_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </span>
+                    <?php endif; ?>
+                </button>
+                <span class="home-hunts__filters-count" data-home-hunts-count data-default-count="<?php echo esc_attr($initial_results_count); ?>"><?php echo esc_html($results_label); ?></span>
+            </div>
+        </form>
+    </div>
+    <div class="home-hunts__search">
         <?php
         echo cta_render_search_form('home-hunts', [
-            'class'             => 'table-search--inline table-search--compact',
+            'class'             => 'home-hunts__search-form table-search--inline table-search--compact',
             'label'             => '',
             'placeholder'       => __('Rechercher une chasse', 'chassesautresor-com'),
             'submit_icon'       => 'search',

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -26,6 +26,18 @@ function cta_get_table_search_submit_icon_markup(string $icon): string
     }
 }
 
+if (!function_exists('cta_get_reset_icon_markup')) {
+    /**
+     * Returns the SVG markup for reset buttons.
+     */
+    function cta_get_reset_icon_markup(): string
+    {
+        return '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+            . '<path fill="currentColor" d="M12 5V2L8 6l4 4V7c3.309 0 6 2.691 6 6s-2.691 6-6 6-6-2.691-6-6H4c0 4.418 3.582 8 8s8-3.582 8-8-3.582-8-8-8z" />'
+            . '</svg>';
+    }
+}
+
 /**
  * Renders the HTML markup for a table search form.
  *
@@ -272,8 +284,22 @@ function cta_render_search_form(string $key, array $overrides = []): string
                 <?php endif; ?>
             </button>
             <?php if ($show_reset) : ?>
-            <button type="button" class="table-search__reset" data-table-search-reset<?php echo '' === $search_value ? ' hidden' : ''; ?>>
-                <span class="table-search__reset-text"><?php echo esc_html($reset_label); ?></span>
+            <?php
+            $reset_icon_markup = function_exists('cta_get_reset_icon_markup')
+                ? cta_get_reset_icon_markup()
+                : '';
+            ?>
+            <button
+                type="button"
+                class="table-search__reset"
+                data-table-search-reset<?php echo '' === $search_value ? ' hidden' : ''; ?>
+                aria-label="<?php echo esc_attr($reset_label); ?>"
+            >
+                <?php if ('' !== $reset_icon_markup) : ?>
+                <span class="table-search__reset-icon" aria-hidden="true">
+                    <?php echo $reset_icon_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </span>
+                <?php endif; ?>
             </button>
             <?php endif; ?>
         </div>

--- a/wp-content/themes/chassesautresor/inc/search/form.php
+++ b/wp-content/themes/chassesautresor/inc/search/form.php
@@ -33,7 +33,8 @@ if (!function_exists('cta_get_reset_icon_markup')) {
     function cta_get_reset_icon_markup(): string
     {
         return '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
-            . '<path fill="currentColor" d="M12 5V2L8 6l4 4V7c3.309 0 6 2.691 6 6s-2.691 6-6 6-6-2.691-6-6H4c0 4.418 3.582 8 8s8-3.582 8-8-3.582-8-8-8z" />'
+            . '<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"'
+            . ' d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" />'
             . '</svg>';
     }
 }


### PR DESCRIPTION
## Résumé
- Séparation du formulaire de filtres et du bloc de recherche sur la page d’accueil avec un bouton de remise à zéro iconique.
- Ajout d’une icône générique de réinitialisation réutilisée par le formulaire de recherche et stylage associé.
- Mise à jour des styles et du script des filtres pour gérer la nouvelle structure et harmoniser l’apparence des boutons.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d11c649cb48332ae58d49c2c0cdd05