### PR TITLE
Affiche les formats court et long des dates de chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/js/core/champ-date-hooks.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/champ-date-hooks.js
@@ -7,6 +7,30 @@ window.onDateFieldUpdated = function(input, valeur) {
   const champ = input.closest('[data-champ]')?.dataset.champ;
   if (!champ) return;
 
+  const updateDisplay = (element, longText, shortText) => {
+    if (!element) return;
+    if (typeof window.catUpdateHuntDateDisplay === 'function') {
+      window.catUpdateHuntDateDisplay(element, {
+        longText,
+        shortText
+      });
+    } else {
+      element.textContent = longText;
+    }
+  };
+
+  const formatLocalized = (val) => (
+    (typeof window.formatDateLocalized === 'function')
+      ? window.formatDateLocalized(val)
+      : val
+  );
+
+  const formatShort = (val) => (
+    (typeof window.formatHuntDateShort === 'function')
+      ? window.formatHuntDateShort(val)
+      : val
+  );
+
   const handlers = {
     'enigme_acces_date': (val) => {
       const span = document.querySelector('.date-deblocage');
@@ -14,20 +38,25 @@ window.onDateFieldUpdated = function(input, valeur) {
     },
     'chasse_infos_date_debut': (val) => {
       const span = document.querySelector('.date-debut');
-      if (span) span.textContent = (typeof window.formatDateLocalized === 'function') ? window.formatDateLocalized(val) : val;
+      if (!span) return;
+      updateDisplay(span, formatLocalized(val), formatShort(val));
     },
     'chasse_infos_date_fin': (val) => {
       const span = document.querySelector('.date-fin');
       if (!span) return;
 
       const checkboxIllimitee = document.getElementById('duree-illimitee');
-      if (checkboxIllimitee && checkboxIllimitee.checked) {
+      const toggleLimitee = document.getElementById('date-fin-limitee');
+      const isUnlimited = (toggleLimitee && !toggleLimitee.checked)
+        || (checkboxIllimitee && checkboxIllimitee.checked);
+
+      if (isUnlimited) {
         const txtUnlimited = (window.catI18n && window.catI18n.texts && window.catI18n.texts.unlimited)
           ? window.catI18n.texts.unlimited
           : 'Illimitée';
-        span.textContent = txtUnlimited;
+        updateDisplay(span, txtUnlimited, txtUnlimited);
       } else {
-        span.textContent = (typeof window.formatDateLocalized === 'function') ? window.formatDateLocalized(val) : val;
+        updateDisplay(span, formatLocalized(val), formatShort(val));
       }
     }
     // Ajoutez ici d'autres handlers spécifiques si nécessaire

--- a/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
@@ -27,6 +27,107 @@ function formatDateFr(dateStr) {
   });
 }
 
+function getPreferredLocale() {
+  const wpLocale = (window.catI18n && window.catI18n.locale) ? String(window.catI18n.locale) : '';
+  const docLang = (document.documentElement && document.documentElement.lang) ? document.documentElement.lang : '';
+  const navLang = (navigator && (navigator.language || (navigator.languages && navigator.languages[0])));
+  return wpLocale || docLang || navLang || 'fr-FR';
+}
+
+function formatHuntDateShort(dateStr) {
+  if (!dateStr) return '';
+  const parsed = new Date(String(dateStr).replace(' ', 'T'));
+  if (Number.isNaN(parsed.getTime())) return dateStr;
+
+  const locale = getPreferredLocale();
+  try {
+    return parsed.toLocaleDateString(locale, {
+      day: '2-digit',
+      month: '2-digit',
+      year: '2-digit'
+    });
+  } catch (error) {
+    return parsed.toLocaleDateString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: '2-digit'
+    });
+  }
+}
+
+function normalizeDateText(value, fallback) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed !== '') {
+      return trimmed;
+    }
+  }
+
+  if (typeof fallback === 'string') {
+    const fallbackTrimmed = fallback.trim();
+    if (fallbackTrimmed !== '') {
+      return fallbackTrimmed;
+    }
+  }
+
+  return '';
+}
+
+function updateHuntDateDisplay(element, options = {}) {
+  if (!element) return;
+
+  const currentLong = element.dataset?.dateLong || '';
+  const currentShort = element.dataset?.dateShort || currentLong;
+  const longText = normalizeDateText(options.longText, currentLong);
+  const shortText = normalizeDateText(options.shortText, currentShort || longText);
+
+  element.dataset.dateLong = longText;
+  element.dataset.dateShort = shortText;
+
+  const shortNode = element.querySelector('.date-short');
+  const longNode = element.querySelector('.date-long');
+
+  if (shortNode) {
+    shortNode.textContent = shortText;
+  }
+
+  if (longNode) {
+    longNode.textContent = longText;
+  }
+
+  if (!shortNode && !longNode) {
+    element.textContent = longText;
+  }
+}
+
+function getUnlimitedLabel() {
+  return (window.catI18n && window.catI18n.texts && window.catI18n.texts.unlimited)
+    ? window.catI18n.texts.unlimited
+    : 'Illimitée';
+}
+
+function isChasseUnlimited() {
+  const toggleLimitee = document.getElementById('date-fin-limitee');
+  const checkboxIllimitee = document.getElementById('duree-illimitee');
+
+  if (toggleLimitee && checkboxIllimitee) {
+    return !toggleLimitee.checked || checkboxIllimitee.checked;
+  }
+
+  if (toggleLimitee) {
+    return !toggleLimitee.checked;
+  }
+
+  if (checkboxIllimitee) {
+    return checkboxIllimitee.checked;
+  }
+
+  return false;
+}
+
+window.formatHuntDateShort = formatHuntDateShort;
+window.catUpdateHuntDateDisplay = updateHuntDateDisplay;
+
 
 
 // ==============================
