### PR TITLE
Add demo hunt reset workflow

### DIFF
--- a/tests/CaDemoResetUserProgressTest.php
+++ b/tests/CaDemoResetUserProgressTest.php
@@ -1,0 +1,429 @@
+<?php
+
+namespace CaDemoResetUserProgressTest;
+
+use PHPUnit\Framework\TestCase;
+
+class CaDemoResetUserProgressTest extends TestCase
+{
+    private function bootstrapHelpers(): void
+    {
+        if (!defined('CA_DEMO_ORGANISATEUR_LOGINS')) {
+            define('CA_DEMO_ORGANISATEUR_LOGINS', []);
+        }
+
+        $codeBlocks = [
+            <<<'PHP'
+namespace {
+    if (!class_exists('wpdb')) {
+        class wpdb
+        {
+            public string $prefix = 'wp_';
+            public string $usermeta = 'wp_usermeta';
+            public array $deleted_rows = [];
+            public array $queries = [];
+            private array $mockResults = [];
+            private array $mockCols = [];
+
+            public function prepare(string $query, ...$args): array
+            {
+                if (count($args) === 1 && is_array($args[0])) {
+                    $args = $args[0];
+                }
+
+                return [
+                    'query' => $query,
+                    'args'  => array_values($args),
+                ];
+            }
+
+            private function buildKey($prepared): string
+            {
+                if (is_array($prepared) && isset($prepared['query'])) {
+                    return $prepared['query'] . '|' . json_encode($prepared['args']);
+                }
+
+                return (string) $prepared;
+            }
+
+            public function register_results(string $query, array $args, array $results): void
+            {
+                $this->mockResults[$this->buildKey(['query' => $query, 'args' => array_values($args)])] = $results;
+            }
+
+            public function register_cols(string $query, array $args, array $cols): void
+            {
+                $this->mockCols[$this->buildKey(['query' => $query, 'args' => array_values($args)])] = $cols;
+            }
+
+            public function delete(string $table, array $where, array $formats = []): int
+            {
+                $this->deleted_rows[] = [
+                    'table'   => $table,
+                    'where'   => $where,
+                    'formats' => $formats,
+                ];
+
+                return 1;
+            }
+
+            public function get_col($prepared): array
+            {
+                return $this->mockCols[$this->buildKey($prepared)] ?? [];
+            }
+
+            public function get_results($prepared): array
+            {
+                return $this->mockResults[$this->buildKey($prepared)] ?? [];
+            }
+
+            public function query($prepared): bool
+            {
+                $this->queries[] = $this->buildKey($prepared);
+
+                return true;
+            }
+        }
+    }
+}
+PHP
+            ,
+            <<<'PHP'
+namespace {
+    if (!class_exists('WP_User')) {
+        class WP_User
+        {
+            public int $ID;
+            public array $roles = [];
+            public string $display_name = '';
+            public string $user_login = '';
+
+            public function __construct(int $id)
+            {
+                $this->ID = $id;
+                $this->display_name = 'Player ' . $id;
+                $this->user_login = 'player' . $id;
+            }
+
+            public function add_role($role): void
+            {
+                if (!in_array($role, $this->roles, true)) {
+                    $this->roles[] = $role;
+                }
+            }
+
+            public function remove_role($role): void
+            {
+                $this->roles = array_values(array_filter(
+                    $this->roles,
+                    static function ($registeredRole) use ($role) {
+                        return $registeredRole !== $role;
+                    }
+                ));
+            }
+
+            public function set_role($role): void
+            {
+                $this->roles = [$role];
+            }
+        }
+    }
+}
+PHP
+            ,
+            <<<'PHP'
+namespace {
+    if (!function_exists('get_organisateur_from_chasse')) {
+        function get_organisateur_from_chasse($chasseId)
+        {
+            return 321;
+        }
+    }
+
+    if (!function_exists('get_field')) {
+        function get_field($field, $postId = null)
+        {
+            global $mock_fields;
+
+            if ('utilisateurs_associes' === $field) {
+                return [new WP_User(42)];
+            }
+
+            return $mock_fields[$postId][$field] ?? null;
+        }
+    }
+
+    if (!function_exists('get_user_by')) {
+        function get_user_by($field, $value)
+        {
+            return new WP_User((int) $value);
+        }
+    }
+
+    if (!function_exists('get_userdata')) {
+        function get_userdata($userId)
+        {
+            return new WP_User((int) $userId);
+        }
+    }
+
+    if (!function_exists('recuperer_enigmes_associees')) {
+        function recuperer_enigmes_associees(int $chasseId): array
+        {
+            global $enigmes_map;
+
+            return $enigmes_map[$chasseId] ?? [];
+        }
+    }
+
+    if (!function_exists('update_field')) {
+        function update_field($name, $value, $postId)
+        {
+            global $updated_fields, $updated_fields_log;
+
+            if (!is_array($updated_fields ?? null)) {
+                $updated_fields = [];
+            }
+
+            if (!is_array($updated_fields_log ?? null)) {
+                $updated_fields_log = [];
+            }
+
+            $updated_fields[$name] = $value;
+            $updated_fields_log[] = [$name, $value, $postId];
+
+            return true;
+        }
+    }
+
+    if (!function_exists('delete_field')) {
+        function delete_field($name, $postId)
+        {
+            global $deleted_fields;
+            $deleted_fields[] = [$name, $postId];
+
+            return true;
+        }
+    }
+
+    if (!function_exists('delete_user_meta')) {
+        function delete_user_meta($userId, $key)
+        {
+            global $deleted_user_meta;
+            $deleted_user_meta[] = [$userId, $key];
+
+            return true;
+        }
+    }
+
+    if (!function_exists('clean_user_cache')) {
+        function clean_user_cache($userId)
+        {
+            global $cleaned_user_cache;
+            $cleaned_user_cache[] = $userId;
+        }
+    }
+}
+PHP
+            ,
+            <<<'PHP'
+namespace {
+    if (!function_exists('mettre_a_jour_statuts_chasse')) {
+        function mettre_a_jour_statuts_chasse($chasseId)
+        {
+            global $updated_statuses;
+            $updated_statuses[] = $chasseId;
+        }
+    }
+
+    if (!function_exists('chasse_clear_infos_affichage_cache')) {
+        function chasse_clear_infos_affichage_cache($chasseId)
+        {
+            global $cleared_chasse_cache;
+            $cleared_chasse_cache[] = $chasseId;
+        }
+    }
+
+    if (!function_exists('enigme_clear_sidebar_cache')) {
+        function enigme_clear_sidebar_cache($chasseId, $userId)
+        {
+            global $cleared_sidebar_cache;
+            $cleared_sidebar_cache[] = [$chasseId, $userId];
+        }
+    }
+
+    if (!function_exists('utilisateur_est_engage_dans_chasse')) {
+        function utilisateur_est_engage_dans_chasse($userId, $chasseId)
+        {
+            global $engaged_users;
+            $key = $chasseId . ':' . $userId;
+
+            return !empty($engaged_users[$key]);
+        }
+    }
+
+    if (!function_exists('is_user_logged_in')) {
+        function is_user_logged_in()
+        {
+            return true;
+        }
+    }
+
+    if (!function_exists('get_current_user_id')) {
+        function get_current_user_id()
+        {
+            return 23;
+        }
+    }
+
+    if (!function_exists('wp_verify_nonce')) {
+        function wp_verify_nonce($nonce, $action)
+        {
+            return $nonce === $action;
+        }
+    }
+
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($value)
+        {
+            return (string) $value;
+        }
+    }
+
+    if (!function_exists('wp_unslash')) {
+        function wp_unslash($value)
+        {
+            return $value;
+        }
+    }
+
+    if (!function_exists('wp_send_json_error')) {
+        function wp_send_json_error($data)
+        {
+            throw new \RuntimeException('ajax-error:' . json_encode($data));
+        }
+    }
+
+    if (!function_exists('wp_send_json_success')) {
+        function wp_send_json_success($data)
+        {
+            throw new \RuntimeException('ajax-success:' . json_encode($data));
+        }
+    }
+}
+PHP
+        ];
+
+        foreach ($codeBlocks as $block) {
+            eval($block);
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_resets_tables_and_metas(): void
+    {
+        $this->bootstrapHelpers();
+
+        global $wpdb, $mock_fields, $enigmes_map, $updated_fields, $updated_fields_log, $deleted_fields,
+            $deleted_user_meta, $cleaned_user_cache, $updated_statuses, $cleared_chasse_cache,
+            $cleared_sidebar_cache, $force_demo_overrides, $engaged_users;
+
+        $wpdb = new \wpdb();
+        $mock_fields = [
+            15 => [
+                'chasse_cache_gagnants'        => 'Player 23',
+                'chasse_cache_date_decouverte' => '2024-01-01 10:00:00',
+                'chasse_cache_complet'         => 1,
+            ],
+        ];
+        $enigmes_map = [15 => [101, 102]];
+        $updated_fields = [];
+        $updated_fields_log = [];
+        $deleted_fields = [];
+        $deleted_user_meta = [];
+        $cleaned_user_cache = [];
+        $updated_statuses = [];
+        $cleared_chasse_cache = [];
+        $cleared_sidebar_cache = [];
+        $force_demo_overrides = [15 => true];
+        $engaged_users = ['15:23' => true];
+
+        $wpdb->register_results(
+            'SELECT user_id, date_win FROM wp_chasse_winners WHERE chasse_id = %d ORDER BY date_win ASC',
+            [15],
+            []
+        );
+        $wpdb->register_cols(
+            'SELECT DISTINCT indice_id FROM wp_indices_deblocages WHERE user_id = %d AND chasse_id = %d',
+            [23, 15],
+            [301]
+        );
+        $wpdb->register_cols(
+            'SELECT DISTINCT indice_id FROM wp_indices_deblocages WHERE user_id = %d AND enigme_id IN (%d,%d)',
+            [23, 101, 102],
+            [302]
+        );
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse/demo.php';
+
+        $result = \ca_demo_reset_user_progress(15, 23);
+
+        $this->assertTrue($result);
+
+        $tables = array_column($wpdb->deleted_rows, 'table');
+        $this->assertContains('wp_chasse_winners', $tables);
+        $this->assertContains('wp_engagements', $tables);
+        $hasIndicesDelete = false;
+        foreach ($wpdb->queries as $query) {
+            if (strpos($query, 'wp_indices_deblocages') !== false) {
+                $hasIndicesDelete = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($hasIndicesDelete);
+
+        $this->assertContains(['chasse_cache_gagnants', '', 15], $updated_fields_log);
+        $this->assertContains(['chasse_cache_complet', 0, 15], $updated_fields_log);
+        $this->assertContains(['chasse_cache_date_decouverte', 15], $deleted_fields);
+
+        $expectedMeta = [
+            [23, 'souscription_chasse_15'],
+            [23, 'statut_enigme_101'],
+            [23, 'statut_enigme_102'],
+            [23, 'enigme_101_resolution_date'],
+            [23, 'enigme_102_resolution_date'],
+            [23, 'indice_debloque_301'],
+            [23, 'indice_debloque_302'],
+        ];
+        foreach ($expectedMeta as $meta) {
+            $this->assertContains($meta, $deleted_user_meta);
+        }
+
+        $this->assertSame([23], $cleaned_user_cache);
+        $this->assertSame([15], $updated_statuses);
+        $this->assertSame([15], $cleared_chasse_cache);
+        $this->assertContains([15, 23], $cleared_sidebar_cache);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_returns_false_when_not_demo(): void
+    {
+        $this->bootstrapHelpers();
+
+        global $wpdb, $force_demo_overrides;
+
+        $wpdb = new \wpdb();
+        $force_demo_overrides = [42 => false];
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse/demo.php';
+
+        $this->assertFalse(\ca_demo_reset_user_progress(42, 23));
+    }
+}

--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -384,10 +384,10 @@ class GenererCtaChasseTest extends TestCase
         $cta = generer_cta_chasse(123, 21);
 
         $this->assertTrue(ca_demo_is_demo_hunt(123));
-        $this->assertSame('engage', $cta['type']);
+        $this->assertSame('reset_demo', $cta['type']);
         $this->assertTrue($cta['is_demo']);
-        $this->assertStringContainsString('Voir mes énigmes', $cta['cta_html']);
-        $this->assertStringNotContainsString('<form', $cta['cta_html']);
+        $this->assertStringContainsString('Réinitialiser ma progression', $cta['cta_html']);
+        $this->assertStringContainsString('data-ca-demo-reset', $cta['cta_html']);
     }
 
     public function test_finished_hunt_requires_engagement_cta(): void

--- a/wp-content/themes/chassesautresor/assets/js/chasse-demo-reset.js
+++ b/wp-content/themes/chassesautresor/assets/js/chasse-demo-reset.js
@@ -1,0 +1,85 @@
+(function () {
+    function getButton(event) {
+        if (!event) {
+            return null;
+        }
+
+        var target = event.target;
+
+        if (target && typeof target.closest === 'function') {
+            return target.closest('[data-ca-demo-reset]');
+        }
+
+        if (target && target.parentElement && typeof target.parentElement.closest === 'function') {
+            return target.parentElement.closest('[data-ca-demo-reset]');
+        }
+
+        return null;
+    }
+
+    function handleClick(event) {
+        var button = getButton(event);
+        if (!button) {
+            return;
+        }
+
+        if (typeof caDemoReset === 'undefined') {
+            return;
+        }
+
+        event.preventDefault();
+
+        if (!window.confirm(caDemoReset.confirm)) {
+            return;
+        }
+
+        var nonce = button.getAttribute('data-nonce');
+        var chasseId = button.getAttribute('data-chasse-id');
+
+        if (!nonce || !chasseId) {
+            alert(caDemoReset.nonceError);
+            return;
+        }
+
+        button.disabled = true;
+
+        var params = new URLSearchParams();
+        params.append('action', 'ca_demo_reset_chasse');
+        params.append('nonce', nonce);
+        params.append('chasse_id', chasseId);
+
+        fetch(caDemoReset.ajaxUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            credentials: 'same-origin',
+            body: params.toString(),
+        })
+            .then(function (response) {
+                return response.json();
+            })
+            .then(function (data) {
+                if (data && data.success) {
+                    alert(caDemoReset.success);
+                    window.location.reload();
+                    return;
+                }
+
+                var message = caDemoReset.error;
+                if (data && data.data && data.data.message) {
+                    message = data.data.message;
+                }
+
+                alert(message);
+            })
+            .catch(function () {
+                alert(caDemoReset.error);
+            })
+            .finally(function () {
+                button.disabled = false;
+            });
+    }
+
+    document.addEventListener('click', handleClick);
+})();

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -477,6 +477,29 @@ add_action('wp_enqueue_scripts', function () {
             filemtime($theme_path . '/assets/js/chasse-engagement.js'),
             true
         );
+
+        $current_chasse_id = get_queried_object_id();
+        if (
+            $current_chasse_id
+            && function_exists('ca_demo_is_demo_hunt')
+            && ca_demo_is_demo_hunt((int) $current_chasse_id)
+        ) {
+            wp_enqueue_script(
+                'chasse-demo-reset',
+                $script_dir . 'chasse-demo-reset.js',
+                [],
+                filemtime($theme_path . '/assets/js/chasse-demo-reset.js'),
+                true
+            );
+
+            wp_localize_script('chasse-demo-reset', 'caDemoReset', [
+                'ajaxUrl'    => admin_url('admin-ajax.php'),
+                'confirm'    => __('Voulez-vous vraiment réinitialiser votre progression de démonstration ?', 'chassesautresor-com'),
+                'success'    => __('Votre progression a été réinitialisée.', 'chassesautresor-com'),
+                'error'      => __('Impossible de réinitialiser votre progression pour le moment.', 'chassesautresor-com'),
+                'nonceError' => __('Votre session a expiré. Merci de recharger la page.', 'chassesautresor-com'),
+            ]);
+        }
     }
 });
 

