### PR TITLE
Ajout des méta-étiquettes de taxonomie pour les fiches chasse

### DIFF
--- a/tests/ChasseRegionsFallbackTest.php
+++ b/tests/ChasseRegionsFallbackTest.php
@@ -14,11 +14,72 @@ if (!function_exists('is_wp_error')) {
     }
 }
 
+if (!class_exists('WP_Term')) {
+    class WP_Term
+    {
+        public $term_id;
+        public $slug = '';
+        public $name = '';
+        public $taxonomy = '';
+
+        public function __construct($data)
+        {
+            foreach ((array) $data as $key => $value) {
+                $this->$key = $value;
+            }
+        }
+    }
+}
+
 if (!function_exists('get_field')) {
     function get_field($field, $post_id) {
         global $acf_mocked_fields;
 
         return $acf_mocked_fields[$post_id][$field] ?? null;
+    }
+}
+
+$mocked_terms = [];
+
+if (!function_exists('get_term')) {
+    function get_term($term_id, $taxonomy) {
+        global $mocked_terms;
+
+        $term_id = (int) $term_id;
+
+        return $mocked_terms[$taxonomy][$term_id] ?? false;
+    }
+}
+
+if (!function_exists('get_term_by')) {
+    function get_term_by($field, $value, $taxonomy) {
+        global $mocked_terms;
+
+        foreach ($mocked_terms[$taxonomy] ?? [] as $term) {
+            if (!$term instanceof WP_Term) {
+                continue;
+            }
+
+            if ($field === 'slug' && $term->slug === $value) {
+                return $term;
+            }
+
+            if ($field === 'name' && $term->name === $value) {
+                return $term;
+            }
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('get_term_link')) {
+    function get_term_link($term) {
+        if ($term instanceof WP_Term) {
+            return 'https://example.com/' . $term->taxonomy . '/' . $term->slug;
+        }
+
+        return '';
     }
 }
 
@@ -46,6 +107,83 @@ class ChasseRegionsFallbackTest extends TestCase
                 'nom'  => 'Bretagne',
                 'slug' => 'bretagne',
                 'lien' => '',
+            ],
+        ];
+
+        $this->assertSame($expected, chasse_preparer_termes_affichage($chasse_id, 'chasse_region'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_term_identifier_string_is_resolved(): void
+    {
+        global $acf_mocked_fields, $mocked_terms;
+
+        $chasse_id = 654;
+        $mocked_terms = [
+            'chasse_region' => [
+                9 => new WP_Term((object) [
+                    'term_id'  => 9,
+                    'slug'     => 'occitanie',
+                    'name'     => 'Occitanie',
+                    'taxonomy' => 'chasse_region',
+                ]),
+            ],
+        ];
+
+        $acf_mocked_fields = [
+            $chasse_id => [
+                'chasse_region' => 'term_9',
+            ],
+        ];
+
+        $expected = [
+            [
+                'nom'  => 'Occitanie',
+                'slug' => 'occitanie',
+                'lien' => 'https://example.com/chasse_region/occitanie',
+            ],
+        ];
+
+        $this->assertSame($expected, chasse_preparer_termes_affichage($chasse_id, 'chasse_region'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_array_value_with_term_identifier_is_resolved(): void
+    {
+        global $acf_mocked_fields, $mocked_terms;
+
+        $chasse_id = 987;
+        $mocked_terms = [
+            'chasse_region' => [
+                77 => new WP_Term((object) [
+                    'term_id'  => 77,
+                    'slug'     => 'ile-de-france',
+                    'name'     => 'Île-de-France',
+                    'taxonomy' => 'chasse_region',
+                ]),
+            ],
+        ];
+
+        $acf_mocked_fields = [
+            $chasse_id => [
+                'chasse_region' => [
+                    'label' => 'Île-de-France',
+                    'value' => 'term:77',
+                ],
+            ],
+        ];
+
+        $expected = [
+            [
+                'nom'  => 'Île-de-France',
+                'slug' => 'ile-de-france',
+                'lien' => 'https://example.com/chasse_region/ile-de-france',
             ],
         ];
 

--- a/tests/ChasseRegionsFallbackTest.php
+++ b/tests/ChasseRegionsFallbackTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_get_post_terms')) {
+    function wp_get_post_terms($post_id, $taxonomy, $args = []) {
+        return [];
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) {
+        return false;
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($field, $post_id) {
+        global $acf_mocked_fields;
+
+        return $acf_mocked_fields[$post_id][$field] ?? null;
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
+
+class ChasseRegionsFallbackTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_string_field_is_exposed_as_region_badge(): void
+    {
+        global $acf_mocked_fields;
+
+        $chasse_id = 321;
+        $acf_mocked_fields = [
+            $chasse_id => [
+                'chasse_region' => 'Bretagne',
+            ],
+        ];
+
+        $expected = [
+            [
+                'nom'  => 'Bretagne',
+                'slug' => 'bretagne',
+                'lien' => '',
+            ],
+        ];
+
+        $this->assertSame($expected, chasse_preparer_termes_affichage($chasse_id, 'chasse_region'));
+    }
+}
+

--- a/tests/ChasseRegionsFallbackTest.php
+++ b/tests/ChasseRegionsFallbackTest.php
@@ -42,12 +42,22 @@ if (!function_exists('get_field')) {
 $mocked_terms = [];
 
 if (!function_exists('get_term')) {
-    function get_term($term_id, $taxonomy) {
+    function get_term($term_id, $taxonomy = '') {
         global $mocked_terms;
 
         $term_id = (int) $term_id;
 
-        return $mocked_terms[$taxonomy][$term_id] ?? false;
+        if ($taxonomy !== '' && isset($mocked_terms[$taxonomy][$term_id])) {
+            return $mocked_terms[$taxonomy][$term_id];
+        }
+
+        foreach ($mocked_terms as $terms) {
+            if (isset($terms[$term_id])) {
+                return $terms[$term_id];
+            }
+        }
+
+        return false;
     }
 }
 
@@ -184,6 +194,43 @@ class ChasseRegionsFallbackTest extends TestCase
                 'nom'  => 'Île-de-France',
                 'slug' => 'ile-de-france',
                 'lien' => 'https://example.com/chasse_region/ile-de-france',
+            ],
+        ];
+
+        $this->assertSame($expected, chasse_preparer_termes_affichage($chasse_id, 'chasse_region'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_numeric_region_id_is_resolved_via_taxonomy_alias(): void
+    {
+        global $acf_mocked_fields, $mocked_terms;
+
+        $chasse_id = 741;
+        $mocked_terms = [
+            'region' => [
+                29 => new WP_Term((object) [
+                    'term_id'  => 29,
+                    'slug'     => 'paca',
+                    'name'     => 'PACA',
+                    'taxonomy' => 'region',
+                ]),
+            ],
+        ];
+
+        $acf_mocked_fields = [
+            $chasse_id => [
+                'chasse_region' => '29',
+            ],
+        ];
+
+        $expected = [
+            [
+                'nom'  => 'PACA',
+                'slug' => 'paca',
+                'lien' => 'https://example.com/region/paca',
             ],
         ];
 

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1408,13 +1408,40 @@ function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): arr
     }
 
     $terms = wp_get_post_terms($chasse_id, $taxonomy, ['orderby' => 'term_order']);
-    if (is_wp_error($terms) || empty($terms)) {
+    if (is_wp_error($terms)) {
+        $terms = [];
+    }
+
+    if (empty($terms) && function_exists('get_field')) {
+        $acf_fields = [
+            'chasse_region' => 'chasse_region',
+            'theme_chasse'  => 'chasse_theme',
+        ];
+
+        if (isset($acf_fields[$taxonomy])) {
+            $raw_terms = get_field($acf_fields[$taxonomy], $chasse_id);
+            if ($raw_terms instanceof \WP_Term) {
+                $terms = [$raw_terms];
+            } elseif (is_array($raw_terms)) {
+                $terms = array_values(array_filter(
+                    $raw_terms,
+                    static fn($term) => $term instanceof \WP_Term
+                ));
+            }
+        }
+    }
+
+    if (empty($terms)) {
         return [];
     }
 
     $items = [];
 
     foreach ($terms as $term) {
+        if (!$term instanceof \WP_Term) {
+            continue;
+        }
+
         $link = '';
         if (function_exists('get_term_link')) {
             $link = get_term_link($term);

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1403,13 +1403,13 @@ function render_chasse_solutions(int $chasse_id, int $user_id): void
  */
 function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): array
 {
-    if (!function_exists('wp_get_post_terms')) {
-        return [];
-    }
+    $terms = [];
 
-    $terms = wp_get_post_terms($chasse_id, $taxonomy, ['orderby' => 'term_order']);
-    if (is_wp_error($terms)) {
-        $terms = [];
+    if (function_exists('wp_get_post_terms')) {
+        $terms = wp_get_post_terms($chasse_id, $taxonomy, ['orderby' => 'term_order']);
+        if (is_wp_error($terms)) {
+            $terms = [];
+        }
     }
 
     if (empty($terms) && function_exists('get_field')) {
@@ -1420,13 +1420,13 @@ function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): arr
 
         if (isset($acf_fields[$taxonomy])) {
             $raw_terms = get_field($acf_fields[$taxonomy], $chasse_id);
+
             if ($raw_terms instanceof \WP_Term) {
                 $terms = [$raw_terms];
             } elseif (is_array($raw_terms)) {
-                $terms = array_values(array_filter(
-                    $raw_terms,
-                    static fn($term) => $term instanceof \WP_Term
-                ));
+                $terms = chasse_is_list($raw_terms) ? $raw_terms : [$raw_terms];
+            } elseif ($raw_terms !== null && $raw_terms !== '') {
+                $terms = [$raw_terms];
             }
         }
     }
@@ -1438,26 +1438,260 @@ function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): arr
     $items = [];
 
     foreach ($terms as $term) {
-        if (!$term instanceof \WP_Term) {
-            continue;
-        }
+        $item = chasse_normalize_term_for_display($term, $taxonomy);
 
+        if ($item !== null) {
+            $items[] = $item;
+        }
+    }
+
+    return $items;
+}
+
+/**
+ * Normalise une valeur de terme afin de la rendre exploitable pour l'affichage.
+ *
+ * @param mixed  $term     Valeur brute issue de WordPress ou d'ACF.
+ * @param string $taxonomy Taxonomie ciblée.
+ *
+ * @return array{nom: string, slug: string, lien: string}|null
+ */
+function chasse_normalize_term_for_display($term, string $taxonomy): ?array
+{
+    $wp_term = chasse_resolve_term_candidate($term, $taxonomy);
+
+    if ($wp_term instanceof \WP_Term) {
         $link = '';
+
         if (function_exists('get_term_link')) {
-            $link = get_term_link($term);
+            $link = get_term_link($wp_term);
             if (is_wp_error($link)) {
                 $link = '';
             }
         }
 
-        $items[] = [
-            'nom'  => $term->name,
-            'slug' => $term->slug,
-            'lien' => $link,
+        return [
+            'nom'  => $wp_term->name,
+            'slug' => $wp_term->slug,
+            'lien' => is_string($link) ? $link : '',
         ];
     }
 
-    return $items;
+    $name = '';
+    $link = '';
+    $slug_candidates = [];
+
+    if (is_array($term)) {
+        $link_candidates = [
+            $term['lien'] ?? null,
+            $term['link'] ?? null,
+            $term['url'] ?? null,
+        ];
+
+        foreach ($link_candidates as $link_candidate) {
+            if (!is_string($link_candidate)) {
+                continue;
+            }
+
+            $trimmed = trim($link_candidate);
+
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $link = $trimmed;
+            break;
+        }
+
+        $name_candidates = [
+            $term['nom'] ?? null,
+            $term['name'] ?? null,
+            $term['label'] ?? null,
+            $term['value'] ?? null,
+        ];
+
+        foreach ($name_candidates as $candidate) {
+            if (!is_string($candidate) && !is_numeric($candidate)) {
+                continue;
+            }
+
+            $candidate_value = trim((string) $candidate);
+
+            if ($candidate_value === '') {
+                continue;
+            }
+
+            $name = $candidate_value;
+            break;
+        }
+
+        $slug_candidates[] = $term['slug'] ?? null;
+        if (isset($term['value']) && is_string($term['value'])) {
+            $slug_candidates[] = $term['value'];
+        }
+    } elseif (is_string($term) || is_numeric($term)) {
+        $name = trim((string) $term);
+    }
+
+    if ($name === '') {
+        return null;
+    }
+
+    $slug_candidates[] = $name;
+
+    $slug = '';
+
+    foreach ($slug_candidates as $candidate) {
+        if (!is_string($candidate) && !is_numeric($candidate)) {
+            continue;
+        }
+
+        $candidate_value = trim((string) $candidate);
+
+        if ($candidate_value === '') {
+            continue;
+        }
+
+        if (function_exists('sanitize_title')) {
+            $slug = sanitize_title($candidate_value);
+        } else {
+            $slug = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $candidate_value));
+            $slug = trim($slug, '-');
+        }
+
+        if ($slug !== '') {
+            break;
+        }
+    }
+
+    return [
+        'nom'  => $name,
+        'slug' => $slug,
+        'lien' => $link,
+    ];
+}
+
+/**
+ * Tente de transformer une valeur brute en objet \WP_Term.
+ *
+ * @param mixed  $candidate Valeur récupérée via ACF ou le cache.
+ * @param string $taxonomy  Taxonomie ciblée.
+ *
+ * @return \WP_Term|null
+ */
+function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
+{
+    if ($candidate instanceof \WP_Term) {
+        return $candidate;
+    }
+
+    if (is_array($candidate) && isset($candidate['term'])) {
+        $resolved = chasse_resolve_term_candidate($candidate['term'], $taxonomy);
+
+        if ($resolved instanceof \WP_Term) {
+            return $resolved;
+        }
+    }
+
+    if (is_numeric($candidate) && function_exists('get_term')) {
+        $term = get_term((int) $candidate, $taxonomy);
+
+        if ($term instanceof \WP_Term && !is_wp_error($term)) {
+            return $term;
+        }
+    }
+
+    if (is_array($candidate)) {
+        $id_keys = ['term_id', 'termId', 'ID', 'id', 'value'];
+
+        foreach ($id_keys as $key) {
+            if (!isset($candidate[$key]) || !is_numeric($candidate[$key])) {
+                continue;
+            }
+
+            if (!function_exists('get_term')) {
+                break;
+            }
+
+            $term = get_term((int) $candidate[$key], $taxonomy);
+
+            if ($term instanceof \WP_Term && !is_wp_error($term)) {
+                return $term;
+            }
+        }
+
+        $slug_keys = ['slug', 'value'];
+
+        foreach ($slug_keys as $key) {
+            if (!isset($candidate[$key]) || !is_string($candidate[$key])) {
+                continue;
+            }
+
+            if (!function_exists('get_term_by')) {
+                break;
+            }
+
+            $term = get_term_by('slug', trim($candidate[$key]), $taxonomy);
+
+            if ($term instanceof \WP_Term) {
+                return $term;
+            }
+        }
+
+        $name_keys = ['nom', 'name', 'label', 'value'];
+
+        foreach ($name_keys as $key) {
+            if (!isset($candidate[$key]) || !is_string($candidate[$key])) {
+                continue;
+            }
+
+            if (!function_exists('get_term_by')) {
+                break;
+            }
+
+            $term = get_term_by('name', trim($candidate[$key]), $taxonomy);
+
+            if ($term instanceof \WP_Term) {
+                return $term;
+            }
+        }
+    }
+
+    if (is_string($candidate) && function_exists('get_term_by')) {
+        $candidate = trim($candidate);
+
+        if ($candidate !== '') {
+            $term = get_term_by('slug', $candidate, $taxonomy);
+
+            if ($term instanceof \WP_Term) {
+                return $term;
+            }
+
+            $term = get_term_by('name', $candidate, $taxonomy);
+
+            if ($term instanceof \WP_Term) {
+                return $term;
+            }
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Vérifie si un tableau est indexé numériquement en séquence.
+ */
+function chasse_is_list(array $array): bool
+{
+    if (function_exists('array_is_list')) {
+        return array_is_list($array);
+    }
+
+    if ($array === []) {
+        return true;
+    }
+
+    return array_keys($array) === range(0, count($array) - 1);
 }
 
 function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit = 300, array $options = []): array

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1449,6 +1449,75 @@ function chasse_preparer_termes_affichage(int $chasse_id, string $taxonomy): arr
 }
 
 /**
+ * Format raw term items into HTML snippets for the meta-etiquette blocks.
+ *
+ * @param array<int, array<string, mixed>>|null $terms Raw terms as returned by chasse_preparer_termes_affichage.
+ *
+ * @return string[]
+ */
+function chasse_format_meta_terms($terms): array
+{
+    if (!is_array($terms) || $terms === []) {
+        return [];
+    }
+
+    $escape_html = static function (string $value): string {
+        if (function_exists('esc_html')) {
+            return esc_html($value);
+        }
+
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    };
+
+    $format_url = static function (string $url): string {
+        if (function_exists('esc_url')) {
+            return esc_url($url);
+        }
+
+        $sanitized = filter_var($url, FILTER_SANITIZE_URL);
+
+        return is_string($sanitized) ? $sanitized : '';
+    };
+
+    $formatted = [];
+
+    foreach ($terms as $term) {
+        if (!is_array($term)) {
+            continue;
+        }
+
+        $raw_name = $term['nom'] ?? ($term['name'] ?? '');
+        $name     = trim((string) $raw_name);
+
+        if ($name === '') {
+            continue;
+        }
+
+        $raw_link = $term['lien'] ?? ($term['link'] ?? '');
+        $link     = is_string($raw_link) ? trim($raw_link) : '';
+
+        $escaped_name = $escape_html($name);
+
+        if ($link !== '') {
+            $escaped_link = $format_url($link);
+
+            if ($escaped_link !== '') {
+                $formatted[] = sprintf(
+                    '<a class="meta-etiquette__value" href="%s">%s</a>',
+                    $escaped_link,
+                    $escaped_name
+                );
+                continue;
+            }
+        }
+
+        $formatted[] = sprintf('<span class="meta-etiquette__value">%s</span>', $escaped_name);
+    }
+
+    return $formatted;
+}
+
+/**
  * Normalise une valeur de terme afin de la rendre exploitable pour l'affichage.
  *
  * @param mixed  $term     Valeur brute issue de WordPress ou d'ACF.

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1716,25 +1716,47 @@ function chasse_extract_term_id_from_value($value, string $taxonomy): ?int
  */
 function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
 {
-    $load_term_from_value = static function ($value) use ($taxonomy): ?\WP_Term {
+    $taxonomy_candidates = chasse_resolve_taxonomy_aliases($taxonomy);
+
+    $load_term_from_value = static function ($value) use ($taxonomy_candidates): ?\WP_Term {
         if (!function_exists('get_term')) {
             return null;
         }
 
-        $term_id = chasse_extract_term_id_from_value($value, $taxonomy);
+        $term_id = null;
+
+        foreach ($taxonomy_candidates as $taxonomy_candidate) {
+            $term_id = chasse_extract_term_id_from_value($value, $taxonomy_candidate);
+
+            if ($term_id !== null) {
+                break;
+            }
+        }
 
         if ($term_id === null) {
             return null;
         }
 
-        $term = get_term($term_id, $taxonomy);
+        foreach ($taxonomy_candidates as $taxonomy_candidate) {
+            $term = get_term($term_id, $taxonomy_candidate);
 
-        if ($term instanceof \WP_Term) {
-            return $term;
+            if ($term instanceof \WP_Term) {
+                return $term;
+            }
+
+            if (function_exists('is_wp_error') && is_wp_error($term)) {
+                continue;
+            }
         }
 
-        if (function_exists('is_wp_error') && is_wp_error($term)) {
-            return null;
+        $term = get_term($term_id);
+
+        if ($term instanceof \WP_Term) {
+            $term_taxonomy = property_exists($term, 'taxonomy') ? (string) $term->taxonomy : '';
+
+            if ($term_taxonomy === '' || in_array($term_taxonomy, $taxonomy_candidates, true)) {
+                return $term;
+            }
         }
 
         return null;
@@ -1789,10 +1811,12 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
                 $slug = trim((string) $candidate[$key]);
 
                 if ($slug !== '') {
-                    $term = get_term_by('slug', $slug, $taxonomy);
+                    foreach ($taxonomy_candidates as $taxonomy_candidate) {
+                        $term = get_term_by('slug', $slug, $taxonomy_candidate);
 
-                    if ($term instanceof \WP_Term) {
-                        return $term;
+                        if ($term instanceof \WP_Term) {
+                            return $term;
+                        }
                     }
                 }
             }
@@ -1818,10 +1842,12 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
                     continue;
                 }
 
-                $term = get_term_by('name', $name_candidate, $taxonomy);
+                foreach ($taxonomy_candidates as $taxonomy_candidate) {
+                    $term = get_term_by('name', $name_candidate, $taxonomy_candidate);
 
-                if ($term instanceof \WP_Term) {
-                    return $term;
+                    if ($term instanceof \WP_Term) {
+                        return $term;
+                    }
                 }
             }
         }
@@ -1837,21 +1863,46 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
                 return $term;
             }
 
-            $term = get_term_by('slug', $candidate, $taxonomy);
+            foreach ($taxonomy_candidates as $taxonomy_candidate) {
+                $term = get_term_by('slug', $candidate, $taxonomy_candidate);
 
-            if ($term instanceof \WP_Term) {
-                return $term;
-            }
+                if ($term instanceof \WP_Term) {
+                    return $term;
+                }
 
-            $term = get_term_by('name', $candidate, $taxonomy);
+                $term = get_term_by('name', $candidate, $taxonomy_candidate);
 
-            if ($term instanceof \WP_Term) {
-                return $term;
+                if ($term instanceof \WP_Term) {
+                    return $term;
+                }
             }
         }
     }
 
     return null;
+}
+
+/**
+ * Build a list of taxonomy aliases that may be used in the database.
+ */
+function chasse_resolve_taxonomy_aliases(string $taxonomy): array
+{
+    $candidates = [$taxonomy];
+
+    $aliases = [
+        'chasse_region' => ['chasse_regions', 'region', 'regions'],
+        'theme_chasse'  => ['chasse_theme', 'theme_chasses', 'themes_chasse'],
+    ];
+
+    if (isset($aliases[$taxonomy])) {
+        foreach ($aliases[$taxonomy] as $alias) {
+            if (!in_array($alias, $candidates, true)) {
+                $candidates[] = $alias;
+            }
+        }
+    }
+
+    return $candidates;
 }
 
 /**

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1507,6 +1507,9 @@ function chasse_normalize_term_for_display($term, string $taxonomy): ?array
             $term['nom'] ?? null,
             $term['name'] ?? null,
             $term['label'] ?? null,
+            $term['title'] ?? null,
+            $term['post_title'] ?? null,
+            $term['display_name'] ?? null,
             $term['value'] ?? null,
         ];
 
@@ -1518,6 +1521,19 @@ function chasse_normalize_term_for_display($term, string $taxonomy): ?array
             $candidate_value = trim((string) $candidate);
 
             if ($candidate_value === '') {
+                continue;
+            }
+
+            if (ctype_digit($candidate_value)) {
+                continue;
+            }
+
+            $taxonomy_pattern = '/^' . preg_quote($taxonomy, '/') . '[_:-]?\d+$/i';
+            if (preg_match('/^term[_:-]?\d+$/i', $candidate_value)
+                || preg_match('/^term\s+\d+$/i', $candidate_value)
+                || preg_match('/^term\s*id\s*[:=]?\s*\d+$/i', $candidate_value)
+                || preg_match($taxonomy_pattern, $candidate_value)
+            ) {
                 continue;
             }
 
@@ -1572,6 +1588,56 @@ function chasse_normalize_term_for_display($term, string $taxonomy): ?array
 }
 
 /**
+ * Extract a numeric term identifier from raw data returned by ACF or caches.
+ *
+ * @param mixed  $value    Raw candidate value.
+ * @param string $taxonomy Related taxonomy slug.
+ *
+ * @return int|null
+ */
+function chasse_extract_term_id_from_value($value, string $taxonomy): ?int
+{
+    if (is_int($value)) {
+        return $value;
+    }
+
+    if (is_float($value) || (is_numeric($value) && !is_string($value))) {
+        return (int) $value;
+    }
+
+    if (!is_string($value)) {
+        return null;
+    }
+
+    $trimmed = trim($value);
+
+    if ($trimmed === '') {
+        return null;
+    }
+
+    if (ctype_digit($trimmed)) {
+        return (int) $trimmed;
+    }
+
+    $taxonomy_pattern = '/^' . preg_quote($taxonomy, '/') . '[_:-]?\d+$/i';
+    $patterns = [
+        '/^term[_:-]?(\d+)$/i',
+        '/^term\s+(\d+)$/i',
+        '/^term\s*id\s*[:=]?\s*(\d+)$/i',
+        $taxonomy_pattern,
+        '/^id[_:-]?(\d+)$/i',
+    ];
+
+    foreach ($patterns as $pattern) {
+        if (preg_match($pattern, $trimmed, $matches)) {
+            return (int) $matches[1];
+        }
+    }
+
+    return null;
+}
+
+/**
  * Tente de transformer une valeur brute en objet \WP_Term.
  *
  * @param mixed  $candidate Valeur récupérée via ACF ou le cache.
@@ -1581,6 +1647,30 @@ function chasse_normalize_term_for_display($term, string $taxonomy): ?array
  */
 function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
 {
+    $load_term_from_value = static function ($value) use ($taxonomy): ?\WP_Term {
+        if (!function_exists('get_term')) {
+            return null;
+        }
+
+        $term_id = chasse_extract_term_id_from_value($value, $taxonomy);
+
+        if ($term_id === null) {
+            return null;
+        }
+
+        $term = get_term($term_id, $taxonomy);
+
+        if ($term instanceof \WP_Term) {
+            return $term;
+        }
+
+        if (function_exists('is_wp_error') && is_wp_error($term)) {
+            return null;
+        }
+
+        return null;
+    };
+
     if ($candidate instanceof \WP_Term) {
         return $candidate;
     }
@@ -1593,12 +1683,9 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
         }
     }
 
-    if (is_numeric($candidate) && function_exists('get_term')) {
-        $term = get_term((int) $candidate, $taxonomy);
-
-        if ($term instanceof \WP_Term && !is_wp_error($term)) {
-            return $term;
-        }
+    $term_from_root_candidate = $load_term_from_value($candidate);
+    if ($term_from_root_candidate instanceof \WP_Term) {
+        return $term_from_root_candidate;
     }
 
     if (is_array($candidate)) {
@@ -1609,13 +1696,9 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
                 continue;
             }
 
-            if (!function_exists('get_term')) {
-                break;
-            }
+            $term = $load_term_from_value($candidate[$key]);
 
-            $term = get_term((int) $candidate[$key], $taxonomy);
-
-            if ($term instanceof \WP_Term && !is_wp_error($term)) {
+            if ($term instanceof \WP_Term) {
                 return $term;
             }
         }
@@ -1623,36 +1706,54 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
         $slug_keys = ['slug', 'value'];
 
         foreach ($slug_keys as $key) {
-            if (!isset($candidate[$key]) || !is_string($candidate[$key])) {
+            if (!isset($candidate[$key]) || (!is_string($candidate[$key]) && !is_numeric($candidate[$key]))) {
                 continue;
             }
 
-            if (!function_exists('get_term_by')) {
-                break;
-            }
-
-            $term = get_term_by('slug', trim($candidate[$key]), $taxonomy);
+            $term = $load_term_from_value($candidate[$key]);
 
             if ($term instanceof \WP_Term) {
                 return $term;
+            }
+
+            if (function_exists('get_term_by')) {
+                $slug = trim((string) $candidate[$key]);
+
+                if ($slug !== '') {
+                    $term = get_term_by('slug', $slug, $taxonomy);
+
+                    if ($term instanceof \WP_Term) {
+                        return $term;
+                    }
+                }
             }
         }
 
-        $name_keys = ['nom', 'name', 'label', 'value'];
+        $name_keys = ['nom', 'name', 'label', 'value', 'title', 'post_title', 'display_name'];
 
         foreach ($name_keys as $key) {
-            if (!isset($candidate[$key]) || !is_string($candidate[$key])) {
+            if (!isset($candidate[$key]) || (!is_string($candidate[$key]) && !is_numeric($candidate[$key]))) {
                 continue;
             }
 
-            if (!function_exists('get_term_by')) {
-                break;
-            }
-
-            $term = get_term_by('name', trim($candidate[$key]), $taxonomy);
+            $term = $load_term_from_value($candidate[$key]);
 
             if ($term instanceof \WP_Term) {
                 return $term;
+            }
+
+            if (function_exists('get_term_by')) {
+                $name_candidate = trim((string) $candidate[$key]);
+
+                if ($name_candidate === '') {
+                    continue;
+                }
+
+                $term = get_term_by('name', $name_candidate, $taxonomy);
+
+                if ($term instanceof \WP_Term) {
+                    return $term;
+                }
             }
         }
     }
@@ -1661,6 +1762,12 @@ function chasse_resolve_term_candidate($candidate, string $taxonomy): ?\WP_Term
         $candidate = trim($candidate);
 
         if ($candidate !== '') {
+            $term = $load_term_from_value($candidate);
+
+            if ($term instanceof \WP_Term) {
+                return $term;
+            }
+
             $term = get_term_by('slug', $candidate, $taxonomy);
 
             if ($term instanceof \WP_Term) {

--- a/wp-content/themes/chassesautresor/single-chasse.php
+++ b/wp-content/themes/chassesautresor/single-chasse.php
@@ -33,14 +33,6 @@ $peut_voir_aside    = $est_engage_chasse
 
 // Récupération centralisée des infos
 $infos_chasse = preparer_infos_affichage_chasse($chasse_id, $user_id);
-$region_principale = is_array($infos_chasse['region_principale'] ?? null) ? $infos_chasse['region_principale'] : null;
-$themes_badges = array_values(array_filter(
-    is_array($infos_chasse['themes'] ?? null) ? $infos_chasse['themes'] : [],
-    static function ($theme) {
-        return is_array($theme) && !empty($theme['nom']);
-    }
-));
-
 // Champs principaux
 $champs = $infos_chasse['champs'];
 $lot = $champs['lot'];
@@ -265,29 +257,6 @@ if ($peut_voir_aside) {
                 <?= esc_html($error_message); ?>
             </div>
         <?php endif; ?>
-    <?php endif; ?>
-
-    <?php if (!empty($region_principale) || !empty($themes_badges)) : ?>
-        <div class="chasse-meta-badges chasse-badges">
-            <?php if (!empty($region_principale['nom'])) : ?>
-                <?php if (!empty($region_principale['lien'])) : ?>
-                    <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
-                        <?php echo esc_html($region_principale['nom']); ?>
-                    </a>
-                <?php else : ?>
-                    <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
-                <?php endif; ?>
-            <?php endif; ?>
-            <?php foreach ($themes_badges as $theme_badge) : ?>
-                <?php if (!empty($theme_badge['lien'])) : ?>
-                    <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme_badge['lien']); ?>">
-                        <?php echo esc_html($theme_badge['nom']); ?>
-                    </a>
-                <?php else : ?>
-                    <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme_badge['nom']); ?></span>
-                <?php endif; ?>
-            <?php endforeach; ?>
-        </div>
     <?php endif; ?>
 
     <!-- 📦 Fiche complète (images + méta + actions) -->

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -557,41 +557,8 @@ if ($edition_active && !$est_complet) {
         <?php endif; ?>
 
         <?php
-        $format_meta_terms = static function (?array $terms): array {
-            if (!is_array($terms)) {
-                return [];
-            }
-
-            $build_term_output = static function ($term): string {
-                if (!is_array($term)) {
-                    return '';
-                }
-
-                $raw_name = $term['nom'] ?? $term['name'] ?? '';
-                $name = trim((string) $raw_name);
-                if ($name === '') {
-                    return '';
-                }
-
-                $raw_link = $term['lien'] ?? $term['link'] ?? '';
-                $link = trim((string) $raw_link);
-                if ($link !== '') {
-                    $escaped_link = esc_url($link);
-                    if ($escaped_link !== '') {
-                        return '<a class="meta-etiquette__value" href="' . $escaped_link . '">' . esc_html($name) . '</a>';
-                    }
-                }
-
-                return '<span class="meta-etiquette__value">' . esc_html($name) . '</span>';
-            };
-
-            $html_terms = array_map($build_term_output, $terms);
-
-            return array_values(array_filter($html_terms));
-        };
-
-        $regions_links = $format_meta_terms($infos_chasse['regions'] ?? null);
-        $themes_links = $format_meta_terms($infos_chasse['themes'] ?? null);
+        $regions_links = chasse_format_meta_terms($infos_chasse['regions'] ?? null);
+        $themes_links = chasse_format_meta_terms($infos_chasse['themes'] ?? null);
         ?>
         <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
             <div class="chasse-fiche-metas bloc-metas-inline">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -557,81 +557,62 @@ if ($edition_active && !$est_complet) {
         <?php endif; ?>
 
         <?php
-        $regions_terms = array_values(array_filter(
-            is_array($infos_chasse['regions'] ?? null) ? $infos_chasse['regions'] : [],
-            static function ($region) {
-                return is_array($region) && !empty($region['nom']);
+        $format_meta_terms = static function (?array $terms): array {
+            if (!is_array($terms)) {
+                return [];
             }
-        ));
-        $themes_terms = array_values(array_filter(
-            is_array($infos_chasse['themes'] ?? null) ? $infos_chasse['themes'] : [],
-            static function ($theme) {
-                return is_array($theme) && !empty($theme['nom']);
-            }
-        ));
+
+            $build_term_output = static function ($term): string {
+                if (!is_array($term)) {
+                    return '';
+                }
+
+                $raw_name = $term['nom'] ?? $term['name'] ?? '';
+                $name = trim((string) $raw_name);
+                if ($name === '') {
+                    return '';
+                }
+
+                $raw_link = $term['lien'] ?? $term['link'] ?? '';
+                $link = trim((string) $raw_link);
+                if ($link !== '') {
+                    $escaped_link = esc_url($link);
+                    if ($escaped_link !== '') {
+                        return '<a class="meta-etiquette__value" href="' . $escaped_link . '">' . esc_html($name) . '</a>';
+                    }
+                }
+
+                return '<span class="meta-etiquette__value">' . esc_html($name) . '</span>';
+            };
+
+            $html_terms = array_map($build_term_output, $terms);
+
+            return array_values(array_filter($html_terms));
+        };
+
+        $regions_links = $format_meta_terms($infos_chasse['regions'] ?? null);
+        $themes_links = $format_meta_terms($infos_chasse['themes'] ?? null);
         ?>
-        <?php if (!empty($regions_terms) || !empty($themes_terms)) : ?>
+        <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
             <div class="chasse-fiche-metas bloc-metas-inline">
-                <?php if (!empty($regions_terms)) : ?>
+                <?php if (!empty($regions_links)) : ?>
                     <?php
-                    $regions_label = _n('Région :', 'Régions :', count($regions_terms), 'chassesautresor-com');
-                    $regions_links = array_filter(
-                        array_map(
-                            static function ($region) {
-                                $name = esc_html((string) ($region['nom'] ?? ''));
-                                if ($name === '') {
-                                    return '';
-                                }
-
-                                $link = !empty($region['lien']) ? esc_url($region['lien']) : '';
-
-                                if ($link !== '') {
-                                    return '<a class="meta-etiquette__value" href="' . $link . '">' . $name . '</a>';
-                                }
-
-                                return '<span class="meta-etiquette__value">' . $name . '</span>';
-                            },
-                            $regions_terms
-                        )
-                    );
+                    $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
                     ?>
-                    <?php if (!empty($regions_links)) : ?>
-                        <div class="meta-etiquette meta-etiquette--regions">
-                            <span><?php echo esc_html($regions_label); ?></span>
-                            <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
-                        </div>
-                    <?php endif; ?>
+                    <div class="meta-etiquette meta-etiquette--regions">
+                        <span><?php echo esc_html($regions_label); ?></span>
+                        <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                    </div>
                 <?php endif; ?>
 
-                <?php if (!empty($themes_terms)) : ?>
+                <?php if (!empty($themes_links)) : ?>
                     <?php
-                    $themes_label = _n('Thème :', 'Thèmes :', count($themes_terms), 'chassesautresor-com');
-                    $themes_links = array_filter(
-                        array_map(
-                            static function ($theme) {
-                                $name = esc_html((string) ($theme['nom'] ?? ''));
-                                if ($name === '') {
-                                    return '';
-                                }
-
-                                $link = !empty($theme['lien']) ? esc_url($theme['lien']) : '';
-
-                                if ($link !== '') {
-                                    return '<a class="meta-etiquette__value" href="' . $link . '">' . $name . '</a>';
-                                }
-
-                                return '<span class="meta-etiquette__value">' . $name . '</span>';
-                            },
-                            $themes_terms
-                        )
-                    );
+                    $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
                     ?>
-                    <?php if (!empty($themes_links)) : ?>
-                        <div class="meta-etiquette meta-etiquette--themes">
-                            <span><?php echo esc_html($themes_label); ?></span>
-                            <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
-                        </div>
-                    <?php endif; ?>
+                    <div class="meta-etiquette meta-etiquette--themes">
+                        <span><?php echo esc_html($themes_label); ?></span>
+                        <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                    </div>
                 <?php endif; ?>
             </div>
         <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -557,8 +557,18 @@ if ($edition_active && !$est_complet) {
         <?php endif; ?>
 
         <?php
-        $regions_links = chasse_format_meta_terms($infos_chasse['regions'] ?? null);
-        $themes_links = chasse_format_meta_terms($infos_chasse['themes'] ?? null);
+        $regions_terms = $infos_chasse['regions'] ?? null;
+        if (empty($regions_terms)) {
+            $regions_terms = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
+        }
+
+        $themes_terms = $infos_chasse['themes'] ?? null;
+        if (empty($themes_terms)) {
+            $themes_terms = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
+        }
+
+        $regions_links = chasse_format_meta_terms($regions_terms);
+        $themes_links = chasse_format_meta_terms($themes_terms);
         ?>
         <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
             <div class="chasse-fiche-metas bloc-metas-inline">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -556,6 +556,86 @@ if ($edition_active && !$est_complet) {
             </div>
         <?php endif; ?>
 
+        <?php
+        $regions_terms = array_values(array_filter(
+            is_array($infos_chasse['regions'] ?? null) ? $infos_chasse['regions'] : [],
+            static function ($region) {
+                return is_array($region) && !empty($region['nom']);
+            }
+        ));
+        $themes_terms = array_values(array_filter(
+            is_array($infos_chasse['themes'] ?? null) ? $infos_chasse['themes'] : [],
+            static function ($theme) {
+                return is_array($theme) && !empty($theme['nom']);
+            }
+        ));
+        ?>
+        <?php if (!empty($regions_terms) || !empty($themes_terms)) : ?>
+            <div class="chasse-fiche-metas bloc-metas-inline">
+                <?php if (!empty($regions_terms)) : ?>
+                    <?php
+                    $regions_label = _n('Région :', 'Régions :', count($regions_terms), 'chassesautresor-com');
+                    $regions_links = array_filter(
+                        array_map(
+                            static function ($region) {
+                                $name = esc_html((string) ($region['nom'] ?? ''));
+                                if ($name === '') {
+                                    return '';
+                                }
+
+                                $link = !empty($region['lien']) ? esc_url($region['lien']) : '';
+
+                                if ($link !== '') {
+                                    return '<a class="meta-etiquette__value" href="' . $link . '">' . $name . '</a>';
+                                }
+
+                                return '<span class="meta-etiquette__value">' . $name . '</span>';
+                            },
+                            $regions_terms
+                        )
+                    );
+                    ?>
+                    <?php if (!empty($regions_links)) : ?>
+                        <div class="meta-etiquette meta-etiquette--regions">
+                            <span><?php echo esc_html($regions_label); ?></span>
+                            <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                        </div>
+                    <?php endif; ?>
+                <?php endif; ?>
+
+                <?php if (!empty($themes_terms)) : ?>
+                    <?php
+                    $themes_label = _n('Thème :', 'Thèmes :', count($themes_terms), 'chassesautresor-com');
+                    $themes_links = array_filter(
+                        array_map(
+                            static function ($theme) {
+                                $name = esc_html((string) ($theme['nom'] ?? ''));
+                                if ($name === '') {
+                                    return '';
+                                }
+
+                                $link = !empty($theme['lien']) ? esc_url($theme['lien']) : '';
+
+                                if ($link !== '') {
+                                    return '<a class="meta-etiquette__value" href="' . $link . '">' . $name . '</a>';
+                                }
+
+                                return '<span class="meta-etiquette__value">' . $name . '</span>';
+                            },
+                            $themes_terms
+                        )
+                    );
+                    ?>
+                    <?php if (!empty($themes_links)) : ?>
+                        <div class="meta-etiquette meta-etiquette--themes">
+                            <span><?php echo esc_html($themes_label); ?></span>
+                            <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                        </div>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+
       </div>
   </div>
 </section>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -92,13 +92,8 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' role="img" tabindex="0"';
 }
 
-$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
-$themes = array_values(array_filter(
-    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
-    static function ($theme) {
-        return is_array($theme) && !empty($theme['nom']);
-    }
-));
+$regions_links = chasse_format_meta_terms($infos['regions'] ?? null);
+$themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
@@ -115,26 +110,27 @@ $themes = array_values(array_filter(
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
-            <?php if (!empty($region_principale) || !empty($themes)) : ?>
-                <div class="chasse-card-badges chasse-badges">
-                    <?php if (!empty($region_principale['nom'])) : ?>
-                        <?php if (!empty($region_principale['lien'])) : ?>
-                            <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
-                                <?php echo esc_html($region_principale['nom']); ?>
-                            </a>
-                        <?php else : ?>
-                            <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
-                        <?php endif; ?>
+            <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
+                <div class="bloc-metas-inline bloc-metas-inline--compact">
+                    <?php if (!empty($regions_links)) : ?>
+                        <?php
+                        $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
+                        ?>
+                        <div class="meta-etiquette meta-etiquette--regions">
+                            <span><?php echo esc_html($regions_label); ?></span>
+                            <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                        </div>
                     <?php endif; ?>
-                    <?php foreach ($themes as $theme) : ?>
-                        <?php if (!empty($theme['lien'])) : ?>
-                            <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
-                                <?php echo esc_html($theme['nom']); ?>
-                            </a>
-                        <?php else : ?>
-                            <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
-                        <?php endif; ?>
-                    <?php endforeach; ?>
+
+                    <?php if (!empty($themes_links)) : ?>
+                        <?php
+                        $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
+                        ?>
+                        <div class="meta-etiquette meta-etiquette--themes">
+                            <span><?php echo esc_html($themes_label); ?></span>
+                            <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                        </div>
+                    <?php endif; ?>
                 </div>
             <?php endif; ?>
             <?php echo $infos['lot_html']; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -48,13 +48,8 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' role="img" tabindex="0"';
 }
 
-$region_principale = is_array($infos['region_principale'] ?? null) ? $infos['region_principale'] : null;
-$themes = array_values(array_filter(
-    is_array($infos['themes'] ?? null) ? $infos['themes'] : [],
-    static function ($theme) {
-        return is_array($theme) && !empty($theme['nom']);
-    }
-));
+$regions_links = chasse_format_meta_terms($infos['regions'] ?? null);
+$themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
@@ -119,26 +114,27 @@ $themes = array_values(array_filter(
             <h3 class="carte-wide__titre">
                 <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
             </h3>
-            <?php if (!empty($region_principale) || !empty($themes)) : ?>
-                <div class="chasse-card-badges chasse-badges">
-                    <?php if (!empty($region_principale['nom'])) : ?>
-                        <?php if (!empty($region_principale['lien'])) : ?>
-                            <a class="chasse-badge chasse-badge--region" href="<?php echo esc_url($region_principale['lien']); ?>">
-                                <?php echo esc_html($region_principale['nom']); ?>
-                            </a>
-                        <?php else : ?>
-                            <span class="chasse-badge chasse-badge--region"><?php echo esc_html($region_principale['nom']); ?></span>
-                        <?php endif; ?>
+            <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
+                <div class="bloc-metas-inline bloc-metas-inline--compact">
+                    <?php if (!empty($regions_links)) : ?>
+                        <?php
+                        $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
+                        ?>
+                        <div class="meta-etiquette meta-etiquette--regions">
+                            <span><?php echo esc_html($regions_label); ?></span>
+                            <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                        </div>
                     <?php endif; ?>
-                    <?php foreach ($themes as $theme) : ?>
-                        <?php if (!empty($theme['lien'])) : ?>
-                            <a class="chasse-badge chasse-badge--theme" href="<?php echo esc_url($theme['lien']); ?>">
-                                <?php echo esc_html($theme['nom']); ?>
-                            </a>
-                        <?php else : ?>
-                            <span class="chasse-badge chasse-badge--theme"><?php echo esc_html($theme['nom']); ?></span>
-                        <?php endif; ?>
-                    <?php endforeach; ?>
+
+                    <?php if (!empty($themes_links)) : ?>
+                        <?php
+                        $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
+                        ?>
+                        <div class="meta-etiquette meta-etiquette--themes">
+                            <span><?php echo esc_html($themes_label); ?></span>
+                            <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                        </div>
+                    <?php endif; ?>
                 </div>
             <?php endif; ?>
         </div>


### PR DESCRIPTION
Affichage des badges taxonomiques au bas des fiches chasse.

- Affiche les régions et thèmes liés à la chasse dans la fiche via un conteneur « meta-etiquette », avec des liens lorsqu’ils existent. 
- Filtre et sécurise les termes associés en gérant le singulier/pluriel des libellés.

**Testing**
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d13c22dc288332bf07144d1011e335