### PR TITLE
Fix homepage hunts filter results duplication

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -215,14 +215,21 @@
   }
 
   function clearHunts() {
-    const startNode = filtersWrapper ? filtersWrapper.nextSibling : form.nextSibling;
+    const toolbar = grid.querySelector('.home-hunts__toolbar');
+    const startNode = toolbar ? toolbar.nextSibling : grid.firstChild;
     let node = startNode;
 
-    while (node && node !== feedbackElement) {
+    while (node) {
+      if (node === feedbackElement) {
+        break;
+      }
+
       const next = node.nextSibling;
+
       if (node.parentNode) {
         node.parentNode.removeChild(node);
       }
+
       node = next;
     }
   }


### PR DESCRIPTION
Résumé : corrige la mise à jour des résultats filtrés des chasses sur la page d'accueil pour éviter les doublons.

- Ajuste le nettoyage du contenu de la grille pour repartir des filtres avant d'insérer les nouveaux résultats.
- Empêche l'accumulation d'éléments de chasse obsolètes lorsque les filtres sont modifiés via AJAX.

**Tests**
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d13cf48f048332aba1daf483f101ff