### PR TITLE
Ajoute une image de repli pour les héros des pages

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -226,14 +226,35 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
             echo '</div>';
         }
     } elseif ( is_page() && ! is_user_account_area() ) {
-        $image_id  = get_post_thumbnail_id();
-        $image_url = $image_id ? imagify_get_webp_url( wp_get_attachment_image_url( $image_id, 'full' ) ) : '';
+        $image_id     = get_post_thumbnail_id();
+        $fallback_url = function_exists( 'get_theme_file_uri' )
+            ? get_theme_file_uri( 'assets/images/carte-surchargee.jpg' )
+            : '';
+        $image_url    = '';
 
-        get_header_fallback([
-            'titre'       => get_the_title(),
-            'sous_titre'  => '',
-            'image_fond'  => $image_url,
-        ]);
+        if ( $image_id ) {
+            $image_url = wp_get_attachment_image_url( $image_id, 'full' );
+
+            if ( $image_url && function_exists( 'imagify_get_webp_url' ) ) {
+                $webp_url = imagify_get_webp_url( $image_url );
+
+                if ( $webp_url ) {
+                    $image_url = $webp_url;
+                }
+            }
+        }
+
+        if ( ! $image_url ) {
+            $image_url = $fallback_url;
+        }
+
+        get_header_fallback(
+            [
+                'titre'      => get_the_title(),
+                'sous_titre' => '',
+                'image_fond' => $image_url,
+            ]
+        );
     }
     
     astra_content_before();

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -228,7 +228,7 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
     } elseif ( is_page() && ! is_user_account_area() ) {
         $image_id     = get_post_thumbnail_id();
         $fallback_url = function_exists( 'get_theme_file_uri' )
-            ? get_theme_file_uri( 'assets/images/carte-surchargee.jpg' )
+            ? get_theme_file_uri( 'assets/images/institutionnels.webp' )
             : '';
         $image_url    = '';
 

--- a/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
+++ b/wp-content/themes/chassesautresor/template-parts/headers/fallback-header.php
@@ -17,14 +17,22 @@ if ( ! isset( $args ) || ! is_array( $args ) ) {
     return;
 }
 
-$titre       = isset( $args['titre'] ) ? wp_kses_post( $args['titre'] ) : '';
-$sous_titre  = isset( $args['sous_titre'] ) ? esc_html( $args['sous_titre'] ) : '';
-$image_url   = isset( $args['image_fond'] ) ? esc_url( $args['image_fond'] ) : '';
-$logo_id     = isset( $args['logo_id'] ) ? absint( $args['logo_id'] ) : 0;
+$titre           = isset( $args['titre'] ) ? wp_kses_post( $args['titre'] ) : '';
+$sous_titre      = isset( $args['sous_titre'] ) ? esc_html( $args['sous_titre'] ) : '';
+$image_url       = isset( $args['image_fond'] ) ? esc_url( $args['image_fond'] ) : '';
+$logo_id         = isset( $args['logo_id'] ) ? absint( $args['logo_id'] ) : 0;
+$overlay_classes = [ 'hero-overlay' ];
+$inline_style    = '';
+
+if ( $image_url ) {
+    $inline_style = sprintf( ' style="background-image: url(\'%s\');"', $image_url );
+} else {
+    $overlay_classes[] = 'hero-overlay--default';
+}
 ?>
 
 <section class="bandeau-hero fallback-header">
-  <div class="hero-overlay" <?php if ( $image_url ) : ?>style="background-image: url('<?php echo $image_url; ?>');"<?php endif; ?>>
+  <div class="<?php echo esc_attr( implode( ' ', $overlay_classes ) ); ?>"<?php echo $inline_style; ?>>
     <div class="contenu-hero">
       <?php if ( $logo_id ) : ?>
         <?php echo wp_get_attachment_image( $logo_id, 'full', false, [ 'class' => 'hero-logo' ] ); ?>


### PR DESCRIPTION
Résumé : Ajout d'un visuel de repli pour les pages sans image mise en avant.

- Ajout d'une URL d'arrière-plan de secours pour les pages hors espace compte dans le header du thème.
- Ajout de la classe `hero-overlay--default` par défaut et affichage conditionnel du style inline dans le fallback header.

## Testing
- npm run build:css
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d167ca196883328f2bbd4f9d4fdca0