### PR TITLE
Fix hunts filter count display on load

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -238,11 +238,24 @@
     if (isVisible) {
       countElement.hidden = false;
       countElement.removeAttribute('aria-hidden');
+
+      if (countElement.style) {
+        if (typeof countElement.style.removeProperty === 'function') {
+          countElement.style.removeProperty('display');
+        } else {
+          countElement.style.display = '';
+        }
+      }
+
       return;
     }
 
     countElement.hidden = true;
     countElement.setAttribute('aria-hidden', 'true');
+
+    if (countElement.style) {
+      countElement.style.display = 'none';
+    }
   }
 
   function updateCount(total, allowFallback = true) {

--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -230,6 +230,21 @@
     return `${formatNumber(countValue)} ${countValue > 1 ? pluralWord : singularWord}`;
   }
 
+  function setCountVisibility(isVisible) {
+    if (!countElement) {
+      return;
+    }
+
+    if (isVisible) {
+      countElement.hidden = false;
+      countElement.removeAttribute('aria-hidden');
+      return;
+    }
+
+    countElement.hidden = true;
+    countElement.setAttribute('aria-hidden', 'true');
+  }
+
   function updateCount(total, allowFallback = true) {
     if (!countElement) {
       return;
@@ -246,11 +261,13 @@
       if (countElement.dataset) {
         delete countElement.dataset.count;
       }
+      setCountVisibility(false);
       return;
     }
 
     countElement.textContent = formatCountLabel(value);
     countElement.dataset.count = String(value);
+    setCountVisibility(true);
   }
 
   function clearHunts() {

--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -43,10 +43,45 @@
     countElement.dataset.template = countElement.textContent || '';
   }
 
-  const defaultCountValue = countElement
-    ? parseInt(countElement.dataset.defaultCount || '', 10)
-    : null;
+  function normalizeCount(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(0, Math.trunc(value));
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+
+      if (trimmed.length === 0) {
+        return null;
+      }
+
+      const cleaned = trimmed.replace(/[^0-9]/gu, '');
+
+      if (cleaned.length === 0) {
+        return null;
+      }
+
+      const parsed = parseInt(cleaned, 10);
+
+      if (Number.isFinite(parsed)) {
+        return Math.max(0, parsed);
+      }
+    }
+
+    return null;
+  }
+
+  let defaultCountValue = countElement ? normalizeCount(countElement.dataset.defaultCount || '') : null;
   const defaultTemplate = countElement ? countElement.dataset.template || '' : '';
+
+  if (countElement && defaultCountValue === null) {
+    const existingCount = normalizeCount(countElement.dataset.count || countElement.textContent || '');
+
+    if (existingCount !== null) {
+      defaultCountValue = existingCount;
+      countElement.dataset.defaultCount = String(defaultCountValue);
+    }
+  }
 
   if (resetButton && resetLabel) {
     resetButton.setAttribute('aria-label', resetLabel);
@@ -200,7 +235,7 @@
       return;
     }
 
-    let value = typeof total === 'number' && Number.isFinite(total) ? Math.max(0, Math.trunc(total)) : null;
+    let value = normalizeCount(total);
 
     if (null === value) {
       value = Number.isFinite(defaultCountValue) ? Math.max(0, Math.trunc(defaultCountValue)) : null;
@@ -449,7 +484,7 @@
       replaceHunts('');
     }
 
-    const totalValue = typeof payload.total === 'number' ? payload.total : null;
+    const totalValue = normalizeCount(payload.total);
 
     if (totalValue !== null) {
       updateCount(totalValue);
@@ -636,6 +671,10 @@
     searchInput.addEventListener('input', () => {
       toggleSearchReset(getSearchTerm() !== '');
     });
+  }
+
+  if (countElement && defaultCountValue !== null) {
+    updateCount(defaultCountValue);
   }
 
   toggleSearchReset(getSearchTerm() !== '');

--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -230,18 +230,22 @@
     return `${formatNumber(countValue)} ${countValue > 1 ? pluralWord : singularWord}`;
   }
 
-  function updateCount(total) {
+  function updateCount(total, allowFallback = true) {
     if (!countElement) {
       return;
     }
 
     let value = normalizeCount(total);
 
-    if (null === value) {
+    if (null === value && allowFallback) {
       value = Number.isFinite(defaultCountValue) ? Math.max(0, Math.trunc(defaultCountValue)) : null;
     }
 
     if (null === value) {
+      countElement.textContent = '';
+      if (countElement.dataset) {
+        delete countElement.dataset.count;
+      }
       return;
     }
 
@@ -623,7 +627,7 @@
   function onResetClick(event) {
     event.preventDefault();
     restoreDefaults();
-    updateCount(defaultCountValue);
+    updateCount(null, false);
     clearFeedback();
     submitFilters();
   }
@@ -673,8 +677,8 @@
     });
   }
 
-  if (countElement && defaultCountValue !== null) {
-    updateCount(defaultCountValue);
+  if (countElement) {
+    updateCount(null, false);
   }
 
   toggleSearchReset(getSearchTerm() !== '');

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -172,7 +172,13 @@ ob_start();
                         </span>
                     <?php endif; ?>
                 </button>
-                <span class="home-hunts__filters-count" data-home-hunts-count data-default-count="<?php echo esc_attr($initial_results_count); ?>"><?php echo esc_html($results_label); ?></span>
+                <span
+                    class="home-hunts__filters-count"
+                    data-home-hunts-count
+                    data-default-count="<?php echo esc_attr($initial_results_count); ?>"
+                    hidden
+                    aria-hidden="true"
+                ><?php echo esc_html($results_label); ?></span>
             </div>
         </form>
     </div>


### PR DESCRIPTION
Résumé : Corrige l'affichage du compteur de résultats sur la page d'accueil.

- Normalise la lecture du nombre de résultats pour les filtres de chasse.
- Initialise le compteur lors du chargement et accepte les totaux renvoyés en chaîne.

**Tests**
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d145e731b88332a7b1941a26e74b6b