### PR TITLE
Gérer le mode démo dans les stats et CTA

### DIFF
--- a/tests/CaGetUserEngagedHuntIdsTest.php
+++ b/tests/CaGetUserEngagedHuntIdsTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('WP_User')) {
+    class WP_User
+    {
+        public int $ID = 0;
+
+        public string $user_login = '';
+
+        public array $roles = [];
+
+        public function __construct($data = 0)
+        {
+            if (is_object($data)) {
+                $this->ID         = isset($data->ID) ? (int) $data->ID : 0;
+                $this->user_login = isset($data->user_login) ? (string) $data->user_login : '';
+            } elseif (is_array($data)) {
+                $this->ID         = isset($data['ID']) ? (int) $data['ID'] : 0;
+                $this->user_login = isset($data['user_login']) ? (string) $data['user_login'] : '';
+            } elseif (is_int($data)) {
+                $this->ID         = $data;
+                $this->user_login = 'user' . $data;
+            } else {
+                $this->user_login = (string) $data;
+            }
+        }
+
+        public function add_role($role): void
+        {
+            if (!in_array($role, $this->roles, true)) {
+                $this->roles[] = $role;
+            }
+        }
+
+        public function remove_role($role): void
+        {
+            $this->roles = array_values(array_filter(
+                $this->roles,
+                static function ($registered_role) use ($role) {
+                    return $registered_role !== $role;
+                }
+            ));
+        }
+
+        public function set_role($role): void
+        {
+            $this->roles = [$role];
+        }
+    }
+}
+
+/**
+ * @runInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+class CaGetUserEngagedHuntIdsTest extends TestCase
+{
+    public function test_demo_hunts_are_filtered_out(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/fixtures/');
+        }
+
+        if (!function_exists('apply_filters')) {
+            function apply_filters($hook, $value, ...$args)
+            {
+                global $wp_filter;
+
+                if (
+                    isset($wp_filter[$hook])
+                    && is_object($wp_filter[$hook])
+                    && method_exists($wp_filter[$hook], 'apply_filters')
+                ) {
+                    $arguments = $args;
+                    array_unshift($arguments, $value);
+
+                    return $wp_filter[$hook]->apply_filters($value, $arguments);
+                }
+
+                return $value;
+            }
+        }
+
+        if (!function_exists('get_post_status')) {
+            function get_post_status($post_id)
+            {
+                return 'publish';
+            }
+        }
+
+        if (!function_exists('get_field')) {
+            function get_field($field, $post_id = null)
+            {
+                global $fields, $post_fields;
+
+                return $fields[$post_id][$field] ?? $post_fields[$post_id][$field] ?? null;
+            }
+        }
+
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $cap)
+            {
+                return false;
+            }
+        }
+
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+            {
+                return false;
+            }
+        }
+
+        if (!function_exists('chasse_est_visible_pour_utilisateur')) {
+            function chasse_est_visible_pour_utilisateur($chasse_id, $user_id)
+            {
+                return true;
+            }
+        }
+
+        if (!function_exists('get_organisateur_from_chasse')) {
+            function get_organisateur_from_chasse($chasse_id)
+            {
+                return $chasse_id === 60 ? 5 : 10;
+            }
+        }
+
+        if (!function_exists('get_user_by')) {
+            function get_user_by($field, $value)
+            {
+                $login = ((int) $value === 42) ? 'demo' : 'regular';
+
+                return new WP_User([
+                    'ID'         => (int) $value,
+                    'user_login' => $login,
+                ]);
+            }
+        }
+
+        global $fields, $post_fields;
+
+        $fields = [
+            5  => [
+                'utilisateurs_associes'          => [
+                    ['ID' => 42],
+                ],
+                'chasse_cache_statut_validation' => 'valide',
+            ],
+            10 => [
+                'utilisateurs_associes'          => [
+                    ['ID' => 84],
+                ],
+                'chasse_cache_statut_validation' => 'valide',
+            ],
+            60 => [
+                'chasse_cache_statut_validation' => 'valide',
+            ],
+            70 => [
+                'chasse_cache_statut_validation' => 'valide',
+            ],
+            80 => [
+                'chasse_cache_statut_validation' => 'valide',
+            ],
+        ];
+
+        $post_fields = [];
+
+        $GLOBALS['wp_filter']['ca_demo_organisateur_logins'] = new class
+        {
+            public function apply_filters($value, $args)
+            {
+                $current = is_array($args[0] ?? null) ? $args[0] : [];
+                $current[] = 'demo';
+
+                return array_values(array_unique(array_filter(array_map(
+                    static function ($login) {
+                        return is_string($login) ? strtolower(trim($login)) : null;
+                    },
+                    $current
+                ))));
+            }
+        };
+
+        $GLOBALS['wp_filter']['ca_demo_is_demo_hunt'] = new class
+        {
+            public function apply_filters($value, $args)
+            {
+                $chasse_id = isset($args[1]) ? (int) $args[1] : 0;
+
+                if (in_array($chasse_id, [60, 90], true)) {
+                    return true;
+                }
+
+                return $value;
+            }
+        };
+
+        $wpdb = new class
+        {
+            public string $prefix = 'wp_';
+
+            public function prepare(string $query, int $user_id): string
+            {
+                return $query;
+            }
+
+            public function get_col(string $query): array
+            {
+                return [60, 70, 70, 80, 60];
+            }
+        };
+
+        $GLOBALS['wpdb'] = $wpdb;
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/user-functions.php';
+
+        $this->assertTrue(ca_demo_is_demo_hunt(60));
+        $this->assertFalse(ca_demo_is_demo_hunt(70));
+
+        $result = ca_get_user_engaged_hunt_ids(123);
+
+        $this->assertSame([70, 80], $result);
+
+        unset(
+            $GLOBALS['wp_filter']['ca_demo_organisateur_logins'],
+            $GLOBALS['wp_filter']['ca_demo_is_demo_hunt']
+        );
+        unset($GLOBALS['wpdb']);
+    }
+}

--- a/tests/EmailSendTitleTest.php
+++ b/tests/EmailSendTitleTest.php
@@ -37,7 +37,16 @@ if (!function_exists('home_url')) {
     }
 }
 if (!function_exists('apply_filters')) {
-    function apply_filters($tag, $value) {
+    function apply_filters($tag, $value, ...$args) {
+        global $wp_filter;
+
+        if (isset($wp_filter[$tag]) && is_object($wp_filter[$tag]) && method_exists($wp_filter[$tag], 'apply_filters')) {
+            $arguments = $args;
+            array_unshift($arguments, $value);
+
+            return $wp_filter[$tag]->apply_filters($value, $arguments);
+        }
+
         return $value;
     }
 }

--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -8,10 +8,81 @@ if (!function_exists('current_user_can')) {
     }
 }
 
+if (!class_exists('WP_User')) {
+    class WP_User
+    {
+        public int $ID = 0;
+
+        public string $user_login = '';
+
+        public array $roles = [];
+
+        /**
+         * @param mixed $data
+         */
+        public function __construct($data = 0)
+        {
+            if (is_object($data)) {
+                $this->ID         = isset($data->ID) ? (int) $data->ID : 0;
+                $this->user_login = isset($data->user_login) ? (string) $data->user_login : '';
+            } elseif (is_array($data)) {
+                $this->ID         = isset($data['ID']) ? (int) $data['ID'] : 0;
+                $this->user_login = isset($data['user_login']) ? (string) $data['user_login'] : '';
+            } elseif (is_int($data)) {
+                $this->ID         = $data;
+                $this->user_login = 'user' . $data;
+            } else {
+                $this->user_login = (string) $data;
+            }
+        }
+
+        public function add_role($role): void
+        {
+            if (!in_array($role, $this->roles, true)) {
+                $this->roles[] = $role;
+            }
+        }
+
+        public function remove_role($role): void
+        {
+            $this->roles = array_values(array_filter(
+                $this->roles,
+                static function ($registered_role) use ($role) {
+                    return $registered_role !== $role;
+                }
+            ));
+        }
+
+        public function set_role($role): void
+        {
+            $this->roles = [$role];
+        }
+    }
+}
+
 if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
     function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
     {
         return false;
+    }
+}
+
+if (!function_exists('get_organisateur_from_chasse')) {
+    function get_organisateur_from_chasse($chasse_id)
+    {
+        return 5;
+    }
+}
+
+if (!function_exists('get_user_by')) {
+    function get_user_by($field, $value)
+    {
+        $login = ((int) $value === 42) ? 'demo' : 'regular';
+
+        return new WP_User([
+            'ID'         => (int) $value,
+            'user_login' => $login,
+        ]);
     }
 }
 
