### PR TITLE
Add hero separator to homepage

### DIFF
--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -212,6 +212,30 @@ $after_items_markup = sprintf(
 );
 ?>
 
+<div class="separateur-avec-icone">
+    <span class="trait-gauche"></span>
+    <span class="icone-svg">
+        <svg
+            viewBox="0 0 100 100"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            role="img"
+            class="iconify iconify--gis"
+            preserveAspectRatio="xMidYMid meet"
+        >
+            <path
+                d="M65.809 5a2.5 2.5 0 0 0-1.03.232L34.166 19.453L3.553 5.233C1.896 4.462 0 5.672 0 7.5v70.29a2.5 2.5 0 0 0 1.447 2.267l31.666 14.71a2.5 2.5 0 0 0 2.108 0l30.613-14.22l30.613 14.22c1.657.77 3.553-.44 3.553-2.267V22.21a2.5 2.5 0 0 0-1.447-2.267L66.887 5.233A2.5 2.5 0 0 0 65.809 5zm1.142 5.775L95 23.805v64.777L67.322 75.725l-3 .01l-28.676 13.322l-.369-64.606L63.953 11.13l.05 10.88h3zM5 11.418l27.275 12.67l.371 64.95L5 76.192z"
+                fill="currentColor"
+            ></path>
+            <path
+                d="M41.366 66.968h19.807a7.5 7.5 0 0 0 7.062 5a7.5 7.5 0 0 0 7.063-5h14.77v-5h-14.77a7.5 7.5 0 0 0-7.063-5a7.5 7.5 0 0 0-7.06 5H41.366zm0-16.13h4.924a7.5 7.5 0 0 0 7.063 5a7.5 7.5 0 0 0 7.062-5h29.652v-5H60.415a7.5 7.5 0 0 0-7.062-5a7.5 7.5 0 0 0-7.061 5h-4.926zm0-16.132h29.916a7.5 7.5 0 0 0 7.063 5a7.5 7.5 0 0 0 7.062-5h4.66v-5h-4.66a7.5 7.5 0 0 0-7.062-5a7.5 7.5 0 0 0-7.06 5h-29.92z"
+                fill="currentColor"
+            ></path>
+        </svg>
+    </span>
+    <span class="trait-droite"></span>
+</div>
+
 <div id="primary" class="content-area">
     <main id="home-page">
         <section class="chasses">


### PR DESCRIPTION
## Résumé
Ajout du séparateur décoratif entre le hero et les filtres de la page d’accueil.

## Changements notables
- Ajout du composant `separateur-avec-icone` entre le hero et la zone de filtrage des chasses.

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d1654655cc833289a86a683ef0c9e1