### PR TITLE
Ajuste les filtres de la page d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -101,10 +101,10 @@ body.accueil-fullscreen {
     border: 0;
     margin: 0;
     padding: 0;
-}
-
-.home-hunts__filters-group--cost legend {
-    margin-bottom: var(--space-xs);
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-md);
 }
 
 .home-hunts__filters select {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8416,10 +8416,10 @@ body.accueil-fullscreen {
   border: 0;
   margin: 0;
   padding: 0;
-}
-
-.home-hunts__filters-group--cost legend {
-  margin-bottom: var(--space-xs);
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-md);
 }
 
 .home-hunts__filters select {

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -107,12 +107,12 @@ ob_start();
             aria-label="<?php echo esc_attr(__('Filtrer les chasses', 'chassesautresor-com')); ?>"
         >
             <div class="home-hunts__filters-group home-hunts__filters-group--status">
-                <label for="home-hunts-status"><?php echo esc_html(__('Statut', 'chassesautresor-com')); ?></label>
                 <select
                     id="home-hunts-status"
                     name="home-hunts-status"
                     data-home-hunts-select="statut"
                     data-default-value="<?php echo esc_attr($default_status_filter); ?>"
+                    aria-label="<?php echo esc_attr(__('Statut', 'chassesautresor-com')); ?>"
                 >
                     <?php foreach ($status_options as $status_value => $status_label) : ?>
                         <?php
@@ -130,8 +130,11 @@ ob_start();
                     <?php endforeach; ?>
                 </select>
             </div>
-            <fieldset class="home-hunts__filters-group home-hunts__filters-group--cost" data-home-hunts-cost-group>
-                <legend><?php echo esc_html(__('Coût', 'chassesautresor-com')); ?></legend>
+            <fieldset
+                class="home-hunts__filters-group home-hunts__filters-group--cost"
+                data-home-hunts-cost-group
+                aria-label="<?php echo esc_attr(__('Coût', 'chassesautresor-com')); ?>"
+            >
                 <?php foreach ($cost_options as $cost_value => $cost_option) : ?>
                     <?php
                     $is_cost_available = in_array($cost_value, $available_cost_values, true);


### PR DESCRIPTION
## Résumé
- Réduit la hauteur du bloc de filtres de l'accueil en retirant les libellés visibles tout en conservant leur accessibilité.
- Affiche les options de coût sur une seule ligne et met à jour les styles compilés correspondants.

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d1340050508332a175c2fe08be5cb8