### PR TITLE
Supprime la région du bloc CTA sur la page chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -353,21 +353,6 @@ a.chasse-badge.chasse-badge--region:focus-visible {
     color: var(--color-gris-3);
 }
 
-.caracteristique-region__link,
-.caracteristique-region__text {
-  color: inherit;
-  font-weight: 600;
-}
-
-.caracteristique-region__link {
-  text-decoration: none;
-
-  &:hover,
-  &:focus-visible {
-    text-decoration: underline;
-  }
-}
-
 .meta-regular .meta-indic {
     background: none;
     border: none;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1326,19 +1326,6 @@ a.chasse-badge.chasse-badge--region:focus-visible {
   color: var(--color-gris-3);
 }
 
-.caracteristique-region__link,
-.caracteristique-region__text {
-  color: inherit;
-  font-weight: 600;
-}
-
-.caracteristique-region__link {
-  text-decoration: none;
-}
-.caracteristique-region__link:hover, .caracteristique-region__link:focus-visible {
-  text-decoration: underline;
-}
-
 .meta-regular .meta-indic {
   background: none;
   border: none;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -511,25 +511,6 @@ if ($edition_active && !$est_complet) {
               </span>
             </div>
 
-            <?php if (!empty($infos_chasse['region_principale']) && !empty($infos_chasse['region_principale']['nom'])) : ?>
-              <?php
-              $region_main = $infos_chasse['region_principale'];
-              $region_main_name = (string) $region_main['nom'];
-              $region_main_link = $region_main['lien'] ?? '';
-              ?>
-              <div class="caracteristique caracteristique-region">
-                <span class="caracteristique-icone" aria-hidden="true">📍</span>
-                <span class="caracteristique-label"><?= esc_html__('Région', 'chassesautresor-com'); ?></span>
-                <span class="caracteristique-valeur">
-                  <?php if ($region_main_link !== '') : ?>
-                    <a class="caracteristique-region__link" href="<?= esc_url($region_main_link); ?>"><?= esc_html($region_main_name); ?></a>
-                  <?php else : ?>
-                    <span class="caracteristique-region__text"><?= esc_html($region_main_name); ?></span>
-                  <?php endif; ?>
-                </span>
-              </div>
-            <?php endif; ?>
-
             <?php if ($top_avances['nb'] > 0 && $top_avances['enigmes'] > 0) : ?>
               <?php
               $txt_top = sprintf(


### PR DESCRIPTION
Supprime l'information de région du bloc CTA de la page chasse.

- Retire l'entrée « Région » de la liste des caractéristiques affichées sur la fiche chasse.
- Nettoie les styles SCSS et CSS associés à cette caractéristique désormais absente.

**Testing**
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d2c921dbe483328fb10ebf17b927a4