@@ -36,15 +137,36 @@ function mettreAJourAffichageDateFin() {
   console.log('[mettreAJourAffichageDateFin]');
   const spanDateFin = document.querySelector('.chasse-date-plage .date-fin');
   const inputDateFin = document.getElementById('chasse-date-fin');
-  const toggleLimitee = document.getElementById('date-fin-limitee');
+  if (!spanDateFin) return;
 
-  if (!spanDateFin || !inputDateFin || !toggleLimitee) return;
-
-  if (!toggleLimitee.checked) {
-    spanDateFin.textContent = 'Illimitée';
-  } else {
-    spanDateFin.textContent = formatDateFr(inputDateFin.value);
+  if (isChasseUnlimited()) {
+    const unlimitedLabel = getUnlimitedLabel();
+    updateHuntDateDisplay(spanDateFin, {
+      longText: unlimitedLabel,
+      shortText: unlimitedLabel
+    });
+    return;
   }
+
+  if (!inputDateFin || !inputDateFin.value) {
+    updateHuntDateDisplay(spanDateFin, {
+      longText: '',
+      shortText: ''
+    });
+    return;
+  }
+
+  const formattedLong = (typeof window.formatDateLocalized === 'function')
+    ? window.formatDateLocalized(inputDateFin.value)
+    : formatDateFr(inputDateFin.value);
+  const formattedShort = window.formatHuntDateShort
+    ? window.formatHuntDateShort(inputDateFin.value)
+    : formatHuntDateShort(inputDateFin.value);
+
+  updateHuntDateDisplay(spanDateFin, {
+    longText: formattedLong,
+    shortText: formattedShort || formattedLong
+  });
 }
 // ==============================
 // 📅 initChampDate
@@ -204,3 +326,36 @@ function initChampDate(input) {
   };
   window.mettreAJourAffichageDateFin = override;
 })();
