### PR TITLE
Configure default demo organizer login

### DIFF
--- a/tests/CaGetUserEngagedHuntIdsTest.php
+++ b/tests/CaGetUserEngagedHuntIdsTest.php
@@ -61,85 +61,27 @@ class CaGetUserEngagedHuntIdsTest extends TestCase
 {
     public function test_demo_hunts_are_filtered_out(): void
     {
-        if (!defined('ABSPATH')) {
-            define('ABSPATH', __DIR__ . '/fixtures/');
-        }
+        $this->bootstrapDemoTestEnvironment();
 
-        if (!function_exists('apply_filters')) {
-            function apply_filters($hook, $value, ...$args)
-            {
-                global $wp_filter;
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/constants.php';
 
-                if (
-                    isset($wp_filter[$hook])
-                    && is_object($wp_filter[$hook])
-                    && method_exists($wp_filter[$hook], 'apply_filters')
-                ) {
-                    $arguments = $args;
-                    array_unshift($arguments, $value);
+        $GLOBALS['test_chasse_organisateur_map'] = [
+            60 => 5,
+            70 => 10,
+            80 => 10,
+            90 => 5,
+        ];
 
-                    return $wp_filter[$hook]->apply_filters($value, $arguments);
-                }
-
-                return $value;
-            }
-        }
-
-        if (!function_exists('get_post_status')) {
-            function get_post_status($post_id)
-            {
-                return 'publish';
-            }
-        }
-
-        if (!function_exists('get_field')) {
-            function get_field($field, $post_id = null)
-            {
-                global $fields, $post_fields;
-
-                return $fields[$post_id][$field] ?? $post_fields[$post_id][$field] ?? null;
-            }
-        }
-
-        if (!function_exists('user_can')) {
-            function user_can($user_id, $cap)
-            {
-                return false;
-            }
-        }
-
-        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
-            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
-            {
-                return false;
-            }
-        }
-
-        if (!function_exists('chasse_est_visible_pour_utilisateur')) {
-            function chasse_est_visible_pour_utilisateur($chasse_id, $user_id)
-            {
-                return true;
-            }
-        }
-
-        if (!function_exists('get_organisateur_from_chasse')) {
-            function get_organisateur_from_chasse($chasse_id)
-            {
-                return $chasse_id === 60 ? 5 : 10;
-            }
-        }
-
-        if (!function_exists('get_user_by')) {
-            function get_user_by($field, $value)
-            {
-                $login = ((int) $value === 42) ? 'demo' : 'regular';
-
-                return new WP_User([
-                    'ID'         => (int) $value,
-                    'user_login' => $login,
-                ]);
-            }
-        }
+        $GLOBALS['test_users_by_id'] = [
+            42 => [
+                'ID'         => 42,
+                'user_login' => 'demo',
+            ],
+            84 => [
+                'ID'         => 84,
+                'user_login' => 'regular',
+            ],
+        ];
 
         global $fields, $post_fields;
 
@@ -229,6 +171,121 @@ class CaGetUserEngagedHuntIdsTest extends TestCase
             $GLOBALS['wp_filter']['ca_demo_organisateur_logins'],
             $GLOBALS['wp_filter']['ca_demo_is_demo_hunt']
         );
+
+        unset(
+            $GLOBALS['test_chasse_organisateur_map'],
+            $GLOBALS['test_users_by_id']
+        );
+
         unset($GLOBALS['wpdb']);
+    }
+
+    public function test_default_demo_login_flags_hunt(): void
+    {
+        $script  = __DIR__ . '/scripts/verify_default_demo_login.php';
+        $command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script) . ' 2>&1';
+
+        exec($command, $output, $exitCode);
+
+        $this->assertSame(0, $exitCode, implode(PHP_EOL, $output));
+    }
+
+    private function bootstrapDemoTestEnvironment(): void
+    {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/fixtures/');
+        }
+
+        if (!function_exists('apply_filters')) {
+            function apply_filters($hook, $value, ...$args)
+            {
+                global $wp_filter;
+
+                if (
+                    isset($wp_filter[$hook])
+                    && is_object($wp_filter[$hook])
+                    && method_exists($wp_filter[$hook], 'apply_filters')
+                ) {
+                    $arguments = $args;
+                    array_unshift($arguments, $value);
+
+                    return $wp_filter[$hook]->apply_filters($value, $arguments);
+                }
+
+                return $value;
+            }
+        }
+
+        if (!function_exists('get_post_status')) {
+            function get_post_status($post_id)
+            {
+                return 'publish';
+            }
+        }
+
+        if (!function_exists('get_field')) {
+            function get_field($field, $post_id = null)
+            {
+                global $fields, $post_fields;
+
+                return $fields[$post_id][$field] ?? $post_fields[$post_id][$field] ?? null;
+            }
+        }
+
+        if (!function_exists('user_can')) {
+            function user_can($user_id, $cap)
+            {
+                return false;
+            }
+        }
+
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+            {
+                return false;
+            }
+        }
+
+        if (!function_exists('chasse_est_visible_pour_utilisateur')) {
+            function chasse_est_visible_pour_utilisateur($chasse_id, $user_id)
+            {
+                return true;
+            }
+        }
+
+        if (!function_exists('get_organisateur_from_chasse')) {
+            function get_organisateur_from_chasse($chasse_id)
+            {
+                $map = $GLOBALS['test_chasse_organisateur_map'] ?? [];
+
+                return $map[$chasse_id] ?? 0;
+            }
+        }
+
+        if (!function_exists('get_user_by')) {
+            function get_user_by($field, $value)
+            {
+                $users = $GLOBALS['test_users_by_id'] ?? [];
+
+                $user_id = (int) $value;
+
+                if ($field === 'id' && isset($users[$user_id])) {
+                    return new WP_User($users[$user_id]);
+                }
+
+                if ($field === 'login') {
+                    foreach ($users as $user) {
+                        if (isset($user['user_login']) && $user['user_login'] === $value) {
+                            return new WP_User($user);
+                        }
+                    }
+                }
+
+                return new WP_User([
+                    'ID'         => $user_id,
+                    'user_login' => $users[$user_id]['user_login'] ?? ('user' . $user_id),
+                ]);
+            }
+        }
     }
 }

