### PR TITLE
Refine compact hunt cards layout

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -226,6 +226,26 @@
     justify-content: flex-start;
     gap: var(--space-sm);
     flex-wrap: nowrap;
+    width: 100%;
+  }
+
+  .carte-cart__footer-organisateur {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .carte-cart__organisateur-logo {
+    display: block;
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+    filter: grayscale(100%);
+  }
+
+  .carte-cart__footer-dates {
+    margin-left: auto;
   }
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -218,35 +218,6 @@
     margin: 0 0 var(--space-xs);
   }
 
-  .carte-cart__footer {
-    padding: 0 var(--space-md) var(--space-md);
-    font-size: 0.875rem;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: var(--space-sm);
-    flex-wrap: nowrap;
-    width: 100%;
-  }
-
-  .carte-cart__footer-organisateur {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-  }
-
-  .carte-cart__organisateur-logo {
-    display: block;
-    width: 48px;
-    height: 48px;
-    object-fit: contain;
-    filter: grayscale(100%);
-  }
-
-  .carte-cart__footer-dates {
-    margin-left: auto;
-  }
 }
 
 /* ========== 🎁 Récompense dans les cartes compactes ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -205,33 +205,6 @@
 .carte-cart .carte-cart__titre {
   margin: 0 0 var(--space-xs);
 }
-.carte-cart .carte-cart__footer {
-  padding: 0 var(--space-md) var(--space-md);
-  font-size: 0.875rem;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: var(--space-sm);
-  flex-wrap: nowrap;
-  width: 100%;
-}
-.carte-cart .carte-cart__footer-organisateur {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-.carte-cart .carte-cart__organisateur-logo {
-  display: block;
-  width: 48px;
-  height: 48px;
-  -o-object-fit: contain;
-     object-fit: contain;
-  filter: grayscale(100%);
-}
-.carte-cart .carte-cart__footer-dates {
-  margin-left: auto;
-}
 
 /* ========== 🎁 Récompense dans les cartes compactes ========== */
 .carte-compact .chasse-lot,

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -213,6 +213,24 @@
   justify-content: flex-start;
   gap: var(--space-sm);
   flex-wrap: nowrap;
+  width: 100%;
+}
+.carte-cart .carte-cart__footer-organisateur {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.carte-cart .carte-cart__organisateur-logo {
+  display: block;
+  width: 48px;
+  height: 48px;
+  -o-object-fit: contain;
+     object-fit: contain;
+  filter: grayscale(100%);
+}
+.carte-cart .carte-cart__footer-dates {
+  margin-left: auto;
 }
 
 /* ========== 🎁 Récompense dans les cartes compactes ========== */

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1995,9 +1995,6 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $image_ratio_padding = '';
 
     $organisateur_id = get_organisateur_from_chasse($chasse_id);
-    $organisateur_logo_id = 0;
-    $organisateur_logo_url = '';
-    $organisateur_nom = '';
 
     if ($image_width > 0 && $image_height > 0) {
         $image_ratio = $image_width . ' / ' . $image_height;
@@ -2008,34 +2005,6 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
             $image_ratio_padding = rtrim(rtrim(sprintf('%.6F', $ratio_padding_value), '0'), '.');
             if ($image_ratio_padding !== '') {
                 $image_ratio_padding .= '%';
-            }
-        }
-    }
-
-    if ($organisateur_id) {
-        $organisateur_nom = get_the_title($organisateur_id);
-
-        $logo_field = get_field('logo_organisateur', $organisateur_id, false);
-
-        if (!empty($logo_field)) {
-            if (is_array($logo_field)) {
-                $organisateur_logo_id = (int) reset($logo_field);
-            } else {
-                $organisateur_logo_id = (int) $logo_field;
-            }
-        }
-
-        if ($organisateur_logo_id > 0) {
-            $logo_data = wp_get_attachment_image_src($organisateur_logo_id, 'thumbnail');
-            if (is_array($logo_data) && !empty($logo_data[0])) {
-                $organisateur_logo_url = (string) $logo_data[0];
-            }
-        }
-
-        if ($organisateur_logo_url === '') {
-            $fallback_logo = wp_get_attachment_image_src(3927, 'thumbnail');
-            if (is_array($fallback_logo) && !empty($fallback_logo[0])) {
-                $organisateur_logo_url = (string) $fallback_logo[0];
             }
         }
     }
