### PR TITLE
Aligne le texte des énigmes à gauche

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_enigme.scss
@@ -683,6 +683,7 @@ li.active .enigme-menu__edit {
   font-size: clamp(1rem, 1.2vw + 0.9rem, 1.25rem);
   line-height: 1.6;
   overflow-wrap: anywhere;
+  text-align: left;
 
   ul {
     list-style: disc;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -6948,6 +6948,7 @@ li.active .enigme-menu__edit {
   font-size: clamp(1rem, 1.2vw + 0.9rem, 1.25rem);
   line-height: 1.6;
   overflow-wrap: anywhere;
+  text-align: left;
 }
 .enigme-texte ul {
   list-style: disc;


### PR DESCRIPTION
Résumé: Aligne le contenu textuel des énigmes sur la page dédiée.

Modifications:
- Ajoute une règle `text-align: left` à la section `.enigme-texte` dans les sources SCSS.
- Met à jour la feuille de style compilée pour appliquer le même alignement.

Tests:
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68da4442d4b083328b81acec2c0f9191