### PR TITLE
Supprimer la mention support technique sur le contact organisateur

### DIFF
--- a/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-contact-form.php
+++ b/wp-content/themes/chassesautresor/template-parts/organisateur/organisateur-partial-contact-form.php
@@ -71,8 +71,7 @@ if ($est_en_creation) :
 
     <div class="bloc-discret">
       <p class="txt-sous-titre">
-        Utilisez ce formulaire pour envoyer un message à l’organisateur.<br>
-        Pour toute question technique liée au site, <a href="https://chassesautresor.com/contact">utilisez ce formulaire</a>.
+        Utilisez ce formulaire pour envoyer un message à l’organisateur.
       </p>
 
       <?php


### PR DESCRIPTION
Suppression de la mention de support technique sur la page de contact de l’organisateur.

- Retrait de la phrase redirigeant vers le support technique depuis le bloc introductif du formulaire de contact.

## Tests
- ✅ `composer install`
- ✅ `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d946b2e090833287f9e58492741c87