### PR TITLE
Ajuste les messages des chasses de démonstration

### DIFF
--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -812,7 +812,7 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
             return $response([
                 'cta_html'    => $button_html,
                 'cta_message' => '<p class="cta-reset-demo__message">' . esc_html__(
-                    'Vous participez à cette chasse de démonstration.',
+                    'Ceci est une chasse de démonstration',
                     'chassesautresor-com'
                 ) . '</p>',
                 'type'        => 'reset_demo',

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -540,11 +540,6 @@ if ($edition_active && !$est_complet) {
             <div class="cta-message" aria-live="polite"><?= $cta_data['cta_message']; ?></div>
             <div class="cta-action">
               <?= $cta_data['cta_html']; ?>
-              <?php if ($cta_type === 'reset_demo') : ?>
-                <p class="cta-reset-demo__confirm">
-                  <?php esc_html_e('Confirmez la réinitialisation dans la fenêtre qui s’ouvrira.', 'chassesautresor-com'); ?>
-                </p>
-              <?php endif; ?>
             </div>
           </div>
           </div>


### PR DESCRIPTION
Résumé rapide : Mise à jour de l'affichage pour les chasses de démonstration.

- Remplacement du message au-dessus du CTA pour les chasses de démonstration.
- Suppression de la note superflue sous le bouton de réinitialisation des chasses de démonstration.

## Tests
- source ./setup-env.sh && composer install && vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d743b473908332889e0590559ed66b