### PR TITLE
Planifie le reset des chasses démo après victoire

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse/demo.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/demo.php
@@ -8,312 +8,395 @@ defined('ABSPATH') || exit();
  *
  * @return bool
  */
-function ca_demo_is_demo_hunt(int $chasse_id): bool
-{
-    static $cache = [];
-
-    if ($chasse_id <= 0) {
-        return false;
-    }
-
-    $overrides = $GLOBALS['force_demo_overrides'] ?? [];
-    if (isset($overrides[$chasse_id])) {
-        return (bool) $overrides[$chasse_id];
-    }
-
-    if (isset($cache[$chasse_id])) {
-        return $cache[$chasse_id];
-    }
-
-    if (!function_exists('get_organisateur_from_chasse')) {
-        $cache[$chasse_id] = false;
-
-        return $cache[$chasse_id];
-    }
-
-    $organisateur_id = get_organisateur_from_chasse($chasse_id);
-    if (!$organisateur_id) {
-        $cache[$chasse_id] = false;
-
-        return $cache[$chasse_id];
-    }
-
-    $configured_logins = CA_DEMO_ORGANISATEUR_LOGINS;
-    if (!is_array($configured_logins)) {
-        $configured_logins = [];
-    }
-
-    $configured_logins = array_filter(array_map(
-        static function ($login) {
-            $login = is_string($login) ? trim($login) : '';
-
-            return $login !== '' ? strtolower($login) : null;
-        },
-        $configured_logins
-    ));
-
-    /** @var string[] $allowed_logins */
-    $allowed_logins = apply_filters('ca_demo_organisateur_logins', array_values($configured_logins));
-    $allowed_logins = array_filter(array_map(
-        static function ($login) {
-            return is_string($login) ? strtolower(trim($login)) : null;
-        },
-        $allowed_logins
-    ));
-
-    if (empty($allowed_logins)) {
-        $cache[$chasse_id] = (bool) apply_filters(
+if (!function_exists('ca_demo_is_demo_hunt')) {
+    function ca_demo_is_demo_hunt(int $chasse_id): bool
+    {
+        static $cache = [];
+    
+        if ($chasse_id <= 0) {
+            return false;
+        }
+    
+        $overrides = $GLOBALS['force_demo_overrides'] ?? [];
+        if (isset($overrides[$chasse_id])) {
+            return (bool) $overrides[$chasse_id];
+        }
+    
+        if (isset($cache[$chasse_id])) {
+            return $cache[$chasse_id];
+        }
+    
+        if (!function_exists('get_organisateur_from_chasse')) {
+            $cache[$chasse_id] = false;
+    
+            return $cache[$chasse_id];
+        }
+    
+        $organisateur_id = get_organisateur_from_chasse($chasse_id);
+        if (!$organisateur_id) {
+            $cache[$chasse_id] = false;
+    
+            return $cache[$chasse_id];
+        }
+    
+        $configured_logins = CA_DEMO_ORGANISATEUR_LOGINS;
+        if (!is_array($configured_logins)) {
+            $configured_logins = [];
+        }
+    
+        $configured_logins = array_filter(array_map(
+            static function ($login) {
+                $login = is_string($login) ? trim($login) : '';
+    
+                return $login !== '' ? strtolower($login) : null;
+            },
+            $configured_logins
+        ));
+    
+        /** @var string[] $allowed_logins */
+        $allowed_logins = apply_filters('ca_demo_organisateur_logins', array_values($configured_logins));
+        $allowed_logins = array_filter(array_map(
+            static function ($login) {
+                return is_string($login) ? strtolower(trim($login)) : null;
+            },
+            $allowed_logins
+        ));
+    
+        if (empty($allowed_logins)) {
+            $cache[$chasse_id] = (bool) apply_filters(
+                'ca_demo_is_demo_hunt',
+                false,
+                $chasse_id,
+                [
+                    'organisateur_id' => $organisateur_id,
+                    'allowed_logins'  => [],
+                ]
+            );
+    
+            return $cache[$chasse_id];
+        }
+    
+        $associated_users = function_exists('get_field')
+            ? get_field('utilisateurs_associes', $organisateur_id)
+            : [];
+        if (!is_array($associated_users) || empty($associated_users)) {
+            $cache[$chasse_id] = (bool) apply_filters(
+                'ca_demo_is_demo_hunt',
+                false,
+                $chasse_id,
+                [
+                    'organisateur_id' => $organisateur_id,
+                    'allowed_logins'  => $allowed_logins,
+                ]
+            );
+    
+            return $cache[$chasse_id];
+        }
+    
+        $is_demo = false;
+    
+        foreach ($associated_users as $user_entry) {
+            if ($user_entry instanceof WP_User) {
+                $user = $user_entry;
+            } elseif (is_array($user_entry) && isset($user_entry['ID'])) {
+                $user = get_user_by('id', (int) $user_entry['ID']);
+            } elseif (is_numeric($user_entry)) {
+                $user = get_user_by('id', (int) $user_entry);
+            } else {
+                $user = null;
+            }
+    
+            if (!$user instanceof WP_User) {
+                continue;
+            }
+    
+            $login = strtolower($user->user_login);
+            if (in_array($login, $allowed_logins, true)) {
+                $is_demo = true;
+                break;
+            }
+        }
+    
+        $filtered = (bool) apply_filters(
             'ca_demo_is_demo_hunt',
-            false,
-            $chasse_id,
-            [
-                'organisateur_id' => $organisateur_id,
-                'allowed_logins'  => [],
-            ]
-        );
-
-        return $cache[$chasse_id];
-    }
-
-    $associated_users = function_exists('get_field')
-        ? get_field('utilisateurs_associes', $organisateur_id)
-        : [];
-    if (!is_array($associated_users) || empty($associated_users)) {
-        $cache[$chasse_id] = (bool) apply_filters(
-            'ca_demo_is_demo_hunt',
-            false,
+            $is_demo,
             $chasse_id,
             [
                 'organisateur_id' => $organisateur_id,
                 'allowed_logins'  => $allowed_logins,
             ]
         );
-
+    
+        $cache[$chasse_id] = $filtered;
+    
         return $cache[$chasse_id];
     }
-
-    $is_demo = false;
-
-    foreach ($associated_users as $user_entry) {
-        if ($user_entry instanceof WP_User) {
-            $user = $user_entry;
-        } elseif (is_array($user_entry) && isset($user_entry['ID'])) {
-            $user = get_user_by('id', (int) $user_entry['ID']);
-        } elseif (is_numeric($user_entry)) {
-            $user = get_user_by('id', (int) $user_entry);
-        } else {
-            $user = null;
-        }
-
-        if (!$user instanceof WP_User) {
-            continue;
-        }
-
-        $login = strtolower($user->user_login);
-        if (in_array($login, $allowed_logins, true)) {
-            $is_demo = true;
-            break;
-        }
-    }
-
-    $filtered = (bool) apply_filters(
-        'ca_demo_is_demo_hunt',
-        $is_demo,
-        $chasse_id,
-        [
-            'organisateur_id' => $organisateur_id,
-            'allowed_logins'  => $allowed_logins,
-        ]
-    );
-
-    $cache[$chasse_id] = $filtered;
-
-    return $cache[$chasse_id];
 }
 
-function ca_demo_reset_user_progress(int $chasse_id, int $user_id): bool
-{
-    if ($chasse_id <= 0 || $user_id <= 0) {
-        return false;
-    }
-
-    if (!ca_demo_is_demo_hunt($chasse_id)) {
-        return false;
-    }
-
-    global $wpdb;
-
-    if (!isset($wpdb)) {
-        return false;
-    }
-
-    $chasse_id = (int) $chasse_id;
-    $user_id   = (int) $user_id;
-
-    $engagements_table = $wpdb->prefix . 'engagements';
-    $statuts_table     = $wpdb->prefix . 'enigme_statuts_utilisateur';
-    $tentatives_table  = $wpdb->prefix . 'enigme_tentatives';
-    $indices_table     = $wpdb->prefix . 'indices_deblocages';
-    $winners_table     = $wpdb->prefix . 'chasse_winners';
-
-    $enigme_ids = [];
-    if (function_exists('recuperer_enigmes_associees')) {
-        $enigme_ids = array_map('intval', recuperer_enigmes_associees($chasse_id));
-    }
-
-    $db_enigmes = $wpdb->get_col(
-        $wpdb->prepare(
-            "SELECT DISTINCT enigme_id FROM {$engagements_table} WHERE user_id = %d AND chasse_id = %d AND enigme_id IS NOT NULL",
-            $user_id,
-            $chasse_id
-        )
-    );
-
-    if (!empty($db_enigmes)) {
-        $enigme_ids = array_merge($enigme_ids, array_map('intval', $db_enigmes));
-    }
-
-    $enigme_ids = array_values(array_filter(array_unique($enigme_ids)));
-
-    $indice_ids = $wpdb->get_col(
-        $wpdb->prepare(
-            "SELECT DISTINCT indice_id FROM {$indices_table} WHERE user_id = %d AND chasse_id = %d",
-            $user_id,
-            $chasse_id
-        )
-    );
-
-    if (!empty($enigme_ids)) {
-        $placeholders = implode(',', array_fill(0, count($enigme_ids), '%d'));
-        $indices_from_enigmes = $wpdb->get_col(
+if (!function_exists('ca_demo_reset_user_progress')) {
+    function ca_demo_reset_user_progress(int $chasse_id, int $user_id): bool
+    {
+        if ($chasse_id <= 0 || $user_id <= 0) {
+            return false;
+        }
+    
+        if (!ca_demo_is_demo_hunt($chasse_id)) {
+            return false;
+        }
+    
+        global $wpdb;
+    
+        if (!isset($wpdb)) {
+            return false;
+        }
+    
+        $chasse_id = (int) $chasse_id;
+        $user_id   = (int) $user_id;
+    
+        $engagements_table = $wpdb->prefix . 'engagements';
+        $statuts_table     = $wpdb->prefix . 'enigme_statuts_utilisateur';
+        $tentatives_table  = $wpdb->prefix . 'enigme_tentatives';
+        $indices_table     = $wpdb->prefix . 'indices_deblocages';
+        $winners_table     = $wpdb->prefix . 'chasse_winners';
+    
+        $enigme_ids = [];
+        if (function_exists('recuperer_enigmes_associees')) {
+            $enigme_ids = array_map('intval', recuperer_enigmes_associees($chasse_id));
+        }
+    
+        $db_enigmes = $wpdb->get_col(
             $wpdb->prepare(
-                "SELECT DISTINCT indice_id FROM {$indices_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
-                array_merge([$user_id], $enigme_ids)
+                "SELECT DISTINCT enigme_id FROM {$engagements_table} WHERE user_id = %d AND chasse_id = %d AND enigme_id IS NOT NULL",
+                $user_id,
+                $chasse_id
             )
         );
-
-        if (!empty($indices_from_enigmes)) {
-            $indice_ids = array_merge($indice_ids, array_map('intval', $indices_from_enigmes));
+    
+        if (!empty($db_enigmes)) {
+            $enigme_ids = array_merge($enigme_ids, array_map('intval', $db_enigmes));
         }
-    }
-
-    $indice_ids = array_values(array_filter(array_unique(array_map('intval', $indice_ids))));
-
-    $wpdb->delete($winners_table, ['user_id' => $user_id, 'chasse_id' => $chasse_id], ['%d', '%d']);
-
-    $remaining_winners = $wpdb->get_results(
-        $wpdb->prepare(
-            "SELECT user_id, date_win FROM {$winners_table} WHERE chasse_id = %d ORDER BY date_win ASC",
-            $chasse_id
-        )
-    );
-
-    $winner_names = [];
-    $win_date     = null;
-
-    foreach ($remaining_winners as $row) {
-        $winner_id = isset($row->user_id) ? (int) $row->user_id : 0;
-        $user      = $winner_id > 0 ? get_userdata($winner_id) : null;
-
-        if ($user) {
-            $display_name = $user->display_name ?: $user->user_login;
-            if ($display_name !== '') {
-                $winner_names[] = $display_name;
+    
+        $enigme_ids = array_values(array_filter(array_unique($enigme_ids)));
+    
+        $indice_ids = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT DISTINCT indice_id FROM {$indices_table} WHERE user_id = %d AND chasse_id = %d",
+                $user_id,
+                $chasse_id
+            )
+        );
+    
+        if (!empty($enigme_ids)) {
+            $placeholders = implode(',', array_fill(0, count($enigme_ids), '%d'));
+            $indices_from_enigmes = $wpdb->get_col(
+                $wpdb->prepare(
+                    "SELECT DISTINCT indice_id FROM {$indices_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                    array_merge([$user_id], $enigme_ids)
+                )
+            );
+    
+            if (!empty($indices_from_enigmes)) {
+                $indice_ids = array_merge($indice_ids, array_map('intval', $indices_from_enigmes));
             }
         }
-
-        if ($win_date === null && !empty($row->date_win)) {
-            $win_date = (string) $row->date_win;
+    
+        $indice_ids = array_values(array_filter(array_unique(array_map('intval', $indice_ids))));
+    
+        $wpdb->delete($winners_table, ['user_id' => $user_id, 'chasse_id' => $chasse_id], ['%d', '%d']);
+    
+        $remaining_winners = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT user_id, date_win FROM {$winners_table} WHERE chasse_id = %d ORDER BY date_win ASC",
+                $chasse_id
+            )
+        );
+    
+        $winner_names = [];
+        $win_date     = null;
+    
+        foreach ($remaining_winners as $row) {
+            $winner_id = isset($row->user_id) ? (int) $row->user_id : 0;
+            $user      = $winner_id > 0 ? get_userdata($winner_id) : null;
+    
+            if ($user) {
+                $display_name = $user->display_name ?: $user->user_login;
+                if ($display_name !== '') {
+                    $winner_names[] = $display_name;
+                }
+            }
+    
+            if ($win_date === null && !empty($row->date_win)) {
+                $win_date = (string) $row->date_win;
+            }
         }
+    
+        if (function_exists('update_field')) {
+            $list = implode(', ', $winner_names);
+            update_field('chasse_cache_gagnants', $list, $chasse_id);
+    
+            if ($win_date) {
+                update_field('chasse_cache_date_decouverte', $win_date, $chasse_id);
+            } elseif (function_exists('delete_field')) {
+                delete_field('chasse_cache_date_decouverte', $chasse_id);
+            } else {
+                update_field('chasse_cache_date_decouverte', '', $chasse_id);
+            }
+    
+            update_field('chasse_cache_complet', empty($winner_names) ? 0 : 1, $chasse_id);
+        }
+    
+        $wpdb->delete($engagements_table, ['user_id' => $user_id, 'chasse_id' => $chasse_id], ['%d', '%d']);
+    
+        if (!empty($enigme_ids)) {
+            $placeholders = implode(',', array_fill(0, count($enigme_ids), '%d'));
+    
+            $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM {$engagements_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                    array_merge([$user_id], $enigme_ids)
+                )
+            );
+    
+            $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM {$statuts_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                    array_merge([$user_id], $enigme_ids)
+                )
+            );
+    
+            $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM {$tentatives_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                    array_merge([$user_id], $enigme_ids)
+                )
+            );
+    
+            $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM {$indices_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
+                    array_merge([$user_id], $enigme_ids)
+                )
+            );
+        }
+    
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$indices_table} WHERE user_id = %d AND chasse_id = %d",
+                $user_id,
+                $chasse_id
+            )
+        );
+    
+        if (function_exists('delete_user_meta')) {
+            delete_user_meta($user_id, "souscription_chasse_{$chasse_id}");
+    
+            foreach ($enigme_ids as $enigme_id) {
+                delete_user_meta($user_id, "statut_enigme_{$enigme_id}");
+                delete_user_meta($user_id, "enigme_{$enigme_id}_resolution_date");
+            }
+    
+            foreach ($indice_ids as $indice_id) {
+                delete_user_meta($user_id, "indice_debloque_{$indice_id}");
+            }
+        }
+    
+        if (function_exists('clean_user_cache')) {
+            clean_user_cache($user_id);
+        }
+    
+        if (function_exists('mettre_a_jour_statuts_chasse')) {
+            mettre_a_jour_statuts_chasse($chasse_id);
+        }
+    
+        if (function_exists('chasse_clear_infos_affichage_cache')) {
+            chasse_clear_infos_affichage_cache($chasse_id);
+        }
+    
+        if (function_exists('enigme_clear_sidebar_cache')) {
+            enigme_clear_sidebar_cache($chasse_id, $user_id);
+        }
+    
+        return true;
     }
