### PR TITLE
Masquer la progression des chasses pour les organisateurs

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/boucle-chasses.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/boucle-chasses.php
@@ -10,6 +10,7 @@ $after_items    = $args['after_items'] ?? '';
 $query          = $args['query'] ?? null;
 $chasse_ids     = $args['chasse_ids'] ?? null;
 $highlight_label = $args['highlight_label'] ?? '';
+$show_progression = $args['show_progression'] ?? true;
 
 if ($query instanceof WP_Query) {
     $chasse_ids = array_map(
@@ -43,6 +44,7 @@ $chasse_ids = array_values(array_filter($chasse_ids, function ($chasse_id) use (
     if ('carte' === $mode) {
         get_template_part('template-parts/chasse/chasse-card-compact', null, [
             'chasse_id' => $chasse_id,
+            'show_progression' => $show_progression,
         ]);
         continue;
     }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -6,6 +6,7 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 }
 
 $chasse_id = (int) $args['chasse_id'];
+$show_progression = $args['show_progression'] ?? true;
 $infos     = preparer_infos_affichage_carte_chasse(
     $chasse_id,
     300,
@@ -74,7 +75,7 @@ if ($has_reward) {
             </div>
         </a>
     </div>
-    <?php if ($resolvables > 0) : ?>
+    <?php if ($show_progression && $resolvables > 0) : ?>
         <div class="carte-compact__progression-wrapper">
             <div class="carte-compact__progression">
                 <div class="meta-etiquette carte-compact__progression-label">

--- a/wp-content/themes/chassesautresor/templates/myaccount/content-organisation.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/content-organisation.php
@@ -117,6 +117,7 @@ $can_create_hunt = function_exists('utilisateur_peut_ajouter_chasse')
                 'mode'        => 'carte',
                 'grid_class'  => 'cards-grid myaccount-organisation-hunts-grid',
                 'chasse_ids'  => $chasse_ids,
+                'show_progression' => false,
             )
         );
         ?>


### PR DESCRIPTION
## Résumé
- masque l'affichage de la progression des chasses dans l'espace organisateur
- ajoute la propagation d'un indicateur pour désactiver la progression dans les cartes compactes

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d457c88f088332a47bba96b3966a0d