--- a/tests/scripts/verify_default_demo_login.php
+++ b/tests/scripts/verify_default_demo_login.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../fixtures/');
+}
+
+require_once __DIR__ . '/../../wp-content/themes/chassesautresor/inc/constants.php';
+
+if (!class_exists('WP_User')) {
+    class WP_User
+    {
+        public int $ID = 0;
+
+        public string $user_login = '';
+
+        public array $roles = [];
+
+        public function __construct($data = 0)
+        {
+            if (is_object($data)) {
+                $this->ID         = isset($data->ID) ? (int) $data->ID : 0;
+                $this->user_login = isset($data->user_login) ? (string) $data->user_login : '';
+            } elseif (is_array($data)) {
+                $this->ID         = isset($data['ID']) ? (int) $data['ID'] : 0;
+                $this->user_login = isset($data['user_login']) ? (string) $data['user_login'] : '';
+            } elseif (is_int($data)) {
+                $this->ID         = $data;
+                $this->user_login = 'user' . $data;
+            } else {
+                $this->user_login = (string) $data;
+            }
+        }
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value, ...$args)
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action(...$args): void
+    {
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter(...$args): void
+    {
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($field, $post_id = null)
+    {
+        global $fields, $post_fields;
+
+        return $fields[$post_id][$field] ?? $post_fields[$post_id][$field] ?? null;
+    }
+}
+
+if (!function_exists('get_organisateur_from_chasse')) {
+    function get_organisateur_from_chasse($chasse_id)
+    {
+        return 200;
+    }
+}
+
+require_once __DIR__ . '/../../wp-content/themes/chassesautresor/inc/chasse/demo.php';
+
+global $fields, $post_fields;
+
+$fields = [
+    200 => [
+        'utilisateurs_associes'          => [
+            new WP_User([
+                'ID'         => 101,
+                'user_login' => 'organisateur1',
+            ]),
+        ],
+        'chasse_cache_statut_validation' => 'valide',
+    ],
+    100 => [
+        'chasse_cache_statut_validation' => 'valide',
+    ],
+];
+
+$post_fields = [];
+
+if (CA_DEMO_ORGANISATEUR_LOGINS !== ['organisateur1']) {
+    fwrite(STDERR, 'Unexpected default logins: ' . json_encode(CA_DEMO_ORGANISATEUR_LOGINS));
+    exit(1);
+}
+
+if (!ca_demo_is_demo_hunt(100)) {
+    fwrite(STDERR, 'ca_demo_is_demo_hunt returned false');
+    exit(1);
+}
+
+exit(0);

--- a/wp-content/themes/chassesautresor/docs/demo-mode.md
+++ b/wp-content/themes/chassesautresor/docs/demo-mode.md
@@ -6,6 +6,7 @@ Le thème permet de marquer automatiquement certaines chasses comme « Démo�
 
 - **Constante** : `CA_DEMO_ORGANISATEUR_LOGINS`
   - Définit la liste par défaut des logins organisateur pour lesquels toutes les chasses liées doivent être considérées comme des chasses de démonstration.
+  - Par défaut, le login `organisateur1` est configuré comme organisateur de démonstration.
   - La constante peut être définie dans `wp-config.php` ou dans un mu-plugin avant le chargement du thème.
 - **Filtre** : `ca_demo_organisateur_logins`
   - Permet d’ajouter/supprimer dynamiquement des logins à la liste finale utilisée par le cœur du thème.

--- a/wp-content/themes/chassesautresor/inc/constants.php
+++ b/wp-content/themes/chassesautresor/inc/constants.php
@@ -14,7 +14,9 @@ if (!defined('CA_DEMO_ORGANISATEUR_LOGINS')) {
      *
      * Utilisez le filtre `ca_demo_organisateur_logins` pour enrichir cette liste dynamiquement.
      */
-    define('CA_DEMO_ORGANISATEUR_LOGINS', []);
+    define('CA_DEMO_ORGANISATEUR_LOGINS', [
+        'organisateur1',
+    ]);
 }
 
 // --------------------------------------------------


### PR DESCRIPTION
Résumé: Configure le login démo par défaut et sécurise sa couverture de test.

- Définit `organisateur1` comme valeur par défaut de `CA_DEMO_ORGANISATEUR_LOGINS` et met à jour la documentation associée.
- Adapte `CaGetUserEngagedHuntIdsTest` et ajoute un script isolé pour valider qu'une chasse liée à `organisateur1` est détectée comme démo sans surcharge.

## Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68d690b966a88332a9b664b3ee58b8a3