### PR TITLE
Add recommended hunts slider to account empty state

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/engaged-hunts-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/engaged-hunts-pager.js
@@ -95,6 +95,9 @@
 
         if (typeof data.html === 'string') {
           container.innerHTML = data.html;
+          if (window.caRecommendedSlider && typeof window.caRecommendedSlider.init === 'function') {
+            window.caRecommendedSlider.init(container);
+          }
         }
 
         const newPage = typeof data.page === 'number' && data.page > 0 ? data.page : page;

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -15,6 +15,14 @@ document.addEventListener('DOMContentLoaded', () => {
   let outsideClickHandler = null;
   let keydownHandler = null;
 
+  const initRecommendedSlider = (root = document) => {
+    if (window.caRecommendedSlider && typeof window.caRecommendedSlider.init === 'function') {
+      window.caRecommendedSlider.init(root);
+    }
+  };
+
+  initRecommendedSlider(document);
+
   const setSidebarExpanded = (isOpen) => {
     if (!sidebarToggle) {
       return;
@@ -178,6 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
         siteMessages.innerHTML = messages;
       }
       content.innerHTML = data.data.html;
+      initRecommendedSlider(content);
       decorateMessages();
       fadeFlash();
       document

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -46,18 +46,24 @@
       slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
     });
 
-    function getViewportWidth() {
-      if (!viewport) {
+    function getOffset() {
+      if (!slides.length) {
         return 0;
       }
 
-      const { clientWidth } = viewport;
-      return clientWidth || 0;
+      const activeSlide = slides[currentIndex];
+      if (!activeSlide) {
+        return 0;
+      }
+
+      const firstSlide = slides[0];
+      const baseOffset = firstSlide ? firstSlide.offsetLeft : 0;
+      const targetOffset = activeSlide.offsetLeft;
+      return Math.max(0, targetOffset - baseOffset);
     }
 
     function update() {
-      const viewportWidth = getViewportWidth();
-      const offset = viewportWidth * currentIndex;
+      const offset = getOffset();
       track.style.transform = `translate3d(-${offset}px, 0, 0)`;
       slides.forEach((slide, index) => {
         const isActive = index === currentIndex;
@@ -111,11 +117,21 @@
       window.requestAnimationFrame(update);
     };
 
-    window.addEventListener('resize', handleResize);
+    let resizeObserver = null;
+    if (typeof ResizeObserver === 'function' && viewport) {
+      resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(viewport);
+    } else {
+      window.addEventListener('resize', handleResize);
+    }
 
     let observer = null;
     const cleanup = () => {
-      window.removeEventListener('resize', handleResize);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      } else {
+        window.removeEventListener('resize', handleResize);
+      }
       slider.removeEventListener('recommended-slider:destroy', cleanup);
       if (observer) {
         observer.disconnect();

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -29,6 +29,7 @@
     const next = slider.querySelector(NEXT_SELECTOR);
     const totalSlides = slides.length;
     let currentIndex = 0;
+    let slideOffsets = [];
 
     const label = slider.getAttribute('data-slider-label');
     if (label) {
@@ -46,17 +47,25 @@
       slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
     });
 
+    function measureOffsets() {
+      const previousTransform = track.style.transform;
+      track.style.transform = 'translate3d(0, 0, 0)';
+
+      const baseOffset = slides[0] ? slides[0].offsetLeft : 0;
+      slideOffsets = slides.map((slide) => {
+        const offset = slide.offsetLeft - baseOffset;
+        return Number.isFinite(offset) && offset >= 0 ? offset : 0;
+      });
+
+      track.style.transform = previousTransform;
+    }
+
     function getOffset() {
-      if (!viewport) {
-        return 0;
+      if (!slideOffsets.length) {
+        measureOffsets();
       }
 
-      const viewportRect = viewport.getBoundingClientRect();
-      if (!viewportRect || viewportRect.width <= 0) {
-        return 0;
-      }
-
-      return Math.max(0, viewportRect.width * currentIndex);
+      return slideOffsets[currentIndex] || 0;
     }
 
     function update() {
@@ -77,10 +86,16 @@
     }
 
     function goTo(index) {
-      if (index < 0 || index >= totalSlides || index === currentIndex) {
+      if (index === currentIndex) {
         return;
       }
-      currentIndex = index;
+
+      const clampedIndex = Math.max(0, Math.min(index, totalSlides - 1));
+      if (clampedIndex === currentIndex) {
+        return;
+      }
+
+      currentIndex = clampedIndex;
       update();
     }
 
@@ -111,7 +126,10 @@
     });
 
     const handleResize = () => {
-      window.requestAnimationFrame(update);
+      window.requestAnimationFrame(() => {
+        measureOffsets();
+        update();
+      });
     };
 
     let resizeObserver = null;
@@ -147,6 +165,7 @@
       observer.observe(document.body, { childList: true, subtree: true });
     }
 
+    measureOffsets();
     slider.dataset.sliderReady = '1';
     update();
   }

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -1,0 +1,112 @@
+(function () {
+  const SLIDER_SELECTOR = '[data-recommended-slider]';
+  const TRACK_SELECTOR = '[data-recommended-slider-track]';
+  const SLIDE_SELECTOR = '[data-recommended-slide]';
+  const PREV_SELECTOR = '[data-recommended-slider-prev]';
+  const NEXT_SELECTOR = '[data-recommended-slider-next]';
+
+  function toElement(root) {
+    if (root && typeof root.querySelectorAll === 'function') {
+      return root;
+    }
+    return document;
+  }
+
+  function initSlider(slider) {
+    if (!slider || slider.dataset.sliderReady === '1') {
+      return;
+    }
+
+    const track = slider.querySelector(TRACK_SELECTOR);
+    const slides = track ? Array.from(track.querySelectorAll(SLIDE_SELECTOR)) : [];
+
+    if (!track || !slides.length) {
+      return;
+    }
+
+    const prev = slider.querySelector(PREV_SELECTOR);
+    const next = slider.querySelector(NEXT_SELECTOR);
+    const totalSlides = slides.length;
+    let currentIndex = 0;
+
+    const label = slider.getAttribute('data-slider-label');
+    if (label) {
+      slider.setAttribute('aria-label', label);
+    }
+
+    slider.setAttribute('role', 'region');
+    slider.setAttribute('aria-roledescription', 'carousel');
+    slider.setAttribute('tabindex', '0');
+    slider.setAttribute('data-slides-count', String(totalSlides));
+
+    slides.forEach((slide, index) => {
+      slide.setAttribute('role', 'group');
+      slide.setAttribute('aria-roledescription', 'slide');
+      slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
+    });
+
+    function update() {
+      track.style.transform = `translateX(-${currentIndex * 100}%)`;
+      slides.forEach((slide, index) => {
+        const isActive = index === currentIndex;
+        slide.classList.toggle('is-active', isActive);
+        slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+
+      if (prev) {
+        prev.disabled = currentIndex === 0;
+      }
+      if (next) {
+        next.disabled = currentIndex === totalSlides - 1;
+      }
+    }
+
+    function goTo(index) {
+      if (index < 0 || index >= totalSlides || index === currentIndex) {
+        return;
+      }
+      currentIndex = index;
+      update();
+    }
+
+    if (prev) {
+      prev.addEventListener('click', () => {
+        goTo(currentIndex - 1);
+      });
+    }
+
+    if (next) {
+      next.addEventListener('click', () => {
+        goTo(currentIndex + 1);
+      });
+    }
+
+    slider.addEventListener('keydown', (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        goTo(currentIndex - 1);
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        goTo(currentIndex + 1);
+      }
+    });
+
+    slider.dataset.sliderReady = '1';
+    update();
+  }
+
+  function init(root) {
+    const context = toElement(root);
+    const sliders = context.querySelectorAll(SLIDER_SELECTOR);
+    sliders.forEach(initSlider);
+  }
+
+  window.caRecommendedSlider = window.caRecommendedSlider || {};
+  window.caRecommendedSlider.init = function initRecommendedSlider(root) {
+    init(root);
+  };
+})();

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -29,7 +29,6 @@
     const next = slider.querySelector(NEXT_SELECTOR);
     const totalSlides = slides.length;
     let currentIndex = 0;
-    let slideOffsets = [];
 
     const label = slider.getAttribute('data-slider-label');
     if (label) {
@@ -40,6 +39,8 @@
     slider.setAttribute('aria-roledescription', 'carousel');
     slider.setAttribute('tabindex', '0');
     slider.setAttribute('data-slides-count', String(totalSlides));
+    slider.style.setProperty('--recommended-slider-count', String(totalSlides));
+    track.style.setProperty('--recommended-slider-count', String(totalSlides));
 
     slides.forEach((slide, index) => {
       slide.setAttribute('role', 'group');
@@ -47,30 +48,9 @@
       slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
     });
 
-    function measureOffsets() {
-      const previousTransform = track.style.transform;
-      track.style.transform = 'translate3d(0, 0, 0)';
-
-      const baseOffset = slides[0] ? slides[0].offsetLeft : 0;
-      slideOffsets = slides.map((slide) => {
-        const offset = slide.offsetLeft - baseOffset;
-        return Number.isFinite(offset) && offset >= 0 ? offset : 0;
-      });
-
-      track.style.transform = previousTransform;
-    }
-
-    function getOffset() {
-      if (!slideOffsets.length) {
-        measureOffsets();
-      }
-
-      return slideOffsets[currentIndex] || 0;
-    }
-
     function update() {
-      const offset = getOffset();
-      track.style.transform = `translate3d(-${offset}px, 0, 0)`;
+      const offsetPercent = totalSlides > 0 ? (currentIndex / totalSlides) * 100 : 0;
+      track.style.transform = `translate3d(-${offsetPercent}%, 0, 0)`;
       slides.forEach((slide, index) => {
         const isActive = index === currentIndex;
         slide.classList.toggle('is-active', isActive);
@@ -125,28 +105,8 @@
       }
     });
 
-    const handleResize = () => {
-      window.requestAnimationFrame(() => {
-        measureOffsets();
-        update();
-      });
-    };
-
-    let resizeObserver = null;
-    if (typeof ResizeObserver === 'function' && viewport) {
-      resizeObserver = new ResizeObserver(handleResize);
-      resizeObserver.observe(viewport);
-    } else {
-      window.addEventListener('resize', handleResize);
-    }
-
     let observer = null;
     const cleanup = () => {
-      if (resizeObserver) {
-        resizeObserver.disconnect();
-      } else {
-        window.removeEventListener('resize', handleResize);
-      }
       slider.removeEventListener('recommended-slider:destroy', cleanup);
       if (observer) {
         observer.disconnect();
@@ -165,7 +125,6 @@
       observer.observe(document.body, { childList: true, subtree: true });
     }
 
-    measureOffsets();
     slider.dataset.sliderReady = '1';
     update();
   }

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -47,19 +47,16 @@
     });
 
     function getOffset() {
-      if (!slides.length) {
+      if (!viewport) {
         return 0;
       }
 
-      const activeSlide = slides[currentIndex];
-      if (!activeSlide) {
+      const viewportRect = viewport.getBoundingClientRect();
+      if (!viewportRect || viewportRect.width <= 0) {
         return 0;
       }
 
-      const firstSlide = slides[0];
-      const baseOffset = firstSlide ? firstSlide.offsetLeft : 0;
-      const targetOffset = activeSlide.offsetLeft;
-      return Math.max(0, targetOffset - baseOffset);
+      return Math.max(0, viewportRect.width * currentIndex);
     }
 
     function update() {

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -18,9 +18,10 @@
     }
 
     const track = slider.querySelector(TRACK_SELECTOR);
+    const viewport = slider.querySelector('[data-recommended-slider-viewport]');
     const slides = track ? Array.from(track.querySelectorAll(SLIDE_SELECTOR)) : [];
 
-    if (!track || !slides.length) {
+    if (!track || !slides.length || !viewport) {
       return;
     }
 
@@ -45,17 +46,18 @@
       slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
     });
 
-    function getOffset() {
-      const activeSlide = slides[currentIndex];
-      if (!activeSlide) {
+    function getViewportWidth() {
+      if (!viewport) {
         return 0;
       }
 
-      return activeSlide.offsetLeft || 0;
+      const { clientWidth } = viewport;
+      return clientWidth || 0;
     }
 
     function update() {
-      const offset = getOffset();
+      const viewportWidth = getViewportWidth();
+      const offset = viewportWidth * currentIndex;
       track.style.transform = `translate3d(-${offset}px, 0, 0)`;
       slides.forEach((slide, index) => {
         const isActive = index === currentIndex;

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -32,6 +32,7 @@
     let slideOffsets = [];
     let resizeObserver = null;
     let resizeHandler = null;
+    let autoplayId = null;
 
     const label = slider.getAttribute('data-slider-label');
     if (label) {
@@ -77,29 +78,73 @@
       }
     }
 
-    function goTo(index) {
-      if (index === currentIndex) {
-        return;
+    function goTo(index, options = {}) {
+      const settings = Object.assign({ wrap: false }, options);
+
+      if (totalSlides <= 1) {
+        return false;
       }
 
-      const clampedIndex = Math.max(0, Math.min(index, totalSlides - 1));
-      if (clampedIndex === currentIndex) {
-        return;
+      const maxIndex = totalSlides - 1;
+      let targetIndex = index;
+
+      if (settings.wrap) {
+        targetIndex = ((index % totalSlides) + totalSlides) % totalSlides;
+      } else {
+        targetIndex = Math.max(0, Math.min(index, maxIndex));
       }
 
-      currentIndex = clampedIndex;
+      if (targetIndex === currentIndex) {
+        return false;
+      }
+
+      currentIndex = targetIndex;
       update();
+      return true;
+    }
+
+    function stopAutoplay() {
+      if (autoplayId) {
+        window.clearInterval(autoplayId);
+        autoplayId = null;
+      }
+    }
+
+    function startAutoplay() {
+      if (autoplayId || totalSlides <= 1) {
+        return;
+      }
+
+      const delay = Number(slider.getAttribute('data-slider-autoplay-delay')) || 6000;
+      autoplayId = window.setInterval(() => {
+        const changed = goTo(currentIndex + 1, { wrap: true });
+        if (!changed && totalSlides > 1) {
+          currentIndex = 0;
+          update();
+        }
+      }, Math.max(delay, 1000));
+    }
+
+    function restartAutoplay() {
+      stopAutoplay();
+      startAutoplay();
     }
 
     if (prev) {
       prev.addEventListener('click', () => {
-        goTo(currentIndex - 1);
+        const moved = goTo(currentIndex - 1);
+        if (moved) {
+          restartAutoplay();
+        }
       });
     }
 
     if (next) {
       next.addEventListener('click', () => {
-        goTo(currentIndex + 1);
+        const moved = goTo(currentIndex + 1);
+        if (moved) {
+          restartAutoplay();
+        }
       });
     }
 
@@ -110,10 +155,25 @@
 
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
-        goTo(currentIndex - 1);
+        const moved = goTo(currentIndex - 1);
+        if (moved) {
+          restartAutoplay();
+        }
       } else if (event.key === 'ArrowRight') {
         event.preventDefault();
-        goTo(currentIndex + 1);
+        const moved = goTo(currentIndex + 1);
+        if (moved) {
+          restartAutoplay();
+        }
+      }
+    });
+
+    slider.addEventListener('mouseenter', stopAutoplay);
+    slider.addEventListener('mouseleave', startAutoplay);
+    slider.addEventListener('focusin', stopAutoplay);
+    slider.addEventListener('focusout', (event) => {
+      if (!slider.contains(event.relatedTarget)) {
+        startAutoplay();
       }
     });
 
@@ -132,12 +192,14 @@
         window.removeEventListener('resize', resizeHandler);
         resizeHandler = null;
       }
+      stopAutoplay();
     };
 
     slider.addEventListener('recommended-slider:destroy', cleanup);
 
     refreshOffsets();
     update();
+    startAutoplay();
 
     if (typeof ResizeObserver === 'function') {
       resizeObserver = new ResizeObserver(handleResize);

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -29,6 +29,9 @@
     const next = slider.querySelector(NEXT_SELECTOR);
     const totalSlides = slides.length;
     let currentIndex = 0;
+    let slideOffsets = [];
+    let resizeObserver = null;
+    let resizeHandler = null;
 
     const label = slider.getAttribute('data-slider-label');
     if (label) {
@@ -48,9 +51,18 @@
       slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
     });
 
+    function refreshOffsets() {
+      const firstOffset = slides.length > 0 ? slides[0].offsetLeft : 0;
+      slideOffsets = slides.map((slide) => slide.offsetLeft - firstOffset);
+    }
+
+    function applyTransform() {
+      const offset = slideOffsets[currentIndex] || 0;
+      track.style.transform = `translate3d(-${offset}px, 0, 0)`;
+    }
+
     function update() {
-      const offsetPercent = totalSlides > 0 ? (currentIndex / totalSlides) * 100 : 0;
-      track.style.transform = `translate3d(-${offsetPercent}%, 0, 0)`;
+      applyTransform();
       slides.forEach((slide, index) => {
         const isActive = index === currentIndex;
         slide.classList.toggle('is-active', isActive);
@@ -105,20 +117,41 @@
       }
     });
 
-    let observer = null;
+    const handleResize = () => {
+      refreshOffsets();
+      applyTransform();
+    };
+
     const cleanup = () => {
       slider.removeEventListener('recommended-slider:destroy', cleanup);
-      if (observer) {
-        observer.disconnect();
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
+      if (resizeHandler) {
+        window.removeEventListener('resize', resizeHandler);
+        resizeHandler = null;
       }
     };
 
     slider.addEventListener('recommended-slider:destroy', cleanup);
 
+    refreshOffsets();
+    update();
+
+    if (typeof ResizeObserver === 'function') {
+      resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(viewport);
+    } else {
+      resizeHandler = handleResize;
+      window.addEventListener('resize', resizeHandler);
+    }
+
     if (typeof MutationObserver === 'function') {
-      observer = new MutationObserver(() => {
+      const observer = new MutationObserver(() => {
         if (!document.body.contains(slider)) {
           cleanup();
+          observer.disconnect();
         }
       });
 
@@ -126,7 +159,6 @@
     }
 
     slider.dataset.sliderReady = '1';
-    update();
   }
 
   function init(root) {

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -45,8 +45,18 @@
       slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
     });
 
+    function getOffset() {
+      const activeSlide = slides[currentIndex];
+      if (!activeSlide) {
+        return 0;
+      }
+
+      return activeSlide.offsetLeft || 0;
+    }
+
     function update() {
-      track.style.transform = `translateX(-${currentIndex * 100}%)`;
+      const offset = getOffset();
+      track.style.transform = `translate3d(-${offset}px, 0, 0)`;
       slides.forEach((slide, index) => {
         const isActive = index === currentIndex;
         slide.classList.toggle('is-active', isActive);
@@ -94,6 +104,33 @@
         goTo(currentIndex + 1);
       }
     });
+
+    const handleResize = () => {
+      window.requestAnimationFrame(update);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    let observer = null;
+    const cleanup = () => {
+      window.removeEventListener('resize', handleResize);
+      slider.removeEventListener('recommended-slider:destroy', cleanup);
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+
+    slider.addEventListener('recommended-slider:destroy', cleanup);
+
+    if (typeof MutationObserver === 'function') {
+      observer = new MutationObserver(() => {
+        if (!document.body.contains(slider)) {
+          cleanup();
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
 
     slider.dataset.sliderReady = '1';
     update();

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -740,8 +740,9 @@
 
 
 .recommended-slider__track {
+    --recommended-slider-count: 1;
     display: flex;
-    width: 100%;
+    width: calc(100% * var(--recommended-slider-count));
     min-height: 100%;
     transition: transform 0.4s ease;
     will-change: transform;

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -728,11 +728,13 @@
     display: flex;
     align-items: center;
     gap: var(--space-sm);
+    width: 100%;
 }
 
 .recommended-slider__viewport {
     position: relative;
-    flex: 1;
+    flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     border-radius: 10px;
     scroll-snap-type: x mandatory;
@@ -761,6 +763,15 @@
 
 .recommended-slider__slide-inner > * {
     width: 100%;
+}
+
+.myaccount-recommended-slider[data-slides-count='1'] .recommended-slider__viewport {
+    max-width: min(100%, 360px);
+    margin: 0 auto;
+}
+
+.myaccount-recommended-slider[data-slides-count='1'] .recommended-slider__track {
+    justify-content: center;
 }
 
 .recommended-slider__control {

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -724,8 +724,77 @@
     color: hsl(var(--muted-foreground));
 }
 
-.myaccount-chasses-recommandees-grid {
-    gap: var(--space-lg);
+.myaccount-recommended-slider {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+}
+
+.recommended-slider__viewport {
+    position: relative;
+    flex: 1;
+    overflow: hidden;
+    border-radius: 10px;
+    scroll-snap-type: x mandatory;
+}
+
+.recommended-slider__track {
+    display: flex;
+    width: 100%;
+    min-height: 100%;
+    transition: transform 0.4s ease;
+    will-change: transform;
+}
+
+.recommended-slider__slide {
+    flex: 0 0 100%;
+    scroll-snap-align: center;
+}
+
+.recommended-slider__slide-inner {
+    display: flex;
+    width: 100%;
+    padding: 0 var(--space-xs);
+}
+
+.recommended-slider__slide-inner > * {
+    width: 100%;
+}
+
+.recommended-slider__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-size: 1.25rem;
+    line-height: 1;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.recommended-slider__control span {
+    pointer-events: none;
+}
+
+.recommended-slider__control:hover,
+.recommended-slider__control:focus-visible {
+    background: hsl(var(--card));
+    border-color: hsl(var(--primary));
+    color: hsl(var(--primary));
+}
+
+.recommended-slider__control:focus-visible {
+    outline: 2px solid hsl(var(--primary));
+    outline-offset: 2px;
+}
+
+.recommended-slider__control:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
 }
 
 .myaccount-recommended-hunts-cta {
@@ -748,8 +817,14 @@
         padding: var(--space-xl);
     }
 
-    .myaccount-chasses-recommandees-grid {
-        gap: var(--space-2xl);
+    .myaccount-recommended-slider {
+        gap: var(--space-md);
+    }
+
+    .recommended-slider__control {
+        width: 48px;
+        height: 48px;
+        font-size: 1.5rem;
     }
 
     .myaccount-recommended-hunts-cta {

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -744,7 +744,6 @@
 .recommended-slider__track {
     --recommended-slider-count: 1;
     display: flex;
-    width: calc(100% * var(--recommended-slider-count));
     min-height: 100%;
     transition: transform 0.4s ease;
     will-change: transform;
@@ -752,13 +751,16 @@
 
 .recommended-slider__slide {
     flex: 0 0 100%;
+    display: flex;
+    justify-content: center;
+    padding: 0 var(--space-xs);
+    box-sizing: border-box;
     scroll-snap-align: center;
 }
 
 .recommended-slider__slide-inner {
-    display: flex;
     width: 100%;
-    padding: 0 var(--space-xs);
+    max-width: 320px;
 }
 
 .recommended-slider__slide-inner > * {

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -738,10 +738,9 @@
     scroll-snap-type: x mandatory;
 }
 
+
 .recommended-slider__track {
-    display: grid;
-    grid-auto-flow: column;
-    grid-auto-columns: 100%;
+    display: flex;
     width: 100%;
     min-height: 100%;
     transition: transform 0.4s ease;
@@ -749,6 +748,7 @@
 }
 
 .recommended-slider__slide {
+    flex: 0 0 100%;
     scroll-snap-align: center;
 }
 

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -713,8 +713,8 @@
     gap: var(--space-lg);
     padding: var(--space-lg);
     border-radius: 12px;
-    background: hsl(var(--card));
-    border: 1px solid hsl(var(--border));
+    background: transparent;
+    border: 0;
 }
 
 .myaccount-recommended-hunts .myaccount-placeholder,
@@ -739,7 +739,9 @@
 }
 
 .recommended-slider__track {
-    display: flex;
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 100%;
     width: 100%;
     min-height: 100%;
     transition: transform 0.4s ease;
@@ -747,7 +749,6 @@
 }
 
 .recommended-slider__slide {
-    flex: 0 0 100%;
     scroll-snap-align: center;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10339,7 +10339,6 @@ footer .site-footer-primary-section-3 {
 .recommended-slider__track {
   --recommended-slider-count: 1;
   display: flex;
-  width: calc(100% * var(--recommended-slider-count));
   min-height: 100%;
   transition: transform 0.4s ease;
   will-change: transform;
@@ -10347,13 +10346,16 @@ footer .site-footer-primary-section-3 {
 
 .recommended-slider__slide {
   flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0 var(--space-xs);
+  box-sizing: border-box;
   scroll-snap-align: center;
 }
 
 .recommended-slider__slide-inner {
-  display: flex;
   width: 100%;
-  padding: 0 var(--space-xs);
+  max-width: 320px;
 }
 
 .recommended-slider__slide-inner > * {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10335,9 +10335,7 @@ footer .site-footer-primary-section-3 {
 }
 
 .recommended-slider__track {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 100%;
+  display: flex;
   width: 100%;
   min-height: 100%;
   transition: transform 0.4s ease;
@@ -10345,6 +10343,7 @@ footer .site-footer-primary-section-3 {
 }
 
 .recommended-slider__slide {
+  flex: 0 0 100%;
   scroll-snap-align: center;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10309,8 +10309,8 @@ footer .site-footer-primary-section-3 {
   gap: var(--space-lg);
   padding: var(--space-lg);
   border-radius: 12px;
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
+  background: transparent;
+  border: 0;
 }
 
 .myaccount-recommended-hunts .myaccount-placeholder,
@@ -10335,7 +10335,9 @@ footer .site-footer-primary-section-3 {
 }
 
 .recommended-slider__track {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 100%;
   width: 100%;
   min-height: 100%;
   transition: transform 0.4s ease;
@@ -10343,7 +10345,6 @@ footer .site-footer-primary-section-3 {
 }
 
 .recommended-slider__slide {
-  flex: 0 0 100%;
   scroll-snap-align: center;
 }
 

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10324,11 +10324,13 @@ footer .site-footer-primary-section-3 {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  width: 100%;
 }
 
 .recommended-slider__viewport {
   position: relative;
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   border-radius: 10px;
   scroll-snap-type: x mandatory;
@@ -10356,6 +10358,15 @@ footer .site-footer-primary-section-3 {
 
 .recommended-slider__slide-inner > * {
   width: 100%;
+}
+
+.myaccount-recommended-slider[data-slides-count="1"] .recommended-slider__viewport {
+  max-width: min(100%, 360px);
+  margin: 0 auto;
+}
+
+.myaccount-recommended-slider[data-slides-count="1"] .recommended-slider__track {
+  justify-content: center;
 }
 
 .recommended-slider__control {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10335,8 +10335,9 @@ footer .site-footer-primary-section-3 {
 }
 
 .recommended-slider__track {
+  --recommended-slider-count: 1;
   display: flex;
-  width: 100%;
+  width: calc(100% * var(--recommended-slider-count));
   min-height: 100%;
   transition: transform 0.4s ease;
   will-change: transform;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10303,6 +10303,102 @@ footer .site-footer-primary-section-3 {
   transition: opacity 0.2s ease;
 }
 
+.myaccount-recommended-hunts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding: var(--space-lg);
+  border-radius: 12px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+}
+
+.myaccount-recommended-hunts .myaccount-placeholder,
+.myaccount-recommended-hunts-intro {
+  margin: 0;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+}
+
+.myaccount-recommended-slider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.recommended-slider__viewport {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  border-radius: 10px;
+  scroll-snap-type: x mandatory;
+}
+
+.recommended-slider__track {
+  display: flex;
+  width: 100%;
+  min-height: 100%;
+  transition: transform 0.4s ease;
+  will-change: transform;
+}
+
+.recommended-slider__slide {
+  flex: 0 0 100%;
+  scroll-snap-align: center;
+}
+
+.recommended-slider__slide-inner {
+  display: flex;
+  width: 100%;
+  padding: 0 var(--space-xs);
+}
+
+.recommended-slider__slide-inner > * {
+  width: 100%;
+}
+
+.recommended-slider__control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-size: 1.25rem;
+  line-height: 1;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.recommended-slider__control span {
+  pointer-events: none;
+}
+
+.recommended-slider__control:hover,
+.recommended-slider__control:focus-visible {
+  background: hsl(var(--card));
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary));
+}
+
+.recommended-slider__control:focus-visible {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+}
+
+.recommended-slider__control:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.myaccount-recommended-hunts-cta {
+  align-self: stretch;
+  text-align: center;
+  justify-content: center;
+}
+
 .myaccount-chasses-engagees.engaged-hunts-loading .myaccount-chasses-engagees-content {
   opacity: 0.6;
   pointer-events: none;
@@ -10312,6 +10408,23 @@ footer .site-footer-primary-section-3 {
   gap: var(--space-3xl);
 }
 
+@media (min-width: 768px) {
+  .myaccount-recommended-hunts {
+    padding: var(--space-xl);
+  }
+  .myaccount-recommended-slider {
+    gap: var(--space-md);
+  }
+  .recommended-slider__control {
+    width: 48px;
+    height: 48px;
+    font-size: 1.5rem;
+  }
+  .myaccount-recommended-hunts-cta {
+    align-self: center;
+    min-width: 260px;
+  }
+}
 .myaccount-section-header {
   display: flex;
   flex-wrap: wrap;

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -410,9 +410,17 @@ add_action('wp_enqueue_scripts', function () {
 
     if (is_account_page() && is_user_logged_in()) {
         wp_enqueue_script(
+            'recommended-hunts-slider',
+            $script_dir . 'recommended-hunts-slider.js',
+            [],
+            filemtime($theme_path . '/assets/js/recommended-hunts-slider.js'),
+            true
+        );
+
+        wp_enqueue_script(
             'myaccount',
             $script_dir . 'myaccount.js',
-            [],
+            ['recommended-hunts-slider'],
             filemtime($theme_path . '/assets/js/myaccount.js'),
             true
         );

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1241,6 +1241,38 @@ function ca_render_recommended_hunts_empty_state(): string
         }
     }
 
+    if (count($recommended_ids) < 3) {
+        $completed_query_args = apply_filters(
+            'ca_recommended_hunts_completed_query_args',
+            [
+                'post_type'      => 'chasse',
+                'post_status'    => 'publish',
+                'posts_per_page' => 3 - count($recommended_ids),
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'no_found_rows'  => true,
+                'fields'         => 'ids',
+                'suppress_filters' => false,
+                'meta_query'     => [
+                    [
+                        'key'   => 'chasse_cache_statut',
+                        'value' => 'termine',
+                    ],
+                    [
+                        'key'   => 'chasse_cache_statut_validation',
+                        'value' => 'valide',
+                    ],
+                ],
+                'post__not_in'   => $recommended_ids,
+            ]
+        );
+
+        $completed_ids = array_map('intval', get_posts($completed_query_args));
+        if (!empty($completed_ids)) {
+            $recommended_ids = array_values(array_unique(array_merge($recommended_ids, $completed_ids)));
+        }
+    }
+
     $recommended_ids = array_slice($recommended_ids, 0, 3);
 
     /**

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1164,28 +1164,103 @@ function ca_get_engaged_hunts_content_html(
  */
 function ca_render_recommended_hunts_empty_state(): string
 {
-    $query_args = [
-        'post_type'      => 'chasse',
-        'post_status'    => 'publish',
-        'posts_per_page' => 3,
-        'meta_key'       => 'ca_total_engagements',
-        'orderby'        => 'meta_value_num',
-        'order'          => 'DESC',
-        'no_found_rows'  => true,
+    $valid_statuses = ['a_venir', 'en_cours', 'payante'];
+    $base_meta_query = [
+        'relation' => 'AND',
+        [
+            'key'     => 'chasse_cache_statut',
+            'value'   => $valid_statuses,
+            'compare' => 'IN',
+        ],
+        [
+            'key'   => 'chasse_cache_statut_validation',
+            'value' => 'valide',
+        ],
     ];
 
-    /**
-     * Allow third-parties to tweak the recommended hunts query.
-     */
-    $query_args = apply_filters('ca_recommended_hunts_empty_state_query_args', $query_args);
+    $recent_query_args = apply_filters(
+        'ca_recommended_hunts_recent_query_args',
+        [
+            'post_type'      => 'chasse',
+            'post_status'    => 'publish',
+            'posts_per_page' => 2,
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'no_found_rows'  => true,
+            'fields'         => 'ids',
+            'suppress_filters' => false,
+            'meta_query'     => $base_meta_query,
+        ]
+    );
 
-    $recommended_query = new WP_Query($query_args);
+    $recent_ids = array_map('intval', get_posts($recent_query_args));
+
+    $active_meta_query = $base_meta_query;
+    $active_meta_query[0]['value'] = ['en_cours', 'payante'];
+
+    $popular_query_args = apply_filters(
+        'ca_recommended_hunts_popular_query_args',
+        [
+            'post_type'      => 'chasse',
+            'post_status'    => 'publish',
+            'posts_per_page' => 1,
+            'meta_key'       => 'ca_total_engagements',
+            'orderby'        => 'meta_value_num',
+            'order'          => 'DESC',
+            'no_found_rows'  => true,
+            'fields'         => 'ids',
+            'suppress_filters' => false,
+            'meta_query'     => $active_meta_query,
+        ]
+    );
+
+    $popular_ids = array_map('intval', get_posts($popular_query_args));
+
+    $recommended_ids = array_values(array_unique(array_merge($recent_ids, $popular_ids)));
+
+    if (count($recommended_ids) < 3) {
+        $fallback_query_args = apply_filters(
+            'ca_recommended_hunts_fallback_query_args',
+            [
+                'post_type'      => 'chasse',
+                'post_status'    => 'publish',
+                'posts_per_page' => 3 - count($recommended_ids),
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'no_found_rows'  => true,
+                'fields'         => 'ids',
+                'suppress_filters' => false,
+                'meta_query'     => $base_meta_query,
+                'post__not_in'   => $recommended_ids,
+            ]
+        );
+
+        $additional_ids = array_map('intval', get_posts($fallback_query_args));
+        if (!empty($additional_ids)) {
+            $recommended_ids = array_values(array_unique(array_merge($recommended_ids, $additional_ids)));
+        }
+    }
+
+    $recommended_ids = array_slice($recommended_ids, 0, 3);
+
+    /**
+     * Allow third-parties to tweak the final recommended hunts selection.
+     *
+     * @param int[] $recommended_ids Selected hunt identifiers.
+     */
+    $recommended_ids = apply_filters('ca_recommended_hunts_empty_state_ids', $recommended_ids);
+    $recommended_ids = array_values(array_unique(array_filter(array_map('intval', (array) $recommended_ids))));
 
     $catalog_url = apply_filters(
         'ca_recommended_hunts_catalog_url',
         home_url('/'),
         '/'
     );
+
+    $slider_label = __('Chasses recommandées', 'chassesautresor-com');
+    $show_controls = count($recommended_ids) > 1;
+    $slider_id = wp_unique_id('recommended-slider-');
+    $track_id  = $slider_id . '-track';
 
     ob_start();
     ?>
@@ -1194,20 +1269,67 @@ function ca_render_recommended_hunts_empty_state(): string
             <?php esc_html_e('Vous ne participez à aucune chasse pour le moment. Voici quelques idées pour démarrer votre prochaine aventure.', 'chassesautresor-com'); ?>
         </p>
 
-        <?php if ($recommended_query->have_posts()) : ?>
-            <?php
-            get_template_part(
-                'template-parts/chasse/boucle-chasses',
-                null,
-                [
-                    'show_header' => false,
-                    'mode'        => 'carte',
-                    'grid_class'  => 'cards-grid myaccount-chasses-recommandees-grid',
-                    'query'       => $recommended_query,
-                    'show_progression' => false,
-                ]
-            );
-            ?>
+        <?php if (!empty($recommended_ids)) : ?>
+            <div
+                id="<?php echo esc_attr($slider_id); ?>"
+                class="myaccount-recommended-slider"
+                data-recommended-slider
+                data-slider-label="<?php echo esc_attr($slider_label); ?>"
+            >
+                <?php if ($show_controls) : ?>
+                    <button
+                        type="button"
+                        class="recommended-slider__control recommended-slider__control--prev"
+                        data-recommended-slider-prev
+                        aria-controls="<?php echo esc_attr($track_id); ?>"
+                        aria-label="<?php esc_attr_e('Afficher la chasse précédente', 'chassesautresor-com'); ?>"
+                        disabled
+                    >
+                        <span aria-hidden="true">&#10094;</span>
+                    </button>
+                <?php endif; ?>
+
+                <div class="recommended-slider__viewport" data-recommended-slider-viewport>
+                    <div
+                        id="<?php echo esc_attr($track_id); ?>"
+                        class="recommended-slider__track"
+                        data-recommended-slider-track
+                    >
+                        <?php foreach ($recommended_ids as $index => $chasse_id) : ?>
+                            <div
+                                class="recommended-slider__slide"
+                                data-recommended-slide
+                                data-slide-index="<?php echo esc_attr((string) $index); ?>"
+                            >
+                                <div class="recommended-slider__slide-inner">
+                                    <?php
+                                    get_template_part(
+                                        'template-parts/chasse/chasse-card-compact',
+                                        null,
+                                        [
+                                            'chasse_id'        => $chasse_id,
+                                            'show_progression' => false,
+                                        ]
+                                    );
+                                    ?>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+
+                <?php if ($show_controls) : ?>
+                    <button
+                        type="button"
+                        class="recommended-slider__control recommended-slider__control--next"
+                        data-recommended-slider-next
+                        aria-controls="<?php echo esc_attr($track_id); ?>"
+                        aria-label="<?php esc_attr_e('Afficher la chasse suivante', 'chassesautresor-com'); ?>"
+                    >
+                        <span aria-hidden="true">&#10095;</span>
+                    </button>
+                <?php endif; ?>
+            </div>
         <?php else : ?>
             <p class="myaccount-recommended-hunts-intro">
                 <?php esc_html_e('Aucune recommandation disponible pour le moment, mais notre catalogue vous attend.', 'chassesautresor-com'); ?>
@@ -1219,8 +1341,6 @@ function ca_render_recommended_hunts_empty_state(): string
         </a>
     </div>
     <?php
-
-    wp_reset_postdata();
 
     return ob_get_clean();
 }


### PR DESCRIPTION
## Résumé
- Ajout d’un carrousel dédié aux chasses recommandées dans l’état vide du tableau de bord
- Nouvelle logique de sélection des chasses publiques récentes et populaires avec filtres personnalisables
- Intégration du script/front et des styles responsives pour le slider et recompilation des assets

## Testing
- `npm run build:css`
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d538e4fef0833284a7687f2a6a47f6