### PR TITLE
Add recommended hunts slider

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/engaged-hunts-pager.js
+++ b/wp-content/themes/chassesautresor/assets/js/engaged-hunts-pager.js
@@ -95,6 +95,9 @@
 
         if (typeof data.html === 'string') {
           container.innerHTML = data.html;
+          if (window.caRecommendedSlider && typeof window.caRecommendedSlider.init === 'function') {
+            window.caRecommendedSlider.init(container);
+          }
         }
 
         const newPage = typeof data.page === 'number' && data.page > 0 ? data.page : page;

--- a/wp-content/themes/chassesautresor/assets/js/myaccount.js
+++ b/wp-content/themes/chassesautresor/assets/js/myaccount.js
@@ -15,6 +15,14 @@ document.addEventListener('DOMContentLoaded', () => {
   let outsideClickHandler = null;
   let keydownHandler = null;
 
+  const initRecommendedSlider = (root = document) => {
+    if (window.caRecommendedSlider && typeof window.caRecommendedSlider.init === 'function') {
+      window.caRecommendedSlider.init(root);
+    }
+  };
+
+  initRecommendedSlider(document);
+
   const setSidebarExpanded = (isOpen) => {
     if (!sidebarToggle) {
       return;
@@ -178,6 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
         siteMessages.innerHTML = messages;
       }
       content.innerHTML = data.data.html;
+      initRecommendedSlider(content);
       decorateMessages();
       fadeFlash();
       document

--- a/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
+++ b/wp-content/themes/chassesautresor/assets/js/recommended-hunts-slider.js
@@ -1,0 +1,236 @@
+(function () {
+  const SLIDER_SELECTOR = '[data-recommended-slider]';
+  const TRACK_SELECTOR = '[data-recommended-slider-track]';
+  const SLIDE_SELECTOR = '[data-recommended-slide]';
+  const PREV_SELECTOR = '[data-recommended-slider-prev]';
+  const NEXT_SELECTOR = '[data-recommended-slider-next]';
+
+  function toElement(root) {
+    if (root && typeof root.querySelectorAll === 'function') {
+      return root;
+    }
+    return document;
+  }
+
+  function initSlider(slider) {
+    if (!slider || slider.dataset.sliderReady === '1') {
+      return;
+    }
+
+    const track = slider.querySelector(TRACK_SELECTOR);
+    const viewport = slider.querySelector('[data-recommended-slider-viewport]');
+    const slides = track ? Array.from(track.querySelectorAll(SLIDE_SELECTOR)) : [];
+
+    if (!track || !slides.length || !viewport) {
+      return;
+    }
+
+    const prev = slider.querySelector(PREV_SELECTOR);
+    const next = slider.querySelector(NEXT_SELECTOR);
+    const totalSlides = slides.length;
+    let currentIndex = 0;
+    let slideOffsets = [];
+    let resizeObserver = null;
+    let resizeHandler = null;
+    let autoplayId = null;
+
+    const label = slider.getAttribute('data-slider-label');
+    if (label) {
+      slider.setAttribute('aria-label', label);
+    }
+
+    slider.setAttribute('role', 'region');
+    slider.setAttribute('aria-roledescription', 'carousel');
+    slider.setAttribute('tabindex', '0');
+    slider.setAttribute('data-slides-count', String(totalSlides));
+    slider.style.setProperty('--recommended-slider-count', String(totalSlides));
+    track.style.setProperty('--recommended-slider-count', String(totalSlides));
+
+    slides.forEach((slide, index) => {
+      slide.setAttribute('role', 'group');
+      slide.setAttribute('aria-roledescription', 'slide');
+      slide.setAttribute('aria-label', `${index + 1} / ${totalSlides}`);
+    });
+
+    function refreshOffsets() {
+      const firstOffset = slides.length > 0 ? slides[0].offsetLeft : 0;
+      slideOffsets = slides.map((slide) => slide.offsetLeft - firstOffset);
+    }
+
+    function applyTransform() {
+      const offset = slideOffsets[currentIndex] || 0;
+      track.style.transform = `translate3d(-${offset}px, 0, 0)`;
+    }
+
+    function update() {
+      applyTransform();
+      slides.forEach((slide, index) => {
+        const isActive = index === currentIndex;
+        slide.classList.toggle('is-active', isActive);
+        slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+
+      if (prev) {
+        prev.disabled = currentIndex === 0;
+      }
+      if (next) {
+        next.disabled = currentIndex === totalSlides - 1;
+      }
+    }
+
+    function goTo(index, options = {}) {
+      const settings = Object.assign({ wrap: false }, options);
+
+      if (totalSlides <= 1) {
+        return false;
+      }
+
+      const maxIndex = totalSlides - 1;
+      let targetIndex = index;
+
+      if (settings.wrap) {
+        targetIndex = ((index % totalSlides) + totalSlides) % totalSlides;
+      } else {
+        targetIndex = Math.max(0, Math.min(index, maxIndex));
+      }
+
+      if (targetIndex === currentIndex) {
+        return false;
+      }
+
+      currentIndex = targetIndex;
+      update();
+      return true;
+    }
+
+    function stopAutoplay() {
+      if (autoplayId) {
+        window.clearInterval(autoplayId);
+        autoplayId = null;
+      }
+    }
+
+    function startAutoplay() {
+      if (autoplayId || totalSlides <= 1) {
+        return;
+      }
+
+      const delay = Number(slider.getAttribute('data-slider-autoplay-delay')) || 6000;
+      autoplayId = window.setInterval(() => {
+        const changed = goTo(currentIndex + 1, { wrap: true });
+        if (!changed && totalSlides > 1) {
+          currentIndex = 0;
+          update();
+        }
+      }, Math.max(delay, 1000));
+    }
+
+    function restartAutoplay() {
+      stopAutoplay();
+      startAutoplay();
+    }
+
+    if (prev) {
+      prev.addEventListener('click', () => {
+        const moved = goTo(currentIndex - 1);
+        if (moved) {
+          restartAutoplay();
+        }
+      });
+    }
+
+    if (next) {
+      next.addEventListener('click', () => {
+        const moved = goTo(currentIndex + 1);
+        if (moved) {
+          restartAutoplay();
+        }
+      });
+    }
+
+    slider.addEventListener('keydown', (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        const moved = goTo(currentIndex - 1);
+        if (moved) {
+          restartAutoplay();
+        }
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        const moved = goTo(currentIndex + 1);
+        if (moved) {
+          restartAutoplay();
+        }
+      }
+    });
+
+    slider.addEventListener('mouseenter', stopAutoplay);
+    slider.addEventListener('mouseleave', startAutoplay);
+    slider.addEventListener('focusin', stopAutoplay);
+    slider.addEventListener('focusout', (event) => {
+      if (!slider.contains(event.relatedTarget)) {
+        startAutoplay();
+      }
+    });
+
+    const handleResize = () => {
+      refreshOffsets();
+      applyTransform();
+    };
+
+    const cleanup = () => {
+      slider.removeEventListener('recommended-slider:destroy', cleanup);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
+      if (resizeHandler) {
+        window.removeEventListener('resize', resizeHandler);
+        resizeHandler = null;
+      }
+      stopAutoplay();
+    };
+
+    slider.addEventListener('recommended-slider:destroy', cleanup);
+
+    refreshOffsets();
+    update();
+    startAutoplay();
+
+    if (typeof ResizeObserver === 'function') {
+      resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(viewport);
+    } else {
+      resizeHandler = handleResize;
+      window.addEventListener('resize', resizeHandler);
+    }
+
+    if (typeof MutationObserver === 'function') {
+      const observer = new MutationObserver(() => {
+        if (!document.body.contains(slider)) {
+          cleanup();
+          observer.disconnect();
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    slider.dataset.sliderReady = '1';
+  }
+
+  function init(root) {
+    const context = toElement(root);
+    const sliders = context.querySelectorAll(SLIDER_SELECTOR);
+    sliders.forEach(initSlider);
+  }
+
+  window.caRecommendedSlider = window.caRecommendedSlider || {};
+  window.caRecommendedSlider.init = function initRecommendedSlider(root) {
+    init(root);
+  };
+})();

--- a/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_mon-compte.scss
@@ -713,8 +713,8 @@
     gap: var(--space-lg);
     padding: var(--space-lg);
     border-radius: 12px;
-    background: hsl(var(--card));
-    border: 1px solid hsl(var(--border));
+    background: transparent;
+    border: 0;
 }
 
 .myaccount-recommended-hunts .myaccount-placeholder,
@@ -724,8 +724,92 @@
     color: hsl(var(--muted-foreground));
 }
 
-.myaccount-chasses-recommandees-grid {
-    gap: var(--space-lg);
+.myaccount-recommended-slider {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    width: 100%;
+}
+
+.recommended-slider__viewport {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    border-radius: 10px;
+    scroll-snap-type: x mandatory;
+}
+
+
+.recommended-slider__track {
+    --recommended-slider-count: 1;
+    display: flex;
+    min-height: 100%;
+    transition: transform 0.4s ease;
+    will-change: transform;
+}
+
+.recommended-slider__slide {
+    flex: 0 0 100%;
+    display: flex;
+    justify-content: center;
+    padding: 0 var(--space-xs);
+    box-sizing: border-box;
+    scroll-snap-align: center;
+}
+
+.recommended-slider__slide-inner {
+    width: 100%;
+    max-width: 320px;
+}
+
+.recommended-slider__slide-inner > * {
+    width: 100%;
+}
+
+.myaccount-recommended-slider[data-slides-count='1'] .recommended-slider__viewport {
+    max-width: min(100%, 360px);
+    margin: 0 auto;
+}
+
+.myaccount-recommended-slider[data-slides-count='1'] .recommended-slider__track {
+    justify-content: center;
+}
+
+.recommended-slider__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-size: 1.25rem;
+    line-height: 1;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.recommended-slider__control span {
+    pointer-events: none;
+}
+
+.recommended-slider__control:hover,
+.recommended-slider__control:focus-visible {
+    background: hsl(var(--card));
+    border-color: hsl(var(--primary));
+    color: hsl(var(--primary));
+}
+
+.recommended-slider__control:focus-visible {
+    outline: 2px solid hsl(var(--primary));
+    outline-offset: 2px;
+}
+
+.recommended-slider__control:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
 }
 
 .myaccount-recommended-hunts-cta {
@@ -748,8 +832,14 @@
         padding: var(--space-xl);
     }
 
-    .myaccount-chasses-recommandees-grid {
-        gap: var(--space-2xl);
+    .myaccount-recommended-slider {
+        gap: var(--space-md);
+    }
+
+    .recommended-slider__control {
+        width: 48px;
+        height: 48px;
+        font-size: 1.5rem;
     }
 
     .myaccount-recommended-hunts-cta {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -10361,8 +10361,8 @@ footer .site-footer-primary-section-3 {
   gap: var(--space-lg);
   padding: var(--space-lg);
   border-radius: 12px;
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
+  background: transparent;
+  border: 0;
 }
 
 .myaccount-recommended-hunts .myaccount-placeholder,
@@ -10372,8 +10372,91 @@ footer .site-footer-primary-section-3 {
   color: hsl(var(--muted-foreground));
 }
 
-.myaccount-chasses-recommandees-grid {
-  gap: var(--space-lg);
+.myaccount-recommended-slider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.recommended-slider__viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  border-radius: 10px;
+  scroll-snap-type: x mandatory;
+}
+
+.recommended-slider__track {
+  --recommended-slider-count: 1;
+  display: flex;
+  min-height: 100%;
+  transition: transform 0.4s ease;
+  will-change: transform;
+}
+
+.recommended-slider__slide {
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0 var(--space-xs);
+  box-sizing: border-box;
+  scroll-snap-align: center;
+}
+
+.recommended-slider__slide-inner {
+  width: 100%;
+  max-width: 320px;
+}
+
+.recommended-slider__slide-inner > * {
+  width: 100%;
+}
+
+.myaccount-recommended-slider[data-slides-count="1"] .recommended-slider__viewport {
+  max-width: min(100%, 360px);
+  margin: 0 auto;
+}
+
+.myaccount-recommended-slider[data-slides-count="1"] .recommended-slider__track {
+  justify-content: center;
+}
+
+.recommended-slider__control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-size: 1.25rem;
+  line-height: 1;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.recommended-slider__control span {
+  pointer-events: none;
+}
+
+.recommended-slider__control:hover,
+.recommended-slider__control:focus-visible {
+  background: hsl(var(--card));
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary));
+}
+
+.recommended-slider__control:focus-visible {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+}
+
+.recommended-slider__control:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .myaccount-recommended-hunts-cta {
@@ -10395,8 +10478,13 @@ footer .site-footer-primary-section-3 {
   .myaccount-recommended-hunts {
     padding: var(--space-xl);
   }
-  .myaccount-chasses-recommandees-grid {
-    gap: var(--space-2xl);
+  .myaccount-recommended-slider {
+    gap: var(--space-md);
+  }
+  .recommended-slider__control {
+    width: 48px;
+    height: 48px;
+    font-size: 1.5rem;
   }
   .myaccount-recommended-hunts-cta {
     align-self: center;

--- a/wp-content/themes/chassesautresor/functions.php
+++ b/wp-content/themes/chassesautresor/functions.php
@@ -410,9 +410,17 @@ add_action('wp_enqueue_scripts', function () {
 
     if (is_account_page() && is_user_logged_in()) {
         wp_enqueue_script(
+            'recommended-hunts-slider',
+            $script_dir . 'recommended-hunts-slider.js',
+            [],
+            filemtime($theme_path . '/assets/js/recommended-hunts-slider.js'),
+            true
+        );
+
+        wp_enqueue_script(
             'myaccount',
             $script_dir . 'myaccount.js',
-            [],
+            ['recommended-hunts-slider'],
             filemtime($theme_path . '/assets/js/myaccount.js'),
             true
         );

--- a/wp-content/themes/chassesautresor/inc/user-functions.php
+++ b/wp-content/themes/chassesautresor/inc/user-functions.php
@@ -1175,55 +1175,135 @@ function ca_get_engaged_hunts_content_html(
  */
 function ca_render_recommended_hunts_empty_state(): string
 {
-    $query_args = [
-        'post_type'      => 'chasse',
-        'post_status'    => 'publish',
-        'posts_per_page' => 3,
-        'meta_key'       => 'ca_total_engagements',
-        'orderby'        => 'meta_value_num',
-        'order'          => 'DESC',
-        'no_found_rows'  => true,
+    $valid_statuses = ['a_venir', 'en_cours', 'payante'];
+    $base_meta_query = [
+        'relation' => 'AND',
+        [
+            'key'     => 'chasse_cache_statut',
+            'value'   => $valid_statuses,
+            'compare' => 'IN',
+        ],
+        [
+            'key'   => 'chasse_cache_statut_validation',
+            'value' => 'valide',
+        ],
     ];
 
-    /**
-     * Allow third-parties to tweak the recommended hunts query.
-     */
-    $query_args = apply_filters('ca_recommended_hunts_empty_state_query_args', $query_args);
+    $recent_query_args = apply_filters(
+        'ca_recommended_hunts_recent_query_args',
+        [
+            'post_type'        => 'chasse',
+            'post_status'      => 'publish',
+            'posts_per_page'   => 2,
+            'orderby'          => 'date',
+            'order'            => 'DESC',
+            'no_found_rows'    => true,
+            'fields'           => 'ids',
+            'suppress_filters' => false,
+            'meta_query'       => $base_meta_query,
+        ]
+    );
 
-    $recommended_query = new WP_Query($query_args);
+    $recent_ids = array_map('intval', get_posts($recent_query_args));
 
-    if (
-        is_object($recommended_query)
-        && isset($recommended_query->posts)
-        && is_array($recommended_query->posts)
-    ) {
-        $recommended_query->posts = array_values(array_filter(
-            $recommended_query->posts,
-            static function ($post) {
-                $chasse_id = is_object($post) ? ($post->ID ?? 0) : (int) $post;
+    $active_meta_query = $base_meta_query;
+    $active_meta_query[0]['value'] = ['en_cours', 'payante'];
 
-                if ($chasse_id <= 0) {
-                    return false;
-                }
+    $popular_query_args = apply_filters(
+        'ca_recommended_hunts_popular_query_args',
+        [
+            'post_type'        => 'chasse',
+            'post_status'      => 'publish',
+            'posts_per_page'   => 1,
+            'meta_key'         => 'ca_total_engagements',
+            'orderby'          => 'meta_value_num',
+            'order'            => 'DESC',
+            'no_found_rows'    => true,
+            'fields'           => 'ids',
+            'suppress_filters' => false,
+            'meta_query'       => $active_meta_query,
+        ]
+    );
 
-                return !function_exists('ca_demo_is_demo_hunt')
-                    || !ca_demo_is_demo_hunt((int) $chasse_id);
-            }
-        ));
-        $recommended_query->post_count = count($recommended_query->posts);
-        if (property_exists($recommended_query, 'found_posts')) {
-            $recommended_query->found_posts = $recommended_query->post_count;
-        }
-        if (method_exists($recommended_query, 'rewind_posts')) {
-            $recommended_query->rewind_posts();
+    $popular_ids = array_map('intval', get_posts($popular_query_args));
+
+    $recommended_ids = array_values(array_unique(array_merge($recent_ids, $popular_ids)));
+
+    if (count($recommended_ids) < 3) {
+        $fallback_query_args = apply_filters(
+            'ca_recommended_hunts_fallback_query_args',
+            [
+                'post_type'        => 'chasse',
+                'post_status'      => 'publish',
+                'posts_per_page'   => 3 - count($recommended_ids),
+                'orderby'          => 'date',
+                'order'            => 'DESC',
+                'no_found_rows'    => true,
+                'fields'           => 'ids',
+                'suppress_filters' => false,
+                'meta_query'       => $base_meta_query,
+                'post__not_in'     => $recommended_ids,
+            ]
+        );
+
+        $additional_ids = array_map('intval', get_posts($fallback_query_args));
+        if (!empty($additional_ids)) {
+            $recommended_ids = array_values(array_unique(array_merge($recommended_ids, $additional_ids)));
         }
     }
+
+    if (count($recommended_ids) < 3) {
+        $completed_query_args = apply_filters(
+            'ca_recommended_hunts_completed_query_args',
+            [
+                'post_type'        => 'chasse',
+                'post_status'      => 'publish',
+                'posts_per_page'   => 3 - count($recommended_ids),
+                'orderby'          => 'date',
+                'order'            => 'DESC',
+                'no_found_rows'    => true,
+                'fields'           => 'ids',
+                'suppress_filters' => false,
+                'meta_query'       => [
+                    [
+                        'key'   => 'chasse_cache_statut',
+                        'value' => 'termine',
+                    ],
+                    [
+                        'key'   => 'chasse_cache_statut_validation',
+                        'value' => 'valide',
+                    ],
+                ],
+                'post__not_in'     => $recommended_ids,
+            ]
+        );
+
+        $completed_ids = array_map('intval', get_posts($completed_query_args));
+        if (!empty($completed_ids)) {
+            $recommended_ids = array_values(array_unique(array_merge($recommended_ids, $completed_ids)));
+        }
+    }
+
+    $recommended_ids = array_slice($recommended_ids, 0, 3);
+
+    /**
+     * Allow third-parties to tweak the final recommended hunts selection.
+     *
+     * @param int[] $recommended_ids Selected hunt identifiers.
+     */
+    $recommended_ids = apply_filters('ca_recommended_hunts_empty_state_ids', $recommended_ids);
+    $recommended_ids = array_values(array_unique(array_filter(array_map('intval', (array) $recommended_ids))));
 
     $catalog_url = apply_filters(
         'ca_recommended_hunts_catalog_url',
         home_url('/'),
         '/'
     );
+
+    $slider_label = __('Chasses recommandées', 'chassesautresor-com');
+    $show_controls = count($recommended_ids) > 1;
+    $slider_id = wp_unique_id('recommended-slider-');
+    $track_id  = $slider_id . '-track';
 
     ob_start();
     ?>
@@ -1232,20 +1312,67 @@ function ca_render_recommended_hunts_empty_state(): string
             <?php esc_html_e('Vous ne participez à aucune chasse pour le moment. Voici quelques idées pour démarrer votre prochaine aventure.', 'chassesautresor-com'); ?>
         </p>
 
-        <?php if ($recommended_query->have_posts()) : ?>
-            <?php
-            get_template_part(
-                'template-parts/chasse/boucle-chasses',
-                null,
-                [
-                    'show_header' => false,
-                    'mode'        => 'carte',
-                    'grid_class'  => 'cards-grid myaccount-chasses-recommandees-grid',
-                    'query'       => $recommended_query,
-                    'show_progression' => false,
-                ]
-            );
-            ?>
+        <?php if (!empty($recommended_ids)) : ?>
+            <div
+                id="<?php echo esc_attr($slider_id); ?>"
+                class="myaccount-recommended-slider"
+                data-recommended-slider
+                data-slider-label="<?php echo esc_attr($slider_label); ?>"
+            >
+                <?php if ($show_controls) : ?>
+                    <button
+                        type="button"
+                        class="recommended-slider__control recommended-slider__control--prev"
+                        data-recommended-slider-prev
+                        aria-controls="<?php echo esc_attr($track_id); ?>"
+                        aria-label="<?php esc_attr_e('Afficher la chasse précédente', 'chassesautresor-com'); ?>"
+                        disabled
+                    >
+                        <span aria-hidden="true">&#10094;</span>
+                    </button>
+                <?php endif; ?>
+
+                <div class="recommended-slider__viewport" data-recommended-slider-viewport>
+                    <div
+                        id="<?php echo esc_attr($track_id); ?>"
+                        class="recommended-slider__track"
+                        data-recommended-slider-track
+                    >
+                        <?php foreach ($recommended_ids as $index => $chasse_id) : ?>
+                            <div
+                                class="recommended-slider__slide"
+                                data-recommended-slide
+                                data-slide-index="<?php echo esc_attr((string) $index); ?>"
+                            >
+                                <div class="recommended-slider__slide-inner">
+                                    <?php
+                                    get_template_part(
+                                        'template-parts/chasse/chasse-card-compact',
+                                        null,
+                                        [
+                                            'chasse_id'        => $chasse_id,
+                                            'show_progression' => false,
+                                        ]
+                                    );
+                                    ?>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+
+                <?php if ($show_controls) : ?>
+                    <button
+                        type="button"
+                        class="recommended-slider__control recommended-slider__control--next"
+                        data-recommended-slider-next
+                        aria-controls="<?php echo esc_attr($track_id); ?>"
+                        aria-label="<?php esc_attr_e('Afficher la chasse suivante', 'chassesautresor-com'); ?>"
+                    >
+                        <span aria-hidden="true">&#10095;</span>
+                    </button>
+                <?php endif; ?>
+            </div>
         <?php else : ?>
             <p class="myaccount-recommended-hunts-intro">
                 <?php esc_html_e('Aucune recommandation disponible pour le moment, mais notre catalogue vous attend.', 'chassesautresor-com'); ?>
@@ -1257,8 +1384,6 @@ function ca_render_recommended_hunts_empty_state(): string
         </a>
     </div>
     <?php
-
-    wp_reset_postdata();
 
     return ob_get_clean();
 }


### PR DESCRIPTION
Résumé : Ajout d'un carrousel de chasses recommandées dans l'espace Mon Compte.

- Introduit un module JavaScript pour initialiser un carrousel accessible des chasses recommandées et l'intègre aux chargements AJAX du tableau de bord.
- Revoit la sélection PHP des chasses recommandées pour combiner nouveautés, succès populaires et solutions de repli, avec un rendu en slider.
- Met à jour les styles SCSS/CSS pour présenter le carrousel et charge les scripts nécessaires sur la page Mon Compte.

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d64bd808548332b44c5b5b880bb5cb