### PR TITLE
Aligne verticalement les filtres de la home

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -239,7 +239,7 @@ body.accueil-fullscreen {
     .home-hunts__filters-form {
         flex-direction: row;
         flex-wrap: wrap;
-        align-items: flex-end;
+        align-items: center;
         flex: 1 1 auto;
     }
 
@@ -253,7 +253,7 @@ body.accueil-fullscreen {
 
     .home-hunts__filters-actions {
         flex: 0 0 auto;
-        align-items: flex-end;
+        align-items: center;
         justify-content: flex-end;
         margin-left: auto;
     }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8549,7 +8549,7 @@ body.accueil-fullscreen {
   .home-hunts__filters-form {
     flex-direction: row;
     flex-wrap: wrap;
-    align-items: flex-end;
+    align-items: center;
     flex: 1 1 auto;
   }
   .home-hunts__filters-group {
@@ -8560,7 +8560,7 @@ body.accueil-fullscreen {
   }
   .home-hunts__filters-actions {
     flex: 0 0 auto;
-    align-items: flex-end;
+    align-items: center;
     justify-content: flex-end;
     margin-left: auto;
   }


### PR DESCRIPTION
Alignement du bloc de filtres de la home.

- Centre verticalement les champs du formulaire de filtres sur desktop.
- Met à jour la feuille de style compilée.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d14dee48b08332a3b0febb3247ac9d