### PR TITLE
Mettre à jour l'URL du catalogue recommandé

### DIFF
--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1181,7 +1181,11 @@ function ca_render_recommended_hunts_empty_state(): string
 
     $recommended_query = new WP_Query($query_args);
 
-    $catalog_url = apply_filters('ca_recommended_hunts_catalog_url', home_url('/chasses/'));
+    $catalog_url = apply_filters(
+        'ca_recommended_hunts_catalog_url',
+        home_url('/'),
+        '/'
+    );
 
     ob_start();
     ?>


### PR DESCRIPTION
Résumé
- Ajuste l’URL par défaut du catalogue des recommandations pour s’appuyer sur `home_url('/')`.
- Transmet le chemin par défaut au filtre `ca_recommended_hunts_catalog_url` afin de conserver les personnalisations éventuelles.

Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d52c56946c83328590b05ce79b7a97