### PR TITLE
Assurer un cache utilisateur pour le mode démo

### DIFF
--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -1,0 +1,18 @@
+# Mode démo
+
+## Cache du statut de chasse démo
+
+La fonction `ca_demo_is_demo_hunt()` conserve un cache mémoire pour éviter de recalculer le statut "démo" d'une chasse à chaque appel. La clé du cache inclut désormais l'identifiant de l'utilisateur courant (via `get_current_user_id()`) afin que chaque personne obtienne son propre statut.
+
+Un filtre `ca_demo_cache_context` permet d'ajuster les fragments utilisés pour générer la clé. Le filtre reçoit le contexte courant (par défaut `['user_id' => get_current_user_id()]`) et l'identifiant de la chasse. Vous pouvez y ajouter ou retirer des éléments en fonction de vos besoins d'intégration, par exemple pour mutualiser le cache entre plusieurs comptes techniques ou segmenter le résultat selon d'autres attributs.
+
+```php
+add_filter('ca_demo_cache_context', function (array $context, int $chasse_id): array {
+    // Ex.: partage le cache pour les utilisateurs d'un même tenant.
+    $context['tenant'] = get_current_tenant_key();
+
+    return $context;
+});
+```
+
+Si le filtre retourne une valeur vide ou non valide, `ca_demo_is_demo_hunt()` retombe automatiquement sur le comportement par défaut basé sur l'identifiant utilisateur.

--- a/wp-content/themes/chassesautresor/inc/chasse/demo.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/demo.php
@@ -21,22 +21,83 @@ if (!function_exists('ca_demo_is_demo_hunt')) {
         if (isset($overrides[$chasse_id])) {
             return (bool) $overrides[$chasse_id];
         }
-    
-        if (isset($cache[$chasse_id])) {
-            return $cache[$chasse_id];
+
+        $current_user_id = function_exists('get_current_user_id')
+            ? (int) get_current_user_id()
+            : 0;
+
+        $default_context = [
+            'user_id' => $current_user_id,
+        ];
+
+        $cache_context = $default_context;
+
+        if (function_exists('apply_filters')) {
+            $cache_context = apply_filters('ca_demo_cache_context', $default_context, $chasse_id);
+        }
+
+        if (!is_array($cache_context)) {
+            $cache_context = [];
+        }
+
+        if ($cache_context === []) {
+            $cache_context = $default_context;
+        }
+
+        $normalized_context = [];
+
+        foreach ($cache_context as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $normalized_context[$key] = $value;
+
+                continue;
+            }
+
+            if (is_object($value) && method_exists($value, '__toString')) {
+                $normalized_context[$key] = (string) $value;
+
+                continue;
+            }
+
+            $normalized_context[$key] = serialize($value);
+        }
+
+        $is_assoc_context = array_keys($normalized_context) !== range(0, count($normalized_context) - 1);
+
+        if ($is_assoc_context) {
+            ksort($normalized_context);
+        }
+
+        $cache_key_payload = [
+            'chasse_id' => $chasse_id,
+            'context'   => $normalized_context,
+        ];
+
+        $encoded_payload = function_exists('wp_json_encode')
+            ? wp_json_encode($cache_key_payload)
+            : json_encode($cache_key_payload);
+
+        if (!is_string($encoded_payload) || $encoded_payload === '') {
+            $encoded_payload = serialize($cache_key_payload);
+        }
+
+        $cache_key = 'ca_demo_' . md5($encoded_payload);
+
+        if (isset($cache[$cache_key])) {
+            return $cache[$cache_key];
         }
     
         if (!function_exists('get_organisateur_from_chasse')) {
-            $cache[$chasse_id] = false;
-    
-            return $cache[$chasse_id];
+            $cache[$cache_key] = false;
+
+            return $cache[$cache_key];
         }
-    
+
         $organisateur_id = get_organisateur_from_chasse($chasse_id);
         if (!$organisateur_id) {
-            $cache[$chasse_id] = false;
-    
-            return $cache[$chasse_id];
+            $cache[$cache_key] = false;
+
+            return $cache[$cache_key];
         }
     
         $configured_logins = CA_DEMO_ORGANISATEUR_LOGINS;
@@ -63,7 +124,7 @@ if (!function_exists('ca_demo_is_demo_hunt')) {
         ));
     
         if (empty($allowed_logins)) {
-            $cache[$chasse_id] = (bool) apply_filters(
+            $cache[$cache_key] = (bool) apply_filters(
                 'ca_demo_is_demo_hunt',
                 false,
                 $chasse_id,
@@ -72,15 +133,15 @@ if (!function_exists('ca_demo_is_demo_hunt')) {
                     'allowed_logins'  => [],
                 ]
             );
-    
-            return $cache[$chasse_id];
+
+            return $cache[$cache_key];
         }
-    
+
         $associated_users = function_exists('get_field')
             ? get_field('utilisateurs_associes', $organisateur_id)
             : [];
         if (!is_array($associated_users) || empty($associated_users)) {
-            $cache[$chasse_id] = (bool) apply_filters(
+            $cache[$cache_key] = (bool) apply_filters(
                 'ca_demo_is_demo_hunt',
                 false,
                 $chasse_id,
@@ -89,8 +150,8 @@ if (!function_exists('ca_demo_is_demo_hunt')) {
                     'allowed_logins'  => $allowed_logins,
                 ]
             );
-    
-            return $cache[$chasse_id];
+
+            return $cache[$cache_key];
         }
     
         $is_demo = false;
@@ -127,9 +188,9 @@ if (!function_exists('ca_demo_is_demo_hunt')) {
             ]
         );
     
-        $cache[$chasse_id] = $filtered;
-    
-        return $cache[$chasse_id];
+        $cache[$cache_key] = $filtered;
+
+        return $cache[$cache_key];
     }
 }
 