+}
 
-    if (function_exists('update_field')) {
-        $list = implode(', ', $winner_names);
-        update_field('chasse_cache_gagnants', $list, $chasse_id);
+if (!function_exists('ca_demo_schedule_reset')) {
+    function ca_demo_schedule_reset(int $chasse_id, int $user_id): void
+    {
+        $chasse_id = (int) $chasse_id;
+        $user_id   = (int) $user_id;
 
-        if ($win_date) {
-            update_field('chasse_cache_date_decouverte', $win_date, $chasse_id);
-        } elseif (function_exists('delete_field')) {
-            delete_field('chasse_cache_date_decouverte', $chasse_id);
+        if ($chasse_id <= 0 || $user_id <= 0) {
+            return;
+        }
+
+        if (function_exists('ca_demo_is_demo_hunt') && !ca_demo_is_demo_hunt($chasse_id)) {
+            return;
+        }
+
+        $delay = (int) apply_filters('ca_demo_reset_delay', 5, $chasse_id, $user_id);
+        if ($delay < 0) {
+            $delay = 0;
+        }
+
+        $hook      = 'ca_demo_run_reset_event';
+        $scheduled = false;
+
+        if (function_exists('wp_schedule_single_event')) {
+            if (function_exists('wp_next_scheduled')) {
+                $existing = wp_next_scheduled($hook, [$chasse_id, $user_id]);
+                if ($existing && function_exists('wp_unschedule_event')) {
+                    wp_unschedule_event($existing, $hook, [$chasse_id, $user_id]);
+                }
+            }
+
+            $timestamp = time() + $delay;
+            $scheduled = wp_schedule_single_event($timestamp, $hook, [$chasse_id, $user_id]);
+        }
+
+        if ($scheduled) {
+            cat_debug(sprintf('🗓️ [DEMO] Reset scheduled for hunt %d (user %d) in %d seconds.', $chasse_id, $user_id, $delay));
         } else {
-            update_field('chasse_cache_date_decouverte', '', $chasse_id);
+            cat_debug(sprintf('⚠️ [DEMO] Reset scheduling failed for hunt %d (user %d), running immediately.', $chasse_id, $user_id));
+            ca_demo_reset_user_progress($chasse_id, $user_id);
         }
 
-        update_field('chasse_cache_complet', empty($winner_names) ? 0 : 1, $chasse_id);
-    }
-
-    $wpdb->delete($engagements_table, ['user_id' => $user_id, 'chasse_id' => $chasse_id], ['%d', '%d']);
-
-    if (!empty($enigme_ids)) {
-        $placeholders = implode(',', array_fill(0, count($enigme_ids), '%d'));
-
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$engagements_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
-                array_merge([$user_id], $enigme_ids)
-            )
-        );
-
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$statuts_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
-                array_merge([$user_id], $enigme_ids)
-            )
-        );
-
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$tentatives_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
-                array_merge([$user_id], $enigme_ids)
-            )
-        );
-
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$indices_table} WHERE user_id = %d AND enigme_id IN ({$placeholders})",
-                array_merge([$user_id], $enigme_ids)
-            )
-        );
-    }
-
-    $wpdb->query(
-        $wpdb->prepare(
-            "DELETE FROM {$indices_table} WHERE user_id = %d AND chasse_id = %d",
-            $user_id,
-            $chasse_id
-        )
-    );
-
-    if (function_exists('delete_user_meta')) {
-        delete_user_meta($user_id, "souscription_chasse_{$chasse_id}");
-
-        foreach ($enigme_ids as $enigme_id) {
-            delete_user_meta($user_id, "statut_enigme_{$enigme_id}");
-            delete_user_meta($user_id, "enigme_{$enigme_id}_resolution_date");
+        if (function_exists('chasse_clear_infos_affichage_cache')) {
+            chasse_clear_infos_affichage_cache($chasse_id);
         }
 
-        foreach ($indice_ids as $indice_id) {
-            delete_user_meta($user_id, "indice_debloque_{$indice_id}");
+        if (function_exists('enigme_clear_sidebar_cache')) {
+            enigme_clear_sidebar_cache($chasse_id, $user_id);
         }
     }
 
-    if (function_exists('clean_user_cache')) {
-        clean_user_cache($user_id);
+    add_action('ca_demo_schedule_reset', 'ca_demo_schedule_reset', 10, 2);
+}
+
+if (!function_exists('ca_demo_execute_scheduled_reset')) {
+    function ca_demo_execute_scheduled_reset(int $chasse_id, int $user_id): void
+    {
+        $chasse_id = (int) $chasse_id;
+        $user_id   = (int) $user_id;
+
+        if ($chasse_id <= 0 || $user_id <= 0) {
+            return;
+        }
+
+        cat_debug(sprintf('▶️ [DEMO] Running scheduled reset for hunt %d (user %d).', $chasse_id, $user_id));
+
+        ca_demo_reset_user_progress($chasse_id, $user_id);
+
+        if (function_exists('chasse_clear_infos_affichage_cache')) {
+            chasse_clear_infos_affichage_cache($chasse_id);
+        }
+
+        if (function_exists('enigme_clear_sidebar_cache')) {
+            enigme_clear_sidebar_cache($chasse_id, $user_id);
+        }
     }
 
-    if (function_exists('mettre_a_jour_statuts_chasse')) {
-        mettre_a_jour_statuts_chasse($chasse_id);
-    }
-
-    if (function_exists('chasse_clear_infos_affichage_cache')) {
-        chasse_clear_infos_affichage_cache($chasse_id);
-    }
-
-    if (function_exists('enigme_clear_sidebar_cache')) {
-        enigme_clear_sidebar_cache($chasse_id, $user_id);
-    }
-
-    return true;
+    add_action('ca_demo_run_reset_event', 'ca_demo_execute_scheduled_reset', 10, 2);
 }
 
 function ca_demo_reset_chasse_ajax(): void

--- a/wp-content/themes/chassesautresor/inc/gamify-functions.php
+++ b/wp-content/themes/chassesautresor/inc/gamify-functions.php
@@ -433,6 +433,10 @@ function verifier_fin_de_chasse($user_id, $enigme_id)
 
     if ($nb_resolues === count($validables) && $engagements_ok) {
         gerer_chasse_terminee($chasse_id);
+
+        if (function_exists('ca_demo_is_demo_hunt') && ca_demo_is_demo_hunt((int) $chasse_id)) {
+            do_action('ca_demo_schedule_reset', (int) $chasse_id, (int) $user_id);
+        }
     }
 }
 add_action('enigme_resolue', function($user_id, $enigme_id) {

--- a/wp-content/themes/chassesautresor/tests/demo_chasse_completion.test.php
+++ b/wp-content/themes/chassesautresor/tests/demo_chasse_completion.test.php
@@ -1,0 +1,233 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DemoChasseCompletionTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_demo_hunt_completion_triggers_victory_and_schedules_reset(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__);
+        }
+
+        if (!defined('CA_DEMO_ORGANISATEUR_LOGINS')) {
+            define('CA_DEMO_ORGANISATEUR_LOGINS', []);
+        }
+
+        $GLOBALS['mock_calls'] = [
+            'demo'         => [],
+            'finish'       => [],
+            'reset'        => [],
+            'actions'      => [],
+            'filters'      => [],
+            'cache_chasse' => [],
+            'cache_enigme' => [],
+        ];
+
+        global $mock_actions, $scheduled_events;
+        $mock_actions    = [];
+        $scheduled_events = [];
+
+        if (!function_exists('add_action')) {
+            function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void
+            {
+                global $mock_actions;
+                $mock_actions[$hook][] = [
+                    'callback'      => $callback,
+                    'accepted_args' => $accepted_args,
+                ];
+            }
+        }
+
+        if (!function_exists('do_action')) {
+            function do_action($hook, ...$args): void
+            {
+                global $mock_actions;
+                $GLOBALS['mock_calls']['actions'][] = [$hook, $args];
+
+                if (empty($mock_actions[$hook])) {
+                    return;
+                }
+
+                foreach ($mock_actions[$hook] as $listener) {
+                    $callback      = $listener['callback'];
+                    $accepted_args = (int) $listener['accepted_args'];
+                    $callback_args = $accepted_args > 0 ? array_slice($args, 0, $accepted_args) : [];
+                    call_user_func_array($callback, $callback_args);
+                }
+            }
+        }
+
+        if (!function_exists('apply_filters')) {
+            function apply_filters($hook, $value)
+            {
+                $args = func_get_args();
+                $GLOBALS['mock_calls']['filters'][] = $args;
+
+                return $value;
+            }
+        }
+
+        if (!function_exists('cat_debug')) {
+            function cat_debug($message): void
+            {
+                $GLOBALS['mock_calls']['logs'][] = $message;
+            }
+        }
+
+        if (!function_exists('wp_schedule_single_event')) {
+            function wp_schedule_single_event($timestamp, $hook, $args = [])
+            {
+                global $scheduled_events;
+                $scheduled_events[] = [
+                    'timestamp' => $timestamp,
+                    'hook'      => $hook,
+                    'args'      => $args,
+                ];
+
+                return true;
+            }
+        }
+
+        if (!function_exists('wp_next_scheduled')) {
+            function wp_next_scheduled($hook, $args = [])
+            {
+                global $scheduled_events;
+                foreach ($scheduled_events as $event) {
+                    if ($event['hook'] === $hook && $event['args'] === $args) {
+                        return $event['timestamp'];
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        if (!function_exists('wp_unschedule_event')) {
+            function wp_unschedule_event($timestamp, $hook, $args = [])
+            {
+                global $scheduled_events;
+                foreach ($scheduled_events as $index => $event) {
+                    if ($event['hook'] === $hook && $event['args'] === $args) {
+                        unset($scheduled_events[$index]);
+                    }
+                }
+
+                $scheduled_events = array_values($scheduled_events);
+
+                return true;
+            }
+        }
+
+        if (!function_exists('chasse_clear_infos_affichage_cache')) {
+            function chasse_clear_infos_affichage_cache($chasse_id): void
+            {
+                $GLOBALS['mock_calls']['cache_chasse'][] = (int) $chasse_id;
+            }
+        }
+
+        if (!function_exists('enigme_clear_sidebar_cache')) {
+            function enigme_clear_sidebar_cache($chasse_id, $user_id): void
+            {
+                $GLOBALS['mock_calls']['cache_enigme'][] = [(int) $chasse_id, (int) $user_id];
+            }
+        }
+
+        if (!function_exists('recuperer_id_chasse_associee')) {
+            function recuperer_id_chasse_associee($enigme_id)
+            {
+                return 777;
+            }
+        }
+
+        if (!function_exists('recuperer_enigmes_associees')) {
+            function recuperer_enigmes_associees($chasse_id)
+            {
+                return [11, 12];
+            }
+        }
+
+        if (!function_exists('get_field')) {
+            function get_field($field, $post_id)
+            {
+                if ($field === 'chasse_mode_fin') {
+                    return 'automatique';
+                }
+
+                if ($field === 'enigme_mode_validation') {
+                    return 'auto';
+                }
+
+                return null;
+            }
+        }
+
+        if (!function_exists('ca_demo_is_demo_hunt')) {
+            function ca_demo_is_demo_hunt($chasse_id)
+            {
+                $GLOBALS['mock_calls']['demo'][] = (int) $chasse_id;
+
+                return true;
+            }
+        }
+
+        if (!function_exists('gerer_chasse_terminee')) {
+            function gerer_chasse_terminee($chasse_id): void
+            {
+                $GLOBALS['mock_calls']['finish'][] = (int) $chasse_id;
+            }
+        }
+
+        if (!function_exists('ca_demo_reset_user_progress')) {
+            function ca_demo_reset_user_progress($chasse_id, $user_id)
+            {
+                $GLOBALS['mock_calls']['reset'][] = [(int) $chasse_id, (int) $user_id];
+
+                return true;
+            }
+        }
+
+        if (!isset($GLOBALS['wpdb'])) {
+            $GLOBALS['wpdb'] = new class() {
+                public $prefix = 'wp_';
+                public $get_var_returns = [2];
+
+                public function prepare($query, $args = null)
+                {
+                    return $query;
+                }
+
+                public function get_var($query)
+                {
+                    return array_shift($this->get_var_returns);
+                }
+            };
+        }
+
+        require_once __DIR__ . '/../inc/chasse/demo.php';
+        require_once __DIR__ . '/../inc/gamify-functions.php';
+
+        $this->assertNotEmpty($mock_actions['ca_demo_schedule_reset'] ?? []);
+        $this->assertNotEmpty($mock_actions['ca_demo_run_reset_event'] ?? []);
+
+        verifier_fin_de_chasse(123, 456);
+
+        $this->assertSame([777], $GLOBALS['mock_calls']['finish']);
+        $this->assertNotEmpty($GLOBALS['mock_calls']['demo']);
+        $this->assertCount(1, $scheduled_events);
+        $this->assertSame('ca_demo_run_reset_event', $scheduled_events[0]['hook']);
+        $this->assertSame([777, 123], $scheduled_events[0]['args']);
+        $this->assertSame([], $GLOBALS['mock_calls']['reset']);
+        $this->assertContains(777, $GLOBALS['mock_calls']['cache_chasse']);
+        $this->assertContains([777, 123], $GLOBALS['mock_calls']['cache_enigme']);
+
+        do_action('ca_demo_run_reset_event', 777, 123);
+
+        $this->assertSame([[777, 123]], $GLOBALS['mock_calls']['reset']);
+        $this->assertSame([777], $GLOBALS['mock_calls']['finish']);
+    }
+}


### PR DESCRIPTION
Résumé : Planification automatique du reset des chasses de démonstration une fois toutes les énigmes validées.

- Déclenche un hook de reset dédié lorsqu’une chasse démo est terminée par un joueur.
- Planifie ou exécute immédiatement le reset des progrès démo en purgeant les caches associés et en journalisant l’opération.
- Ajoute un test isolé qui vérifie la victoire et la planification du reset sans doublon de victoire.

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d68ad96e9c83328a706a3df9b07e80