### PR TITLE
Add admin delete action to chasse edition panel

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-edition-main.php
@@ -933,6 +933,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
             <button type="submit" name="validation_admin_action" value="bannir" class="bouton-secondaire" onclick="return confirm('Bannir cette chasse&nbsp;?');">
               <i class="fa-solid fa-triangle-exclamation"></i> Bannir
             </button>
+            <button type="submit" name="validation_admin_action" value="supprimer" class="bouton-secondaire btn-danger" onclick="return confirm('<?php echo esc_js(__('Supprimer cette chasse&nbsp;?', 'chassesautresor-com')); ?>');">
+              <i class="fa-solid fa-trash"></i> <?php echo esc_html__('Supprimer', 'chassesautresor-com'); ?>
+            </button>
           </form>
         <?php endif; ?>
       </div>


### PR DESCRIPTION
Résumé : Ajout d'une action de suppression de chasse pour les administrateurs dans le panneau d'édition.

- Ajout d'un bouton « Supprimer » aux actions d'administration de la fiche de chasse.
- Réutilisation du workflow `validation_admin_action=supprimer` déjà existant via le formulaire `admin-post.php`.

## Testing
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d941c8360083328b3b1aef1b451219