### PR TITLE
Remplacer le badge de statut par le badge démo sur les cartes de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -171,7 +171,7 @@ if ($edition_active && !$est_complet) {
           >
               <?php if ($is_demo && $demo_badge) : ?>
                 <span
-                    class="badge-demo"
+                    class="badge-statut badge-demo"
                     role="img"
                     aria-label="<?= esc_attr($demo_badge['aria_label'] ?? $demo_badge['screen_text'] ?? ''); ?>"
                     <?php if ($demo_badge_description_id) : ?>aria-describedby="<?= esc_attr($demo_badge_description_id); ?>"<?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -13,6 +13,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 // Récupération centralisée des informations
 $infos_chasse = $args['infos_chasse'] ?? preparer_infos_affichage_chasse($chasse_id);
 $statut = $infos_chasse['statut'];
+$is_demo = !empty($infos_chasse['is_demo']);
+$demo_badge = is_array($infos_chasse['demo_badge'] ?? null) ? $infos_chasse['demo_badge'] : null;
+$demo_badge_description_id = $is_demo && $demo_badge ? wp_unique_id('badge-demo-desc-') : '';
 
 
 // Champs principaux (avec fallback direct en meta)
@@ -166,10 +169,30 @@ if ($edition_active && !$est_complet) {
               data-mode-auto-icon="<?= esc_attr($mode_auto_icon); ?>"
               data-mode-manuel-icon="<?= esc_attr($mode_manual_icon); ?>"
           >
-              <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>"
-                data-post-id="<?= esc_attr($chasse_id); ?>">
-                <?= esc_html($statut_label); ?>
-              </span>
+              <?php if ($is_demo && $demo_badge) : ?>
+                <span
+                    class="badge-demo"
+                    role="img"
+                    aria-label="<?= esc_attr($demo_badge['aria_label'] ?? $demo_badge['screen_text'] ?? ''); ?>"
+                    <?php if ($demo_badge_description_id) : ?>aria-describedby="<?= esc_attr($demo_badge_description_id); ?>"<?php endif; ?>
+                    title="<?= esc_attr($demo_badge['title'] ?? ''); ?>"
+                >
+                  <?php if (!empty($demo_badge['icon_html'])) : ?>
+                    <span class="badge-demo__icon" aria-hidden="true">
+                      <?= $demo_badge['icon_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- icône SVG préparée. ?>
+                    </span>
+                  <?php endif; ?>
+                  <span class="badge-demo__label"><?= esc_html($demo_badge['label'] ?? ''); ?></span>
+                  <?php if ($demo_badge_description_id) : ?>
+                    <span id="<?= esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?= esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                  <?php endif; ?>
+                </span>
+              <?php else : ?>
+                <span class="badge-statut statut-<?= esc_attr($statut_for_class); ?>"
+                  data-post-id="<?= esc_attr($chasse_id); ?>">
+                  <?= esc_html($statut_label); ?>
+                </span>
+              <?php endif; ?>
               <?php if ($cout_points > 0) : ?>
                 <span
                     class="badge-cout"

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-cart.php
@@ -92,18 +92,44 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
     $badge_attributes .= ' role="img" tabindex="0"';
 }
 
+$is_demo = !empty($infos['is_demo']);
+$demo_badge = is_array($infos['demo_badge'] ?? null) ? $infos['demo_badge'] : null;
+$demo_badge_description_id = $is_demo && $demo_badge ? wp_unique_id('badge-demo-desc-') : '';
+
 ?>
 <div class="carte carte-chasse carte-cart <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-cart__lien">
         <div <?php echo $wrapper_attributes; ?>>
-            <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-                <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
-                <?php if ($has_badge_icon) : ?>
-                    <span class="badge-statut__icon" aria-hidden="true">
-                        <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+            <div class="carte-badges-stack">
+                <?php if ($is_demo && $demo_badge) : ?>
+                    <span
+                        class="badge-demo"
+                        role="img"
+                        aria-label="<?php echo esc_attr($demo_badge['aria_label'] ?? $demo_badge['screen_text'] ?? ''); ?>"
+                        <?php if ($demo_badge_description_id) : ?>aria-describedby="<?php echo esc_attr($demo_badge_description_id); ?>"<?php endif; ?>
+                        title="<?php echo esc_attr($demo_badge['title'] ?? ''); ?>"
+                    >
+                        <?php if (!empty($demo_badge['icon_html'])) : ?>
+                            <span class="badge-demo__icon" aria-hidden="true">
+                                <?php echo $demo_badge['icon_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- icône préparée. ?>
+                            </span>
+                        <?php endif; ?>
+                        <span class="badge-demo__label"><?php echo esc_html($demo_badge['label'] ?? ''); ?></span>
+                        <?php if ($demo_badge_description_id) : ?>
+                            <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                        <?php endif; ?>
+                    </span>
+                <?php else : ?>
+                    <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                        <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+                        <?php if ($has_badge_icon) : ?>
+                            <span class="badge-statut__icon" aria-hidden="true">
+                                <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                            </span>
+                        <?php endif; ?>
                     </span>
                 <?php endif; ?>
-            </span>
+            </div>
             <?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé ci-dessus. ?>
         </div>
         <div class="carte-cart__contenu">

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-compact.php
@@ -53,9 +53,6 @@ if ($has_reward) {
         <a href="<?php echo esc_url($infos['permalink']); ?>" class="carte-compact__lien">
             <div class="carte-compact__image-wrapper">
                 <div class="carte-badges-stack">
-                    <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-                        <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
-                    </span>
                     <?php if ($is_demo && $demo_badge) : ?>
                         <span
                             class="badge-demo"
@@ -73,6 +70,10 @@ if ($has_reward) {
                             <?php if ($demo_badge_description_id) : ?>
                                 <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
                             <?php endif; ?>
+                        </span>
+                    <?php else : ?>
+                        <span class="badge-statut <?php echo esc_attr($infos['badge_class']); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                            <?php echo $infos['badge_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
                         </span>
                     <?php endif; ?>
                 </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card-wide.php
@@ -53,15 +53,6 @@ $has_reward = !empty($reward_title) && (float) $reward_value > 0;
 <div class="carte carte-chasse carte-wide <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-wide__image">
         <div class="carte-badges-stack">
-            <span class="badge-statut <?php echo esc_attr($badge_classes); ?>"
-                data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-                <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
-                <?php if ($has_badge_icon) : ?>
-                    <span class="badge-statut__icon" aria-hidden="true">
-                        <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
-                    </span>
-                <?php endif; ?>
-            </span>
             <?php if ($is_demo && $demo_badge) : ?>
                 <span
                     class="badge-demo"
@@ -78,6 +69,16 @@ $has_reward = !empty($reward_title) && (float) $reward_value > 0;
                     <span class="badge-demo__label"><?php echo esc_html($demo_badge['label'] ?? ''); ?></span>
                     <?php if ($demo_badge_description_id) : ?>
                         <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                    <?php endif; ?>
+                </span>
+            <?php else : ?>
+                <span class="badge-statut <?php echo esc_attr($badge_classes); ?>"
+                    data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                    <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+                    <?php if ($has_badge_icon) : ?>
+                        <span class="badge-statut__icon" aria-hidden="true">
+                            <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                        </span>
                     <?php endif; ?>
                 </span>
             <?php endif; ?>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-card.php
@@ -41,14 +41,6 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
 <div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($infos['classe_statut'] . ' ' . $completion_class)); ?>">
     <div class="carte-ligne__image">
         <div class="carte-badges-stack">
-            <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
-                <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
-                <?php if ($has_badge_icon) : ?>
-                    <span class="badge-statut__icon" aria-hidden="true">
-                        <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
-                    </span>
-                <?php endif; ?>
-            </span>
             <?php if ($is_demo && $demo_badge) : ?>
                 <span
                     class="badge-demo"
@@ -65,6 +57,15 @@ if ($badge_has_interaction && $badge_tooltip !== '') {
                     <span class="badge-demo__label"><?php echo esc_html($demo_badge['label'] ?? ''); ?></span>
                     <?php if ($demo_badge_description_id) : ?>
                         <span id="<?php echo esc_attr($demo_badge_description_id); ?>" class="screen-reader-text"><?php echo esc_html($demo_badge['screen_text'] ?? ''); ?></span>
+                    <?php endif; ?>
+                </span>
+            <?php else : ?>
+                <span class="badge-statut <?php echo esc_attr($badge_classes); ?>" data-post-id="<?php echo esc_attr($chasse_id); ?>"<?= $badge_attributes; ?>>
+                    <span class="badge-statut__label"><?php echo esc_html($badge_label); ?></span>
+                    <?php if ($has_badge_icon) : ?>
+                        <span class="badge-statut__icon" aria-hidden="true">
+                            <?php echo $badge_icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- contenu préparé et sécurisé en amont. ?>
+                        </span>
                     <?php endif; ?>
                 </span>
             <?php endif; ?>


### PR DESCRIPTION
Résumé
Cette mise à jour remplace le badge de statut par le badge démo sur toutes les cartes de chasses pour les chasses de démonstration.

- Remplace l'affichage du badge de statut par le badge démo dans les cartes large et ligne lorsque la chasse est en mode démo.
- Adapte les cartes compactes et mobiles pour afficher uniquement le badge démo et le rendre visible sur toutes les résolutions.

Tests
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d744aeffb08332872b21529e84f7e4