### PR TITLE
Centrage vertical du logo organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_organisateurs.scss
@@ -109,6 +109,9 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
   max-width: 90vw;
   max-height: 300px;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -11163,6 +11163,9 @@ a.bouton-edition-attention {
 }
 
 .header-organisateur__col--logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
   max-width: 90vw;
   max-height: 300px;


### PR DESCRIPTION
Résumé : Centre verticalement le logo de l'organisateur dans l'en-tête.

- Ajout d'un conteneur flex pour centrer verticalement le logo dans la colonne dédiée.
- Recompilation de la feuille de style distribuée pour refléter la modification SCSS.

## Testing
- `npm run build:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d8c3b0950883329bbf7959595e47c8