### PR TITLE
Redirect my account brand link to dashboard

### DIFF
--- a/wp-content/themes/chassesautresor/templates/myaccount/layout.php
+++ b/wp-content/themes/chassesautresor/templates/myaccount/layout.php
@@ -63,7 +63,7 @@ get_header();
     <div class="myaccount-sidebar-backdrop" aria-hidden="true"></div>
     <aside id="myaccount-sidebar" class="myaccount-sidebar">
         <div class="myaccount-brand">
-            <a href="<?php echo esc_url(home_url('/')); ?>">
+            <a href="<?php echo esc_url(home_url('/mon-compte/')); ?>">
                 <?php echo esc_html($display_name); ?>
             </a>
             <button


### PR DESCRIPTION
Résumé
- Redirige le lien du bloc d'en-tête "Mon compte" vers l'accueil utilisateur.

Changements
- Remplace l'URL de la marque dans le layout des pages Mon compte par le chemin /mon-compte/.

Testing
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d4b8cb3f588332b75cee528f58ff71