+
+const previousOnDateFieldUpdated = window.onDateFieldUpdated;
+window.onDateFieldUpdated = function(input, valeur) {
+  if (typeof previousOnDateFieldUpdated === 'function') {
+    previousOnDateFieldUpdated(input, valeur);
+  }
+
+  const champ = input?.closest('[data-champ]')?.dataset?.champ;
+  if (!champ) return;
+
+  if (champ === 'chasse_infos_date_debut') {
+    const spanDateDebut = document.querySelector('.chasse-date-plage .date-debut');
+    if (!spanDateDebut) return;
+
+    const formattedLong = valeur
+      ? ((typeof window.formatDateLocalized === 'function')
+        ? window.formatDateLocalized(valeur)
+        : formatDateFr(valeur))
+      : '';
+    const formattedShort = valeur
+      ? (window.formatHuntDateShort
+        ? window.formatHuntDateShort(valeur)
+        : formatHuntDateShort(valeur))
+      : '';
+
+    updateHuntDateDisplay(spanDateDebut, {
+      longText: formattedLong,
+      shortText: formattedShort || formattedLong
+    });
+  } else if (champ === 'chasse_infos_date_fin') {
+    mettreAJourAffichageDateFin();
+  }
+};

--- a/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
+++ b/wp-content/themes/chassesautresor/assets/js/core/date-fields.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // date, datetime-local...). L'important est qu'ils possèdent la classe
   // `.champ-date-edit`.
   document.querySelectorAll('input.champ-date-edit').forEach(initChampDate);
+  initResponsiveDateVisibility();
 });
 
 
