### PR TITLE
Inclure les taxonomies dans la recherche d'accueil

### DIFF
--- a/tests/homepage_filters.test.php
+++ b/tests/homepage_filters.test.php
@@ -14,6 +14,9 @@ use PHPUnit\\Framework\\TestCase;
  * - chasse_est_visible_pour_utilisateur() always returns true during tests.
  * - preparer_infos_affichage_chasse() returns fixtures stored in $mocked_chasse_infos.
  * - get_field() proxies selected ACF fields when helpers fall back to it.
+ * - get_the_title() returns values stored in $mocked_post_titles.
+ * - get_post_field() exposes excerpts defined in $mocked_post_fields.
+ * - wp_get_post_terms() retrieves taxonomy fixtures from $mocked_taxonomy_terms.
  */
 if (!class_exists('WP_Query')) {
     class WP_Query
@@ -106,7 +109,9 @@ class HomepageFiltersTest extends TestCase
             define('ABSPATH', __DIR__ . '/');
         }
 
-        global $mocked_wp_query_posts, $mocked_chasse_infos;
+        $this->ensureHomepageFilterStubs();
+
+        global $mocked_wp_query_posts, $mocked_chasse_infos, $mocked_post_titles, $mocked_post_fields, $mocked_taxonomy_terms;
 
         $mocked_wp_query_posts = [101, 102, 103, 104];
         $mocked_chasse_infos = [
@@ -139,6 +144,10 @@ class HomepageFiltersTest extends TestCase
                 'nb_enigmes_payantes' => 1,
             ],
         ];
+
+        $mocked_post_titles      = [];
+        $mocked_post_fields      = [];
+        $mocked_taxonomy_terms   = [];
 
         require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/homepage-filters.php';
 
@@ -216,5 +225,146 @@ class HomepageFiltersTest extends TestCase
             ],
             $pointsResults['available_filters']['cout']
         );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_search_matches_taxonomy_terms(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/');
+        }
+
+        $this->ensureHomepageFilterStubs();
+
+        global $mocked_wp_query_posts, $mocked_chasse_infos, $mocked_taxonomy_terms, $mocked_post_titles, $mocked_post_fields;
+
+        $mocked_wp_query_posts = [201, 202, 203];
+        $mocked_chasse_infos = [
+            201 => [
+                'statut' => 'en_cours',
+                'champs' => [
+                    'cout_points' => 0,
+                ],
+                'nb_enigmes_payantes' => 0,
+            ],
+            202 => [
+                'statut' => 'en_cours',
+                'champs' => [
+                    'cout_points' => 0,
+                ],
+                'nb_enigmes_payantes' => 0,
+            ],
+            203 => [
+                'statut' => 'en_cours',
+                'champs' => [
+                    'cout_points' => 0,
+                ],
+                'nb_enigmes_payantes' => 0,
+            ],
+        ];
+
+        $mocked_taxonomy_terms = [
+            201 => [
+                'chasse_region' => [
+                    ['nom' => 'PACA'],
+                ],
+                'theme_chasse' => [
+                    ['nom' => 'Aventure'],
+                ],
+            ],
+            202 => [
+                'chasse_region' => [
+                    ['nom' => 'Bretagne'],
+                ],
+                'theme_chasse' => [
+                    ['nom' => 'Patrimoine'],
+                ],
+            ],
+            203 => [
+                'chasse_region' => [
+                    ['nom' => 'Île-de-France'],
+                ],
+                'theme_chasse' => [
+                    ['nom' => 'Gastronomie'],
+                ],
+            ],
+        ];
+
+        $mocked_post_titles = [
+            201 => 'Chasse Provence',
+            202 => 'Chasse Bretagne',
+            203 => 'Chasse Paris',
+        ];
+
+        $mocked_post_fields = [
+            201 => ['post_excerpt' => ''],
+            202 => ['post_excerpt' => ''],
+            203 => ['post_excerpt' => ''],
+        ];
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/homepage-filters.php';
+
+        $regionResults = ca_home_filter_chasse_ids([
+            'search' => 'bretagne',
+        ]);
+
+        $this->assertSame([202], $regionResults['ids']);
+        $this->assertSame(1, $regionResults['total']);
+
+        $themeResults = ca_home_filter_chasse_ids([
+            'search' => 'aventure',
+        ]);
+
+        $this->assertSame([201], $themeResults['ids']);
+        $this->assertSame(1, $themeResults['total']);
+    }
+
+    private function ensureHomepageFilterStubs(): void
+    {
+        if (!function_exists('get_the_title')) {
+            function get_the_title($post = 0)
+            {
+                global $mocked_post_titles;
+
+                $post_id = 0;
+
+                if (is_object($post) && isset($post->ID)) {
+                    $post_id = (int) $post->ID;
+                } elseif (is_numeric($post)) {
+                    $post_id = (int) $post;
+                }
+
+                return $mocked_post_titles[$post_id] ?? 'Post ' . $post_id;
+            }
+        }
+
+        if (!function_exists('get_post_field')) {
+            function get_post_field($field, $post_id, $context = 'display')
+            {
+                global $mocked_post_fields;
+
+                if ('post_excerpt' === $field) {
+                    return $mocked_post_fields[$post_id]['post_excerpt'] ?? '';
+                }
+
+                return $mocked_post_fields[$post_id][$field] ?? '';
+            }
+        }
+
+        if (!function_exists('wp_get_post_terms')) {
+            function wp_get_post_terms($post_id, $taxonomy, $args = [])
+            {
+                global $mocked_taxonomy_terms;
+
+                if (!isset($mocked_taxonomy_terms[$post_id][$taxonomy])) {
+                    return [];
+                }
+
+                return $mocked_taxonomy_terms[$post_id][$taxonomy];
+            }
+        }
     }
 }

