### PR TITLE
Retirer le lien fallback du CTA de réinitialisation démo

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -544,12 +544,6 @@ if ($edition_active && !$est_complet) {
                 <p class="cta-reset-demo__confirm">
                   <?php esc_html_e('Confirmez la réinitialisation dans la fenêtre qui s’ouvrira.', 'chassesautresor-com'); ?>
                 </p>
-                <a
-                  class="cta-reset-demo__fallback bouton-secondaire"
-                  href="<?= esc_url(get_permalink($chasse_id) . '#chasse-enigmes-wrapper'); ?>"
-                >
-                  <?php esc_html_e('Voir mes énigmes', 'chassesautresor-com'); ?>
-                </a>
               <?php endif; ?>
             </div>
           </div>


### PR DESCRIPTION
Résumé :
- Supprime le lien de fallback affiché avec le CTA de réinitialisation en mode démo.
- Conserve les messages d'information du CTA pour guider l'utilisateur.

Testing :
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d7424336b08332997bb629443f3357