@@ -98,6 +99,96 @@ function updateHuntDateDisplay(element, options = {}) {
   if (!shortNode && !longNode) {
     element.textContent = longText;
   }
+
+  applyResponsiveDateVisibility(element);
+}
+
+const DATE_FORMAT_MEDIA_QUERY = '(min-width: 1024px)';
+let dateFormatMediaMatcher = null;
+
+function handleDateFormatMediaChange() {
+  applyResponsiveDateVisibility();
+}
+
+function ensureDateFormatMediaMatcher() {
+  if (dateFormatMediaMatcher || typeof window.matchMedia !== 'function') {
+    return dateFormatMediaMatcher;
+  }
+
+  dateFormatMediaMatcher = window.matchMedia(DATE_FORMAT_MEDIA_QUERY);
+
+  if (typeof dateFormatMediaMatcher.addEventListener === 'function') {
+    dateFormatMediaMatcher.addEventListener('change', handleDateFormatMediaChange);
+  } else if (typeof dateFormatMediaMatcher.addListener === 'function') {
+    dateFormatMediaMatcher.addListener(handleDateFormatMediaChange);
+  }
+
+  return dateFormatMediaMatcher;
+}
+
+function isDesktopForDateFormatting() {
+  const matcher = ensureDateFormatMediaMatcher();
+  return matcher ? matcher.matches : false;
+}
+
+function toggleDateFormatNodes(element, isDesktop) {
+  if (!(element instanceof Element)) {
+    return;
+  }
+
+  const shortNode = element.querySelector('.date-short');
+  const longNode = element.querySelector('.date-long');
+
+  if (shortNode) {
+    if (isDesktop) {
+      shortNode.hidden = true;
+      shortNode.setAttribute('aria-hidden', 'true');
+    } else {
+      shortNode.hidden = false;
+      shortNode.setAttribute('aria-hidden', 'false');
+    }
+  }
+
+  if (longNode) {
+    if (isDesktop) {
+      longNode.hidden = false;
+      longNode.setAttribute('aria-hidden', 'false');
+    } else {
+      longNode.hidden = true;
+      longNode.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  if (!shortNode && !longNode && element.dataset) {
+    const dataset = element.dataset;
+    const fallbackText = isDesktop
+      ? normalizeDateText(dataset.dateLong, dataset.dateShort)
+      : normalizeDateText(dataset.dateShort, dataset.dateLong);
+
+    if (fallbackText !== '') {
+      element.textContent = fallbackText;
+    }
+  }
+}
+
+function applyResponsiveDateVisibility(context) {
+  const isDesktop = isDesktopForDateFormatting();
+
+  if (context instanceof Element) {
+    toggleDateFormatNodes(context, isDesktop);
+    return;
+  }
+
+  document
+    .querySelectorAll('.chasse-date-plage .date-debut, .chasse-date-plage .date-fin')
+    .forEach((element) => {
+      toggleDateFormatNodes(element, isDesktop);
+    });
+}
+
+function initResponsiveDateVisibility() {
+  ensureDateFormatMediaMatcher();
+  applyResponsiveDateVisibility();
 }
 
 function getUnlimitedLabel() {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -408,19 +408,27 @@ a.chasse-badge.chasse-badge--region:focus-visible {
     align-items: center;
     gap: var(--space-xxs);
     white-space: nowrap;
-}
 
-.chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
-    display: none;
+    .date-debut,
+    .date-fin {
+        display: inline-flex;
+        gap: var(--space-3xs);
+    }
+
+    .date-long {
+        display: none;
+    }
 }
 
 @media (--bp-desktop) {
-    .chasse-fiche-container > .meta-row .chasse-date-plage .date-short {
-        display: none;
-    }
+    .chasse-fiche-container > .meta-row .chasse-date-plage {
+        .date-short {
+            display: none;
+        }
 
-    .chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
-        display: inline;
+        .date-long {
+            display: inline;
+        }
     }
 }
 .chasse-details-wrapper .bloc-metas-inline {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -418,6 +418,11 @@ a.chasse-badge.chasse-badge--region:focus-visible {
     .date-long {
         display: none;
     }
+
+    .date-short[hidden],
+    .date-long[hidden] {
+        display: none !important;
+    }
 }
 
 @media (--bp-desktop) {

--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -409,6 +409,20 @@ a.chasse-badge.chasse-badge--region:focus-visible {
     gap: var(--space-xxs);
     white-space: nowrap;
 }
+
+.chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
+    display: none;
+}
+
+@media (--bp-desktop) {
+    .chasse-fiche-container > .meta-row .chasse-date-plage .date-short {
+        display: none;
+    }
+
+    .chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
+        display: inline;
+    }
+}
 .chasse-details-wrapper .bloc-metas-inline {
     margin: var(--space-xl) 0;
     color: white;

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1399,6 +1399,10 @@ a.chasse-badge.chasse-badge--region:focus-visible {
 .chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
   display: none;
 }
+.chasse-fiche-container > .meta-row .chasse-date-plage .date-short[hidden],
+.chasse-fiche-container > .meta-row .chasse-date-plage .date-long[hidden] {
+  display: none !important;
+}
 
 @media (min-width: 1024px) {
   .chasse-fiche-container > .meta-row .chasse-date-plage .date-short {

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1391,7 +1391,23 @@ a.chasse-badge.chasse-badge--region:focus-visible {
   gap: var(--space-xxs);
   white-space: nowrap;
 }
+.chasse-fiche-container > .meta-row .chasse-date-plage .date-debut,
+.chasse-fiche-container > .meta-row .chasse-date-plage .date-fin {
+  display: inline-flex;
+  gap: var(--space-3xs);
+}
+.chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
+  display: none;
+}
 
+@media (min-width: 1024px) {
+  .chasse-fiche-container > .meta-row .chasse-date-plage .date-short {
+    display: none;
+  }
+  .chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
+    display: inline;
+  }
+}
 .chasse-details-wrapper .bloc-metas-inline {
   margin: var(--space-xl) 0;
   color: white;
@@ -4025,6 +4041,12 @@ body.edition-active .resume-infos li,
 body.edition-active-chasse .resume-infos li,
 body.edition-active-enigme .resume-infos li {
   cursor: pointer;
+}
+
+body.edition-active .champ-desactive,
+body.edition-active-chasse .champ-desactive,
+body.edition-active-enigme .champ-desactive {
+  cursor: default;
 }
 
 /* ========== 📂 Toggle panneau édition ========== */

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -441,8 +441,8 @@ if ($edition_active && !$est_complet) {
                 data-date-long="<?= esc_attr($date_debut_longue); ?>"
                 data-date-short="<?= esc_attr($date_debut_courte); ?>"
             >
-                <span class="date-short"><?= esc_html($date_debut_courte); ?></span>
-                <span class="date-long"><?= esc_html($date_debut_longue); ?></span>
+              <span class="date-short" aria-hidden="false"><?= esc_html($date_debut_courte); ?></span>
+              <span class="date-long" aria-hidden="true"><?= esc_html($date_debut_longue); ?></span>
             </span>
             <span class="date-separator" aria-hidden="true">–</span>
             <span
@@ -450,8 +450,8 @@ if ($edition_active && !$est_complet) {
                 data-date-long="<?= esc_attr($date_fin_longue); ?>"
                 data-date-short="<?= esc_attr($date_fin_courte); ?>"
             >
-                <span class="date-short"><?= esc_html($date_fin_courte); ?></span>
-                <span class="date-long"><?= esc_html($date_fin_longue); ?></span>
+              <span class="date-short" aria-hidden="false"><?= esc_html($date_fin_courte); ?></span>
+              <span class="date-long" aria-hidden="true"><?= esc_html($date_fin_longue); ?></span>
             </span>
           </span>
         </div>

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -394,6 +394,13 @@ if ($edition_active && !$est_complet) {
           $date_fin_courte = __('Non spécifiée', 'chassesautresor-com');
       }
 
+      $date_debut_longue = $date_debut_formatee !== ''
+          ? $date_debut_formatee
+          : $date_debut_courte;
+      $date_fin_longue = $date_fin_formatee !== ''
+          ? $date_fin_formatee
+          : $date_fin_courte;
+
       if ($illimitee) {
           $date_plage_title = __('Durée illimitée', 'chassesautresor-com');
       } elseif (!empty($date_debut) && !empty($date_fin)) {
@@ -429,9 +436,23 @@ if ($edition_active && !$est_complet) {
             title="<?= esc_attr($date_plage_title); ?>"
             aria-label="<?= esc_attr($date_plage_title); ?>"
           >
-            <span class="date-debut"><?= esc_html($date_debut_courte); ?></span>
+            <span
+                class="date-debut"
+                data-date-long="<?= esc_attr($date_debut_longue); ?>"
+                data-date-short="<?= esc_attr($date_debut_courte); ?>"
+            >
+                <span class="date-short"><?= esc_html($date_debut_courte); ?></span>
+                <span class="date-long"><?= esc_html($date_debut_longue); ?></span>
+            </span>
             <span class="date-separator" aria-hidden="true">–</span>
-            <span class="date-fin"><?= esc_html($date_fin_courte); ?></span>
+            <span
+                class="date-fin"
+                data-date-long="<?= esc_attr($date_fin_longue); ?>"
+                data-date-short="<?= esc_attr($date_fin_courte); ?>"
+            >
+                <span class="date-short"><?= esc_html($date_fin_courte); ?></span>
+                <span class="date-long"><?= esc_html($date_fin_longue); ?></span>
+            </span>
           </span>
         </div>
       </div>


### PR DESCRIPTION
Résumé : Adaptation de l'affichage des dates des chasses selon le viewport.

Modifications notables :
- Ajout des formats court et long des dates dans le template de fiche chasse et exposition via des attributs de données.
- Ajustement du SCSS pour n'afficher que les dates courtes sur mobile et basculer sur les versions longues sur desktop.
- Mise à jour des scripts de gestion des dates pour synchroniser les deux formats, y compris en mode illimité lors de l'édition.

Tests :
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68daa7dc90388332ad7e776901111313