### PR TITLE
feat: permettre la suppression d'une chasse en révision

### DIFF
--- a/tests/SupprimerChasseAjaxTest.php
+++ b/tests/SupprimerChasseAjaxTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in(): bool
+    {
+        global $test_is_logged_in;
+        return (bool) $test_is_logged_in;
+    }
+}
+
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id(): int
+    {
+        global $test_current_user_id;
+        return (int) $test_current_user_id;
+    }
+}
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($post_id)
+    {
+        global $test_post_types;
+        return $test_post_types[$post_id] ?? null;
+    }
+}
+
+if (!function_exists('get_post_status')) {
+    function get_post_status($post_id)
+    {
+        global $test_post_statuses;
+        return $test_post_statuses[$post_id] ?? '';
+    }
+}
+
+if (!function_exists('get_post_meta')) {
+    function get_post_meta($post_id, $key, $single = false)
+    {
+        global $test_post_meta;
+        if (isset($test_post_meta[$post_id][$key])) {
+            return $test_post_meta[$post_id][$key];
+        }
+        return '';
+    }
+}
+
+if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+    function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+    {
+        global $test_associations;
+        return !empty($test_associations[$user_id][$chasse_id]);
+    }
+}
+
+if (!function_exists('recuperer_ids_enigmes_pour_chasse')) {
+    function recuperer_ids_enigmes_pour_chasse($chasse_id): array
+    {
+        global $test_enigmes;
+        return $test_enigmes[$chasse_id] ?? [];
+    }
+}
+
+if (!function_exists('wp_trash_post')) {
+    function wp_trash_post($post_id)
+    {
+        global $trashed_posts, $wp_trash_return_values;
+        $trashed_posts[] = $post_id;
+        if (isset($wp_trash_return_values[$post_id])) {
+            return $wp_trash_return_values[$post_id];
+        }
+        return true;
+    }
+}
+
+if (!function_exists('supprimer_dossier_enigme')) {
+    function supprimer_dossier_enigme($post_id): void
+    {
+        global $deleted_folders;
+        $deleted_folders[] = $post_id;
+    }
+}
+
+if (!function_exists('synchroniser_cache_enigmes_chasse')) {
+    function synchroniser_cache_enigmes_chasse($chasse_id, $forcer = false, $nettoyer = false): void
+    {
+        global $synced_chasses;
+        $synced_chasses[] = [$chasse_id, $forcer, $nettoyer];
+    }
+}
+
+if (!function_exists('home_url')) {
+    function home_url($path = ''): string
+    {
+        return 'https://example.com' . $path;
+    }
+}
+
+if (!function_exists('wp_send_json_error')) {
+    function wp_send_json_error($data = null): void
+    {
+        if (is_array($data)) {
+            throw new Exception(json_encode($data));
+        }
+        throw new Exception((string) $data);
+    }
+}
+
+if (!function_exists('wp_send_json_success')) {
+    function wp_send_json_success($data = null)
+    {
+        global $json_success;
+        $json_success = $data;
+        return $data;
+    }
+}
+
+if (!function_exists('myaccount_add_flash_message')) {
+    function myaccount_add_flash_message(int $user_id, string $message, string $type = 'info', bool $dismissible = false): void
+    {
+        global $flash_messages;
+        $flash_messages[] = compact('user_id', 'message', 'type', 'dismissible');
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+}
+
+require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/edition/edition-chasse.php';
+
+final class SupprimerChasseAjaxTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $test_is_logged_in, $test_post_types, $test_post_statuses, $test_post_meta;
+        global $test_associations, $test_current_user_id, $test_enigmes, $trashed_posts;
+        global $wp_trash_return_values, $deleted_folders, $synced_chasses, $json_success;
+        global $flash_messages;
+
+        $_POST = [];
+
+        $test_is_logged_in = true;
+        $test_post_types = [123 => 'chasse'];
+        $test_post_statuses = [123 => 'pending'];
+        $test_post_meta = [123 => ['chasse_cache_statut' => 'revision']];
+        $test_associations = [1 => [123 => true]];
+        $test_current_user_id = 1;
+        $test_enigmes = [123 => [10, 11]];
+        $trashed_posts = [];
+        $wp_trash_return_values = [];
+        $deleted_folders = [];
+        $synced_chasses = [];
+        $json_success = null;
+        $flash_messages = [];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_refuse_when_user_not_logged_in(): void
+    {
+        global $test_is_logged_in;
+        $test_is_logged_in = false;
+        $_POST['chasse_id'] = 123;
+
+        try {
+            supprimer_chasse_ajax();
+            $this->fail('Expected exception not thrown');
+        } catch (Exception $exception) {
+            $this->assertSame('non_connecte', $exception->getMessage());
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_refuse_when_chasse_not_in_revision(): void
+    {
+        global $test_post_meta;
+        $test_post_meta[123]['chasse_cache_statut'] = 'publication';
+        $_POST['chasse_id'] = 123;
+
+        $this->expectExceptionMessage('chasse_ineligible');
+        supprimer_chasse_ajax();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_refuse_when_chasse_status_not_pending(): void
+    {
+        global $test_post_statuses;
+        $test_post_statuses[123] = 'draft';
+        $_POST['chasse_id'] = 123;
+
+        $this->expectExceptionMessage('chasse_ineligible');
+        supprimer_chasse_ajax();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_deletes_chasse_and_enigmes(): void
+    {
+        global $trashed_posts, $deleted_folders, $synced_chasses, $json_success, $flash_messages;
+        $_POST['chasse_id'] = 123;
+
+        supprimer_chasse_ajax();
+
+        $this->assertSame([10, 11, 123], $trashed_posts);
+        $this->assertSame([10, 11], $deleted_folders);
+        $this->assertSame([[123, true, true]], $synced_chasses);
+        $this->assertSame(
+            ['redirect' => 'https://example.com/mon-compte/organisateurs/'],
+            $json_success
+        );
+        $this->assertCount(1, $flash_messages);
+        $this->assertSame(
+            [
+                'user_id'     => 1,
+                'message'     => 'Votre chasse a été supprimée. Vous pouvez en créer une nouvelle quand vous le souhaitez.',
+                'type'        => 'success',
+                'dismissible' => true,
+            ],
+            $flash_messages[0]
+        );
+    }
+}

--- a/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-edit.js
@@ -77,6 +77,14 @@ function mettreAJourMessageDate() {
 window.calculerMessageDate = calculerMessageDate;
 window.mettreAJourMessageDate = mettreAJourMessageDate;
 
+const translateChasseEdit = (msg) => {
+  const i18n = window.wp && window.wp.i18n;
+  if (i18n && typeof i18n.__ === 'function') {
+    return i18n.__(msg, 'chassesautresor-com');
+  }
+  return msg;
+};
+
 function rafraichirCarteIndices() {
   const card = document.querySelector('.dashboard-card.champ-indices');
   if (!card || !window.ChasseIndices) return;
@@ -181,6 +189,66 @@ window.rafraichirCarteSolutions = rafraichirCarteSolutions;
   inputDateFin?.addEventListener('change', mettreAJourCaracteristiqueDate);
   toggleDateDebut?.addEventListener('change', mettreAJourCaracteristiqueDate);
   toggleDateFin?.addEventListener('change', mettreAJourCaracteristiqueDate);
+
+  const panelEdition = document.querySelector('.edition-panel-chasse');
+  const boutonSupprimer = panelEdition?.querySelector('#bouton-supprimer-chasse');
+
+  if (boutonSupprimer) {
+    boutonSupprimer.addEventListener('click', () => {
+      const chasseId = boutonSupprimer.dataset.chasseId;
+      if (!chasseId) {
+        return;
+      }
+
+      const enigmesCount = parseInt(boutonSupprimer.dataset.enigmesCount || '0', 10);
+      const hasEnigmes = !Number.isNaN(enigmesCount) && enigmesCount > 0;
+
+      const confirmationMessage = hasEnigmes
+        ? translateChasseEdit('Voulez-vous vraiment supprimer cette chasse et toutes ses énigmes ?')
+        : translateChasseEdit('Voulez-vous vraiment supprimer cette chasse ?');
+
+      if (!window.confirm(confirmationMessage)) {
+        return;
+      }
+
+      const ajaxUrl = window.ajaxurl || (window.ChasseIndices && window.ChasseIndices.ajaxUrl) || '';
+      if (!ajaxUrl) {
+        return;
+      }
+
+      const zoneErreur = panelEdition?.querySelector('#erreur-global');
+      if (zoneErreur) {
+        zoneErreur.style.display = 'none';
+        zoneErreur.textContent = '';
+      }
+
+      const fd = new FormData();
+      fd.append('action', 'supprimer_chasse');
+      fd.append('chasse_id', chasseId);
+
+      fetch(ajaxUrl, {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: fd,
+      })
+        .then((response) => response.json())
+        .then((resultat) => {
+          if (!resultat?.success || !resultat.data?.redirect) {
+            throw new Error('invalid');
+          }
+          window.location.href = resultat.data.redirect;
+        })
+        .catch(() => {
+          const messageErreur = translateChasseEdit('Une erreur est survenue lors de la suppression de la chasse.');
+          if (zoneErreur) {
+            zoneErreur.textContent = messageErreur;
+            zoneErreur.style.display = 'block';
+          } else {
+            window.alert(messageErreur);
+          }
+        });
+    });
+  }
 
   // ==============================
   // 🟢 Initialisation des champs

--- a/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
+++ b/wp-content/themes/chassesautresor/inc/edition/edition-chasse.php
@@ -725,3 +725,69 @@ function definir_date_fin_par_defaut($post_id, $post)
   }
 }
 add_action('save_post_chasse', 'definir_date_fin_par_defaut', 10, 2);
+
+add_action('wp_ajax_supprimer_chasse', 'supprimer_chasse_ajax');
+
+/**
+ * Supprime une chasse en attente ainsi que ses énigmes associées.
+ */
+function supprimer_chasse_ajax(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error('non_connecte');
+    }
+
+    $chasse_id = isset($_POST['chasse_id']) ? (int) $_POST['chasse_id'] : 0;
+    if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+        wp_send_json_error('id_invalide');
+    }
+
+    if (get_post_status($chasse_id) !== 'pending') {
+        wp_send_json_error('chasse_ineligible');
+    }
+
+    if (get_post_meta($chasse_id, 'chasse_cache_statut', true) !== 'revision') {
+        wp_send_json_error('chasse_ineligible');
+    }
+
+    $user_id = get_current_user_id();
+    if (!$user_id || !utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
+        wp_send_json_error('acces_refuse');
+    }
+
+    $enigme_ids = array_map('intval', recuperer_ids_enigmes_pour_chasse($chasse_id));
+
+    foreach ($enigme_ids as $enigme_id) {
+        if ($enigme_id <= 0) {
+            continue;
+        }
+
+        wp_trash_post($enigme_id);
+
+        if (function_exists('supprimer_dossier_enigme')) {
+            supprimer_dossier_enigme($enigme_id);
+        }
+    }
+
+    if (function_exists('synchroniser_cache_enigmes_chasse')) {
+        synchroniser_cache_enigmes_chasse($chasse_id, true, true);
+    }
+
+    $trashed = wp_trash_post($chasse_id);
+    if (!$trashed) {
+        wp_send_json_error('erreur_suppression');
+    }
+
+    if (function_exists('myaccount_add_flash_message')) {
+        myaccount_add_flash_message(
+            $user_id,
+            __('Votre chasse a été supprimée. Vous pouvez en créer une nouvelle quand vous le souhaitez.', 'chassesautresor-com'),
+            'success',
+            true
+        );
+    }
+
+    wp_send_json_success([
+        'redirect' => home_url('/mon-compte/organisateurs/'),
+    ]);
+}

--- a/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
+++ b/wp-content/themes/chassesautresor/languages/chassesautresor-com.pot
@@ -3032,3 +3032,23 @@ msgstr ""
 #: inc/user-functions.php:1444
 msgid "Unable to load attempts. Please try again."
 msgstr ""
+
+#: template-parts/chasse/chasse-edition-main.php:922
+msgid "Supprimer la chasse"
+msgstr ""
+
+#: assets/js/chasse-edit.js:207
+msgid "Voulez-vous vraiment supprimer cette chasse et toutes ses énigmes ?"
+msgstr ""
+
+#: assets/js/chasse-edit.js:208
+msgid "Voulez-vous vraiment supprimer cette chasse ?"
+msgstr ""
+
+#: assets/js/chasse-edit.js:242
+msgid "Une erreur est survenue lors de la suppression de la chasse."
+msgstr ""
+
+#: inc/edition/edition-chasse.php:784
+msgid "Votre chasse a été supprimée. Vous pouvez en créer une nouvelle quand vous le souhaitez."
+msgstr ""

--- a/wp-content/themes/chassesautresor/languages/en_US.po
+++ b/wp-content/themes/chassesautresor/languages/en_US.po
@@ -39,6 +39,26 @@ msgstr "Full Screen Home"
 msgid "Français"
 msgstr "French"
 
+#: template-parts/chasse/chasse-edition-main.php:922
+msgid "Supprimer la chasse"
+msgstr "Delete the hunt"
+
+#: assets/js/chasse-edit.js:207
+msgid "Voulez-vous vraiment supprimer cette chasse et toutes ses énigmes ?"
+msgstr "Are you sure you want to delete this hunt and all of its puzzles?"
+
+#: assets/js/chasse-edit.js:208
+msgid "Voulez-vous vraiment supprimer cette chasse ?"
+msgstr "Are you sure you want to delete this hunt?"
+
+#: assets/js/chasse-edit.js:242
+msgid "Une erreur est survenue lors de la suppression de la chasse."
+msgstr "An error occurred while deleting the hunt."
+
+#: inc/edition/edition-chasse.php:784
+msgid "Votre chasse a été supprimée. Vous pouvez en créer une nouvelle quand vous le souhaitez."
+msgstr "Your hunt has been deleted. You can create a new one whenever you want."
+
 #: functions.php:119
 msgid "English"
 msgstr "English"

--- a/wp-content/themes/chassesautresor/languages/fr_FR.po
+++ b/wp-content/themes/chassesautresor/languages/fr_FR.po
@@ -39,6 +39,26 @@ msgstr "Accueil Plein Ecran"
 msgid "Français"
 msgstr "Français"
 
+#: template-parts/chasse/chasse-edition-main.php:922
+msgid "Supprimer la chasse"
+msgstr "Supprimer la chasse"
+
+#: assets/js/chasse-edit.js:207
+msgid "Voulez-vous vraiment supprimer cette chasse et toutes ses énigmes ?"
+msgstr "Voulez-vous vraiment supprimer cette chasse et toutes ses énigmes ?"
+
+#: assets/js/chasse-edit.js:208
+msgid "Voulez-vous vraiment supprimer cette chasse ?"
+msgstr "Voulez-vous vraiment supprimer cette chasse ?"
+
+#: assets/js/chasse-edit.js:242
+msgid "Une erreur est survenue lors de la suppression de la chasse."
+msgstr "Une erreur est survenue lors de la suppression de la chasse."
+
+#: inc/edition/edition-chasse.php:784
+msgid "Votre chasse a été supprimée. Vous pouvez en créer une nouvelle quand vous le souhaitez."
+msgstr "Votre chasse a été supprimée. Vous pouvez en créer une nouvelle quand vous le souhaitez."
+
 #: functions.php:119
 msgid "English"
 msgstr "Anglais"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -19,6 +19,9 @@ $peut_editer_cout  = champ_est_editable('caracteristiques.chasse_infos_cout_poin
 
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
 
+$enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse_id);
+$nombre_enigmes = count($enigme_ids);
+
 $image_id   = $infos_chasse['image_id'] ?? null;
 $image_url  = $image_id ? wp_get_attachment_image_src($image_id, 'thumbnail')[0] : null;
 $description = $infos_chasse['description'];
@@ -45,6 +48,29 @@ $illimitee  = $infos_chasse['champs']['illimitee'];
 $nb_max     = $infos_chasse['champs']['nb_max'] ?? 1;
 $mode_fin   = $infos_chasse['champs']['mode_fin'] ?? 'automatique';
 $statut_metier = $infos_chasse['statut'] ?? 'revision';
+
+$statut_wp     = get_post_status($chasse_id);
+$statut_cache  = get_post_meta($chasse_id, 'chasse_cache_statut', true);
+$current_user  = wp_get_current_user();
+$current_roles = (array) $current_user->roles;
+$roles_autorises = [];
+if (defined('ROLE_ORGANISATEUR')) {
+    $roles_autorises[] = ROLE_ORGANISATEUR;
+} else {
+    $roles_autorises[] = 'organisateur';
+}
+if (defined('ROLE_ORGANISATEUR_CREATION')) {
+    $roles_autorises[] = ROLE_ORGANISATEUR_CREATION;
+} else {
+    $roles_autorises[] = 'organisateur_creation';
+}
+
+$utilisateur_associe = utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
+$peut_supprimer_chasse = $utilisateur_associe
+    && !empty(array_intersect($current_roles, $roles_autorises))
+    && $statut_metier === 'revision'
+    && $statut_cache === 'revision'
+    && $statut_wp === 'pending';
 
 $champTitreParDefaut = 'nouvelle chasse'; // À adapter si besoin
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut);
@@ -885,6 +911,17 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     ?>
 
       <div class="edition-panel-footer">
+        <?php if ($peut_supprimer_chasse) : ?>
+          <button
+            type="button"
+            id="bouton-supprimer-chasse"
+            class="bouton-secondaire"
+            data-chasse-id="<?= esc_attr($chasse_id); ?>"
+            data-enigmes-count="<?= esc_attr($nombre_enigmes); ?>"
+          >
+            <?= esc_html__('Supprimer la chasse', 'chassesautresor-com'); ?>
+          </button>
+        <?php endif; ?>
         <?php if (current_user_can('administrator')) : ?>
           <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="admin-validation-actions form-traitement-validation-chasse">
             <?php wp_nonce_field('validation_admin_' . $chasse_id, 'validation_admin_nonce'); ?>


### PR DESCRIPTION
Résumé: permettre aux organisateurs de supprimer une chasse en révision depuis le panneau d'édition frontale.

- Affichage d'un bouton de suppression conditionnel dans le panneau d'édition, avec informations sur le nombre d'énigmes associées.
- Implémentation de l'action AJAX `supprimer_chasse` qui corbeille la chasse et ses énigmes, déclenche une notification et renvoie l'URL de redirection.
- Ajout des traductions et d'un test unitaire couvrant les cas d'accès et de succès de la suppression.

Testing:
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d4502557348332949c9139ef7a04b4