--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -184,12 +184,16 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
 
             $cta_data = generer_cta_chasse( $latest_chasse_id, get_current_user_id() );
 
-            if ( ( $cta_data['type'] ?? '' ) === 'engage' ) {
+            $latest_cta_type = $cta_data['type'] ?? '';
+
+            if ( $latest_cta_type === 'engage' ) {
                 $cta_data['cta_html'] = sprintf(
                     '<a href="%s" class="bouton-secondaire">%s</a>',
                     esc_url( get_permalink( $latest_chasse_id ) . '#chasse-enigmes-wrapper' ),
                     esc_html__( 'Voir mes énigmes', 'chassesautresor-com' )
                 );
+            } elseif ( $latest_cta_type === 'reset_demo' ) {
+                // Laisser le CTA de réinitialisation tel quel pour les chasses de démonstration.
             }
 
             $cta_data['cta_message'] = '';

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -785,6 +785,29 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
     $engage_override = $GLOBALS['force_engage_override'] ?? null;
     $est_engage = $engage_override !== null ? (bool) $engage_override : utilisateur_est_engage_dans_chasse($user_id, $chasse_id);
     if ($est_engage) {
+        if ($is_demo) {
+            $nonce_action = 'ca_demo_reset_chasse_' . $chasse_id . '_' . $user_id;
+            $nonce = function_exists('wp_create_nonce')
+                ? wp_create_nonce($nonce_action)
+                : $nonce_action;
+
+            $button_html = sprintf(
+                '<button type="button" class="bouton-cta bouton-cta--color" data-ca-demo-reset="1" data-chasse-id="%1$d" data-nonce="%2$s">%3$s</button>',
+                (int) $chasse_id,
+                esc_attr($nonce),
+                esc_html__('Réinitialiser ma progression', 'chassesautresor-com')
+            );
+
+            return $response([
+                'cta_html'    => $button_html,
+                'cta_message' => '<p class="cta-reset-demo__message">' . esc_html__(
+                    'Vous participez à cette chasse de démonstration.',
+                    'chassesautresor-com'
+                ) . '</p>',
+                'type'        => 'reset_demo',
+            ]);
+        }
+
         return $response([
             'cta_html'    => '<a href="#chasse-enigmes-wrapper" class="bouton-secondaire">' . esc_html__('Voir mes énigmes', 'chassesautresor-com') . '</a>',
             'cta_message' => '<p>✅ ' . esc_html__('Vous participez à cette chasse', 'chassesautresor-com') . '</p>',

--- a/wp-content/themes/chassesautresor/inc/chasse/demo.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/demo.php
@@ -16,6 +16,11 @@ function ca_demo_is_demo_hunt(int $chasse_id): bool
         return false;
     }
 
+    $overrides = $GLOBALS['force_demo_overrides'] ?? [];
+    if (isset($overrides[$chasse_id])) {
+        return (bool) $overrides[$chasse_id];
+    }
+
     if (isset($cache[$chasse_id])) {
         return $cache[$chasse_id];
     }
@@ -57,7 +62,15 @@ function ca_demo_is_demo_hunt(int $chasse_id): bool
     ));
 
     if (empty($allowed_logins)) {
-        $cache[$chasse_id] = false;
+        $cache[$chasse_id] = (bool) apply_filters(
+            'ca_demo_is_demo_hunt',
+            false,
+            $chasse_id,
+            [
+                'organisateur_id' => $organisateur_id,
+                'allowed_logins'  => [],
+            ]
+        );
 
         return $cache[$chasse_id];
     }
@@ -66,7 +79,15 @@ function ca_demo_is_demo_hunt(int $chasse_id): bool
         ? get_field('utilisateurs_associes', $organisateur_id)
         : [];
     if (!is_array($associated_users) || empty($associated_users)) {
-        $cache[$chasse_id] = false;
+        $cache[$chasse_id] = (bool) apply_filters(
+            'ca_demo_is_demo_hunt',
+            false,
+            $chasse_id,
+            [
+                'organisateur_id' => $organisateur_id,
+                'allowed_logins'  => $allowed_logins,
+            ]
+        );
 
         return $cache[$chasse_id];
     }
@@ -109,3 +130,239 @@ function ca_demo_is_demo_hunt(int $chasse_id): bool
 
     return $cache[$chasse_id];
 }
