### PR TITLE
Empêcher l'ouverture média sur champs verrouillés

### DIFF
--- a/tests/js/champ-init.test.js
+++ b/tests/js/champ-init.test.js
@@ -1,17 +1,15 @@
 const fs = require('fs');
 const path = require('path');
 
-describe('initChampDeclencheur', () => {
-  let script;
+const script = fs.readFileSync(
+  path.resolve(__dirname, '../../wp-content/themes/chassesautresor/assets/js/core/champ-init.js'),
+  'utf8'
+);
+eval(script);
+global.initChampDeclencheur = initChampDeclencheur;
+global.initZoneClicEdition = initZoneClicEdition;
 
-  beforeAll(() => {
-    script = fs.readFileSync(
-      path.resolve(__dirname, '../../wp-content/themes/chassesautresor/assets/js/core/champ-init.js'),
-      'utf8'
-    );
-    eval(script);
-    global.initChampDeclencheur = initChampDeclencheur;
-  });
+describe('initChampDeclencheur', () => {
 
   beforeEach(() => {
     global.initChampImage = jest.fn();
@@ -71,5 +69,51 @@ describe('initChampDeclencheur', () => {
     trigger.click();
 
     expect(bloc.__ouvrirMedia).not.toHaveBeenCalled();
+  });
+});
+
+describe('initZoneClicEdition', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('n’active pas la zone lorsque le champ est désactivé', () => {
+    document.body.innerHTML = `
+      <ul>
+        <li class="champ-chasse champ-desactive" data-champ="chasse_principale_image">
+          <button class="champ-modifier" aria-disabled="true"></button>
+        </li>
+      </ul>`;
+
+    const zone = document.querySelector('.champ-chasse');
+    const bouton = zone.querySelector('.champ-modifier');
+    const zoneSpy = jest.spyOn(zone, 'addEventListener');
+
+    initZoneClicEdition(bouton);
+
+    expect(zone.style.cursor).toBe('default');
+    expect(zoneSpy).not.toHaveBeenCalled();
+
+    zoneSpy.mockRestore();
+  });
+
+  it('ajoute un gestionnaire lorsque le champ est actif', () => {
+    document.body.innerHTML = `
+      <ul>
+        <li class="champ-chasse" data-champ="chasse_principale_image">
+          <button class="champ-modifier"></button>
+        </li>
+      </ul>`;
+
+    const zone = document.querySelector('.champ-chasse');
+    const bouton = zone.querySelector('.champ-modifier');
+    const zoneSpy = jest.spyOn(zone, 'addEventListener');
+
+    initZoneClicEdition(bouton);
+
+    expect(zone.style.cursor).toBe('pointer');
+    expect(zoneSpy).toHaveBeenCalledTimes(1);
+
+    zoneSpy.mockRestore();
   });
 });

--- a/tests/js/image-utils.test.js
+++ b/tests/js/image-utils.test.js
@@ -4,6 +4,7 @@ describe('initChampImage', () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <div class="champ-organisateur champ-img" data-champ="logo_organisateur" data-cpt="organisateur" data-post-id="123">
+        <button class="champ-modifier" data-champ="logo_organisateur" data-cpt="organisateur" data-post-id="123"></button>
         <img src="" />
         <input class="champ-input" type="hidden" />
         <div class="champ-feedback"></div>
@@ -60,5 +61,20 @@ describe('initChampImage', () => {
     await flush();
     const params = fetch.mock.calls[0][1].body;
     expect(params.get('action')).toBe('modifier_champ_organisateur');
+  });
+
+  it('ignore les blocs désactivés', () => {
+    const bloc = document.querySelector('.champ-organisateur');
+    bloc.classList.add('champ-desactive');
+    const bouton = bloc.querySelector('.champ-modifier');
+    bouton.setAttribute('aria-disabled', 'true');
+    const spy = jest.spyOn(bouton, 'addEventListener');
+
+    initChampImage(bloc);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(bloc.__ouvrirMedia).toBeUndefined();
+
+    spy.mockRestore();
   });
 });

--- a/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-init.js
@@ -501,6 +501,17 @@ function initZoneClicEdition(bouton) {
   const zone = bouton.closest('li') || bouton.closest('[data-champ]');
   if (!zone) return;
 
+  const estZoneDesactive =
+    zone.classList.contains('champ-desactive') ||
+    zone.dataset.noEdit === '1' ||
+    zone.dataset.noEdit === 'true' ||
+    bouton.disabled ||
+    bouton.getAttribute('aria-disabled') === 'true';
+
+  if (estZoneDesactive) {
+    zone.style.cursor = 'default';
+    return;
+  }
 
   zone.style.cursor = 'pointer';
 

--- a/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/image-utils.js
@@ -7,11 +7,27 @@ function initChampImage(bloc) {
   const postId = bloc.dataset.postId;
 
   const feedback = bloc.querySelector('.champ-feedback');
+  const bouton = bloc.querySelector('.champ-modifier');
 
   if (!champ || !cpt || !postId) return;
 
+  const estBlocVerrouille = () =>
+    bloc.classList.contains('champ-desactive') ||
+    bloc.dataset.noEdit === '1' ||
+    bloc.dataset.noEdit === 'true' ||
+    bouton?.disabled ||
+    bouton?.getAttribute('aria-disabled') === 'true';
+
+  if (!bouton || estBlocVerrouille()) {
+    delete bloc.__ouvrirMedia;
+    return;
+  }
+
   // ✅ Création du frame à la volée quand appelé
   const ouvrirMedia = () => {
+    if (estBlocVerrouille()) {
+      return;
+    }
     // ✅ Empêcher double ouverture : reuse si déjà initialisé
     if (bloc.__mediaFrame) {
       bloc.__mediaFrame.open();
@@ -111,7 +127,6 @@ function initChampImage(bloc) {
     frame.open();
   };
 
-  const bouton = bloc.querySelector('.champ-modifier');
   if (bouton && !bouton.classList.contains('ouvrir-panneau-images')) {
     bouton.addEventListener('click', ouvrirMedia);
   }

--- a/wp-content/themes/chassesautresor/assets/scss/_edition.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_edition.scss
@@ -335,6 +335,12 @@ body.edition-active-enigme .resume-infos li {
   cursor: pointer;
 }
 
+body.edition-active .champ-desactive,
+body.edition-active-chasse .champ-desactive,
+body.edition-active-enigme .champ-desactive {
+  cursor: default;
+}
+
 
 /* ========== 📂 Toggle panneau édition ========== */
 section.enigme-wrapper {


### PR DESCRIPTION
Résumé
- Empêche l'ouverture du sélecteur média quand le champ image est désactivé côté interface.
- Désactive l'extension de zone de clic pour les champs marqués comme non éditables et rétablit un curseur neutre.
- Ajoute des tests unitaires pour couvrir ces comportements et ajuste ceux existants.

## Testing
- `npm test`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d95315b32c83328cdacf3ed863ec11