### PR TITLE
Assouplir la largeur du champ de recherche compact

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/components/_table-search.scss
@@ -194,8 +194,8 @@
 
   @media (--bp-mobile) {
     .table-search__field {
-      flex: 0 1 20rem;
-      max-width: 20rem;
+      flex: 1 1 auto;
+      max-width: none;
     }
   }
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1664,8 +1664,8 @@ body.edition-active-chasse .chasse-enigmes-header .liens-placeholder {
 }
 @media (min-width: 600px) {
   .table-search--compact .table-search__field {
-    flex: 0 1 20rem;
-    max-width: 20rem;
+    flex: 1 1 auto;
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
Ajuste la variante compacte de la barre de recherche pour occuper toute la largeur.

- Restaure un comportement flex extensible pour le champ de recherche compact en SCSS.
- Recompile les styles pour propager la mise à jour vers le fichier distribué.

**Tests**
- `npm run build:css`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d150c9bb508332863f4281e65c6889