### PR TITLE
Améliore le contraste du formulaire de contact organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_components.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_components.scss
@@ -1099,12 +1099,26 @@ a.ajout-link:focus-visible {
   max-width: 600px;
   padding-left: var(--space-md);
   padding-right: var(--space-md);
+
+  .wpforms-field-label,
+  .wpforms-field-label-inline,
+  label {
+    color: var(--color-text-primary);
+  }
+
+  .wpforms-field-sublabel,
+  .wpforms-required-label,
+  .wpforms-field-description {
+    color: var(--color-text-primary);
+  }
+
+  .wpforms-required-label {
+    font-weight: 600;
+    color: var(--color-primary);
+  }
 }
 .titre-contact {
   margin-bottom: 0.8rem;
-}
-body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
-    color: var(--color-text-primary);
 }
 @media (--bp-small) {
   .formulaire-contact-wrapper {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -2831,13 +2831,23 @@ a.ajout-link:focus-visible {
   padding-left: var(--space-md);
   padding-right: var(--space-md);
 }
+.formulaire-contact-wrapper .wpforms-field-label,
+.formulaire-contact-wrapper .wpforms-field-label-inline,
+.formulaire-contact-wrapper label {
+  color: var(--color-text-primary);
+}
+.formulaire-contact-wrapper .wpforms-field-sublabel,
+.formulaire-contact-wrapper .wpforms-required-label,
+.formulaire-contact-wrapper .wpforms-field-description {
+  color: var(--color-text-primary);
+}
+.formulaire-contact-wrapper .wpforms-required-label {
+  font-weight: 600;
+  color: var(--color-primary);
+}
 
 .titre-contact {
   margin-bottom: 0.8rem;
-}
-
-body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
-  color: var(--color-text-primary);
 }
 
 @media (min-width: 480px) {


### PR DESCRIPTION
Résumé : Amélioration du contraste des labels sur le formulaire de contact organisateur.

- Harmonise la couleur des labels, sous-labels et descriptions du formulaire avec la charte graphique
- Met en avant les astérisques obligatoires en utilisant la couleur principale et recompilé les styles du thème

## Tests
- npm run build:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9426f0774833291a61f04fbb2ee88