### PR TITLE
Check headers before starting session for site messages

### DIFF
--- a/wp-content/themes/chassesautresor/inc/messages.php
+++ b/wp-content/themes/chassesautresor/inc/messages.php
@@ -92,6 +92,14 @@ function add_site_message(
     }
 
     if (session_status() !== PHP_SESSION_ACTIVE) {
+        if (headers_sent($file, $line)) {
+            $fileInfo = is_string($file) && $file !== '' ? $file : 'unknown';
+            $lineInfo = is_numeric($line) ? (string) $line : 'unknown';
+            error_log(sprintf('[add_site_message] headers already sent (%s:%s), skipping session storage.', $fileInfo, $lineInfo));
+
+            return;
+        }
+
         session_start();
     }
 


### PR DESCRIPTION
## Résumé
- évite de démarrer une session si les en-têtes HTTP sont déjà envoyés
- journalise l'incident et ignore le stockage en session lorsque nécessaire

## Testing
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d207f324a88332b119ac7aa5cb0f9d