### PR TITLE
Corrige l'alignement du fil d'Ariane

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -1347,6 +1347,7 @@ a.addtoany_share span {
   display: flex;
   flex-wrap: wrap;
   list-style: none;
+  margin: 0;
   padding: 0;
   font-size: 0.875rem;
 }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -3083,6 +3083,7 @@ a.addtoany_share span {
   display: flex;
   flex-wrap: wrap;
   list-style: none;
+  margin: 0;
   padding: 0;
   font-size: 0.875rem;
 }


### PR DESCRIPTION
Résumé: Correction de l'alignement du fil d'Ariane afin qu'il colle au bord gauche.

- Supprime la marge par défaut de la liste ordonnée dans le SCSS du fil d'Ariane.
- Régénère la feuille de styles compilée du thème.

## Tests
- npm run build:css
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d22f426a2483329f207492f5803225