### PR TITLE
Center hunt card copy on wide displays

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -774,6 +774,14 @@
     height: 300px;
   }
 
+  .carte-wide__contenu {
+    justify-content: center;
+  }
+
+  .carte-wide__content {
+    flex: 0 1 auto;
+  }
+
   .carte-wide__header {
     flex-direction: row;
     align-items: flex-start;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -737,6 +737,12 @@
     width: 300px;
     height: 300px;
   }
+  .carte-wide__contenu {
+    justify-content: center;
+  }
+  .carte-wide__content {
+    flex: 0 1 auto;
+  }
   .carte-wide__header {
     flex-direction: row;
     align-items: flex-start;


### PR DESCRIPTION
Résumé : Centre le contenu textuel des cartes de chasse larges sur les écrans desktop et au-delà.

- Ajuste les règles SCSS des cartes « wide » pour centrer verticalement la colonne de texte sur grand écran.
- Regénère la feuille de style compilée du thème après les modifications SCSS.

## Testing
- npm run build:css
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d1752437848332a7f51bfbf2de6c4a