--- a/wp-content/themes/chassesautresor/tests/demo_cache_context.test.php
+++ b/wp-content/themes/chassesautresor/tests/demo_cache_context.test.php
@@ -1,0 +1,115 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DemoCacheContextTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_each_user_receives_filtered_status_despite_cache(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__);
+        }
+
+        if (!defined('CA_DEMO_ORGANISATEUR_LOGINS')) {
+            define('CA_DEMO_ORGANISATEUR_LOGINS', []);
+        }
+
+        global $test_filters;
+        $test_filters = [];
+
+        if (!function_exists('add_filter')) {
+            function add_filter($hook, $callback, $priority = 10, $accepted_args = 1): void
+            {
+                global $test_filters;
+
+                if (!isset($test_filters[$hook])) {
+                    $test_filters[$hook] = [];
+                }
+
+                if (!isset($test_filters[$hook][$priority])) {
+                    $test_filters[$hook][$priority] = [];
+                }
+
+                $test_filters[$hook][$priority][] = [
+                    'callback'      => $callback,
+                    'accepted_args' => $accepted_args,
+                ];
+            }
+        }
+
+        if (!function_exists('apply_filters')) {
+            function apply_filters($hook, $value)
+            {
+                global $test_filters;
+
+                $args = func_get_args();
+
+                if (empty($test_filters[$hook])) {
+                    return $value;
+                }
+
+                ksort($test_filters[$hook]);
+
+                foreach ($test_filters[$hook] as $priority => $callbacks) {
+                    foreach ($callbacks as $callback) {
+                        $accepted_args = (int) $callback['accepted_args'];
+                        $callback_args = array_slice($args, 1, $accepted_args);
+                        $value         = call_user_func_array($callback['callback'], $callback_args);
+                        $args[1]       = $value;
+                    }
+                }
+
+                return $value;
+            }
+        }
+
+        if (!function_exists('get_current_user_id')) {
+            function get_current_user_id(): int
+            {
+                return (int) ($GLOBALS['current_user_id'] ?? 0);
+            }
+        }
+
+        if (!function_exists('get_organisateur_from_chasse')) {
+            function get_organisateur_from_chasse(int $chasse_id): int
+            {
+                return 777;
+            }
+        }
+
+        require_once __DIR__ . '/../inc/chasse/demo.php';
+
+        $user_statuses = [
+            101 => true,
+            202 => false,
+        ];
+
+        $filter_calls = [];
+
+        add_filter(
+            'ca_demo_is_demo_hunt',
+            function ($default, $chasse_id, $context) use (&$filter_calls, $user_statuses) {
+                $user_id        = get_current_user_id();
+                $filter_calls[] = $user_id;
+
+                return $user_statuses[$user_id] ?? $default;
+            },
+            10,
+            3
+        );
+
+        $GLOBALS['current_user_id'] = 101;
+        $this->assertTrue(ca_demo_is_demo_hunt(555));
+        $this->assertTrue(ca_demo_is_demo_hunt(555));
+
+        $GLOBALS['current_user_id'] = 202;
+        $this->assertFalse(ca_demo_is_demo_hunt(555));
+        $this->assertFalse(ca_demo_is_demo_hunt(555));
+
+        $this->assertSame([101, 202], $filter_calls);
+    }
+}


### PR DESCRIPTION
Résumé rapide : sécurise le cache du mode démo par utilisateur et documente le nouveau filtre.

- Fait dépendre la clé mémoire de `ca_demo_is_demo_hunt()` du contexte utilisateur et expose le filtre `ca_demo_cache_context`.
- Documente dans `docs/demo-mode.md` la personnalisation possible du cache du mode démo.
- Ajoute un test PHPUnit vérifiant que deux utilisateurs reçoivent bien des statuts distincts malgré la mise en cache.

**Tests**
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d68da9747c8332b949510d89fa3ce7