+
+function ca_demo_reset_user_progress(int $chasse_id, int $user_id): bool
+{
+    if ($chasse_id <= 0 || $user_id <= 0) {
+        return false;
+    }
+
+    if (!ca_demo_is_demo_hunt($chasse_id)) {
+        return false;
+    }
+
+    global $wpdb;
+
+    if (!isset($wpdb)) {
+        return false;
+    }
+
+    $chasse_id = (int) $chasse_id;
+    $user_id   = (int) $user_id;
+
+    $engagements_table = $wpdb->prefix . 'engagements';
+    $statuts_table     = $wpdb->prefix . 'enigme_statuts_utilisateur';
+    $tentatives_table  = $wpdb->prefix . 'enigme_tentatives';
+    $indices_table     = $wpdb->prefix . 'indices_deblocages';
+    $winners_table     = $wpdb->prefix . 'chasse_winners';
+
+    $enigme_ids = [];
+    if (function_exists('recuperer_enigmes_associees')) {
+        $enigme_ids = array_map('intval', recuperer_enigmes_associees($chasse_id));
+    }
+
+    $db_enigmes = $wpdb->get_col(
+        $wpdb->prepare(
+            "SELECT DISTINCT enigme_id FROM {$engagements_table} WHERE user_id = %d AND chasse_id = %d AND enigme_id IS NOT NULL",
+            $user_id,
+            $chasse_id
+        )
+    );
+
+    if (!empty($db_enigmes)) {
+        $enigme_ids = array_merge($enigme_ids, array_map('intval', $db_enigmes));
+    }
+
+    $enigme_ids = array_values(array_filter(array_unique($enigme_ids)));
+
+    $indice_ids = $wpdb->get_col(
+        $wpdb->prepare(
+            "SELECT DISTINCT indice_id FROM {$indices_table} WHERE user_id = %d AND chasse_id = %d",
+            $user_id,
+            $chasse_id
+        )
+    );
+
+    if (!empty($enigme_ids)) {
+        $placeholders = implode(',', array_fill(0, count($enigme_ids), '%d'));
+        $indices_from_enigmes = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT DISTINCT indice_id FROM {$indices_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                array_merge([$user_id], $enigme_ids)
+            )
+        );
+
+        if (!empty($indices_from_enigmes)) {
+            $indice_ids = array_merge($indice_ids, array_map('intval', $indices_from_enigmes));
+        }
+    }
+
+    $indice_ids = array_values(array_filter(array_unique(array_map('intval', $indice_ids))));
+
+    $wpdb->delete($winners_table, ['user_id' => $user_id, 'chasse_id' => $chasse_id], ['%d', '%d']);
+
+    $remaining_winners = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT user_id, date_win FROM {$winners_table} WHERE chasse_id = %d ORDER BY date_win ASC",
+            $chasse_id
+        )
+    );
+
+    $winner_names = [];
+    $win_date     = null;
+
+    foreach ($remaining_winners as $row) {
+        $winner_id = isset($row->user_id) ? (int) $row->user_id : 0;
+        $user      = $winner_id > 0 ? get_userdata($winner_id) : null;
+
+        if ($user) {
+            $display_name = $user->display_name ?: $user->user_login;
+            if ($display_name !== '') {
+                $winner_names[] = $display_name;
+            }
+        }
+
+        if ($win_date === null && !empty($row->date_win)) {
+            $win_date = (string) $row->date_win;
+        }
+    }
+
+    if (function_exists('update_field')) {
+        $list = implode(', ', $winner_names);
+        update_field('chasse_cache_gagnants', $list, $chasse_id);
+
+        if ($win_date) {
+            update_field('chasse_cache_date_decouverte', $win_date, $chasse_id);
+        } elseif (function_exists('delete_field')) {
+            delete_field('chasse_cache_date_decouverte', $chasse_id);
+        } else {
+            update_field('chasse_cache_date_decouverte', '', $chasse_id);
+        }
+
+        update_field('chasse_cache_complet', empty($winner_names) ? 0 : 1, $chasse_id);
+    }
+
+    $wpdb->delete($engagements_table, ['user_id' => $user_id, 'chasse_id' => $chasse_id], ['%d', '%d']);
+
+    if (!empty($enigme_ids)) {
+        $placeholders = implode(',', array_fill(0, count($enigme_ids), '%d'));
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$engagements_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                array_merge([$user_id], $enigme_ids)
+            )
+        );
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$statuts_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                array_merge([$user_id], $enigme_ids)
+            )
+        );
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$tentatives_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                array_merge([$user_id], $enigme_ids)
+            )
+        );
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$indices_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                array_merge([$user_id], $enigme_ids)
+            )
+        );
+    }
+
+    $wpdb->query(
+        $wpdb->prepare(
+            "DELETE FROM {$indices_table} WHERE user_id = %d AND chasse_id = %d",
+            $user_id,
+            $chasse_id
+        )
+    );
+
+    if (function_exists('delete_user_meta')) {
+        delete_user_meta($user_id, "souscription_chasse_{$chasse_id}");
+
+        foreach ($enigme_ids as $enigme_id) {
+            delete_user_meta($user_id, "statut_enigme_{$enigme_id}");
+            delete_user_meta($user_id, "enigme_{$enigme_id}_resolution_date");
+        }
+
+        foreach ($indice_ids as $indice_id) {
+            delete_user_meta($user_id, "indice_debloque_{$indice_id}");
+        }
+    }
+
+    if (function_exists('clean_user_cache')) {
+        clean_user_cache($user_id);
+    }
+
+    if (function_exists('mettre_a_jour_statuts_chasse')) {
+        mettre_a_jour_statuts_chasse($chasse_id);
+    }
+
+    if (function_exists('chasse_clear_infos_affichage_cache')) {
+        chasse_clear_infos_affichage_cache($chasse_id);
+    }
+
+    if (function_exists('enigme_clear_sidebar_cache')) {
+        enigme_clear_sidebar_cache($chasse_id, $user_id);
+    }
+
+    return true;
+}
+
+function ca_demo_reset_chasse_ajax(): void
+{
+    if (!is_user_logged_in()) {
+        wp_send_json_error([
+            'message' => __('Vous devez être connecté pour effectuer cette action.', 'chassesautresor-com'),
+        ]);
+    }
+
+    $chasse_id = isset($_POST['chasse_id']) ? (int) $_POST['chasse_id'] : 0;
+    $nonce     = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
+    $user_id   = get_current_user_id();
+
+    if ($chasse_id <= 0 || $user_id <= 0) {
+        wp_send_json_error([
+            'message' => __('Requête invalide.', 'chassesautresor-com'),
+        ]);
+    }
+
+    $expected_nonce = 'ca_demo_reset_chasse_' . $chasse_id . '_' . $user_id;
+    if (!wp_verify_nonce($nonce, $expected_nonce)) {
+        wp_send_json_error([
+            'message' => __('Votre session a expiré. Rechargez la page puis réessayez.', 'chassesautresor-com'),
+        ]);
+    }
+
+    if (!ca_demo_is_demo_hunt($chasse_id)) {
+        wp_send_json_error([
+            'message' => __('Cette chasse ne peut pas être réinitialisée.', 'chassesautresor-com'),
+        ]);
+    }
+
+    if (!utilisateur_est_engage_dans_chasse($user_id, $chasse_id)) {
+        wp_send_json_error([
+            'message' => __('Vous ne participez pas à cette chasse.', 'chassesautresor-com'),
+        ]);
+    }
+
+    $result = ca_demo_reset_user_progress($chasse_id, $user_id);
+
+    if (!$result) {
+        wp_send_json_error([
+            'message' => __('Impossible de réinitialiser votre progression pour le moment.', 'chassesautresor-com'),
+        ]);
+    }
+
+    wp_send_json_success([
+        'message' => __('Votre progression a été réinitialisée.', 'chassesautresor-com'),
+    ]);
+}
+add_action('wp_ajax_ca_demo_reset_chasse', 'ca_demo_reset_chasse_ajax');

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -538,7 +538,20 @@ if ($edition_active && !$est_complet) {
           ?>
           <div class="cta-chasse-row"<?php echo $cta_id ? ' id="' . esc_attr($cta_id) . '"' : ''; ?>>
             <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
-            <div class="cta-action"><?= $cta_data['cta_html']; ?></div>
+            <div class="cta-action">
+              <?= $cta_data['cta_html']; ?>
+              <?php if ($cta_type === 'reset_demo') : ?>
+                <p class="cta-reset-demo__confirm">
+                  <?php esc_html_e('Confirmez la réinitialisation dans la fenêtre qui s’ouvrira.', 'chassesautresor-com'); ?>
+                </p>
+                <a
+                  class="cta-reset-demo__fallback bouton-secondaire"
+                  href="<?= esc_url(get_permalink($chasse_id) . '#chasse-enigmes-wrapper'); ?>"
+                >
+                  <?php esc_html_e('Voir mes énigmes', 'chassesautresor-com'); ?>
+                </a>
+              <?php endif; ?>
+            </div>
           </div>
           </div>
 


### PR DESCRIPTION
Résumé
Mise en place d'un flux complet de réinitialisation pour les chasses de démonstration.

- Expose un CTA spécifique de réinitialisation sur les chasses démo engagées et adapte les templates/hero.
- Implémente la purge des données d'engagement côté PHP avec action AJAX dédiée et script front.
- Ajoute des tests unitaires pour couvrir la réinitialisation et met à jour les attentes de CTA.

Tests
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml --stop-on-error`


------
https://chatgpt.com/codex/tasks/task_e_68d63b9294e88332bb441495f9df10f1