@@ -2240,9 +2209,6 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'themes'            => $themes,
         'region_principale' => $region_principale,
         'organisateur_id'   => $organisateur_id,
-        'organisateur_logo_id' => $organisateur_logo_id,
-        'organisateur_logo_url' => $organisateur_logo_url,
-        'organisateur_nom'  => $organisateur_nom,
     ];
 
     if (!empty($progression['resolvables'])) {

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1994,6 +1994,11 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     $image_ratio = '';
     $image_ratio_padding = '';
 
+    $organisateur_id = get_organisateur_from_chasse($chasse_id);
+    $organisateur_logo_id = 0;
+    $organisateur_logo_url = '';
+    $organisateur_nom = '';
+
     if ($image_width > 0 && $image_height > 0) {
         $image_ratio = $image_width . ' / ' . $image_height;
 
@@ -2003,6 +2008,34 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
             $image_ratio_padding = rtrim(rtrim(sprintf('%.6F', $ratio_padding_value), '0'), '.');
             if ($image_ratio_padding !== '') {
                 $image_ratio_padding .= '%';
+            }
+        }
+    }
+
+    if ($organisateur_id) {
+        $organisateur_nom = get_the_title($organisateur_id);
+
+        $logo_field = get_field('logo_organisateur', $organisateur_id, false);
+
+        if (!empty($logo_field)) {
+            if (is_array($logo_field)) {
+                $organisateur_logo_id = (int) reset($logo_field);
+            } else {
+                $organisateur_logo_id = (int) $logo_field;
+            }
+        }
+
+        if ($organisateur_logo_id > 0) {
+            $logo_data = wp_get_attachment_image_src($organisateur_logo_id, 'thumbnail');
+            if (is_array($logo_data) && !empty($logo_data[0])) {
+                $organisateur_logo_url = (string) $logo_data[0];
+            }
+        }
+
+        if ($organisateur_logo_url === '') {
+            $fallback_logo = wp_get_attachment_image_src(3927, 'thumbnail');
+            if (is_array($fallback_logo) && !empty($fallback_logo[0])) {
+                $organisateur_logo_url = (string) $fallback_logo[0];
             }
         }
     }
@@ -2206,6 +2239,10 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'regions'           => $regions,
         'themes'            => $themes,
         'region_principale' => $region_principale,
+        'organisateur_id'   => $organisateur_id,
+        'organisateur_logo_id' => $organisateur_logo_id,
+        'organisateur_logo_url' => $organisateur_logo_url,
+        'organisateur_nom'  => $organisateur_nom,
     ];
 
     if (!empty($progression['resolvables'])) {

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -92,16 +92,6 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' role="img" tabindex="0"';
 }
 
-$organisateur_logo_url = $infos['organisateur_logo_url'] ?? '';
-$organisateur_nom = $infos['organisateur_nom'] ?? '';
-$organisateur_logo_alt = __('Logo de l\'organisateur', 'chassesautresor-com');
-
-if ($organisateur_nom !== '') {
-    $organisateur_logo_alt = sprintf(
-        __('Logo de %s', 'chassesautresor-com'),
-        sanitize_text_field($organisateur_nom)
-    );
-}
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
@@ -121,25 +111,4 @@ if ($organisateur_nom !== '') {
             <?php echo $infos['lot_html']; ?>
         </div>
     </a>
-    <div class="carte-cart__footer svg-xsmall">
-        <?php if ($organisateur_logo_url !== '') : ?>
-            <div class="carte-cart__footer-organisateur">
-                <img
-                    class="carte-cart__organisateur-logo"
-                    src="<?php echo esc_url($organisateur_logo_url); ?>"
-                    alt="<?php echo esc_attr($organisateur_logo_alt); ?>"
-                    loading="lazy"
-                    width="48"
-                    height="48"
-                />
-            </div>
-        <?php endif; ?>
-        <div class="carte-cart__footer-dates meta-etiquette">
-            <?php echo get_svg_icon('calendar'); ?>
-            <span class="chasse-date-plage">
-                <span class="date-debut"><?php echo esc_html($infos['date_debut_court']); ?></span> –
-                <span class="date-fin"><?php echo esc_html($infos['date_fin_court']); ?></span>
-            </span>
-        </div>
-    </div>
 </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -92,8 +92,16 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' role="img" tabindex="0"';
 }
 
