### PR TITLE
Improve hunt meta layout for mobile

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -387,6 +387,43 @@ a.chasse-badge.chasse-badge--region:focus-visible {
 .meta-regular .meta-indic__count {
     font-weight: 600;
 }
+
+.chasse-fiche-container > .meta-row {
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    width: 100%;
+}
+
+.chasse-fiche-container > .meta-row .meta-regular {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex-shrink: 0;
+}
+
+.chasse-fiche-container > .meta-row .meta-etiquette {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xxs);
+    flex-shrink: 0;
+}
+
+.chasse-fiche-container > .meta-row .meta-indic {
+    gap: var(--space-xxs);
+    white-space: nowrap;
+}
+
+.chasse-fiche-container > .meta-row .meta-indic__count {
+    font-variant-numeric: tabular-nums;
+}
+
+.chasse-fiche-container > .meta-row .chasse-date-plage {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xxs);
+    white-space: nowrap;
+}
 .chasse-details-wrapper .bloc-metas-inline {
     margin: var(--space-xl) 0;
     color: white;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1368,6 +1368,43 @@ a.chasse-badge.chasse-badge--region:focus-visible {
   font-weight: 600;
 }
 
+.chasse-fiche-container > .meta-row {
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.chasse-fiche-container > .meta-row .meta-regular {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+.chasse-fiche-container > .meta-row .meta-etiquette {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  flex-shrink: 0;
+}
+
+.chasse-fiche-container > .meta-row .meta-indic {
+  gap: var(--space-xxs);
+  white-space: nowrap;
+}
+
+.chasse-fiche-container > .meta-row .meta-indic__count {
+  font-variant-numeric: tabular-nums;
+}
+
+.chasse-fiche-container > .meta-row .chasse-date-plage {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  white-space: nowrap;
+}
+
 .chasse-details-wrapper .bloc-metas-inline {
   margin: var(--space-xl) 0;
   color: white;

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -2034,12 +2034,16 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
 
     $timestamp_debut = convertir_en_timestamp($date_debut);
     $timestamp_fin   = (!$illimitee && $date_fin) ? convertir_en_timestamp($date_fin) : false;
+
+    /* translators: Short date format for hunt metadata (day/month/year). */
+    $short_date_format = _x('d/m/y', 'short date format for hunts', 'chassesautresor-com');
+
     $date_debut_court = $timestamp_debut
-        ? wp_date('d/m/y', $timestamp_debut)
+        ? wp_date($short_date_format, $timestamp_debut)
         : __('Non spécifiée', 'chassesautresor-com');
     $date_fin_court   = $illimitee
         ? __('Illimitée', 'chassesautresor-com')
-        : ($timestamp_fin ? wp_date('d/m/y', $timestamp_fin) : __('Non spécifiée', 'chassesautresor-com'));
+        : ($timestamp_fin ? wp_date($short_date_format, $timestamp_fin) : __('Non spécifiée', 'chassesautresor-com'));
 
     $nb_joueurs       = compter_joueurs_engages_chasse($chasse_id);
     $nb_joueurs_label = formater_nombre_joueurs($nb_joueurs);

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -1921,6 +1921,66 @@ function chasse_is_list(array $array): bool
     return array_keys($array) === range(0, count($array) - 1);
 }
 
+/**
+ * Prépare les représentations courtes des dates d'une chasse.
+ *
+ * @param string|null $start_date Date de début brute.
+ * @param string|null $end_date   Date de fin brute.
+ * @param bool        $is_unlimited Indique si la chasse est illimitée.
+ *
+ * @return array{date_debut_court: string, date_fin_court: string}
+ */
+function chasse_preparer_dates_courtes(?string $start_date, ?string $end_date, bool $is_unlimited): array
+{
+    $start_value = $start_date !== null ? (string) $start_date : null;
+    $end_value   = $end_date !== null ? (string) $end_date : null;
+
+    $start_timestamp = false;
+    if ($start_value !== null && $start_value !== '') {
+        if (function_exists('convertir_en_timestamp')) {
+            $start_timestamp = convertir_en_timestamp($start_value);
+        } else {
+            $start_timestamp = strtotime(str_replace('/', '-', $start_value));
+        }
+    }
+
+    $end_timestamp = false;
+    if (!$is_unlimited && $end_value !== null && $end_value !== '') {
+        if (function_exists('convertir_en_timestamp')) {
+            $end_timestamp = convertir_en_timestamp($end_value);
+        } else {
+            $end_timestamp = strtotime(str_replace('/', '-', $end_value));
+        }
+    }
+
+    if (function_exists('_x')) {
+        /* translators: Short date format for hunt metadata (day/month/year). */
+        $short_date_format = _x('d/m/y', 'short date format for hunts', 'chassesautresor-com');
+    } else {
+        $short_date_format = 'd/m/y';
+    }
+
+    $non_specifiee_label = function_exists('__')
+        ? __('Non spécifiée', 'chassesautresor-com')
+        : 'Non spécifiée';
+    $illimitee_label = function_exists('__')
+        ? __('Illimitée', 'chassesautresor-com')
+        : 'Illimitée';
+
+    $start_short = $start_timestamp
+        ? wp_date($short_date_format, $start_timestamp)
+        : $non_specifiee_label;
+
+    $end_short = $is_unlimited
+        ? $illimitee_label
+        : ($end_timestamp ? wp_date($short_date_format, $end_timestamp) : $non_specifiee_label);
+
+    return [
+        'date_debut_court' => $start_short,
+        'date_fin_court'   => $end_short,
+    ];
+}
+
 function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit = 300, array $options = []): array
 {
     if (get_post_type($chasse_id) !== 'chasse') {
@@ -2032,18 +2092,9 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         ? __('Illimitée', 'chassesautresor-com')
         : ($date_fin ? formater_date($date_fin) : __('Non spécifiée', 'chassesautresor-com'));
 
-    $timestamp_debut = convertir_en_timestamp($date_debut);
-    $timestamp_fin   = (!$illimitee && $date_fin) ? convertir_en_timestamp($date_fin) : false;
-
-    /* translators: Short date format for hunt metadata (day/month/year). */
-    $short_date_format = _x('d/m/y', 'short date format for hunts', 'chassesautresor-com');
-
-    $date_debut_court = $timestamp_debut
-        ? wp_date($short_date_format, $timestamp_debut)
-        : __('Non spécifiée', 'chassesautresor-com');
-    $date_fin_court   = $illimitee
-        ? __('Illimitée', 'chassesautresor-com')
-        : ($timestamp_fin ? wp_date($short_date_format, $timestamp_fin) : __('Non spécifiée', 'chassesautresor-com'));
+    $dates_courtes    = chasse_preparer_dates_courtes($date_debut, $date_fin, (bool) $illimitee);
+    $date_debut_court = $dates_courtes['date_debut_court'];
+    $date_fin_court   = $dates_courtes['date_fin_court'];
 
     $nb_joueurs       = compter_joueurs_engages_chasse($chasse_id);
     $nb_joueurs_label = formater_nombre_joueurs($nb_joueurs);
@@ -2262,6 +2313,33 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     $themes = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
     $region_principale = !empty($regions) ? $regions[0] : null;
 
+    $raw_start_date   = $champs['date_debut'] ?? null;
+    $raw_end_date     = $champs['date_fin'] ?? null;
+    $raw_discovery    = $champs['date_decouverte'] ?? null;
+    $is_unlimited     = !empty($champs['illimitee']);
+    $status_value     = get_field('chasse_cache_statut', $chasse_id) ?: 'revision';
+    $status_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+
+    if ($status_value === 'termine' && !empty($raw_discovery)) {
+        $raw_end_date = $raw_discovery;
+    }
+
+    $start_date_value = null;
+    if (is_string($raw_start_date) && $raw_start_date !== '') {
+        $start_date_value = $raw_start_date;
+    } elseif (is_numeric($raw_start_date)) {
+        $start_date_value = (string) $raw_start_date;
+    }
+
+    $end_date_value = null;
+    if (is_string($raw_end_date) && $raw_end_date !== '') {
+        $end_date_value = $raw_end_date;
+    } elseif (is_numeric($raw_end_date)) {
+        $end_date_value = (string) $raw_end_date;
+    }
+
+    $dates_courtes = chasse_preparer_dates_courtes($start_date_value, $end_date_value, (bool) $is_unlimited);
+
     $description   = get_field('chasse_principale_description', $chasse_id);
     $texte_complet = wp_strip_all_tags($description);
     $extrait       = wp_trim_words($texte_complet, 60, '...');
@@ -2324,11 +2402,13 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
             'nb'      => $top_nb,
             'enigmes' => $top_enigmes,
         ],
-        'statut'            => get_field('chasse_cache_statut', $chasse_id) ?: 'revision',
-        'statut_validation' => get_field('chasse_cache_statut_validation', $chasse_id),
+        'statut'            => $status_value,
+        'statut_validation' => $status_validation,
         'regions'           => $regions,
         'themes'            => $themes,
         'region_principale' => $region_principale,
+        'date_debut_court'  => $dates_courtes['date_debut_court'],
+        'date_fin_court'    => $dates_courtes['date_fin_court'],
     ];
 
     $cache[$user_id] = $memo[$memo_key];

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -331,20 +331,69 @@ if ($edition_active && !$est_complet) {
         </div>
       <?php endif; ?>
 
-      <div class="meta-row svg-xsmall">
+      <?php
+      $total_enigmes_formatted     = number_format_i18n((int) $total_enigmes);
+      $total_enigmes_for_plural    = $total_enigmes === 1 ? 1 : (int) $total_enigmes;
+      $label_total_enigmes         = sprintf(
+          _n('%s énigme', '%s énigmes', $total_enigmes_for_plural, 'chassesautresor-com'),
+          $total_enigmes_formatted
+      );
+      $nb_joueurs_formatted        = number_format_i18n((int) $nb_joueurs);
+      $nb_joueurs_for_plural       = $nb_joueurs === 1 ? 1 : (int) $nb_joueurs;
+      $label_nb_joueurs            = sprintf(
+          _n('%s joueur', '%s joueurs', $nb_joueurs_for_plural, 'chassesautresor-com'),
+          $nb_joueurs_formatted
+      );
+      $date_debut_courte           = (string) ($infos_chasse['date_debut_court'] ?? '');
+      $date_fin_courte             = (string) ($infos_chasse['date_fin_court'] ?? '');
+
+      if ($date_debut_courte === '') {
+          $date_debut_courte = __('Non spécifiée', 'chassesautresor-com');
+      }
+
+      if ($date_fin_courte === '') {
+          $date_fin_courte = __('Non spécifiée', 'chassesautresor-com');
+      }
+
+      if ($illimitee) {
+          $date_plage_title = __('Durée illimitée', 'chassesautresor-com');
+      } elseif (!empty($date_debut) && !empty($date_fin)) {
+          /* translators: %1$s: start date, %2$s: end date. */
+          $date_plage_title = sprintf(__('Du %1$s au %2$s', 'chassesautresor-com'), $date_debut_formatee, $date_fin_formatee);
+      } elseif (!empty($date_debut)) {
+          /* translators: %s: start date. */
+          $date_plage_title = sprintf(__('À partir du %s', 'chassesautresor-com'), $date_debut_formatee);
+      } elseif (!empty($date_fin)) {
+          /* translators: %s: end date. */
+          $date_plage_title = sprintf(__('Jusqu\'au %s', 'chassesautresor-com'), $date_fin_formatee);
+      } else {
+          $date_plage_title = __('Dates non spécifiées', 'chassesautresor-com');
+      }
+      ?>
+      <div class="meta-row svg-xsmall meta-row--headline">
         <div class="meta-regular">
-          <?php echo get_svg_icon('enigme'); ?>
-          <?= esc_html(sprintf(_n('%d énigme', '%d énigmes', $total_enigmes, 'chassesautresor-com'), $total_enigmes)); ?> —
-          <?php echo get_svg_icon('participants'); ?>
-          <?= esc_html(sprintf(_n('%d joueur', '%d joueurs', $nb_joueurs, 'chassesautresor-com'), $nb_joueurs)); ?>
+          <span class="meta-indic meta-indic--static">
+            <?php echo get_svg_icon('enigme'); ?>
+            <span class="meta-indic__count" aria-hidden="true"><?= esc_html($total_enigmes_formatted); ?></span>
+            <span class="screen-reader-text"><?= esc_html($label_total_enigmes); ?></span>
+          </span>
+          <span class="meta-indic meta-indic--static">
+            <?php echo get_svg_icon('participants'); ?>
+            <span class="meta-indic__count" aria-hidden="true"><?= esc_html($nb_joueurs_formatted); ?></span>
+            <span class="screen-reader-text"><?= esc_html($label_nb_joueurs); ?></span>
+          </span>
         </div>
         <div class="meta-etiquette">
           <?php echo get_svg_icon('calendar'); ?>
-          <span class="chasse-date-plage">
-            <span class="date-debut"><?= esc_html($date_debut_formatee); ?></span> –
-            <span class="date-fin"><?= esc_html($date_fin_formatee); ?></span>
+          <span
+            class="chasse-date-plage"
+            title="<?= esc_attr($date_plage_title); ?>"
+            aria-label="<?= esc_attr($date_plage_title); ?>"
+          >
+            <span class="date-debut"><?= esc_html($date_debut_courte); ?></span>
+            <span class="date-separator" aria-hidden="true">–</span>
+            <span class="date-fin"><?= esc_html($date_fin_courte); ?></span>
           </span>
-
         </div>
       </div>
 

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -344,8 +344,24 @@ if ($edition_active && !$est_complet) {
           _n('%s joueur', '%s joueurs', $nb_joueurs_for_plural, 'chassesautresor-com'),
           $nb_joueurs_formatted
       );
-      $date_debut_courte           = (string) ($infos_chasse['date_debut_court'] ?? '');
-      $date_fin_courte             = (string) ($infos_chasse['date_fin_court'] ?? '');
+      $date_debut_courte = (string) ($infos_chasse['date_debut_court'] ?? '');
+      $date_fin_courte   = (string) ($infos_chasse['date_fin_court'] ?? '');
+
+      if ($date_debut_courte === '' || $date_fin_courte === '') {
+          $dates_courtes_fallback = chasse_preparer_dates_courtes(
+              is_string($date_debut) && $date_debut !== '' ? $date_debut : (is_numeric($date_debut) ? (string) $date_debut : null),
+              is_string($date_fin) && $date_fin !== '' ? $date_fin : (is_numeric($date_fin) ? (string) $date_fin : null),
+              !empty($illimitee)
+          );
+
+          if ($date_debut_courte === '') {
+              $date_debut_courte = $dates_courtes_fallback['date_debut_court'];
+          }
+
+          if ($date_fin_courte === '') {
+              $date_fin_courte = $dates_courtes_fallback['date_fin_court'];
+          }
+      }
 
       if ($date_debut_courte === '') {
           $date_debut_courte = __('Non spécifiée', 'chassesautresor-com');


### PR DESCRIPTION
Résumé : Ajuste l'affichage des métadonnées de la fiche chasse pour les écrans mobiles.

- Affiche les nombres d'énigmes et de joueurs avec un format compact et accessible sur la fiche chasse.
- Utilise un format de date court et localisable pour la plage de dates des chasses.
- Ajuste les styles SCSS/CSS afin de maintenir les métas sur une seule ligne sur petits écrans.

**Testing**
- ✅ `npm run build:css`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d20910d9548332924f3de1051f5dc1