### PR TITLE
feat: améliorer le menu Mon Compte sur mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -10,6 +10,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const siteMessages = document.querySelector('.msg-important');
   const sidebar = document.querySelector('.myaccount-sidebar');
   const sidebarToggle = document.querySelector('.myaccount-sidebar-toggle');
+  const sidebarClose = document.querySelector('.myaccount-sidebar-close');
+  const sidebarBackdrop = document.querySelector('.myaccount-sidebar-backdrop');
+  let outsideClickHandler = null;
+  let keydownHandler = null;
 
   const setSidebarExpanded = (isOpen) => {
     if (!sidebarToggle) {
@@ -18,18 +22,79 @@ document.addEventListener('DOMContentLoaded', () => {
     sidebarToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
   };
 
+  const removeDocumentListeners = () => {
+    if (outsideClickHandler) {
+      document.removeEventListener('pointerdown', outsideClickHandler);
+      outsideClickHandler = null;
+    }
+    if (keydownHandler) {
+      document.removeEventListener('keydown', keydownHandler);
+      keydownHandler = null;
+    }
+  };
+
   const closeSidebar = () => {
     if (sidebar) {
       sidebar.classList.remove('is-open');
     }
+    if (sidebarBackdrop) {
+      sidebarBackdrop.classList.remove('is-visible');
+    }
     setSidebarExpanded(false);
+    removeDocumentListeners();
+  };
+
+  const openSidebar = () => {
+    if (!sidebar) {
+      return;
+    }
+    sidebar.classList.add('is-open');
+    if (sidebarBackdrop) {
+      sidebarBackdrop.classList.add('is-visible');
+    }
+    setSidebarExpanded(true);
+
+    if (!outsideClickHandler) {
+      outsideClickHandler = (event) => {
+        const target = event.target;
+        const clickedToggle = sidebarToggle && sidebarToggle.contains(target);
+        if (!sidebar.contains(target) && !clickedToggle) {
+          closeSidebar();
+        }
+      };
+      document.addEventListener('pointerdown', outsideClickHandler);
+    }
+
+    if (!keydownHandler) {
+      keydownHandler = (event) => {
+        if (event.key === 'Escape') {
+          closeSidebar();
+        }
+      };
+      document.addEventListener('keydown', keydownHandler);
+    }
   };
 
   if (sidebar && sidebarToggle) {
     sidebarToggle.addEventListener('click', () => {
-      const isOpen = sidebar.classList.toggle('is-open');
-      setSidebarExpanded(isOpen);
+      if (sidebar.classList.contains('is-open')) {
+        closeSidebar();
+      } else {
+        openSidebar();
+      }
     });
+
+    if (sidebarClose) {
+      sidebarClose.addEventListener('click', () => {
+        closeSidebar();
+      });
+    }
+
+    if (sidebarBackdrop) {
+      sidebarBackdrop.addEventListener('click', () => {
+        closeSidebar();
+      });
+    }
 
     sidebar.querySelectorAll('a').forEach((link) => {
       link.addEventListener('click', () => {

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -8,6 +8,49 @@ document.addEventListener('DOMContentLoaded', () => {
   const content = document.querySelector('.myaccount-content');
   const header = document.querySelector('.myaccount-title');
   const siteMessages = document.querySelector('.msg-important');
+  const sidebar = document.querySelector('.myaccount-sidebar');
+  const sidebarToggle = document.querySelector('.myaccount-sidebar-toggle');
+
+  const setSidebarExpanded = (isOpen) => {
+    if (!sidebarToggle) {
+      return;
+    }
+    sidebarToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  };
+
+  const closeSidebar = () => {
+    if (sidebar) {
+      sidebar.classList.remove('is-open');
+    }
+    setSidebarExpanded(false);
+  };
+
+  if (sidebar && sidebarToggle) {
+    sidebarToggle.addEventListener('click', () => {
+      const isOpen = sidebar.classList.toggle('is-open');
+      setSidebarExpanded(isOpen);
+    });
+
+    sidebar.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        closeSidebar();
+      });
+    });
+
+    const mobileMedia = window.matchMedia('(min-width: 600px)');
+    const handleMediaChange = (event) => {
+      if (event.matches) {
+        closeSidebar();
+      }
+    };
+
+    handleMediaChange(mobileMedia);
+    if (typeof mobileMedia.addEventListener === 'function') {
+      mobileMedia.addEventListener('change', handleMediaChange);
+    } else if (typeof mobileMedia.addListener === 'function') {
+      mobileMedia.addListener(handleMediaChange);
+    }
+  }
 
   if (!navs.length || !content || !siteMessages || typeof ctaMyAccount === 'undefined') {
     return;
@@ -117,6 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       e.preventDefault();
       loadSection(link);
+      closeSidebar();
     });
   });
 

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -87,6 +87,23 @@
     text-transform: none;
 }
 
+.myaccount-sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(6, 10, 31, 0.65);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 150;
+}
+
+.myaccount-sidebar-backdrop.is-visible {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
 .myaccount-sidebar {
     position: fixed;
     top: 0;
@@ -127,6 +144,10 @@
         display: none;
     }
 
+    .myaccount-sidebar-backdrop {
+        display: none;
+    }
+
     .myaccount-sidebar {
         position: sticky;
         top: 0;
@@ -144,6 +165,8 @@
 .myaccount-brand {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    gap: 16px;
     height: 56px;
     padding: 0 16px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -151,6 +174,7 @@
 }
 
 .myaccount-brand a {
+    flex: 1;
     color: inherit;
     text-decoration: none;
 }
@@ -158,6 +182,44 @@
 .myaccount-brand a:hover,
 .myaccount-brand a:focus {
     color: var(--color-primary);
+}
+
+.myaccount-sidebar-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    margin-left: auto;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 999px;
+    background: rgba(6, 10, 31, 0.6);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.myaccount-sidebar-close span {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.myaccount-sidebar-close:hover,
+.myaccount-sidebar-close:focus-visible {
+    background: rgba(6, 10, 31, 0.9);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.myaccount-sidebar-close:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+@media (--bp-mobile) {
+    .myaccount-sidebar-close {
+        display: none;
+    }
 }
 
 .dashboard-nav {

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -7,8 +7,11 @@
     padding-right: 0;
 }
 
+
 .myaccount-layout {
+    position: relative;
     display: flex;
+    flex-direction: column;
     min-height: 100vh;
     width: 100%;
     background-color: var(--color-background);
@@ -25,13 +28,117 @@
     text-transform: none;
 }
 
-.myaccount-sidebar {
-    width: 280px;
-    border-right: 1px solid rgba(255, 255, 255, 0.1);
+.myaccount-sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 16px;
+    padding: 0.75rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
     background: rgba(6, 10, 31, 0.85);
+    color: var(--color-text-primary);
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.myaccount-sidebar-toggle:hover,
+.myaccount-sidebar-toggle:focus-visible {
+    background-color: rgba(6, 10, 31, 1);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.myaccount-sidebar-toggle:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.myaccount-sidebar-toggle-icon {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.myaccount-sidebar-toggle-icon span {
+    width: 20px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.myaccount-sidebar-toggle[aria-expanded='true'] .myaccount-sidebar-toggle-icon span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+}
+
+.myaccount-sidebar-toggle[aria-expanded='true'] .myaccount-sidebar-toggle-icon span:nth-child(2) {
+    opacity: 0;
+}
+
+.myaccount-sidebar-toggle[aria-expanded='true'] .myaccount-sidebar-toggle-icon span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
+}
+
+.myaccount-sidebar-toggle-text {
+    text-transform: none;
+}
+
+.myaccount-sidebar {
+    position: fixed;
+    top: 0;
+    right: auto;
+    bottom: 0;
+    left: 0;
+    width: min(85vw, 320px);
+    max-width: 320px;
+    border-right: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(6, 10, 31, 0.9);
     display: flex;
     flex-direction: column;
     color: var(--color-text-primary);
+    overflow-y: auto;
+    max-height: 100vh;
+    transform: translateX(-100%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 200;
+    box-shadow: 8px 0 30px rgba(5, 10, 30, 0.45);
+}
+
+.myaccount-sidebar.is-open {
+    transform: translateX(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+@media (--bp-mobile) {
+    .myaccount-layout {
+        flex-direction: row;
+    }
+
+    .myaccount-sidebar-toggle {
+        display: none;
+    }
+
+    .myaccount-sidebar {
+        position: sticky;
+        top: 0;
+        bottom: auto;
+        width: 280px;
+        max-width: none;
+        transform: none;
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+        box-shadow: none;
+    }
 }
 
 .myaccount-brand {
@@ -151,6 +258,8 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    position: relative;
+    width: 100%;
 }
 
 .myaccount-header {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9473,7 +9473,9 @@ footer .site-footer-primary-section-3 {
 }
 
 .myaccount-layout {
+  position: relative;
   display: flex;
+  flex-direction: column;
   min-height: 100vh;
   width: 100%;
   background-color: var(--color-background);
@@ -9490,15 +9492,116 @@ footer .site-footer-primary-section-3 {
   text-transform: none;
 }
 
-.myaccount-sidebar {
-  width: 280px;
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
+.myaccount-sidebar-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 16px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
   background: rgba(6, 10, 31, 0.85);
+  color: var(--color-text-primary);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.myaccount-sidebar-toggle:hover,
+.myaccount-sidebar-toggle:focus-visible {
+  background-color: rgb(6, 10, 31);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.myaccount-sidebar-toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.myaccount-sidebar-toggle-icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.myaccount-sidebar-toggle-icon span {
+  width: 20px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.myaccount-sidebar-toggle[aria-expanded=true] .myaccount-sidebar-toggle-icon span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.myaccount-sidebar-toggle[aria-expanded=true] .myaccount-sidebar-toggle-icon span:nth-child(2) {
+  opacity: 0;
+}
+
+.myaccount-sidebar-toggle[aria-expanded=true] .myaccount-sidebar-toggle-icon span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.myaccount-sidebar-toggle-text {
+  text-transform: none;
+}
+
+.myaccount-sidebar {
+  position: fixed;
+  top: 0;
+  right: auto;
+  bottom: 0;
+  left: 0;
+  width: min(85vw, 320px);
+  max-width: 320px;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(6, 10, 31, 0.9);
   display: flex;
   flex-direction: column;
   color: var(--color-text-primary);
+  overflow-y: auto;
+  max-height: 100vh;
+  transform: translateX(-100%);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: transform 0.3s ease, opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 200;
+  box-shadow: 8px 0 30px rgba(5, 10, 30, 0.45);
 }
 
+.myaccount-sidebar.is-open {
+  transform: translateX(0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+@media (min-width: 600px) {
+  .myaccount-layout {
+    flex-direction: row;
+  }
+  .myaccount-sidebar-toggle {
+    display: none;
+  }
+  .myaccount-sidebar {
+    position: sticky;
+    top: 0;
+    bottom: auto;
+    width: 280px;
+    max-width: none;
+    transform: none;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    box-shadow: none;
+  }
+}
 .myaccount-brand {
   display: flex;
   align-items: center;
@@ -9616,6 +9719,8 @@ footer .site-footer-primary-section-3 {
   flex: 1;
   display: flex;
   flex-direction: column;
+  position: relative;
+  width: 100%;
 }
 
 .myaccount-header {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -9551,6 +9551,23 @@ footer .site-footer-primary-section-3 {
   text-transform: none;
 }
 
+.myaccount-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 10, 31, 0.65);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 150;
+}
+
+.myaccount-sidebar-backdrop.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
 .myaccount-sidebar {
   position: fixed;
   top: 0;
@@ -9589,6 +9606,9 @@ footer .site-footer-primary-section-3 {
   .myaccount-sidebar-toggle {
     display: none;
   }
+  .myaccount-sidebar-backdrop {
+    display: none;
+  }
   .myaccount-sidebar {
     position: sticky;
     top: 0;
@@ -9605,6 +9625,8 @@ footer .site-footer-primary-section-3 {
 .myaccount-brand {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 16px;
   height: 56px;
   padding: 0 16px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -9612,6 +9634,7 @@ footer .site-footer-primary-section-3 {
 }
 
 .myaccount-brand a {
+  flex: 1;
   color: inherit;
   text-decoration: none;
 }
@@ -9621,6 +9644,43 @@ footer .site-footer-primary-section-3 {
   color: var(--color-primary);
 }
 
+.myaccount-sidebar-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-left: auto;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(6, 10, 31, 0.6);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.myaccount-sidebar-close span {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.myaccount-sidebar-close:hover,
+.myaccount-sidebar-close:focus-visible {
+  background: rgba(6, 10, 31, 0.9);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.myaccount-sidebar-close:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+@media (min-width: 600px) {
+  .myaccount-sidebar-close {
+    display: none;
+  }
+}
 .dashboard-nav {
   display: flex;
   flex-direction: column;

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -45,7 +45,22 @@ if ($current_user->ID) {
 get_header();
 ?>
 <div class="myaccount-layout">
-    <aside class="myaccount-sidebar">
+    <button
+        type="button"
+        class="myaccount-sidebar-toggle"
+        aria-controls="myaccount-sidebar"
+        aria-expanded="false"
+    >
+        <span class="myaccount-sidebar-toggle-icon" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+        </span>
+        <span class="myaccount-sidebar-toggle-text">
+            <?php esc_html_e('Menu', 'chassesautresor-com'); ?>
+        </span>
+    </button>
+    <aside id="myaccount-sidebar" class="myaccount-sidebar">
         <div class="myaccount-brand">
             <a href="<?php echo esc_url(home_url('/')); ?>">
                 <?php echo esc_html($display_name); ?>

--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -60,11 +60,19 @@ get_header();
             <?php esc_html_e('Menu', 'chassesautresor-com'); ?>
         </span>
     </button>
+    <div class="myaccount-sidebar-backdrop" aria-hidden="true"></div>
     <aside id="myaccount-sidebar" class="myaccount-sidebar">
         <div class="myaccount-brand">
             <a href="<?php echo esc_url(home_url('/')); ?>">
                 <?php echo esc_html($display_name); ?>
             </a>
+            <button
+                type="button"
+                class="myaccount-sidebar-close"
+                aria-label="<?php esc_attr_e('Fermer le menu', 'chassesautresor-com'); ?>"
+            >
+                <span aria-hidden="true">&times;</span>
+            </button>
         </div>
         <?php if ($show_nav) : ?>
         <nav class="dashboard-nav">


### PR DESCRIPTION
Ajout d'un menu latéral mobile pour l'espace Mon Compte.

## Changements notables
- Ajout d'un bouton hamburger accessible qui pilote l'aside de navigation.
- Refonte mobile-first des styles SCSS du layout Mon Compte et recompilation du CSS distribué.
- Extension du script `myaccount.js` pour piloter l'ouverture/fermeture du menu et refermer après navigation.

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d16921e2588332917531afc88afb91