-$regions_links = chasse_format_meta_terms($infos['regions'] ?? null);
-$themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
+$organisateur_logo_url = $infos['organisateur_logo_url'] ?? '';
+$organisateur_nom = $infos['organisateur_nom'] ?? '';
+$organisateur_logo_alt = __('Logo de l\'organisateur', 'chassesautresor-com');
+
+if ($organisateur_nom !== '') {
+    $organisateur_logo_alt = sprintf(
+        __('Logo de %s', 'chassesautresor-com'),
+        sanitize_text_field($organisateur_nom)
+    );
+}
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
@@ -110,44 +118,23 @@ $themes_links = chasse_format_meta_terms($infos['themes'] ?? null);
         </div>
         <div class="carte-cart__contenu">
             <h3 class="carte-cart__titre"><?php echo esc_html($infos['titre']); ?></h3>
-            <?php if (!empty($regions_links) || !empty($themes_links)) : ?>
-                <div class="bloc-metas-inline bloc-metas-inline--compact">
-                    <?php if (!empty($regions_links)) : ?>
-                        <?php
-                        $regions_label = _n('Région :', 'Régions :', count($regions_links), 'chassesautresor-com');
-                        ?>
-                        <div class="meta-etiquette meta-etiquette--regions">
-                            <span><?php echo esc_html($regions_label); ?></span>
-                            <?php echo wp_kses_post(implode(', ', $regions_links)); ?>
-                        </div>
-                    <?php endif; ?>
-
-                    <?php if (!empty($themes_links)) : ?>
-                        <?php
-                        $themes_label = _n('Thème :', 'Thèmes :', count($themes_links), 'chassesautresor-com');
-                        ?>
-                        <div class="meta-etiquette meta-etiquette--themes">
-                            <span><?php echo esc_html($themes_label); ?></span>
-                            <?php echo wp_kses_post(implode(', ', $themes_links)); ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            <?php endif; ?>
             <?php echo $infos['lot_html']; ?>
         </div>
     </a>
-    <div class="carte-cart__footer meta-row svg-xsmall">
-        <div class="meta-regular">
-            <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre d\'énigmes', 'chassesautresor-com'); ?>">
-                <?php echo get_svg_icon('enigme'); ?>
-                <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['total_enigmes'])); ?></span>
-            </button>
-            <button type="button" class="meta-indic" data-tap="<?= esc_attr__('nombre de joueurs', 'chassesautresor-com'); ?>">
-                <?php echo get_svg_icon('participants'); ?>
-                <span class="meta-indic__count"><?php echo esc_html(number_format_i18n($infos['nb_joueurs'])); ?></span>
-            </button>
-        </div>
-        <div class="meta-etiquette">
+    <div class="carte-cart__footer svg-xsmall">
+        <?php if ($organisateur_logo_url !== '') : ?>
+            <div class="carte-cart__footer-organisateur">
+                <img
+                    class="carte-cart__organisateur-logo"
+                    src="<?php echo esc_url($organisateur_logo_url); ?>"
+                    alt="<?php echo esc_attr($organisateur_logo_alt); ?>"
+                    loading="lazy"
+                    width="48"
+                    height="48"
+                />
+            </div>
+        <?php endif; ?>
+        <div class="carte-cart__footer-dates meta-etiquette">
             <?php echo get_svg_icon('calendar'); ?>
             <span class="chasse-date-plage">
                 <span class="date-debut"><?php echo esc_html($infos['date_debut_court']); ?></span> –


### PR DESCRIPTION
## Résumé
- simplifie la carte compacte des chasses en retirant les métadonnées superflues
- ajoute l’icône organisateur en niveau de gris dans le pied de carte
- met à jour les styles SCSS/CSS et reconstruit la feuille compilée

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d207d91a0c83329c6a9a4039d257f5