### PR TITLE
Repositionne la barre de filtres de la page d'accueil

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -17,6 +17,98 @@
     return;
   }
 
+  const toolbar = root.querySelector('[data-home-hunts-toolbar]');
+  const toolbarToggles = toolbar ? Array.from(toolbar.querySelectorAll('[data-home-hunts-toggle]')) : [];
+  const toolbarPanels = {
+    filters: toolbar ? toolbar.querySelector('[data-home-hunts-panel="filters"]') : null,
+    search: toolbar ? toolbar.querySelector('[data-home-hunts-panel="search"]') : null,
+  };
+  const desktopQuery = typeof window.matchMedia === 'function'
+    ? window.matchMedia('(min-width: 1024px)')
+    : null;
+
+  function isDesktopViewport() {
+    return desktopQuery ? desktopQuery.matches : true;
+  }
+
+  let currentMobilePanel = null;
+
+  function updateToolbarPanels(nextPanel) {
+    if (!toolbar || toolbarToggles.length === 0) {
+      return;
+    }
+
+    const normalized = nextPanel === 'filters' || nextPanel === 'search' ? nextPanel : null;
+    const isDesktop = isDesktopViewport();
+
+    toolbarToggles.forEach((button) => {
+      const toggleName = button.dataset ? button.dataset.homeHuntsToggle : '';
+      const shouldExpand = !isDesktop && toggleName === normalized;
+      button.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
+    });
+
+    Object.keys(toolbarPanels).forEach((panelName) => {
+      const panel = toolbarPanels[panelName];
+
+      if (!panel) {
+        return;
+      }
+
+      if (isDesktop) {
+        panel.dataset.collapsed = 'false';
+        panel.removeAttribute('aria-hidden');
+        return;
+      }
+
+      const isActive = panelName === normalized;
+      panel.dataset.collapsed = isActive ? 'false' : 'true';
+
+      if (isActive) {
+        panel.removeAttribute('aria-hidden');
+      } else {
+        panel.setAttribute('aria-hidden', 'true');
+      }
+    });
+
+    if (!isDesktop) {
+      currentMobilePanel = normalized;
+    }
+  }
+
+  if (toolbar && toolbarToggles.length > 0) {
+    toolbar.classList.add('home-hunts__toolbar--enhanced');
+    updateToolbarPanels(currentMobilePanel);
+
+    const handleViewportChange = () => {
+      updateToolbarPanels(currentMobilePanel);
+    };
+
+    if (desktopQuery) {
+      if (typeof desktopQuery.addEventListener === 'function') {
+        desktopQuery.addEventListener('change', handleViewportChange);
+      } else if (typeof desktopQuery.addListener === 'function') {
+        desktopQuery.addListener(handleViewportChange);
+      }
+    }
+
+    toolbarToggles.forEach((button) => {
+      button.addEventListener('click', () => {
+        if (isDesktopViewport()) {
+          return;
+        }
+
+        const targetPanel = button.dataset ? button.dataset.homeHuntsToggle : '';
+
+        if (!targetPanel) {
+          return;
+        }
+
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+        updateToolbarPanels(isExpanded ? null : targetPanel);
+      });
+    });
+  }
+
   const localized = window.homeHuntsFilters || {};
   const endpoint = typeof localized.ajaxUrl === 'string' ? localized.ajaxUrl : '';
   const labels = localized.labels && typeof localized.labels === 'object' ? localized.labels : {};

--- a/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
+++ b/wp-content/themes/chassesautresor/assets/js/home-hunts-filters.js
@@ -11,7 +11,7 @@
     return;
   }
 
