### PR TITLE
Affiche le header organisateur sur la page contact

### DIFF
--- a/wp-content/themes/chassesautresor/header.php
+++ b/wp-content/themes/chassesautresor/header.php
@@ -234,35 +234,61 @@ if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
             echo '</div>';
         }
     } elseif ( is_page() && ! $should_hide_hero ) {
-        $image_id     = get_post_thumbnail_id();
-        $fallback_url = function_exists( 'get_theme_file_uri' )
-            ? get_theme_file_uri( 'assets/images/institutionnels.webp' )
-            : '';
-        $image_url    = '';
+        $has_custom_header = false;
 
-        if ( $image_id ) {
-            $image_url = wp_get_attachment_image_url( $image_id, 'full' );
+        if ( is_page( 'contact' ) && isset( $_GET['email_organisateur'] ) ) {
+            $email_organisateur = sanitize_email( wp_unslash( $_GET['email_organisateur'] ) );
 
-            if ( $image_url && function_exists( 'imagify_get_webp_url' ) ) {
-                $webp_url = imagify_get_webp_url( $image_url );
+            if ( $email_organisateur ) {
+                $organisateur_id = function_exists( 'get_organisateur_id_by_contact_email' )
+                    ? get_organisateur_id_by_contact_email( $email_organisateur )
+                    : null;
 
-                if ( $webp_url ) {
-                    $image_url = $webp_url;
+                if ( $organisateur_id ) {
+                    get_template_part(
+                        'template-parts/organisateur/organisateur-header',
+                        null,
+                        [
+                            'organisateur_id' => $organisateur_id,
+                            'onglet_actif'    => 'contact',
+                        ]
+                    );
+                    $has_custom_header = true;
                 }
             }
         }
 
-        if ( ! $image_url ) {
-            $image_url = $fallback_url;
-        }
+        if ( ! $has_custom_header ) {
+            $image_id     = get_post_thumbnail_id();
+            $fallback_url = function_exists( 'get_theme_file_uri' )
+                ? get_theme_file_uri( 'assets/images/institutionnels.webp' )
+                : '';
+            $image_url    = '';
 
-        get_header_fallback(
-            [
-                'titre'      => get_the_title(),
-                'sous_titre' => '',
-                'image_fond' => $image_url,
-            ]
-        );
+            if ( $image_id ) {
+                $image_url = wp_get_attachment_image_url( $image_id, 'full' );
+
+                if ( $image_url && function_exists( 'imagify_get_webp_url' ) ) {
+                    $webp_url = imagify_get_webp_url( $image_url );
+
+                    if ( $webp_url ) {
+                        $image_url = $webp_url;
+                    }
+                }
+            }
+
+            if ( ! $image_url ) {
+                $image_url = $fallback_url;
+            }
+
+            get_header_fallback(
+                [
+                    'titre'      => get_the_title(),
+                    'sous_titre' => '',
+                    'image_fond' => $image_url,
+                ]
+            );
+        }
     }
     
     astra_content_before();

--- a/wp-content/themes/chassesautresor/inc/organisateur-functions.php
+++ b/wp-content/themes/chassesautresor/inc/organisateur-functions.php
@@ -587,10 +587,71 @@ add_action('wp_ajax_load_conversion_history', 'ajax_load_conversion_history');
 // 📩 FORMULAIRE DE CONTACT ORGANISATEUR (WPForms)
 // ==================================================
 /**
+ * 🔹 get_organisateur_id_by_contact_email → retrouve l’ID organisateur à partir de l’email de contact.
  * 🔹 filtrer_destinataire_contact_organisateur → modifie le destinataire du mail via WPForms (email ACF ou auteur, BCC admin)
  * 🔹 ajouter_endpoint_contact_organisateur → ajoute l’endpoint `/contact` sur les URLs des organisateurs (détection côté template)
  */
 
+/**
+ * Récupère l'ID d'un organisateur à partir de son email de contact public.
+ *
+ * Cette fonction recherche d'abord un CPT "organisateur" dont le champ ACF
+ * `profil_public_email_contact` correspond à l'email fourni. Si rien n'est trouvé,
+ * on tente une correspondance avec l'email de l'auteur du CPT.
+ *
+ * @param string|null $email Email de contact fourni dans l'URL.
+ *
+ * @return int|null ID du CPT organisateur correspondant ou null si introuvable.
+ */
+function get_organisateur_id_by_contact_email(?string $email): ?int
+{
+    $sanitized = sanitize_email((string) $email);
+
+    if ($sanitized === '') {
+        return null;
+    }
+
+    static $cache = [];
+    $cache_key = strtolower($sanitized);
+
+    if (array_key_exists($cache_key, $cache)) {
+        return $cache[$cache_key];
+    }
+
+    $query = get_posts([
+        'post_type'      => 'organisateur',
+        'post_status'    => ['publish', 'pending', 'draft'],
+        'meta_key'       => 'profil_public_email_contact',
+        'meta_value'     => $sanitized,
+        'meta_compare'   => '=',
+        'posts_per_page' => 1,
+        'fields'         => 'ids',
+        'suppress_filters' => false,
+    ]);
+
+    if (!empty($query)) {
+        $organisateur_id = (int) $query[0];
+        $cache[$cache_key] = $organisateur_id;
+
+        return $organisateur_id;
+    }
+
+    $user = get_user_by('email', $sanitized);
+
+    if ($user) {
+        $organisateur_id = get_organisateur_from_user((int) $user->ID);
+
+        if ($organisateur_id) {
+            $cache[$cache_key] = (int) $organisateur_id;
+
+            return (int) $organisateur_id;
+        }
+    }
+
+    $cache[$cache_key] = null;
+
+    return null;
+}
 
 /**
  * Ajoute l'endpoint `contact` aux permaliens des organisateurs.


### PR DESCRIPTION
## Résumé
- Remplacement du hero de la page de contact par le header organisateur dédié.

## Changements
- Ajout d’une fonction permettant de retrouver un organisateur via son email de contact public.
- Affichage conditionnel du header organisateur sur la page /contact lorsque l’email correspond à un profil.

## Tests
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d942aca6c48332adb56c7c0830882e