### PR TITLE
Améliore la gestion des erreurs du reset de chasse démo

### DIFF
--- a/tests/CaDemoResetUserProgressTest.php
+++ b/tests/CaDemoResetUserProgressTest.php
@@ -15,6 +15,61 @@ class CaDemoResetUserProgressTest extends TestCase
         $codeBlocks = [
             <<<'PHP'
 namespace {
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            private string $code;
+            private string $message;
+
+            public function __construct(string $code = '', string $message = '', $data = null)
+            {
+                $this->code    = $code;
+                $this->message = $message;
+            }
+
+            public function get_error_code(): string
+            {
+                return $this->code;
+            }
+
+            public function get_error_message($code = ''): string
+            {
+                return $this->message;
+            }
+        }
+    }
+
+    if (!function_exists('is_wp_error')) {
+        function is_wp_error($thing): bool
+        {
+            return $thing instanceof WP_Error;
+        }
+    }
+
+    if (!function_exists('cat_debug')) {
+        function cat_debug($message): void
+        {
+            global $cat_debug_logs;
+
+            if (!is_array($cat_debug_logs ?? null)) {
+                $cat_debug_logs = [];
+            }
+
+            $cat_debug_logs[] = $message;
+        }
+    }
+
+    if (!function_exists('__')) {
+        function __($text, $domain = null)
+        {
+            return (string) $text;
+        }
+    }
+}
+PHP
+            ,
+            <<<'PHP'
+namespace {
     if (!class_exists('wpdb')) {
         class wpdb
         {
@@ -413,17 +468,44 @@ PHP
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_returns_false_when_not_demo(): void
+    public function test_returns_error_when_not_demo(): void
     {
         $this->bootstrapHelpers();
 
-        global $wpdb, $force_demo_overrides;
+        global $wpdb, $force_demo_overrides, $cat_debug_logs;
 
         $wpdb = new \wpdb();
         $force_demo_overrides = [42 => false];
+        $cat_debug_logs = [];
 
         require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse/demo.php';
 
-        $this->assertFalse(\ca_demo_reset_user_progress(42, 23));
+        $result = \ca_demo_reset_user_progress(42, 23);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('not_demo', $result->get_error_code());
+        $this->assertNotEmpty($cat_debug_logs);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_returns_error_when_wpdb_missing(): void
+    {
+        $this->bootstrapHelpers();
+
+        global $force_demo_overrides, $cat_debug_logs;
+
+        $force_demo_overrides = [77 => true];
+        $cat_debug_logs = [];
+
+        require_once __DIR__ . '/../wp-content/themes/chassesautresor/inc/chasse/demo.php';
+
+        $result = \ca_demo_reset_user_progress(77, 23);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('wpdb_missing', $result->get_error_code());
+        $this->assertNotEmpty($cat_debug_logs);
     }
 }

--- a/wp-content/themes/chassesautresor/inc/chasse/demo.php
+++ b/wp-content/themes/chassesautresor/inc/chasse/demo.php
@@ -195,20 +195,46 @@ if (!function_exists('ca_demo_is_demo_hunt')) {
 }
 
 if (!function_exists('ca_demo_reset_user_progress')) {
-    function ca_demo_reset_user_progress(int $chasse_id, int $user_id): bool
+    /**
+     * @return bool|WP_Error
+     */
+    function ca_demo_reset_user_progress(int $chasse_id, int $user_id)
     {
+        $log_error = static function (string $message): void {
+            if (function_exists('cat_debug')) {
+                cat_debug($message);
+            } else {
+                error_log($message);
+            }
+        };
+
         if ($chasse_id <= 0 || $user_id <= 0) {
-            return false;
+            $log_error(sprintf('❌ [DEMO] Invalid identifiers provided for reset (hunt %d, user %d).', $chasse_id, $user_id));
+
+            return new WP_Error(
+                'invalid_ids',
+                __('Identifiants de chasse ou d’utilisateur invalides.', 'chassesautresor-com')
+            );
         }
-    
+
         if (!ca_demo_is_demo_hunt($chasse_id)) {
-            return false;
+            $log_error(sprintf('⚠️ [DEMO] Hunt %d is not marked as demo. Reset aborted for user %d.', $chasse_id, $user_id));
+
+            return new WP_Error(
+                'not_demo',
+                __('Cette chasse ne peut pas être réinitialisée.', 'chassesautresor-com')
+            );
         }
-    
+
         global $wpdb;
-    
+
         if (!isset($wpdb)) {
-            return false;
+            $log_error(sprintf('❌ [DEMO] $wpdb is unavailable. Unable to reset hunt %d for user %d.', $chasse_id, $user_id));
+
+            return new WP_Error(
+                'wpdb_missing',
+                __('Le service de base de données est indisponible.', 'chassesautresor-com')
+            );
         }
     
         $chasse_id = (int) $chasse_id;
@@ -419,7 +445,12 @@ if (!function_exists('ca_demo_schedule_reset')) {
             cat_debug(sprintf('🗓️ [DEMO] Reset scheduled for hunt %d (user %d) in %d seconds.', $chasse_id, $user_id, $delay));
         } else {
             cat_debug(sprintf('⚠️ [DEMO] Reset scheduling failed for hunt %d (user %d), running immediately.', $chasse_id, $user_id));
-            ca_demo_reset_user_progress($chasse_id, $user_id);
+            $result = ca_demo_reset_user_progress($chasse_id, $user_id);
+
+            if (function_exists('is_wp_error') && is_wp_error($result)) {
+                $message = $result->get_error_message();
+                cat_debug(sprintf('❌ [DEMO] Immediate reset failed for hunt %d (user %d): %s', $chasse_id, $user_id, $message));
+            }
         }
 
         if (function_exists('chasse_clear_infos_affichage_cache')) {
@@ -446,7 +477,12 @@ if (!function_exists('ca_demo_execute_scheduled_reset')) {
 
         cat_debug(sprintf('▶️ [DEMO] Running scheduled reset for hunt %d (user %d).', $chasse_id, $user_id));
 
-        ca_demo_reset_user_progress($chasse_id, $user_id);
+        $result = ca_demo_reset_user_progress($chasse_id, $user_id);
+
+        if (function_exists('is_wp_error') && is_wp_error($result)) {
+            $message = $result->get_error_message();
+            cat_debug(sprintf('❌ [DEMO] Scheduled reset failed for hunt %d (user %d): %s', $chasse_id, $user_id, $message));
+        }
 
         if (function_exists('chasse_clear_infos_affichage_cache')) {
             chasse_clear_infos_affichage_cache($chasse_id);
@@ -499,7 +535,18 @@ function ca_demo_reset_chasse_ajax(): void
 
     $result = ca_demo_reset_user_progress($chasse_id, $user_id);
 
-    if (!$result) {
+    if (function_exists('is_wp_error') && is_wp_error($result)) {
+        $message = $result->get_error_message();
+        if ($message === '') {
+            $message = __('Impossible de réinitialiser votre progression pour le moment.', 'chassesautresor-com');
+        }
+
+        wp_send_json_error([
+            'message' => $message,
+        ]);
+    }
+
+    if ($result !== true) {
         wp_send_json_error([
             'message' => __('Impossible de réinitialiser votre progression pour le moment.', 'chassesautresor-com'),
         ]);


### PR DESCRIPTION
Résumé : Amélioration de la gestion des erreurs lors de la réinitialisation des chasses démo.

- Remplace les `return false` par des `WP_Error` détaillés et journalisés dans `ca_demo_reset_user_progress()`.
- Ajoute la prise en charge de ces erreurs pour les resets planifiés et les appels AJAX.
- Étend la couverture de tests unitaires pour valider les cas d'échec et la journalisation.

## Testing
- ✅ `composer install`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml tests/CaDemoResetUserProgressTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d69708a9c88332b45c2f6f403733e8