### PR TITLE
Empêcher le hero d'accueil sur la page Mon Compte organisation

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -78,9 +78,13 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
     // ==================================================
     // 🧩 HEADER VISUEL (selon contexte)
     // ==================================================
+    $is_account_area      = function_exists( 'is_user_account_area' ) ? is_user_account_area() : false;
+    $is_organisation_page = function_exists( 'myaccount_is_organisation_page' ) ? myaccount_is_organisation_page() : false;
+    $should_hide_hero     = $is_account_area || $is_organisation_page;
+
     if ( is_cart() ) {
         get_template_part('template-parts/header-panier');
-    } elseif ( is_front_page() ) {
+    } elseif ( is_front_page() && ! $should_hide_hero ) {
         $image_url = imagify_get_webp_url( wp_get_attachment_image_url( 8810, 'full' ) );
 
         $line1 = sprintf(
@@ -225,7 +229,7 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
 
             echo '</div>';
         }
-    } elseif ( is_page() && ! is_user_account_area() ) {
+    } elseif ( is_page() && ! $should_hide_hero ) {
         $image_id     = get_post_thumbnail_id();
         $fallback_url = function_exists( 'get_theme_file_uri' )
             ? get_theme_file_uri( 'assets/images/institutionnels.webp' )

--- a/wp-content/themes/chassesautresor/inc/layout-functions.php
+++ b/wp-content/themes/chassesautresor/inc/layout-functions.php
@@ -429,12 +429,22 @@ function get_header_fallback($args = []) {
  * @param array $classes Classes actuelles du body.
  * @return array
  */
-function ajouter_class_has_hero_si_header_fallback( $classes ) {
-    if ( is_front_page() || ( is_page() && ! is_user_account_area() ) ) {
+function ajouter_class_has_hero_si_header_fallback(array $classes): array
+{
+    $is_account_area = function_exists('is_user_account_area') ? is_user_account_area() : false;
+    $is_organisation_page = function_exists('myaccount_is_organisation_page') ? myaccount_is_organisation_page() : false;
+
+    if ($is_account_area || $is_organisation_page) {
+        $classes = array_diff($classes, ['has-hero']);
+
+        return array_values(array_unique($classes));
+    }
+
+    if (is_front_page() || is_page()) {
         $classes[] = 'has-hero';
     }
 
-    return $classes;
+    return array_values(array_unique($classes));
 }
 add_filter( 'body_class', 'ajouter_class_has_hero_si_header_fallback' );
 


### PR DESCRIPTION
## Résumé
Empêche l'affichage du hero dédié à la page d'accueil lorsqu'un organisateur consulte sa page Mon Compte /organisation.

## Changements notables
- Détecte explicitement les contextes "Mon Compte" et organisation avant d'afficher le hero visuel.
- Évite d'afficher le header hero sur les pages Mon Compte en s'appuyant sur un drapeau partagé.

## Testing
- ✅ `composer install`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d4474277388332aed8a34beb9dd55d