--- a/wp-content/themes/chassesautresor/inc/homepage-filters.php
+++ b/wp-content/themes/chassesautresor/inc/homepage-filters.php
@@ -127,6 +127,82 @@ function ca_home_filter_chasse_ids(array $args): array
         'termine'  => ['termine'],
     ];
 
+    $extract_taxonomy_names = static function ($terms): array {
+        if (!is_array($terms)) {
+            return [];
+        }
+
+        $names = [];
+
+        foreach ($terms as $term) {
+            $name = '';
+
+            if (is_array($term)) {
+                $candidates = [
+                    $term['nom'] ?? null,
+                    $term['name'] ?? null,
+                    $term['label'] ?? null,
+                    $term['title'] ?? null,
+                ];
+
+                foreach ($candidates as $candidate) {
+                    if (!is_string($candidate) && !is_numeric($candidate)) {
+                        continue;
+                    }
+
+                    $candidate_value = trim((string) $candidate);
+
+                    if ('' === $candidate_value) {
+                        continue;
+                    }
+
+                    $name = $candidate_value;
+                    break;
+                }
+            } elseif ($term instanceof \WP_Term) {
+                $name = trim((string) $term->name);
+            } elseif (is_string($term) || is_numeric($term)) {
+                $name = trim((string) $term);
+            }
+
+            if ('' === $name) {
+                continue;
+            }
+
+            $names[] = $name;
+        }
+
+        if (empty($names)) {
+            return [];
+        }
+
+        return array_values(array_unique($names));
+    };
+
+    $resolve_taxonomy_terms = static function (int $hunt_id, string $taxonomy) use ($extract_taxonomy_names): array {
+        $terms = [];
+
+        if (function_exists('chasse_preparer_termes_affichage')) {
+            $terms = chasse_preparer_termes_affichage($hunt_id, $taxonomy);
+        } elseif (function_exists('wp_get_post_terms')) {
+            $terms = wp_get_post_terms($hunt_id, $taxonomy, ['orderby' => 'term_order']);
+
+            if (function_exists('is_wp_error') && is_wp_error($terms)) {
+                $terms = [];
+            }
+        }
+
+        if (empty($terms)) {
+            return [];
+        }
+
+        if (!is_array($terms)) {
+            $terms = [$terms];
+        }
+
+        return $extract_taxonomy_names($terms);
+    };
+
     $hunts_data = [];
 
     foreach ($chasse_ids as $chasse_id) {
@@ -167,6 +243,15 @@ function ca_home_filter_chasse_ids(array $args): array
             }
         }
 
+        $region_terms = $resolve_taxonomy_terms($chasse_id, 'chasse_region');
+        $theme_terms  = $resolve_taxonomy_terms($chasse_id, 'theme_chasse');
+
+        $taxonomy_terms = array_merge($region_terms, $theme_terms);
+
+        if (!empty($taxonomy_terms)) {
+            $taxonomy_terms = array_values(array_unique($taxonomy_terms));
+        }
+
         $hunts_data[] = [
             'id'     => (int) $chasse_id,
             'status' => is_string($statut_metier) ? $statut_metier : '',
@@ -174,6 +259,7 @@ function ca_home_filter_chasse_ids(array $args): array
             'title'  => is_string($title) ? $title : '',
             'description' => $description_text,
             'organizer'   => $organizer_name,
+            'taxonomy_terms' => $taxonomy_terms,
         ];
     }
 
@@ -188,6 +274,12 @@ function ca_home_filter_chasse_ids(array $args): array
                     $hunt['description'] ?? '',
                     $hunt['organizer'] ?? '',
                 ];
+
+                if (!empty($hunt['taxonomy_terms']) && is_array($hunt['taxonomy_terms'])) {
+                    foreach ($hunt['taxonomy_terms'] as $term_name) {
+                        $haystacks[] = (string) $term_name;
+                    }
+                }
 
                 foreach ($haystacks as $haystack) {
                     $normalized_value = $normalize_text((string) $haystack);


### PR DESCRIPTION
## Résumé
- étend le filtrage des chasses d'accueil pour indexer les régions et thèmes associés
- ajoute un test unitaire vérifiant la prise en compte des taxonomies dans la recherche

## Détails
- normalise les noms des termes ACF/WordPress afin de les intégrer au haystack de recherche
- gère proprement l'absence de `chasse_preparer_termes_affichage` en se repliant sur `wp_get_post_terms`

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d16aef56d88332a9ad84f1b4ddb1ea