### PR TITLE
Réorganise l'affichage textuel des cartes de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -665,6 +665,12 @@
   height: 100%;
 }
 
+.carte-wide__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 .carte-wide__header {
   display: flex;
   flex-direction: column;
@@ -677,7 +683,6 @@
 .carte-wide__metas {
   margin-top: auto;
   padding-top: var(--space-sm);
-  gap: var(--space-sm);
 }
 
 .carte-wide__metas .meta-regular {

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -665,15 +665,18 @@
   height: 100%;
 }
 
-.carte-wide__content {
-  flex: 1;
-  overflow: hidden;
+.carte-wide__header {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
 }
 
+
 .carte-wide__metas {
-  margin: var(--space-xs) 0 0;
+  margin-top: auto;
+  padding-top: var(--space-sm);
   gap: var(--space-sm);
 }
 
@@ -687,23 +690,71 @@
   font-weight: 600;
 }
 
-.carte-wide__content .chasse-intro-extrait {
-  margin-top: auto;
-  margin-bottom: auto;
+.carte-wide__organisateur {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  color: var(--color-gris-3);
 }
+
+.carte-wide__organisateur-label {
+  font-style: italic;
+}
+
+.carte-wide__organisateur-logo-link {
+  display: inline-flex;
+  align-items: center;
+}
+
+.carte-wide__organisateur-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  filter: grayscale(1);
+  transition: filter 0.3s;
+}
+
+.carte-wide__organisateur-logo-link:hover .carte-wide__organisateur-logo {
+  filter: none;
+}
+
+.carte-wide__organisateur-nom {
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.carte-wide__organisateur-nom:hover {
+  text-decoration: underline;
+}
+
+.carte-wide__reward {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-weight: 700;
+  margin-bottom: var(--space-sm);
+}
+
+.carte-wide__reward .fa-trophy {
+  color: var(--color-gris-3);
+}
+
+.carte-wide__description {
+  margin-bottom: var(--space-sm);
+}
+
+.carte-wide__description .chasse-intro-extrait {
+  margin: 0;
+}
+
 
 .carte-wide__titre {
-  margin-top: 0;
-  margin-bottom: var(--space-xs);
+  margin: 0;
 }
 
-.carte-wide__footer .cta-div {
-  justify-content: center;
-}
-
-.carte-wide__footer {
-  margin-top: auto;
-}
 
 @media (--bp-desktop) {
   .carte-wide {
@@ -718,9 +769,22 @@
     height: 300px;
   }
 
+  .carte-wide__header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-lg);
+  }
+
+  .carte-wide__organisateur {
+    justify-content: flex-end;
+    text-align: right;
+  }
+
   .carte-wide__metas {
     flex-wrap: nowrap;
-    margin-top: 0;
+    margin-top: auto;
+    padding-top: 0;
     max-height: 0;
     opacity: 0;
     visibility: hidden;
@@ -729,12 +793,12 @@
     transition:
       opacity var(--transition-medium),
       max-height var(--transition-medium),
-      margin-top var(--transition-medium);
+      padding-top var(--transition-medium);
   }
 
   .carte-wide:hover .carte-wide__metas,
   .carte-wide:focus-within .carte-wide__metas {
-    margin-top: var(--space-xs);
+    padding-top: var(--space-sm);
     max-height: 200px;
     opacity: 1;
     visibility: visible;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -632,15 +632,17 @@
   height: 100%;
 }
 
-.carte-wide__content {
-  flex: 1;
-  overflow: hidden;
+.carte-wide__header {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
 }
 
 .carte-wide__metas {
-  margin: var(--space-xs) 0 0;
+  margin-top: auto;
+  padding-top: var(--space-sm);
   gap: var(--space-sm);
 }
 
@@ -654,22 +656,69 @@
   font-weight: 600;
 }
 
-.carte-wide__content .chasse-intro-extrait {
-  margin-top: auto;
-  margin-bottom: auto;
+.carte-wide__organisateur {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  color: var(--color-gris-3);
+}
+
+.carte-wide__organisateur-label {
+  font-style: italic;
+}
+
+.carte-wide__organisateur-logo-link {
+  display: inline-flex;
+  align-items: center;
+}
+
+.carte-wide__organisateur-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  filter: grayscale(1);
+  transition: filter 0.3s;
+}
+
+.carte-wide__organisateur-logo-link:hover .carte-wide__organisateur-logo {
+  filter: none;
+}
+
+.carte-wide__organisateur-nom {
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.carte-wide__organisateur-nom:hover {
+  text-decoration: underline;
+}
+
+.carte-wide__reward {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-weight: 700;
+  margin-bottom: var(--space-sm);
+}
+
+.carte-wide__reward .fa-trophy {
+  color: var(--color-gris-3);
+}
+
+.carte-wide__description {
+  margin-bottom: var(--space-sm);
+}
+
+.carte-wide__description .chasse-intro-extrait {
+  margin: 0;
 }
 
 .carte-wide__titre {
-  margin-top: 0;
-  margin-bottom: var(--space-xs);
-}
-
-.carte-wide__footer .cta-div {
-  justify-content: center;
-}
-
-.carte-wide__footer {
-  margin-top: auto;
+  margin: 0;
 }
 
 @media (min-width: 1024px) {
@@ -683,19 +732,30 @@
     width: 300px;
     height: 300px;
   }
+  .carte-wide__header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-lg);
+  }
+  .carte-wide__organisateur {
+    justify-content: flex-end;
+    text-align: right;
+  }
   .carte-wide__metas {
     flex-wrap: nowrap;
-    margin-top: 0;
+    margin-top: auto;
+    padding-top: 0;
     max-height: 0;
     opacity: 0;
     visibility: hidden;
     overflow: hidden;
     pointer-events: none;
-    transition: opacity var(--transition-medium), max-height var(--transition-medium), margin-top var(--transition-medium);
+    transition: opacity var(--transition-medium), max-height var(--transition-medium), padding-top var(--transition-medium);
   }
   .carte-wide:hover .carte-wide__metas,
   .carte-wide:focus-within .carte-wide__metas {
-    margin-top: var(--space-xs);
+    padding-top: var(--space-sm);
     max-height: 200px;
     opacity: 1;
     visibility: visible;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -632,6 +632,12 @@
   height: 100%;
 }
 