@@ -103,6 +174,39 @@ if (!function_exists('date_i18n')) {
     }
 }
 
+if (!function_exists('get_user_points')) {
+    function get_user_points($user_id)
+    {
+        return 100;
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, ...$args)
+    {
+        $value = $args[0] ?? null;
+
+        if ($hook === 'ca_demo_organisateur_logins') {
+            return ['demo'];
+        }
+
+        if ($hook === 'ca_demo_is_demo_hunt') {
+            $chasse_id  = $args[1] ?? null;
+            $overrides = $GLOBALS['force_demo_overrides'] ?? [];
+
+            if ($chasse_id !== null && isset($overrides[$chasse_id])) {
+                return (bool) $overrides[$chasse_id];
+            }
+        }
+
+        return $value;
+    }
+}
+
+if (!defined('CA_DEMO_ORGANISATEUR_LOGINS')) {
+    define('CA_DEMO_ORGANISATEUR_LOGINS', []);
+}
+
 require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse-functions.php';
 
 /**
@@ -116,7 +220,9 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['force_admin_override']        = true;
         $GLOBALS['force_engage_override']       = false;
         $GLOBALS['force_organisateur_override'] = false;
-        $GLOBALS['get_field_values']            = [];
+        $GLOBALS['get_field_values']            = [
+            'utilisateurs_associes' => [],
+        ];
         $cta                                    = generer_cta_chasse(123, 5);
 
         $this->assertSame(
@@ -124,6 +230,7 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<button class="bouton-cta" disabled>Participer</button>',
                 'cta_message' => '',
                 'type'        => 'indisponible',
+                'is_demo'     => false,
             ],
             $cta
         );
@@ -134,7 +241,9 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['force_admin_override']        = false;
         $GLOBALS['force_engage_override']       = false;
         $GLOBALS['force_organisateur_override'] = false;
-        $GLOBALS['get_field_values']            = [];
+        $GLOBALS['get_field_values']            = [
+            'utilisateurs_associes' => [],
+        ];
         $cta                                    = generer_cta_chasse(123, 0);
 
         $this->assertSame(
@@ -142,6 +251,7 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<a href="https://example.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2Fchasse%2F123" class="bouton-cta bouton-cta--color">S\'identifier</a>',
                 'cta_message' => '',
                 'type'        => 'connexion',
+                'is_demo'     => false,
             ],
             $cta
         );
@@ -152,7 +262,9 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['force_admin_override']        = false;
         $GLOBALS['force_engage_override']       = true;
         $GLOBALS['force_organisateur_override'] = false;
-        $GLOBALS['get_field_values']            = [];
+        $GLOBALS['get_field_values']            = [
+            'utilisateurs_associes' => [],
+        ];
         $cta                                    = generer_cta_chasse(123, 1);
 
         $this->assertSame(
@@ -160,6 +272,7 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<a href="#chasse-enigmes-wrapper" class="bouton-secondaire">Voir mes énigmes</a>',
                 'cta_message' => '<p>✅ Vous participez à cette chasse</p>',
                 'type'        => 'engage',
+                'is_demo'     => false,
             ],
             $cta
         );
@@ -173,6 +286,7 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['get_field_values']            = [
             'chasse_cache_statut'            => 'en_cours',
             'chasse_cache_statut_validation' => 'valide',
+            'utilisateurs_associes'          => [],
         ];
 
         $cta          = generer_cta_chasse(123, 5);
@@ -183,6 +297,7 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<a href="' . $expected_url . '" class="bouton-secondaire">Statistiques</a>',
                 'cta_message' => '',
                 'type'        => 'statistiques',
+                'is_demo'     => false,
             ],
             $cta
         );
@@ -196,6 +311,7 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['get_field_values']            = [
             'chasse_cache_statut'            => 'en_cours',
             'chasse_cache_statut_validation' => 'active',
+            'utilisateurs_associes'          => [],
         ];
 
         $cta          = generer_cta_chasse(456, 7);
@@ -206,6 +322,7 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<a href="' . $expected_url . '" class="bouton-secondaire">Statistiques</a>',
                 'cta_message' => '',
                 'type'        => 'statistiques',
+                'is_demo'     => false,
             ],
             $cta
         );
@@ -219,6 +336,7 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['get_field_values']            = [
             'chasse_cache_statut'            => 'payante',
             'chasse_cache_statut_validation' => 'valide',
+            'utilisateurs_associes'          => [],
         ];
 
         $cta          = generer_cta_chasse(789, 11);
@@ -229,10 +347,49 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<a href="' . $expected_url . '" class="bouton-secondaire">Statistiques</a>',
                 'cta_message' => '',
                 'type'        => 'statistiques',
+                'is_demo'     => false,
             ],
             $cta
         );
     }
+
+    public function test_demo_hunt_returns_virtual_engagement_cta(): void
+    {
+        $GLOBALS['force_admin_override']        = false;
+        unset($GLOBALS['force_engage_override']);
+        $GLOBALS['force_organisateur_override'] = false;
+        $GLOBALS['force_demo_overrides']        = [123 => true];
+        $GLOBALS['get_field_values']            = [
+            'chasse_cache_statut'            => 'en_cours',
+            'chasse_cache_statut_validation' => 'valide',
+            'utilisateurs_associes'          => [
+                ['ID' => 42],
+            ],
+        ];
+        $GLOBALS['wpdb'] = new class
+        {
+            public string $prefix = 'wp_';
+
+            public function prepare(string $query, ...$args): string
+            {
+                return $query;
+            }
+
+            public function get_var(string $query)
+            {
+                return null;
+            }
+        };
+
+        $cta = generer_cta_chasse(123, 21);
+
+        $this->assertTrue(ca_demo_is_demo_hunt(123));
+        $this->assertSame('engage', $cta['type']);
+        $this->assertTrue($cta['is_demo']);
+        $this->assertStringContainsString('Voir mes énigmes', $cta['cta_html']);
+        $this->assertStringNotContainsString('<form', $cta['cta_html']);
+    }
+
     public function test_finished_hunt_requires_engagement_cta(): void
     {
         $GLOBALS['force_admin_override']        = false;
@@ -241,6 +398,7 @@ class GenererCtaChasseTest extends TestCase
         $GLOBALS['get_field_values']            = [
             'chasse_cache_statut'            => 'termine',
             'chasse_cache_statut_validation' => 'valide',
+            'utilisateurs_associes'          => [],
         ];
 
         $cta = generer_cta_chasse(123, 5);
@@ -250,6 +408,7 @@ class GenererCtaChasseTest extends TestCase
                 'cta_html'    => '<form method="post" action="/traitement-engagement" class="cta-chasse-form"><input type="hidden" name="chasse_id" value="123"><button type="submit" class="bouton-cta bouton-cta--color">Redécouvrir</button></form>',
                 'cta_message' => 'Cette chasse est terminée',
                 'type'        => 'engager',
+                'is_demo'     => false,
             ],
             $cta,
         );

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -210,6 +210,13 @@ function utilisateur_est_engage_dans_chasse(int $user_id, int $chasse_id): bool
     global $wpdb;
     if (!$user_id || !$chasse_id) return false;
 
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return $user_id > 0;
+    }
+
     $table = $wpdb->prefix . 'engagements';
 
     return (bool) $wpdb->get_var($wpdb->prepare(
@@ -603,6 +610,9 @@ function chasse_calculer_progression_utilisateur(int $chasse_id, int $user_id): 
 {
     $enigmes = recuperer_enigmes_associees($chasse_id);
     $total   = count($enigmes);
+    $is_demo = function_exists('ca_demo_is_demo_hunt')
+        ? ca_demo_is_demo_hunt($chasse_id)
+        : false;
 
     $resolvables = 0;
     if ($total > 0) {
@@ -615,15 +625,32 @@ function chasse_calculer_progression_utilisateur(int $chasse_id, int $user_id): 
     }
 
     $engagees = 0;
+    $resolues = 0;
+
     if ($user_id && $total > 0) {
         global $wpdb;
         $placeholders = implode(',', array_fill(0, $total, '%d'));
-        $sql = "SELECT COUNT(DISTINCT enigme_id) FROM {$wpdb->prefix}engagements WHERE user_id = %d AND enigme_id IN ($placeholders)";
-        $engagees = (int) $wpdb->get_var($wpdb->prepare($sql, array_merge([$user_id], $enigmes)));
+
+        if ($is_demo) {
+            $table_statuts = $wpdb->prefix . 'enigme_statuts_utilisateur';
+            $params        = array_merge([$user_id], $enigmes);
+
+            $sql_engagees = "SELECT COUNT(DISTINCT enigme_id) FROM {$table_statuts}"
+                . " WHERE user_id = %d AND enigme_id IN ($placeholders)"
+                . " AND statut NOT IN ('non_commencee','non_souscrite')";
+            $engagees = (int) $wpdb->get_var($wpdb->prepare($sql_engagees, $params));
+
+            $sql_resolues = "SELECT COUNT(DISTINCT enigme_id) FROM {$table_statuts}"
+                . " WHERE user_id = %d AND enigme_id IN ($placeholders)"
+                . " AND statut IN ('resolue','terminee','terminée')";
+            $resolues = (int) $wpdb->get_var($wpdb->prepare($sql_resolues, $params));
+        } else {
+            $sql = "SELECT COUNT(DISTINCT enigme_id) FROM {$wpdb->prefix}engagements WHERE user_id = %d AND enigme_id IN ($placeholders)";
+            $engagees = (int) $wpdb->get_var($wpdb->prepare($sql, array_merge([$user_id], $enigmes)));
+        }
     }
 
-    $resolues = 0;
-    if ($user_id && function_exists('compter_enigmes_resolues')) {
+    if (!$is_demo && $user_id && function_exists('compter_enigmes_resolues')) {
         $resolues = compter_enigmes_resolues($chasse_id, $user_id);
     }
 
@@ -651,12 +678,20 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     $validation = get_field('chasse_cache_statut_validation', $chasse_id);
     $date_debut = get_field('chasse_infos_date_debut', $chasse_id);
     $date_fin   = get_field('chasse_infos_date_fin', $chasse_id);
+    $is_demo    = function_exists('ca_demo_is_demo_hunt')
+        ? ca_demo_is_demo_hunt($chasse_id)
+        : false;
+    $response   = static function (array $data) use ($is_demo): array {
+        $data['is_demo'] = $is_demo;
+
+        return $data;
+    };
 
     // 🧑‍💻 Utilisateur non connecté
     if (! $user_id) {
         $login_url = wp_login_url($permalink);
 
-        return [
+        return $response([
             'cta_html'    => sprintf(
                 '<a href="%s" class="bouton-cta bouton-cta--color">%s</a>',
                 esc_url($login_url),
@@ -664,15 +699,15 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             ),
             'cta_message' => '',
             'type'        => 'connexion',
-        ];
+        ]);
     }
 
     if (peut_valider_chasse($chasse_id, $user_id)) {
-        return [
+        return $response([
             'cta_html'    => render_form_validation_chasse($chasse_id),
             'cta_message' => '',
             'type'        => 'validation',
-        ];
+        ]);
     }
 
     // 🔐 Admin or organiser info
@@ -683,19 +718,19 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
 
     if ($validation === 'en_attente') {
         if ($is_orga) {
-            return [
+            return $response([
                 'cta_html'    => render_form_annulation_validation_chasse($chasse_id),
                 'cta_message' => '',
                 'type'        => 'annuler_validation',
-            ];
+            ]);
         }
-        return [
+        return $response([
             'cta_html'    => '<span class="bouton-cta bouton-cta--pending" aria-disabled="true">'
                 . esc_html__( 'Demande de validation en cours', 'chassesautresor-com' )
                 . '</span>',
             'cta_message' => '',
             'type'        => 'en_attente',
-        ];
+        ]);
     }
 
     // 🔐 Admin or organiser: front-end edition
@@ -704,7 +739,7 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             ? add_query_arg(['edition' => 'open', 'tab' => 'param'], $permalink)
             : $permalink . '?edition=open&tab=param';
 
-        return [
+        return $response([
             'cta_html'    => sprintf(
                 '<a href="%s" class="bouton-secondaire">%s</a>',
                 esc_url($edition_url),
@@ -712,7 +747,7 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             ),
             'cta_message' => '',
             'type'        => 'edition',
-        ];
+        ]);
     }
 
     if (
@@ -724,7 +759,7 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             ? add_query_arg(['edition' => 'open', 'tab' => 'stats'], $permalink)
             : $permalink . '?edition=open&tab=stats';
 
-        return [
+        return $response([
             'cta_html'    => sprintf(
                 '<a href="%s" class="bouton-secondaire">%s</a>',
                 esc_url($stats_url),
@@ -732,34 +767,34 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             ),
             'cta_message' => '',
             'type'        => 'statistiques',
-        ];
+        ]);
     }
 
     if ($is_admin || $is_orga) {
-        return [
+        return $response([
             'cta_html'    => sprintf(
                 '<button class="bouton-cta" disabled>%s</button>',
                 esc_html__( 'Participer', 'chassesautresor-com' )
             ),
             'cta_message' => '',
             'type'        => 'indisponible',
-        ];
+        ]);
     }
 
     // ✅ Déjà engagé
     $engage_override = $GLOBALS['force_engage_override'] ?? null;
     $est_engage = $engage_override !== null ? (bool) $engage_override : utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
     if ($est_engage) {
-        return [
+        return $response([
             'cta_html'    => '<a href="#chasse-enigmes-wrapper" class="bouton-secondaire">' . esc_html__('Voir mes énigmes', 'chassesautresor-com') . '</a>',
             'cta_message' => '<p>✅ ' . esc_html__('Vous participez à cette chasse', 'chassesautresor-com') . '</p>',
             'type'        => 'engage',
-        ];
+        ]);
     }
 
     // ❌ Chasse non validée
     if ($validation !== 'valide') {
-        return ['cta_html' => '', 'cta_message' => '', 'type' => ''];
+        return $response(['cta_html' => '', 'cta_message' => '', 'type' => '']);
     }
 
     $html    = '';
@@ -831,11 +866,11 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             : __('Cette chasse est terminée', 'chassesautresor-com');
     }
 
-    return [
-        'cta_html'    => $html,
-        'cta_message' => $message,
-        'type'        => $type,
-    ];
+        return $response([
+            'cta_html'    => $html,
+            'cta_message' => $message,
+            'type'        => $type,
+        ]);
 }
 
 /**
@@ -847,6 +882,13 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
 function compter_joueurs_engages_chasse(int $chasse_id): int
 {
     if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+        return 0;
+    }
+
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
         return 0;
     }
 
@@ -881,6 +923,15 @@ function enregistrer_engagement_chasse(int $user_id, int $chasse_id): bool
 
     if (current_user_can('administrator') || utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
         return false;
+    }
+
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        chasse_clear_infos_affichage_cache($chasse_id);
+
+        return true;
     }
 
     $table = $wpdb->prefix . 'engagements';
@@ -2142,7 +2193,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
 
     $user_id = get_current_user_id();
     $progression = chasse_calculer_progression_utilisateur($chasse_id, $user_id);
-    $cta_data = generer_cta_chasse($chasse_id, $user_id);
+    $cta_data    = generer_cta_chasse($chasse_id, $user_id);
 
     $liens = get_field('chasse_principale_liens', $chasse_id);
     $liens = is_array($liens) ? $liens : [];
@@ -2281,6 +2332,7 @@ function preparer_infos_affichage_carte_chasse(int $chasse_id, int $word_limit =
         'cta_html'          => $cta_html,
         'cta_message'       => $cta_message,
         'cta_type'         => $cta_data['type'] ?? '',
+        'cta_is_demo'      => !empty($cta_data['is_demo']),
         'footer_html'       => $footer_html,
         'regions'           => $regions,
         'themes'            => $themes,
@@ -2430,6 +2482,7 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
     }
 
     $progression = chasse_calculer_progression_utilisateur($chasse_id, $user_id);
+    $cta_data    = generer_cta_chasse($chasse_id, $user_id);
 
     $nb_joueurs = compter_joueurs_engages_chasse($chasse_id);
     $top_nb      = 0;
@@ -2461,7 +2514,9 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
         'enigmes_associees'   => $enigmes,
         'total_enigmes'       => count($enigmes),
         'progression'         => $progression,
-        'cta_data'            => generer_cta_chasse($chasse_id, $user_id),
+        'cta_data'            => $cta_data,
+        'cta_type'            => $cta_data['type'] ?? '',
+        'cta_is_demo'         => !empty($cta_data['is_demo']),
         'nb_joueurs'          => $nb_joueurs,
         'nb_enigmes_payantes' => $nb_enigmes_payantes,
         'top_avances'         => [
@@ -2490,6 +2545,36 @@ function preparer_infos_affichage_chasse(int $chasse_id, ?int $user_id = null): 
 function chasse_infos_affichage_cache_key(int $chasse_id): string
 {
     return "chasse_infos_affichage_{$chasse_id}";
+}
+
+function chasse_clear_infos_affichage_cache_for_organisateur(int $organisateur_id): void
+{
+    if ($organisateur_id <= 0) {
+        return;
+    }
+
+    if (!function_exists('get_chasses_de_organisateur')) {
+        return;
+    }
+
+    $query = get_chasses_de_organisateur($organisateur_id);
+    $raw_ids = [];
+
+    if (is_object($query) && isset($query->posts) && is_array($query->posts)) {
+        $raw_ids = $query->posts;
+    } elseif (is_array($query)) {
+        $raw_ids = $query;
+    }
+
+    foreach ($raw_ids as $maybe_id) {
+        $chasse_id = is_object($maybe_id)
+            ? (int) ($maybe_id->ID ?? 0)
+            : (int) $maybe_id;
+
+        if ($chasse_id > 0) {
+            chasse_clear_infos_affichage_cache($chasse_id);
+        }
+    }
 }
 
 function chasse_clear_infos_affichage_cache(int $chasse_id): void
@@ -2531,6 +2616,8 @@ function chasse_invalidate_infos_affichage_cache(int $post_id, \WP_Post $post, b
         if ($chasse_id) {
             chasse_clear_infos_affichage_cache((int) $chasse_id);
         }
+    } elseif ($post->post_type === 'organisateur') {
+        chasse_clear_infos_affichage_cache_for_organisateur($post_id);
     }
 }
 
@@ -2541,11 +2628,25 @@ function chasse_acf_clear_infos_affichage_cache($post_id): void
     }
 
     $post_id = (int) $post_id;
-    if (get_post_type($post_id) === 'chasse') {
+    $type = get_post_type($post_id);
+
+    if ($type === 'chasse') {
         chasse_clear_infos_affichage_cache($post_id);
+    } elseif ($type === 'organisateur') {
+        chasse_clear_infos_affichage_cache_for_organisateur($post_id);
     }
 }
 add_action('acf/save_post', 'chasse_acf_clear_infos_affichage_cache', 20);
 add_action('save_post', 'chasse_invalidate_infos_affichage_cache', 10, 3);
 add_action('chasse_engagement_created', 'chasse_clear_infos_affichage_cache');
 add_action('set_object_terms', 'chasse_invalidate_infos_affichage_terms', 10, 6);
+
+function chasse_acf_handle_utilisateurs_associes($value, $post_id)
+{
+    if (is_numeric($post_id) && get_post_type((int) $post_id) === 'organisateur') {
+        chasse_clear_infos_affichage_cache_for_organisateur((int) $post_id);
+    }
+
+    return $value;
+}
+add_filter('acf/update_value/name=utilisateurs_associes', 'chasse_acf_handle_utilisateurs_associes', 20, 2);

--- a/wp-content/themes/chassesautresor/inc/chasse/stats.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/stats.php
@@ -12,6 +12,13 @@ require_once __DIR__ . '/../enigme/stats.php';
  */
 function chasse_compter_participants(int $chasse_id, string $periode = 'total'): int
 {
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return 0;
+    }
+
     global $wpdb;
     $table = $wpdb->prefix . 'engagements';
     $where = 'chasse_id = %d AND enigme_id IS NULL';
