### PR TITLE
Corrige l'espacement du bouton de réinitialisation sur la page d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -208,7 +208,8 @@ body.accueil-fullscreen {
     .home-hunts__filters-actions {
         flex-direction: row;
         align-items: center;
-        justify-content: flex-end;
+        justify-content: flex-start;
+        align-self: flex-start;
     }
 }
 
@@ -254,8 +255,8 @@ body.accueil-fullscreen {
     .home-hunts__filters-actions {
         flex: 0 0 auto;
         align-items: center;
-        justify-content: flex-end;
-        margin-left: auto;
+        justify-content: flex-start;
+        margin-left: 0;
     }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -249,7 +249,7 @@ body.accueil-fullscreen {
     }
 
     .home-hunts__filters-group--cost {
-        flex: 1 1 260px;
+        flex: 0 1 auto;
     }
 
     .home-hunts__filters-actions {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8543,7 +8543,8 @@ body.accueil-fullscreen {
   .home-hunts__filters-actions {
     flex-direction: row;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: flex-start;
+    align-self: flex-start;
   }
 }
 @media (min-width: 1024px) {
@@ -8581,8 +8582,8 @@ body.accueil-fullscreen {
   .home-hunts__filters-actions {
     flex: 0 0 auto;
     align-items: center;
-    justify-content: flex-end;
-    margin-left: auto;
+    justify-content: flex-start;
+    margin-left: 0;
   }
 }
 .home-hunts__feedback {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8577,7 +8577,7 @@ body.accueil-fullscreen {
     flex: 1 1 220px;
   }
   .home-hunts__filters-group--cost {
-    flex: 1 1 260px;
+    flex: 0 1 auto;
   }
   .home-hunts__filters-actions {
     flex: 0 0 auto;


### PR DESCRIPTION
## Résumé
- Réduit l'espace laissé avant le bouton de réinitialisation des filtres sur la page d'accueil

## Changements notables
- Ajuste l'alignement du conteneur d'actions des filtres afin qu'il reste accolé aux contrôles
- Recompile la feuille de styles du thème pour refléter ces ajustements

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d152719ed88332b222dfb1c0018080