+.carte-wide__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 .carte-wide__header {
   display: flex;
   flex-direction: column;
@@ -643,7 +649,6 @@
 .carte-wide__metas {
   margin-top: auto;
   padding-top: var(--space-sm);
-  gap: var(--space-sm);
 }
 
 .carte-wide__metas .meta-regular {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -136,74 +136,76 @@ $has_reward = !empty($reward_title) && (float) $reward_value > 0;
             <?php endif; ?>
         </div>
 
-        <?php if ($has_reward) : ?>
-            <div class="carte-wide__reward">
-                <i class="fa-solid fa-trophy" aria-hidden="true"></i>
-                <?php
-                echo wp_kses(
-                    sprintf(
-                        esc_html__('%1$s — %2$s%3$s', 'chassesautresor-com'),
-                        esc_html($reward_title),
-                        esc_html(number_format_i18n(round((float) $reward_value), 0)),
-                        '<span class="prix-devise">' . esc_html__('€', 'chassesautresor-com') . '</span>'
-                    ),
-                    [
-                        'span' => [
-                            'class' => [],
-                        ],
-                    ]
-                );
-                ?>
-            </div>
-        <?php endif; ?>
-
-        <div class="carte-wide__description">
-            <?php echo $infos['extrait_html']; ?>
-        </div>
-
-        <div class="carte-wide__metas meta-row svg-xsmall">
-            <div class="meta-regular meta-regular--enigmes">
-                <?php echo get_svg_icon('enigme'); ?>
-                <span class="meta-label">
+        <div class="carte-wide__content">
+            <?php if ($has_reward) : ?>
+                <div class="carte-wide__reward">
+                    <i class="fa-solid fa-trophy" aria-hidden="true"></i>
                     <?php
-                    echo esc_html(
+                    echo wp_kses(
                         sprintf(
-                            _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
-                            $infos['total_enigmes']
-                        )
+                            esc_html__('%1$s — %2$s%3$s', 'chassesautresor-com'),
+                            esc_html($reward_title),
+                            esc_html(number_format_i18n(round((float) $reward_value), 0)),
+                            '<span class="prix-devise">' . esc_html__('€', 'chassesautresor-com') . '</span>'
+                        ),
+                        [
+                            'span' => [
+                                'class' => [],
+                            ],
+                        ]
                     );
                     ?>
-                </span>
-            </div>
-            <div class="meta-regular meta-regular--participants">
-                <?php echo get_svg_icon('participants'); ?>
-                <span class="meta-label"><?php echo esc_html($infos['nb_joueurs_label']); ?></span>
-            </div>
-            <div class="meta-etiquette meta-etiquette--dates">
-                <?php echo get_svg_icon('calendar'); ?>
-                <span class="chasse-date-plage">
-                    <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
-                    <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
-                </span>
-            </div>
-            <?php if (!empty($regions_links)) : ?>
-                <?php
-                $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
-                ?>
-                <div class="meta-etiquette meta-etiquette--regions">
-                    <span><?php echo esc_html($regions_label); ?></span>
-                    <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
                 </div>
             <?php endif; ?>
-            <?php if (!empty($themes_links)) : ?>
-                <?php
-                $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
-                ?>
-                <div class="meta-etiquette meta-etiquette--themes">
-                    <span><?php echo esc_html($themes_label); ?></span>
-                    <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+
+            <div class="carte-wide__description">
+                <?php echo $infos['extrait_html']; ?>
+            </div>
+
+            <div class="carte-wide__metas meta-row svg-xsmall">
+                <div class="meta-regular meta-regular--enigmes">
+                    <?php echo get_svg_icon('enigme'); ?>
+                    <span class="meta-label">
+                        <?php
+                        echo esc_html(
+                            sprintf(
+                                _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                                $infos['total_enigmes']
+                            )
+                        );
+                        ?>
+                    </span>
                 </div>
-            <?php endif; ?>
+                <div class="meta-regular meta-regular--participants">
+                    <?php echo get_svg_icon('participants'); ?>
+                    <span class="meta-label"><?php echo esc_html($infos['nb_joueurs_label']); ?></span>
+                </div>
+                <div class="meta-etiquette meta-etiquette--dates">
+                    <?php echo get_svg_icon('calendar'); ?>
+                    <span class="chasse-date-plage">
+                        <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
+                        <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                    </span>
+                </div>
+                <?php if (!empty($regions_links)) : ?>
+                    <?php
+                    $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
+                    ?>
+                    <div class="meta-etiquette meta-etiquette--regions">
+                        <span><?php echo esc_html($regions_label); ?></span>
+                        <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                    </div>
+                <?php endif; ?>
+                <?php if (!empty($themes_links)) : ?>
+                    <?php
+                    $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
+                    ?>
+                    <div class="meta-etiquette meta-etiquette--themes">
+                        <span><?php echo esc_html($themes_label); ?></span>
+                        <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                    </div>
+                <?php endif; ?>
+            </div>
         </div>
     </div>
 </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -50,6 +50,9 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 
 $regions_links = chasse_format_meta_terms($infos['regions'] ?? null);
 $themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
+$reward_title = get_field('chasse_infos_recompense_titre', $chasse_id);
+$reward_value = get_field('chasse_infos_recompense_valeur', $chasse_id);
+$has_reward = !empty($reward_title) && (float) $reward_value > 0;
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
@@ -114,101 +117,93 @@ $themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
             <h3 class="carte-wide__titre">
                 <a href="<?php echo esc_url($infos['permalink']); ?>"><?php echo esc_html($infos['titre']); ?></a>
             </h3>
+            <?php if ($orga_id) : ?>
+                <div class="carte-wide__organisateur">
+                    <span class="carte-wide__organisateur-label"><?php echo esc_html__('Proposé par', 'chassesautresor-com'); ?></span>
+                    <a class="carte-wide__organisateur-logo-link" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
+                        <img
+                            class="chasse-organisateur__logo carte-wide__organisateur-logo visuel-cpt"
+                            src="<?php echo esc_url($orga_logo_url); ?>"
+                            alt="<?php echo esc_attr__('Logo de l\'organisateur', 'chassesautresor-com'); ?>"
+                            data-cpt="organisateur"
+                            data-post-id="<?php echo esc_attr($orga_id); ?>"
+                        />
+                    </a>
+                    <a class="carte-wide__organisateur-nom" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
+                        <?php echo esc_html(get_the_title($orga_id)); ?>
+                    </a>
+                </div>
+            <?php endif; ?>
         </div>
 
-        <div class="carte-wide__content">
-            <div class="carte-wide__metas meta-row svg-xsmall">
-                <div class="meta-regular meta-regular--enigmes">
-                    <?php echo get_svg_icon('enigme'); ?>
-                    <span class="meta-label">
-                        <?php
-                        echo esc_html(
-                            sprintf(
-                                _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
-                                $infos['total_enigmes']
-                            )
-                        );
-                        ?>
-                    </span>
-                </div>
-                <div class="meta-regular meta-regular--participants">
-                    <?php echo get_svg_icon('participants'); ?>
-                    <span class="meta-label"><?php echo esc_html($infos['nb_joueurs_label']); ?></span>
-                </div>
-                <div class="meta-etiquette meta-etiquette--dates">
-                    <?php echo get_svg_icon('calendar'); ?>
-                    <span class="chasse-date-plage">
-                        <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
-                        <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
-                    </span>
-                </div>
-                <?php if (!empty($regions_links)) : ?>
-                    <?php
-                    $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
-                    ?>
-                    <div class="meta-etiquette meta-etiquette--regions">
-                        <span><?php echo esc_html($regions_label); ?></span>
-                        <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
-                    </div>
-                <?php endif; ?>
-                <?php if (!empty($themes_links)) : ?>
-                    <?php
-                    $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
-                    ?>
-                    <div class="meta-etiquette meta-etiquette--themes">
-                        <span><?php echo esc_html($themes_label); ?></span>
-                        <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
-                    </div>
-                <?php endif; ?>
+        <?php if ($has_reward) : ?>
+            <div class="carte-wide__reward">
+                <i class="fa-solid fa-trophy" aria-hidden="true"></i>
+                <?php
+                echo wp_kses(
+                    sprintf(
+                        esc_html__('%1$s — %2$s%3$s', 'chassesautresor-com'),
+                        esc_html($reward_title),
+                        esc_html(number_format_i18n(round((float) $reward_value), 0)),
+                        '<span class="prix-devise">' . esc_html__('€', 'chassesautresor-com') . '</span>'
+                    ),
+                    [
+                        'span' => [
+                            'class' => [],
+                        ],
+                    ]
+                );
+                ?>
             </div>
+        <?php endif; ?>
 
+        <div class="carte-wide__description">
             <?php echo $infos['extrait_html']; ?>
         </div>
 
-        <?php if ($orga_id) : ?>
-            <?php
-            $reward_title = get_field('chasse_infos_recompense_titre', $chasse_id);
-            $reward_value = get_field('chasse_infos_recompense_valeur', $chasse_id);
-            ?>
-            <div class="carte-wide__footer">
-                <footer class="chasse-footer">
-                    <?php if (!empty($reward_title) && (float) $reward_value > 0) : ?>
-                        <span class="chasse-footer__reward">
-                            <i class="fa-solid fa-trophy" aria-hidden="true"></i>
-                            <?php
-                            echo wp_kses(
-                                sprintf(
-                                    esc_html__('%1$s — %2$s%3$s', 'chassesautresor-com'),
-                                    esc_html($reward_title),
-                                    esc_html(number_format_i18n(round((float) $reward_value), 0)),
-                                    '<span class="prix-devise">' . esc_html__('€', 'chassesautresor-com') . '</span>'
-                                ),
-                                [
-                                    'span' => [
-                                        'class' => [],
-                                    ],
-                                ]
-                            );
-                            ?>
-                        </span>
-                    <?php endif; ?>
-                    <span class="chasse-footer__texte">
-                        <?php echo esc_html__('Proposé par', 'chassesautresor-com'); ?>
-                        <a class="chasse-footer__logo-link" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
-                            <img
-                                class="chasse-organisateur__logo chasse-footer__logo visuel-cpt"
-                                src="<?php echo esc_url($orga_logo_url); ?>"
-                                alt="<?php echo esc_attr__('Logo de l\u2019organisateur', 'chassesautresor-com'); ?>"
-                                data-cpt="organisateur"
-                                data-post-id="<?php echo esc_attr($orga_id); ?>"
-                            />
-                        </a>
-                        <a class="chasse-footer__nom" href="<?php echo esc_url(get_permalink($orga_id)); ?>">
-                            <?php echo esc_html(get_the_title($orga_id)); ?>
-                        </a>
-                    </span>
-                </footer>
+        <div class="carte-wide__metas meta-row svg-xsmall">
+            <div class="meta-regular meta-regular--enigmes">
+                <?php echo get_svg_icon('enigme'); ?>
+                <span class="meta-label">
+                    <?php
+                    echo esc_html(
+                        sprintf(
+                            _n('%d énigme', '%d énigmes', $infos['total_enigmes'], 'chassesautresor-com'),
+                            $infos['total_enigmes']
+                        )
+                    );
+                    ?>
+                </span>
             </div>
-        <?php endif; ?>
+            <div class="meta-regular meta-regular--participants">
+                <?php echo get_svg_icon('participants'); ?>
+                <span class="meta-label"><?php echo esc_html($infos['nb_joueurs_label']); ?></span>
+            </div>
+            <div class="meta-etiquette meta-etiquette--dates">
+                <?php echo get_svg_icon('calendar'); ?>
+                <span class="chasse-date-plage">
+                    <span class="date-debut"><?php echo esc_html($infos['date_debut']); ?></span> –
+                    <span class="date-fin"><?php echo esc_html($infos['date_fin']); ?></span>
+                </span>
+            </div>
+            <?php if (!empty($regions_links)) : ?>
+                <?php
+                $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
+                ?>
+                <div class="meta-etiquette meta-etiquette--regions">
+                    <span><?php echo esc_html($regions_label); ?></span>
+                    <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
+                </div>
+            <?php endif; ?>
+            <?php if (!empty($themes_links)) : ?>
+                <?php
+                $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
+                ?>
+                <div class="meta-etiquette meta-etiquette--themes">
+                    <span><?php echo esc_html($themes_label); ?></span>
+                    <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
+                </div>
+            <?php endif; ?>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Résumé
- Réorganisation de l'affichage des cartes de chasse en largeur.

## Changements notables
- Déplace les informations de l'organisateur dans l'en-tête de la carte et place la récompense sous le titre tout en conservant le descriptif.
- Positionne la ligne de métadonnées en pied de carte et l'affiche uniquement au survol, avec les ajustements CSS associés.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d164d7f6e083329f8c086824366a22