@@ -33,6 +40,13 @@ function chasse_compter_participants(int $chasse_id, string $periode = 'total'):
  */
 function chasse_compter_tentatives(int $chasse_id, string $periode = 'total'): int
 {
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return 0;
+    }
+
     $enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse_id);
     if (!$enigme_ids) {
         return 0;
@@ -63,6 +77,13 @@ function chasse_compter_tentatives(int $chasse_id, string $periode = 'total'): i
  */
 function chasse_compter_points_collectes(int $chasse_id, string $periode = 'total'): int
 {
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return 0;
+    }
+
     $enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse_id);
     if (!$enigme_ids) {
         return 0;
@@ -94,6 +115,13 @@ function chasse_compter_points_collectes(int $chasse_id, string $periode = 'tota
  */
 function chasse_compter_engagements(int $chasse_id): int
 {
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return 0;
+    }
+
     global $wpdb;
     $table = $wpdb->prefix . 'engagements';
     $sql = $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE chasse_id = %d", $chasse_id);
@@ -105,6 +133,13 @@ function chasse_compter_engagements(int $chasse_id): int
  */
 function chasse_calculer_taux_engagement(int $chasse_id, string $periode = 'total'): float
 {
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return 0.0;
+    }
+
     $participants  = chasse_compter_participants($chasse_id, $periode);
     $enigme_ids    = recuperer_ids_enigmes_pour_chasse($chasse_id);
     $total_enigmes = count($enigme_ids);
@@ -141,6 +176,13 @@ function chasse_calculer_taux_engagement(int $chasse_id, string $periode = 'tota
  */
 function chasse_calculer_taux_progression(int $chasse_id, string $periode = 'total'): float
 {
+    if (
+        function_exists('ca_demo_is_demo_hunt')
+        && ca_demo_is_demo_hunt($chasse_id)
+    ) {
+        return 0.0;
+    }
+
     $enigme_ids = recuperer_ids_enigmes_pour_chasse($chasse_id);
     if (!$enigme_ids) {
         return 0.0;

--- a/wp-content/themes/chassesautresor/inc/enigme/access.php
+++ b/wp-content/themes/chassesautresor/inc/enigme/access.php
@@ -26,9 +26,20 @@ function handle_single_enigme_access(): void
     $user_id        = get_current_user_id();
     $edition_active = utilisateur_peut_modifier_post($enigme_id);
     $chasse_id      = recuperer_id_chasse_associee($enigme_id);
+    $est_engage_chasse = false;
 
     if ($chasse_id) {
         verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
+        if ($user_id) {
+            $est_engage_chasse = utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
+            if (
+                !$est_engage_chasse
+                && function_exists('ca_demo_is_demo_hunt')
+                && ca_demo_is_demo_hunt($chasse_id)
+            ) {
+                $est_engage_chasse = true;
+            }
+        }
     }
 
     if (!is_user_logged_in()) {
@@ -38,7 +49,7 @@ function handle_single_enigme_access(): void
     }
 
     if (
-        utilisateur_est_engage_dans_chasse($user_id, $chasse_id) &&
+        $est_engage_chasse &&
         !utilisateur_est_engage_dans_enigme($user_id, $enigme_id) &&
         utilisateur_peut_engager_enigme($enigme_id, $user_id)
     ) {

--- a/wp-content/themes/chassesautresor/inc/organisateur/stats.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur/stats.php
@@ -22,6 +22,18 @@ function organisateur_compter_joueurs_uniques(int $organisateur_id): int
         return 0;
     }
 
+    $ids = array_values(array_filter(
+        $ids,
+        static function ($chasse_id) {
+            return !function_exists('ca_demo_is_demo_hunt')
+                || !ca_demo_is_demo_hunt((int) $chasse_id);
+        }
+    ));
+
+    if (empty($ids)) {
+        return 0;
+    }
+
     global $wpdb;
     $table        = $wpdb->prefix . 'engagements';
     $placeholders = implode(',', array_fill(0, count($ids), '%d'));
@@ -46,7 +58,15 @@ function organisateur_compter_points_collectes(int $organisateur_id): int
 
     $total = 0;
     foreach ($query->posts as $chasse_id) {
-        $total += chasse_compter_points_collectes((int) $chasse_id);
+        $chasse_id = (int) $chasse_id;
+        if (
+            function_exists('ca_demo_is_demo_hunt')
+            && ca_demo_is_demo_hunt($chasse_id)
+        ) {
+            continue;
+        }
+
+        $total += chasse_compter_points_collectes($chasse_id);
     }
 
     return $total;

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -788,24 +788,26 @@ function myaccount_get_persistent_messages(int $user_id): array
  *
  * @return void
  */
-function myaccount_add_flash_message(
-    int $user_id,
-    string $message,
-    string $type = 'info',
-    bool $dismissible = false
-): void {
-    global $wpdb;
+if (!function_exists('myaccount_add_flash_message')) {
+    function myaccount_add_flash_message(
+        int $user_id,
+        string $message,
+        string $type = 'info',
+        bool $dismissible = false
+    ): void {
+        global $wpdb;
 
-    $repo = new UserMessageRepository($wpdb);
-    $repo->insert(
-        $user_id,
-        wp_json_encode([
-            'text'        => $message,
-            'type'        => $type,
-            'dismissible' => $dismissible,
-        ]),
-        'flash'
-    );
+        $repo = new UserMessageRepository($wpdb);
+        $repo->insert(
+            $user_id,
+            wp_json_encode([
+                'text'        => $message,
+                'type'        => $type,
+                'dismissible' => $dismissible,
+            ]),
+            'flash'
+        );
+    }
 }
 
 /**
@@ -815,27 +817,29 @@ function myaccount_add_flash_message(
  *
  * @return array<int, array{text:string,type:string,dismissible:bool}>
  */
-function myaccount_get_flash_messages(int $user_id): array
-{
-    global $wpdb;
+if (!function_exists('myaccount_get_flash_messages')) {
+    function myaccount_get_flash_messages(int $user_id): array
+    {
+        global $wpdb;
 
-    $repo = new UserMessageRepository($wpdb);
-    $rows = $repo->get($user_id, 'flash', false);
-    $messages = [];
+        $repo = new UserMessageRepository($wpdb);
+        $rows = $repo->get($user_id, 'flash', false);
+        $messages = [];
 
-    foreach ($rows as $row) {
-        $data = json_decode($row['message'], true);
-        if (is_array($data) && isset($data['text'])) {
-            $messages[] = [
-                'text'        => (string) $data['text'],
-                'type'        => isset($data['type']) ? (string) $data['type'] : 'info',
-                'dismissible' => !empty($data['dismissible']),
-            ];
+        foreach ($rows as $row) {
+            $data = json_decode($row['message'], true);
+            if (is_array($data) && isset($data['text'])) {
+                $messages[] = [
+                    'text'        => (string) $data['text'],
+                    'type'        => isset($data['type']) ? (string) $data['type'] : 'info',
+                    'dismissible' => !empty($data['dismissible']),
+                ];
+            }
+            $repo->delete((int) $row['id']);
         }
-        $repo->delete((int) $row['id']);
-    }
 
-    return $messages;
+        return $messages;
+    }
 }
 
 /**
@@ -1071,6 +1075,13 @@ function ca_get_user_engaged_hunt_ids(int $user_id): array
             continue;
         }
 
+        if (
+            function_exists('ca_demo_is_demo_hunt')
+            && ca_demo_is_demo_hunt($chasse_id)
+        ) {
+            continue;
+        }
+
         $chasse_ids[] = $chasse_id;
     }
 
@@ -1180,6 +1191,33 @@ function ca_render_recommended_hunts_empty_state(): string
     $query_args = apply_filters('ca_recommended_hunts_empty_state_query_args', $query_args);
 
     $recommended_query = new WP_Query($query_args);
+
+    if (
+        is_object($recommended_query)
+        && isset($recommended_query->posts)
+        && is_array($recommended_query->posts)
+    ) {
+        $recommended_query->posts = array_values(array_filter(
+            $recommended_query->posts,
+            static function ($post) {
+                $chasse_id = is_object($post) ? ($post->ID ?? 0) : (int) $post;
+
+                if ($chasse_id <= 0) {
+                    return false;
+                }
+
+                return !function_exists('ca_demo_is_demo_hunt')
+                    || !ca_demo_is_demo_hunt((int) $chasse_id);
+            }
+        ));
+        $recommended_query->post_count = count($recommended_query->posts);
+        if (property_exists($recommended_query, 'found_posts')) {
+            $recommended_query->found_posts = $recommended_query->post_count;
+        }
+        if (method_exists($recommended_query, 'rewind_posts')) {
+            $recommended_query->rewind_posts();
+        }
+    }
 
     $catalog_url = apply_filters(
         'ca_recommended_hunts_catalog_url',


### PR DESCRIPTION
## Résumé
- Harmonisation de la détection des chasses démo (CTA, progression, stats et engagement virtuel)
- Exclusion des chasses démo dans les agrégats front/back et invalidation des caches lors des bascules
- Couverture de l’ensemble avec des tests PHPUnit robustes (CTA et liste d’engagements)

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d62c7f8040833292f0aa276dd3dfc0