### PR TITLE
Réorganise l'affichage des métadonnées des chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -672,6 +672,21 @@
   flex-direction: column;
 }
 
+.carte-wide__metas {
+  margin: var(--space-xs) 0 0;
+  gap: var(--space-sm);
+}
+
+.carte-wide__metas .meta-regular {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
+.carte-wide__metas .meta-label {
+  font-weight: 600;
+}
+
 .carte-wide__content .chasse-intro-extrait {
   margin-top: auto;
   margin-bottom: auto;
@@ -679,6 +694,7 @@
 
 .carte-wide__titre {
   margin-top: 0;
+  margin-bottom: var(--space-xs);
 }
 
 .carte-wide__footer .cta-div {
@@ -700,6 +716,29 @@
     flex: 0 0 300px;
     width: 300px;
     height: 300px;
+  }
+
+  .carte-wide__metas {
+    flex-wrap: nowrap;
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    overflow: hidden;
+    pointer-events: none;
+    transition:
+      opacity var(--transition-medium),
+      max-height var(--transition-medium),
+      margin-top var(--transition-medium);
+  }
+
+  .carte-wide:hover .carte-wide__metas,
+  .carte-wide:focus-within .carte-wide__metas {
+    margin-top: var(--space-xs);
+    max-height: 200px;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -639,6 +639,21 @@
   flex-direction: column;
 }
 
+.carte-wide__metas {
+  margin: var(--space-xs) 0 0;
+  gap: var(--space-sm);
+}
+
+.carte-wide__metas .meta-regular {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
+.carte-wide__metas .meta-label {
+  font-weight: 600;
+}
+
 .carte-wide__content .chasse-intro-extrait {
   margin-top: auto;
   margin-bottom: auto;
@@ -646,6 +661,7 @@
 
 .carte-wide__titre {
   margin-top: 0;
+  margin-bottom: var(--space-xs);
 }
 
 .carte-wide__footer .cta-div {
@@ -666,6 +682,24 @@
     flex: 0 0 300px;
     width: 300px;
     height: 300px;
+  }
+  .carte-wide__metas {
+    flex-wrap: nowrap;
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    overflow: hidden;
+    pointer-events: none;
+    transition: opacity var(--transition-medium), max-height var(--transition-medium), margin-top var(--transition-medium);
+  }
+  .carte-wide:hover .carte-wide__metas,
+  .carte-wide:focus-within .carte-wide__metas {
+    margin-top: var(--space-xs);
+    max-height: 200px;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 }
 /* ========== ➕ Cartes d'ajout d'énigme et de chasse ========== */

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -114,52 +114,52 @@ $themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
             <h3 class="carte-wide__titre">
                 <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
             </h3>
-            <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
-                <div class="bloc-metas-inline bloc-metas-inline--compact">
-                    <?php if (!empty($regions_links)) : ?>
-                        <?php
-                        $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
-                        ?>
-                        <div class="meta-etiquette meta-etiquette--regions">
-                            <span><?php echo esc_html($regions_label); ?></span>
-                            <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
-                        </div>
-                    <?php endif; ?>
-
-                    <?php if (!empty($themes_links)) : ?>
-                        <?php
-                        $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
-                        ?>
-                        <div class="meta-etiquette meta-etiquette--themes">
-                            <span><?php echo esc_html($themes_label); ?></span>
-                            <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            <?php endif; ?>
         </div>
 
         <div class="carte-wide__content">
-            <div class="meta-row svg-xsmall">
-                <div class="meta-regular">
+            <div class="carte-wide__metas meta-row svg-xsmall">
+                <div class="meta-regular meta-regular--enigmes">
                     <?php echo get_svg_icon('enigme'); ?>
-                    <?php
-                    echo esc_html(
-                        sprintf(
-                            _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
-                            $infos['total_enigmes']
-                        )
-                    );
-                    ?> —
-                    <?php echo get_svg_icon('participants'); ?><?php echo esc_html($infos['nb_joueurs_label']); ?>
+                    <span class="meta-label">
+                        <?php
+                        echo esc_html(
+                            sprintf(
+                                _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                                $infos['total_enigmes']
+                            )
+                        );
+                        ?>
+                    </span>
                 </div>
-                <div class="meta-etiquette">
+                <div class="meta-regular meta-regular--participants">
+                    <?php echo get_svg_icon('participants'); ?>
+                    <span class="meta-label"><?php echo esc_html($infos['nb_joueurs_label']); ?></span>
+                </div>
+                <div class="meta-etiquette meta-etiquette--dates">
                     <?php echo get_svg_icon('calendar'); ?>
                     <span class="chasse-date-plage">
                         <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
                         <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
                     </span>
                 </div>
+                <?php if (!empty($regions_links)) : ?>
+                    <?php
+                    $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
+                    ?>
+                    <div class="meta-etiquette meta-etiquette--regions">
+                        <span><?php echo esc_html($regions_label); ?></span>
+                        <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                    </div>
+                <?php endif; ?>
+                <?php if (!empty($themes_links)) : ?>
+                    <?php
+                    $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
+                    ?>
+                    <div class="meta-etiquette meta-etiquette--themes">
+                        <span><?php echo esc_html($themes_label); ?></span>
+                        <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                    </div>
+                <?php endif; ?>
             </div>
 
             <?php echo $infos['extrait_html']; ?>


### PR DESCRIPTION
Résumé : harmonisation de l'affichage des métadonnées sur les cartes de chasse.
- Regroupe toutes les métadonnées sur une seule ligne et place les taxonomies après les dates.
- Masque les métadonnées au repos sur desktop et les dévoile au survol tout en réduisant l'espace sous le titre.
- Recompile la feuille de style du thème.

## Testing
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d1617f9b1c8332ab344854b16ebc66