### PR TITLE
Uniformiser la hauteur des cartes compactes

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -65,6 +65,7 @@
 }
 
 .carte-compact {
+  --carte-compact-lot-height: 2.5rem;
   width: 100%;
   padding: 0;
   overflow: hidden;
@@ -100,6 +101,18 @@
     flex-grow: 1;
     gap: var(--space-sm);
     padding: var(--space-md);
+  }
+
+  .carte-compact__lot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--carte-compact-lot-height);
+  }
+
+  .carte-compact__lot--empty {
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .carte-compact__titre {
@@ -249,10 +262,6 @@
   width: 20px;
   height: 20px;
   color: var(--color-grey-light);
-}
-
-.carte-compact__lot-placeholder {
-  min-height: 1.75rem;
 }
 
 /* ========== 🌟 Carte mise en avant ========== */

--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -251,6 +251,10 @@
   color: var(--color-grey-light);
 }
 
+.carte-compact__lot-placeholder {
+  min-height: 1.75rem;
+}
+
 /* ========== 🌟 Carte mise en avant ========== */
 .carte-featured {
   position: relative;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -64,6 +64,7 @@
 }
 
 .carte-compact {
+  --carte-compact-lot-height: 2.5rem;
   width: 100%;
   padding: 0;
   overflow: hidden;
@@ -96,6 +97,16 @@
   flex-grow: 1;
   gap: var(--space-sm);
   padding: var(--space-md);
+}
+.carte-compact .carte-compact__lot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--carte-compact-lot-height);
+}
+.carte-compact .carte-compact__lot--empty {
+  visibility: hidden;
+  pointer-events: none;
 }
 .carte-compact .carte-compact__titre {
   margin: 0;
@@ -235,10 +246,6 @@
   width: 20px;
   height: 20px;
   color: var(--color-grey-light);
-}
-
-.carte-compact__lot-placeholder {
-  min-height: 1.75rem;
 }
 
 /* ========== 🌟 Carte mise en avant ========== */

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -237,6 +237,10 @@
   color: var(--color-grey-light);
 }
 
+.carte-compact__lot-placeholder {
+  min-height: 1.75rem;
+}
+
 /* ========== 🌟 Carte mise en avant ========== */
 .carte-featured {
   position: relative;

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -35,6 +35,13 @@ $resolvables = is_array($progression) ? (int) ($progression['resolvables'] ?? 0)
 $resolues_validables = isset($infos['resolues_validables']) ? (int) $infos['resolues_validables'] : 0;
 $lot_html = $infos['lot_html'] ?? '';
 $has_reward = $lot_html !== '';
+$lot_wrapper_classes = 'carte-compact__lot';
+
+if ($has_reward) {
+    $lot_wrapper_classes .= ' carte-compact__lot--filled';
+} else {
+    $lot_wrapper_classes .= ' carte-compact__lot--empty';
+}
 ?>
 <div class="carte-compact-card">
     <div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
@@ -47,11 +54,11 @@ $has_reward = $lot_html !== '';
             </div>
             <div class="carte-compact__contenu">
                 <h3 class="carte-compact__titre"><?php echo esc_html($infos['titre']); ?></h3>
-                <?php if ($has_reward) : ?>
-                    <?php echo $lot_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
-                <?php else : ?>
-                    <div class="carte-compact__lot-placeholder" aria-hidden="true"></div>
-                <?php endif; ?>
+                <div class="<?php echo esc_attr($lot_wrapper_classes); ?>"<?php if (!$has_reward) : ?> aria-hidden="true"<?php endif; ?>>
+                    <?php if ($has_reward) : ?>
+                        <?php echo $lot_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                    <?php endif; ?>
+                </div>
                 <?php
                 get_template_part(
                     'template-parts/chasse/partials/chasse-meta-row',

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -33,6 +33,8 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 $progression = $infos['progression'] ?? null;
 $resolvables = is_array($progression) ? (int) ($progression['resolvables'] ?? 0) : 0;
 $resolues_validables = isset($infos['resolues_validables']) ? (int) $infos['resolues_validables'] : 0;
+$lot_html = $infos['lot_html'] ?? '';
+$has_reward = $lot_html !== '';
 ?>
 <div class="carte-compact-card">
     <div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
@@ -45,7 +47,11 @@ $resolues_validables = isset($infos['resolues_validables']) ? (int) $infos['reso
             </div>
             <div class="carte-compact__contenu">
                 <h3 class="carte-compact__titre"><?php echo esc_html($infos['titre']); ?></h3>
-                <?php echo $infos['lot_html']; ?>
+                <?php if ($has_reward) : ?>
+                    <?php echo $lot_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                <?php else : ?>
+                    <div class="carte-compact__lot-placeholder" aria-hidden="true"></div>
+                <?php endif; ?>
                 <?php
                 get_template_part(
                     'template-parts/chasse/partials/chasse-meta-row',


### PR DESCRIPTION
Résumé : Uniformisation de la hauteur des cartes de chasse compactes.

* Ajout d'un placeholder HTML lorsque la carte n'affiche pas de récompense afin de conserver un espacement constant.
* Définition d'une hauteur minimale dédiée dans les styles SCSS et CSS généré.
* Recompilation des feuilles de style du thème.

## Tests
* `npm run build:css`
* `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d450fb06148332821759a2fcd85bc8