-  const form = grid.querySelector('[data-home-hunts-filters]');
+  const form = root.querySelector('[data-home-hunts-filters]');
 
   if (!form) {
     return;
@@ -285,8 +285,8 @@
   }
 
   function clearHunts() {
-    const toolbar = grid.querySelector('.home-hunts__toolbar');
-    const startNode = toolbar ? toolbar.nextSibling : grid.firstChild;
+    const toolbar = root.querySelector('.home-hunts__toolbar');
+    const startNode = toolbar && grid.contains(toolbar) ? toolbar.nextSibling : grid.firstChild;
     let node = startNode;
 
     while (node) {

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -42,11 +42,13 @@ body.accueil-fullscreen {
 .home-hunts__toolbar-toggles {
     display: none;
     align-items: center;
+    justify-content: center;
     gap: var(--space-sm);
+    width: 100%;
 }
 
 .home-hunts__toolbar--enhanced .home-hunts__toolbar-toggles {
-    display: inline-flex;
+    display: flex;
 }
 
 .home-hunts__toolbar-toggle {

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -39,10 +39,62 @@ body.accueil-fullscreen {
     margin-bottom: var(--space-xl);
 }
 
+.home-hunts__toolbar-toggles {
+    display: none;
+    align-items: center;
+    gap: var(--space-sm);
+}
+
+.home-hunts__toolbar--enhanced .home-hunts__toolbar-toggles {
+    display: inline-flex;
+}
+
+.home-hunts__toolbar-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--color-white);
+    cursor: pointer;
+    transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.home-hunts__toolbar-toggle:hover,
+.home-hunts__toolbar-toggle:focus-visible {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.35);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.home-hunts__toolbar-toggle[aria-expanded="true"] {
+    background: rgba(255, 255, 255, 0.24);
+    border-color: rgba(255, 255, 255, 0.45);
+}
+
+.home-hunts__toolbar-toggle-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.35rem;
+    height: 1.35rem;
+}
+
+.home-hunts__toolbar-toggle-icon svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+}
+
 .home-hunts-filters,
 .home-hunts__filters,
 .home-hunts__search {
-    width: 100%;
     display: flex;
     flex-direction: column;
     gap: var(--space-lg);
@@ -54,6 +106,8 @@ body.accueil-fullscreen {
     color: var(--color-white);
     grid-column: 1 / -1;
     transition: box-shadow var(--transition-medium), transform var(--transition-medium);
+    flex: 1 1 280px;
+    min-width: 0;
 }
 
 .home-hunts__filters {
@@ -66,7 +120,7 @@ body.accueil-fullscreen {
     flex: 1 1 320px;
     max-width: 34rem;
     min-width: 0;
-    margin-left: auto;
+    margin-left: 0;
 }
 
 .home-hunts-filters:focus-within,
@@ -221,9 +275,29 @@ body.accueil-fullscreen {
     white-space: nowrap;
 }
 
+.home-hunts__toolbar--enhanced [data-home-hunts-panel][data-collapsed="true"] {
+    display: none;
+}
+
+.home-hunts__toolbar--enhanced [data-home-hunts-panel][data-collapsed="false"] {
+    display: flex;
+}
+
 @media (--bp-desktop) {
     .home-hunts__toolbar {
         margin-bottom: var(--space-2xl);
+    }
+
+    .home-hunts__toolbar--enhanced .home-hunts__toolbar-toggles {
+        display: none;
+    }
+
+    .home-hunts__toolbar--enhanced [data-home-hunts-panel] {
+        display: flex;
+    }
+
+    .home-hunts__search {
+        margin-left: auto;
     }
 
     .home-hunts__filters-group--cost {

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -121,6 +121,24 @@ body.accueil-fullscreen {
     max-width: 34rem;
     min-width: 0;
     margin-left: 0;
+    
+    .table-search__controls {
+        flex-direction: row;
+        align-items: stretch;
+        gap: var(--space-sm);
+    }
+
+    .table-search__field {
+        flex: 1 1 auto;
+    }
+
+    .table-search__submit {
+        align-self: stretch;
+    }
+
+    .table-search__reset {
+        align-self: center;
+    }
 }
 
 .home-hunts-filters:focus-within,

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -33,7 +33,8 @@ body.accueil-fullscreen {
 .home-hunts__toolbar {
     width: 100%;
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: stretch;
     gap: var(--space-lg);
     margin-bottom: var(--space-xl);
 }
@@ -55,6 +56,19 @@ body.accueil-fullscreen {
     transition: box-shadow var(--transition-medium), transform var(--transition-medium);
 }
 
+.home-hunts__filters {
+    flex: 1 1 420px;
+    max-width: 52rem;
+    min-width: 0;
+}
+
+.home-hunts__search {
+    flex: 1 1 320px;
+    max-width: 34rem;
+    min-width: 0;
+    margin-left: auto;
+}
+
 .home-hunts-filters:focus-within,
 .home-hunts__filters:focus-within,
 .home-hunts__search:focus-within {
@@ -64,7 +78,8 @@ body.accueil-fullscreen {
 
 .home-hunts__filters-form {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: center;
     gap: var(--space-lg);
     width: 100%;
 }
@@ -96,6 +111,7 @@ body.accueil-fullscreen {
     flex-direction: column;
     gap: var(--space-sm);
     min-width: 0;
+    flex: 1 1 220px;
 }
 
 .home-hunts__filters-group--cost {
@@ -141,8 +157,8 @@ body.accueil-fullscreen {
 
 .home-hunts__filters-actions {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    flex-wrap: wrap;
+    align-items: center;
     gap: var(--space-sm);
 }
 
@@ -205,60 +221,13 @@ body.accueil-fullscreen {
     white-space: nowrap;
 }
 
-@media (--bp-mobile) {
-    .home-hunts__filters-actions {
-        flex-direction: row;
-        align-items: center;
-        justify-content: flex-start;
-        align-self: flex-start;
-    }
-}
-
 @media (--bp-desktop) {
     .home-hunts__toolbar {
-        flex-direction: row;
-        align-items: stretch;
         margin-bottom: var(--space-2xl);
-    }
-
-    .home-hunts__filters {
-        flex: 1 1 60%;
-        max-width: 52rem;
-        min-width: 0;
-    }
-
-    .home-hunts__search {
-        flex: 1 1 40%;
-        max-width: 34rem;
-        min-width: 0;
-        margin-left: auto;
-    }
-
-    .home-hunts__search .table-search {
-        max-width: none;
-        margin-left: 0;
-    }
-
-    .home-hunts__filters-form {
-        flex-direction: row;
-        flex-wrap: wrap;
-        align-items: center;
-        flex: 1 1 auto;
-    }
-
-    .home-hunts__filters-group {
-        flex: 1 1 220px;
     }
 
     .home-hunts__filters-group--cost {
         flex: 0 1 auto;
-    }
-
-    .home-hunts__filters-actions {
-        flex: 0 0 auto;
-        align-items: center;
-        justify-content: flex-start;
-        margin-left: 0;
     }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_home.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_home.scss
@@ -35,6 +35,7 @@ body.accueil-fullscreen {
     display: flex;
     flex-direction: column;
     gap: var(--space-lg);
+    margin-bottom: var(--space-xl);
 }
 
 .home-hunts-filters,
@@ -217,6 +218,7 @@ body.accueil-fullscreen {
     .home-hunts__toolbar {
         flex-direction: row;
         align-items: stretch;
+        margin-bottom: var(--space-2xl);
     }
 
     .home-hunts__filters {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8467,7 +8467,8 @@ body.accueil-fullscreen {
 .home-hunts__toolbar {
   width: 100%;
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  align-items: stretch;
   gap: var(--space-lg);
   margin-bottom: var(--space-xl);
 }
@@ -8489,6 +8490,19 @@ body.accueil-fullscreen {
   transition: box-shadow var(--transition-medium), transform var(--transition-medium);
 }
 
+.home-hunts__filters {
+  flex: 1 1 420px;
+  max-width: 52rem;
+  min-width: 0;
+}
+
+.home-hunts__search {
+  flex: 1 1 320px;
+  max-width: 34rem;
+  min-width: 0;
+  margin-left: auto;
+}
+
 .home-hunts-filters:focus-within,
 .home-hunts__filters:focus-within,
 .home-hunts__search:focus-within {
@@ -8498,7 +8512,8 @@ body.accueil-fullscreen {
 
 .home-hunts__filters-form {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-lg);
   width: 100%;
 }
@@ -8530,6 +8545,7 @@ body.accueil-fullscreen {
   flex-direction: column;
   gap: var(--space-sm);
   min-width: 0;
+  flex: 1 1 220px;
 }
 
 .home-hunts__filters-group--cost {
@@ -8575,8 +8591,8 @@ body.accueil-fullscreen {
 
 .home-hunts__filters-actions {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-sm);
 }
 
@@ -8639,52 +8655,12 @@ body.accueil-fullscreen {
   white-space: nowrap;
 }
 
-@media (min-width: 600px) {
-  .home-hunts__filters-actions {
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-    align-self: flex-start;
-  }
-}
 @media (min-width: 1024px) {
   .home-hunts__toolbar {
-    flex-direction: row;
-    align-items: stretch;
     margin-bottom: var(--space-2xl);
-  }
-  .home-hunts__filters {
-    flex: 1 1 60%;
-    max-width: 52rem;
-    min-width: 0;
-  }
-  .home-hunts__search {
-    flex: 1 1 40%;
-    max-width: 34rem;
-    min-width: 0;
-    margin-left: auto;
-  }
-  .home-hunts__search .table-search {
-    max-width: none;
-    margin-left: 0;
-  }
-  .home-hunts__filters-form {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
-    flex: 1 1 auto;
-  }
-  .home-hunts__filters-group {
-    flex: 1 1 220px;
   }
   .home-hunts__filters-group--cost {
     flex: 0 1 auto;
-  }
-  .home-hunts__filters-actions {
-    flex: 0 0 auto;
-    align-items: center;
-    justify-content: flex-start;
-    margin-left: 0;
   }
 }
 .home-hunts__feedback {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8469,6 +8469,7 @@ body.accueil-fullscreen {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
+  margin-bottom: var(--space-xl);
 }
 
 .home-hunts-filters,
@@ -8650,6 +8651,7 @@ body.accueil-fullscreen {
   .home-hunts__toolbar {
     flex-direction: row;
     align-items: stretch;
+    margin-bottom: var(--space-2xl);
   }
   .home-hunts__filters {
     flex: 1 1 60%;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8473,10 +8473,62 @@ body.accueil-fullscreen {
   margin-bottom: var(--space-xl);
 }
 
+.home-hunts__toolbar-toggles {
+  display: none;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.home-hunts__toolbar--enhanced .home-hunts__toolbar-toggles {
+  display: inline-flex;
+}
+
+.home-hunts__toolbar-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-white);
+  cursor: pointer;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.home-hunts__toolbar-toggle:hover,
+.home-hunts__toolbar-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.home-hunts__toolbar-toggle[aria-expanded=true] {
+  background: rgba(255, 255, 255, 0.24);
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.home-hunts__toolbar-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.home-hunts__toolbar-toggle-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
 .home-hunts-filters,
 .home-hunts__filters,
 .home-hunts__search {
-  width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
@@ -8488,6 +8540,8 @@ body.accueil-fullscreen {
   color: var(--color-white);
   grid-column: 1/-1;
   transition: box-shadow var(--transition-medium), transform var(--transition-medium);
+  flex: 1 1 280px;
+  min-width: 0;
 }
 
 .home-hunts__filters {
@@ -8500,7 +8554,7 @@ body.accueil-fullscreen {
   flex: 1 1 320px;
   max-width: 34rem;
   min-width: 0;
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .home-hunts-filters:focus-within,
@@ -8655,9 +8709,26 @@ body.accueil-fullscreen {
   white-space: nowrap;
 }
 
+.home-hunts__toolbar--enhanced [data-home-hunts-panel][data-collapsed=true] {
+  display: none;
+}
+
+.home-hunts__toolbar--enhanced [data-home-hunts-panel][data-collapsed=false] {
+  display: flex;
+}
+
 @media (min-width: 1024px) {
   .home-hunts__toolbar {
     margin-bottom: var(--space-2xl);
+  }
+  .home-hunts__toolbar--enhanced .home-hunts__toolbar-toggles {
+    display: none;
+  }
+  .home-hunts__toolbar--enhanced [data-home-hunts-panel] {
+    display: flex;
+  }
+  .home-hunts__search {
+    margin-left: auto;
   }
   .home-hunts__filters-group--cost {
     flex: 0 1 auto;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8556,6 +8556,20 @@ body.accueil-fullscreen {
   min-width: 0;
   margin-left: 0;
 }
+.home-hunts__search .table-search__controls {
+  flex-direction: row;
+  align-items: stretch;
+  gap: var(--space-sm);
+}
+.home-hunts__search .table-search__field {
+  flex: 1 1 auto;
+}
+.home-hunts__search .table-search__submit {
+  align-self: stretch;
+}
+.home-hunts__search .table-search__reset {
+  align-self: center;
+}
 
 .home-hunts-filters:focus-within,
 .home-hunts__filters:focus-within,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -8476,11 +8476,13 @@ body.accueil-fullscreen {
 .home-hunts__toolbar-toggles {
   display: none;
   align-items: center;
+  justify-content: center;
   gap: var(--space-sm);
+  width: 100%;
 }
 
 .home-hunts__toolbar--enhanced .home-hunts__toolbar-toggles {
-  display: inline-flex;
+  display: flex;
 }
 
 .home-hunts__toolbar-toggle {

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -92,15 +92,54 @@ $results_label = sprintf(
     $initial_results_count
 );
 
-$filters_reset_label = __('Réinitialiser les filtres', 'chassesautresor-com');
-$reset_icon_markup   = function_exists('cta_get_reset_icon_markup')
+$filters_reset_label       = __('Réinitialiser les filtres', 'chassesautresor-com');
+$reset_icon_markup         = function_exists('cta_get_reset_icon_markup')
     ? cta_get_reset_icon_markup()
+    : '';
+$filters_toggle_label      = __('Afficher les filtres', 'chassesautresor-com');
+$search_toggle_label       = __('Afficher la recherche', 'chassesautresor-com');
+$filter_toggle_icon_markup = '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+    . '<path fill="currentColor" d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 .78 1.63l-5.58 6.7a1 1 0 0 0-.22.63v4.54a1 1 0 0 1-.55.9l-3 1.5A1 1 0 0 1 9 19.5v-5.54a1 1 0 0 0-.22-.63L3.2 6.63A1 1 0 0 1 4 5Z" />'
+    . '</svg>';
+$search_toggle_icon_markup = function_exists('cta_get_table_search_submit_icon_markup')
+    ? cta_get_table_search_submit_icon_markup('search')
     : '';
 
 ob_start();
 ?>
-<div class="home-hunts__toolbar">
-    <div class="home-hunts__filters">
+<div class="home-hunts__toolbar" data-home-hunts-toolbar>
+    <div class="home-hunts__toolbar-toggles">
+        <button
+            type="button"
+            class="home-hunts__toolbar-toggle"
+            data-home-hunts-toggle="filters"
+            aria-controls="home-hunts-filters-panel"
+            aria-expanded="false"
+        >
+            <span class="home-hunts__toolbar-toggle-icon" aria-hidden="true">
+                <?php echo $filter_toggle_icon_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </span>
+            <span class="screen-reader-text"><?php echo esc_html($filters_toggle_label); ?></span>
+        </button>
+        <button
+            type="button"
+            class="home-hunts__toolbar-toggle"
+            data-home-hunts-toggle="search"
+            aria-controls="home-hunts-search-panel"
+            aria-expanded="false"
+        >
+            <span class="home-hunts__toolbar-toggle-icon" aria-hidden="true">
+                <?php echo $search_toggle_icon_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </span>
+            <span class="screen-reader-text"><?php echo esc_html($search_toggle_label); ?></span>
+        </button>
+    </div>
+    <div
+        class="home-hunts__panel home-hunts__filters"
+        data-home-hunts-panel="filters"
+        id="home-hunts-filters-panel"
+        data-collapsed="false"
+    >
         <form
             class="home-hunts__filters-form"
             data-home-hunts-filters
@@ -182,7 +221,12 @@ ob_start();
             </div>
         </form>
     </div>
-    <div class="home-hunts__search">
+    <div
+        class="home-hunts__panel home-hunts__search"
+        data-home-hunts-panel="search"
+        id="home-hunts-search-panel"
+        data-collapsed="false"
+    >
         <?php
         echo cta_render_search_form('home-hunts', [
             'class'             => 'home-hunts__search-form table-search--inline table-search--compact',

--- a/wp-content/themes/chassesautresor/front-page.php
+++ b/wp-content/themes/chassesautresor/front-page.php
@@ -234,12 +234,13 @@ $after_items_markup = sprintf(
                     data-home-hunts="true"
                     data-nonce="<?php echo esc_attr($filters_nonce); ?>"
                 >
+                    <?php echo $before_items_markup; ?>
                     <?php
                     get_template_part('template-parts/organisateur/organisateur-partial-boucle-chasses', null, [
                         'chasse_ids' => $chasse_ids,
                         'show_header' => false,
                         'grid_class' => 'organisateur-chasses-grid',
-                        'before_items' => $before_items_markup,
+                        'before_items' => '',
                         'after_items' => $after_items_markup,
                     ]);
                     ?>


### PR DESCRIPTION
Corrige l'affichage de la barre de filtres des chasses sur les résolutions compactes.

- Replace le bloc de filtres/recherche avant la grille des cartes et adapte le script d'actualisation.
- Ajoute une marge dédiée à la barre d'outils et recompile les feuilles de style.

**Testing**
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d1776d8f648332bbcbba158fc14b2a