### PR TITLE
Ajout du badge démo sur les cartes de chasses

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_cartes.scss
@@ -89,8 +89,7 @@
     display: block;
   }
 
-  .badge-statut {
-    position: absolute;
+  .carte-badges-stack {
     top: var(--space-xs);
     left: var(--space-xs);
   }
@@ -216,8 +215,7 @@
     inset: 0;
   }
 
-  .badge-statut {
-    position: absolute;
+  .carte-badges-stack {
     top: var(--space-xs);
     left: var(--space-xs);
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -720,6 +720,23 @@ a.ajout-link:focus-visible {
 }
 
 
+/* ========== 🏷️ BADGES ========== */
+
+.carte-badges-stack {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xxs);
+  z-index: 2;
+
+  .badge-statut,
+  .badge-demo {
+    position: static;
+  }
+}
+
 /* ========== 🏷️ BADGES DE STATUT ========== */
 
 .badge-statut {
@@ -735,6 +752,46 @@ a.ajout-link:focus-visible {
   letter-spacing: 0.03em;
   line-height: 1;
   z-index: 1;
+}
+
+.badge-demo {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  border-radius: 999px;
+  background: rgba(225, 169, 95, 0.85);
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  box-shadow: 0 6px 16px rgba(var(--color-black-rgb), 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.badge-demo__icon {
+  display: inline-flex;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.badge-demo__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.badge-demo__label {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+@media (--bp-desktop) {
+  .badge-demo {
+    font-size: 0.8rem;
+  }
 }
 
 .badge-statut[data-tooltip] {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -86,8 +86,7 @@
      object-fit: cover;
   display: block;
 }
-.carte-compact .badge-statut {
-  position: absolute;
+.carte-compact .carte-badges-stack {
   top: var(--space-xs);
   left: var(--space-xs);
 }
@@ -204,8 +203,7 @@
   position: absolute;
   inset: 0;
 }
-.carte-cart .badge-statut {
-  position: absolute;
+.carte-cart .carte-badges-stack {
   top: var(--space-xs);
   left: var(--space-xs);
 }
@@ -2476,6 +2474,21 @@ a.ajout-link:focus-visible {
   font-size: 12px;
 }
 
+/* ========== 🏷️ BADGES ========== */
+.carte-badges-stack {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xxs);
+  z-index: 2;
+}
+.carte-badges-stack .badge-statut,
+.carte-badges-stack .badge-demo {
+  position: static;
+}
+
 /* ========== 🏷️ BADGES DE STATUT ========== */
 .badge-statut {
   position: absolute;
@@ -2492,6 +2505,45 @@ a.ajout-link:focus-visible {
   z-index: 1;
 }
 
+.badge-demo {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  border-radius: 999px;
+  background: rgba(225, 169, 95, 0.85);
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  box-shadow: 0 6px 16px rgba(var(--color-black-rgb), 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.badge-demo__icon {
+  display: inline-flex;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.badge-demo__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.badge-demo__label {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+@media (min-width: 1024px) {
+  .badge-demo {
+    font-size: 0.8rem;
+  }
+}
 .badge-statut[data-tooltip] {
   cursor: help;
 }
@@ -10303,6 +10355,33 @@ footer .site-footer-primary-section-3 {
   transition: opacity 0.2s ease;
 }
 
+.myaccount-recommended-hunts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding: var(--space-lg);
+  border-radius: 12px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+}
+
+.myaccount-recommended-hunts .myaccount-placeholder,
+.myaccount-recommended-hunts-intro {
+  margin: 0;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+}
+
+.myaccount-chasses-recommandees-grid {
+  gap: var(--space-lg);
+}
+
+.myaccount-recommended-hunts-cta {
+  align-self: stretch;
+  text-align: center;
+  justify-content: center;
+}
+
 .myaccount-chasses-engagees.engaged-hunts-loading .myaccount-chasses-engagees-content {
   opacity: 0.6;
   pointer-events: none;
@@ -10312,6 +10391,18 @@ footer .site-footer-primary-section-3 {
   gap: var(--space-3xl);
 }
 
+@media (min-width: 768px) {
+  .myaccount-recommended-hunts {
+    padding: var(--space-xl);
+  }
+  .myaccount-chasses-recommandees-grid {
+    gap: var(--space-2xl);
+  }
+  .myaccount-recommended-hunts-cta {
+    align-self: center;
+    min-width: 260px;
+  }
+}
 .myaccount-section-header {
   display: flex;
   flex-wrap: wrap;

--- a/wp-content/themes/chassesautresor/docs/demo-mode.md
+++ b/wp-content/themes/chassesautresor/docs/demo-mode.md
@@ -1,0 +1,18 @@
+# Mode démo des chasses
+
+Le thème permet de marquer automatiquement certaines chasses comme « Démo ». Ce statut est calculé à partir des logins des utilisateurs associés au CPT *organisateur* de la chasse.
+
+## Configuration
+
+- **Constante** : `CA_DEMO_ORGANISATEUR_LOGINS`
+  - Définit la liste par défaut des logins organisateur pour lesquels toutes les chasses liées doivent être considérées comme des chasses de démonstration.
+  - La constante peut être définie dans `wp-config.php` ou dans un mu-plugin avant le chargement du thème.
+- **Filtre** : `ca_demo_organisateur_logins`
+  - Permet d’ajouter/supprimer dynamiquement des logins à la liste finale utilisée par le cœur du thème.
+  - Le filtre reçoit et doit retourner un tableau de logins (chaînes de caractères).
+
+## Détection
+
+La fonction `ca_demo_is_demo_hunt( int $chasse_id ): bool` renvoie `true` si la chasse donnée est en mode démo. La valeur est mise en cache pour la durée de la requête et peut être forcée via le filtre `ca_demo_is_demo_hunt`.
+
+Lorsque `true`, les cartes de chasses affichent automatiquement un badge « Démo » en plus du badge de statut principal.

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -628,6 +628,7 @@ require_once $inc_path . 'relations-functions.php';
 require_once $inc_path . 'layout-functions.php';
 require_once $inc_path . 'sidebar.php';
 require_once $inc_path . 'utils/liens.php';
+require_once $inc_path . 'chasse/demo.php';
 require_once $inc_path . 'chasse/stats.php';
 require_once $inc_path . 'organisateur/stats.php';
 require_once $inc_path . 'pager.php';

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -2,6 +2,7 @@
 defined('ABSPATH') || exit;
 
 require_once __DIR__ . '/badge-functions.php';
+require_once __DIR__ . '/chasse/demo.php';
 
 
 //
@@ -120,6 +121,7 @@ function chasse_get_champs($chasse_id)
         'titre_recompense' => get_field('chasse_infos_recompense_titre', $chasse_id) ?? '',
         'valeur_recompense' => get_field('chasse_infos_recompense_valeur', $chasse_id) ?? '',
         'cout_points' => get_field('chasse_infos_cout_points', $chasse_id) ?? 0,
+        'is_demo' => ca_demo_is_demo_hunt((int) $chasse_id),
         // Lecture directe des dates pour éviter un éventuel cache ACF
         'date_debut' => (function () use ($chasse_id) {
             $val = get_field('chasse_infos_date_debut', $chasse_id);
@@ -2070,6 +2072,26 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
     }
 
     $champs = chasse_get_champs($chasse_id);
+    $is_demo = !empty($champs['is_demo']);
+    $demo_label = function_exists('__') ? __('Démo', 'chassesautresor-com') : 'Démo';
+    $demo_aria_label = function_exists('__')
+        ? __('Chasse de démonstration', 'chassesautresor-com')
+        : 'Chasse de démonstration';
+    $demo_title = function_exists('__')
+        ? __('Cette chasse est proposée en mode démonstration.', 'chassesautresor-com')
+        : 'Cette chasse est proposée en mode démonstration.';
+    $demo_screen = function_exists('__')
+        ? __('Chasse en mode démonstration', 'chassesautresor-com')
+        : 'Chasse en mode démonstration';
+    $demo_icon = function_exists('get_svg_icon') ? get_svg_icon('idea') : '';
+    $demo_badge = [
+        'label'       => $demo_label,
+        'aria_label'  => $demo_aria_label,
+        'icon_html'   => $demo_icon,
+        'icon_name'   => 'idea',
+        'title'       => $demo_title,
+        'screen_text' => $demo_screen,
+    ];
     $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
     $themes = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
     $region_principale = !empty($regions) ? $regions[0] : null;
@@ -2264,6 +2286,8 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'themes'            => $themes,
         'region_principale' => $region_principale,
         'organisateur_id'   => $organisateur_id,
+        'is_demo'           => $is_demo,
+        'demo_badge'        => $is_demo ? $demo_badge : null,
     ];
 
     if (!empty($progression['resolvables'])) {
@@ -2291,12 +2315,22 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     $user_id  = $user_id ?? get_current_user_id();
     $memo_key = $chasse_id . '-' . $user_id;
 
-    if (isset($memo[$memo_key])) {
-        return $memo[$memo_key];
-    }
-
     if (get_post_type($chasse_id) !== 'chasse') {
         return [];
+    }
+
+    $current_demo_flag = ca_demo_is_demo_hunt($chasse_id);
+
+    if (isset($memo[$memo_key])) {
+        $memo_demo_flag = isset($memo[$memo_key]['is_demo'])
+            ? (bool) $memo[$memo_key]['is_demo']
+            : (bool) ($memo[$memo_key]['champs']['is_demo'] ?? false);
+
+        if ($memo_demo_flag === $current_demo_flag) {
+            return $memo[$memo_key];
+        }
+
+        unset($memo[$memo_key]);
     }
 
     $cache_key = chasse_infos_affichage_cache_key($chasse_id);
@@ -2307,11 +2341,40 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     }
 
     if (isset($cache[$user_id])) {
-        $memo[$memo_key] = $cache[$user_id];
-        return $memo[$memo_key];
+        $cache_demo_flag = isset($cache[$user_id]['is_demo'])
+            ? (bool) $cache[$user_id]['is_demo']
+            : (bool) ($cache[$user_id]['champs']['is_demo'] ?? false);
+
+        if ($cache_demo_flag === $current_demo_flag) {
+            $memo[$memo_key] = $cache[$user_id];
+            return $memo[$memo_key];
+        }
+
+        chasse_clear_infos_affichage_cache($chasse_id);
+        $cache = [];
     }
 
     $champs = chasse_get_champs($chasse_id);
+    $is_demo = !empty($champs['is_demo']);
+    $demo_label = function_exists('__') ? __('Démo', 'chassesautresor-com') : 'Démo';
+    $demo_aria_label = function_exists('__')
+        ? __('Chasse de démonstration', 'chassesautresor-com')
+        : 'Chasse de démonstration';
+    $demo_title = function_exists('__')
+        ? __('Cette chasse est proposée en mode démonstration.', 'chassesautresor-com')
+        : 'Cette chasse est proposée en mode démonstration.';
+    $demo_screen = function_exists('__')
+        ? __('Chasse en mode démonstration', 'chassesautresor-com')
+        : 'Chasse en mode démonstration';
+    $demo_icon = function_exists('get_svg_icon') ? get_svg_icon('idea') : '';
+    $demo_badge = [
+        'label'       => $demo_label,
+        'aria_label'  => $demo_aria_label,
+        'icon_html'   => $demo_icon,
+        'icon_name'   => 'idea',
+        'title'       => $demo_title,
+        'screen_text' => $demo_screen,
+    ];
     $regions = chasse_preparer_termes_affichage($chasse_id, 'chasse_region');
     $themes = chasse_preparer_termes_affichage($chasse_id, 'theme_chasse');
     $region_principale = !empty($regions) ? $regions[0] : null;
@@ -2412,6 +2475,8 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
         'region_principale' => $region_principale,
         'date_debut_court'  => $dates_courtes['date_debut_court'],
         'date_fin_court'    => $dates_courtes['date_fin_court'],
+        'is_demo'           => $is_demo,
+        'demo_badge'        => $is_demo ? $demo_badge : null,
     ];
 
     $cache[$user_id] = $memo[$memo_key];

--- a/wp-content/themes/chassesautresor/inc/chasse/demo.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/demo.php
@@ -1,0 +1,111 @@
+<?php
+defined('ABSPATH') || exit();
+
+/**
+ * Vérifie si une chasse est marquée comme démo.
+ *
+ * @param int $chasse_id Identifiant de la chasse.
+ *
+ * @return bool
+ */
+function ca_demo_is_demo_hunt(int $chasse_id): bool
+{
+    static $cache = [];
+
+    if ($chasse_id <= 0) {
+        return false;
+    }
+
+    if (isset($cache[$chasse_id])) {
+        return $cache[$chasse_id];
+    }
+
+    if (!function_exists('get_organisateur_from_chasse')) {
+        $cache[$chasse_id] = false;
+
+        return $cache[$chasse_id];
+    }
+
+    $organisateur_id = get_organisateur_from_chasse($chasse_id);
+    if (!$organisateur_id) {
+        $cache[$chasse_id] = false;
+
+        return $cache[$chasse_id];
+    }
+
+    $configured_logins = CA_DEMO_ORGANISATEUR_LOGINS;
+    if (!is_array($configured_logins)) {
+        $configured_logins = [];
+    }
+
+    $configured_logins = array_filter(array_map(
+        static function ($login) {
+            $login = is_string($login) ? trim($login) : '';
+
+            return $login !== '' ? strtolower($login) : null;
+        },
+        $configured_logins
+    ));
+
+    /** @var string[] $allowed_logins */
+    $allowed_logins = apply_filters('ca_demo_organisateur_logins', array_values($configured_logins));
+    $allowed_logins = array_filter(array_map(
+        static function ($login) {
+            return is_string($login) ? strtolower(trim($login)) : null;
+        },
+        $allowed_logins
+    ));
+
+    if (empty($allowed_logins)) {
+        $cache[$chasse_id] = false;
+
+        return $cache[$chasse_id];
+    }
+
+    $associated_users = function_exists('get_field')
+        ? get_field('utilisateurs_associes', $organisateur_id)
+        : [];
+    if (!is_array($associated_users) || empty($associated_users)) {
+        $cache[$chasse_id] = false;
+
+        return $cache[$chasse_id];
+    }
+
+    $is_demo = false;
+
+    foreach ($associated_users as $user_entry) {
+        if ($user_entry instanceof WP_User) {
+            $user = $user_entry;
+        } elseif (is_array($user_entry) && isset($user_entry['ID'])) {
+            $user = get_user_by('id', (int) $user_entry['ID']);
+        } elseif (is_numeric($user_entry)) {
+            $user = get_user_by('id', (int) $user_entry);
+        } else {
+            $user = null;
+        }
+
+        if (!$user instanceof WP_User) {
+            continue;
+        }
+
+        $login = strtolower($user->user_login);
+        if (in_array($login, $allowed_logins, true)) {
+            $is_demo = true;
+            break;
+        }
+    }
+
+    $filtered = (bool) apply_filters(
+        'ca_demo_is_demo_hunt',
+        $is_demo,
+        $chasse_id,
+        [
+            'organisateur_id' => $organisateur_id,
+            'allowed_logins'  => $allowed_logins,
+        ]
+    );
+
+    $cache[$chasse_id] = $filtered;
+
+    return $cache[$chasse_id];
+}

--- a/wp-content/themes/chassesautresor/inc/constants.php
+++ b/wp-content/themes/chassesautresor/inc/constants.php
@@ -8,6 +8,15 @@ if (!defined('ROLE_ORGANISATEUR_CREATION')) {
     define('ROLE_ORGANISATEUR_CREATION', 'organisateur_creation');
 }
 
+if (!defined('CA_DEMO_ORGANISATEUR_LOGINS')) {
+    /**
+     * Liste des logins organisateur considérés comme étant en mode démo.
+     *
+     * Utilisez le filtre `ca_demo_organisateur_logins` pour enrichir cette liste dynamiquement.
+     */
+    define('CA_DEMO_ORGANISATEUR_LOGINS', []);
+}
+
 // --------------------------------------------------
 // 🔢 Solution states
 // --------------------------------------------------

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -31,6 +31,10 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' role="img" tabindex="0"';
 }
 
+$is_demo = !empty($infos['is_demo']);
+$demo_badge = is_array($infos['demo_badge'] ?? null) ? $infos['demo_badge'] : null;
+$demo_badge_description_id = $is_demo && $demo_badge ? wp_unique_id('badge-demo-desc-') : '';
+
 $progression = $infos['progression'] ?? null;
 $resolvables = is_array($progression) ? (int) ($progression['resolvables'] ?? 0) : 0;
 $resolues_validables = isset($infos['resolues_validables']) ? (int) $infos['resolues_validables'] : 0;
@@ -48,9 +52,30 @@ if ($has_reward) {
     <div class="carte carte-chasse carte-compact <?php echo esc_attr($infos['classe_statut']); ?>">
         <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-compact__lien">
             <div class="carte-compact__image-wrapper">
-                <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-                    <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
-                </span>
+                <div class="carte-badges-stack">
+                    <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                        <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                    </span>
+                    <?php if ($is_demo && $demo_badge) : ?>
+                        <span
+                            class="badge-demo"
+                            role="img"
+                            aria-label="<?php echo esc_attr($demo_badge['aria_label'] ?? $demo_badge['screen_text'] ?? ''); ?>"
+                            <?php if ($demo_badge_description_id) : ?>aria-describedby="<?php echo esc_attr($demo_badge_description_id); ?>"<?php endif; ?>
+                            title="<?php echo esc_attr($demo_badge['title'] ?? ''); ?>"
+                        >
+                            <?php if (!empty($demo_badge['icon_html'])) : ?>
+                                <span class="badge-demo__icon" aria-hidden="true">
+                                    <?php echo $demo_badge['icon_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- icône préparée. ?>
+                                </span>
+                            <?php endif; ?>
+                            <span class="badge-demo__label"><?php echo esc_html($demo_badge['label'] ?? ''); ?></span>
+                            <?php if ($demo_badge_description_id) : ?>
+                                <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                            <?php endif; ?>
+                        </span>
+                    <?php endif; ?>
+                </div>
                 <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>" class="carte-compact__image">
             </div>
             <div class="carte-compact__contenu">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -25,6 +25,9 @@ $badge_icon_html = $infos['statut_icon'] ?? '';
 $badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
 $has_badge_icon = $badge_icon_html !== '';
 $badge_classes = $infos['badge_class'] ?? '';
+$is_demo = !empty($infos['is_demo']);
+$demo_badge = is_array($infos['demo_badge'] ?? null) ? $infos['demo_badge'] : null;
+$demo_badge_description_id = $is_demo && $demo_badge ? wp_unique_id('badge-demo-desc-') : '';
 
 if ($has_badge_icon) {
     $badge_classes = trim($badge_classes . ' badge-statut--responsive');
@@ -49,15 +52,36 @@ $has_reward = !empty($reward_title) && (float) $reward_value > 0;
 ?>
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
-        <span class="badge-statut <?php echo esc_attr($badge_classes); ?>"
-            data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-            <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
-            <?php if ($has_badge_icon) : ?>
-                <span class="badge-statut__icon" aria-hidden="true">
-                    <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+        <div class="carte-badges-stack">
+            <span class="badge-statut <?php echo esc_attr($badge_classes); ?>"
+                data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+                <?php if ($has_badge_icon) : ?>
+                    <span class="badge-statut__icon" aria-hidden="true">
+                        <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                    </span>
+                <?php endif; ?>
+            </span>
+            <?php if ($is_demo && $demo_badge) : ?>
+                <span
+                    class="badge-demo"
+                    role="img"
+                    aria-label="<?php echo esc_attr($demo_badge['aria_label'] ?? $demo_badge['screen_text'] ?? ''); ?>"
+                    <?php if ($demo_badge_description_id) : ?>aria-describedby="<?php echo esc_attr($demo_badge_description_id); ?>"<?php endif; ?>
+                    title="<?php echo esc_attr($demo_badge['title'] ?? ''); ?>"
+                >
+                    <?php if (!empty($demo_badge['icon_html'])) : ?>
+                        <span class="badge-demo__icon" aria-hidden="true">
+                            <?php echo $demo_badge['icon_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- icône préparée. ?>
+                        </span>
+                    <?php endif; ?>
+                    <span class="badge-demo__label"><?php echo esc_html($demo_badge['label'] ?? ''); ?></span>
+                    <?php if ($demo_badge_description_id) : ?>
+                        <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                    <?php endif; ?>
                 </span>
             <?php endif; ?>
-        </span>
+        </div>
         <?php if ((int) $infos['cout_points'] > 0) : ?>
         <span
             class="badge-cout"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -18,6 +18,9 @@ $badge_icon_html = $infos['statut_icon'] ?? '';
 $badge_label = $infos['statut_label'] ?? ($infos['badge_content'] ?? '');
 $has_badge_icon = $badge_icon_html !== '';
 $badge_classes = $infos['badge_class'] ?? '';
+$is_demo = !empty($infos['is_demo']);
+$demo_badge = is_array($infos['demo_badge'] ?? null) ? $infos['demo_badge'] : null;
+$demo_badge_description_id = $is_demo && $demo_badge ? wp_unique_id('badge-demo-desc-') : '';
 
 if ($has_badge_icon) {
     $badge_classes = trim($badge_classes . ' badge-statut--responsive');
@@ -37,14 +40,35 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 
 <div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-ligne__image">
-        <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-            <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
-            <?php if ($has_badge_icon) : ?>
-                <span class="badge-statut__icon" aria-hidden="true">
-                    <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+        <div class="carte-badges-stack">
+            <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+                <?php if ($has_badge_icon) : ?>
+                    <span class="badge-statut__icon" aria-hidden="true">
+                        <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                    </span>
+                <?php endif; ?>
+            </span>
+            <?php if ($is_demo && $demo_badge) : ?>
+                <span
+                    class="badge-demo"
+                    role="img"
+                    aria-label="<?php echo esc_attr($demo_badge['aria_label'] ?? $demo_badge['screen_text'] ?? ''); ?>"
+                    <?php if ($demo_badge_description_id) : ?>aria-describedby="<?php echo esc_attr($demo_badge_description_id); ?>"<?php endif; ?>
+                    title="<?php echo esc_attr($demo_badge['title'] ?? ''); ?>"
+                >
+                    <?php if (!empty($demo_badge['icon_html'])) : ?>
+                        <span class="badge-demo__icon" aria-hidden="true">
+                            <?php echo $demo_badge['icon_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- icône SVG préparée. ?>
+                        </span>
+                    <?php endif; ?>
+                    <span class="badge-demo__label"><?php echo esc_html($demo_badge['label'] ?? ''); ?></span>
+                    <?php if ($demo_badge_description_id) : ?>
+                        <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                    <?php endif; ?>
                 </span>
             <?php endif; ?>
-        </span>
+        </div>
         <img src="<?php echo esc_url($infos['image']); ?>" alt="<?php echo esc_attr($infos['titre']); ?>">
     </div>
 


### PR DESCRIPTION
## Résumé
- préparation du mode démo des chasses via une configuration centralisée et un helper dédié
- affichage d’un badge « Démo » accessible sur toutes les cartes de chasse
- mise à jour des styles et de la documentation pour couvrir le nouveau mode

## Tests
- `npm run build:css`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d625daccac833282a7f4f781821318