### PR TITLE
Autoriser l'accès aux énigmes pending pour les organisateurs engagés

### DIFF
--- a/tests/OrganisateurAccessTest.php
+++ b/tests/OrganisateurAccessTest.php
@@ -39,6 +39,22 @@ class OrganisateurAccessTest extends TestCase
         ];
         $this->assertTrue(utilisateur_peut_voir_enigme($enigme_id));
     }
+
+    public function test_organisateur_engage_peut_voir_enigme_pending(): void
+    {
+        global $fields, $enigme_chasse, $post_status, $engagements;
+        $enigme_id   = 5;
+        $chasse_id   = 6;
+        $enigme_chasse = [$enigme_id => $chasse_id];
+        $post_status   = [$enigme_id => 'pending'];
+        $fields        = [
+            $enigme_id => ['enigme_cache_etat_systeme' => 'accessible'],
+            $chasse_id => ['chasse_cache_statut_validation' => 'creation'],
+        ];
+        $engagements = ['1:6' => true];
+
+        $this->assertTrue(utilisateur_peut_voir_enigme($enigme_id));
+    }
 }
 
 if (!function_exists('get_post_type')) {
@@ -77,7 +93,10 @@ if (!function_exists('recuperer_id_chasse_associee')) {
 if (!function_exists('utilisateur_est_engage_dans_chasse')) {
     function utilisateur_est_engage_dans_chasse($user_id, $chasse_id)
     {
-        return false;
+        global $engagements;
+        $key = $user_id . ':' . $chasse_id;
+
+        return $engagements[$key] ?? false;
     }
 }
 if (!function_exists('is_user_logged_in')) {

--- a/tests/UtilisateurPeutVoirEnigmeChasseTermineeTest.php
+++ b/tests/UtilisateurPeutVoirEnigmeChasseTermineeTest.php
@@ -58,6 +58,12 @@ class UtilisateurPeutVoirEnigmeChasseTermineeTest extends TestCase
                 return null;
             }
         }
+        if (!function_exists('utilisateur_est_organisateur_associe_a_chasse')) {
+            function utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
+            {
+                return false;
+            }
+        }
         if (!function_exists('cat_debug')) {
             function cat_debug($message)
             {

--- a/wp-content/themes/chassesautresor/inc/access-functions.php
+++ b/wp-content/themes/chassesautresor/inc/access-functions.php
@@ -501,6 +501,9 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
         return false;
     }
 
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id) ?? '';
+    $est_organisateur  = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);
+
     // 🏁 Chasse terminée : visuels accessibles à tous
     $chasse_terminee = get_field('chasse_cache_statut', $chasse_id) === 'termine';
     if ($chasse_terminee && $post_status === 'publish') {
@@ -510,6 +513,12 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
 
     // ✅ Abonné engagé dans la chasse → peut voir l’image si énigme accessible
     if (utilisateur_est_engage_dans_chasse($user_id, $chasse_id)) {
+        if ($est_organisateur && in_array($statut_validation, ['creation', 'correction', 'en_attente'], true)) {
+            $autorise = in_array($post_status, ['publish', 'pending'], true);
+            cat_debug("🟢 [voir énigme] organisateur engagé → chasse = $statut_validation → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
+            return $autorise;
+        }
+
         $autorise = ($post_status === 'publish') && ($etat_systeme === 'accessible');
         cat_debug("✅ [voir énigme] joueur engagé dans chasse #$chasse_id → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
         return $autorise;
@@ -529,13 +538,12 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
     }
 
     // 🔐 L’utilisateur doit être lié à l’organisateur de la chasse
-    if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
+    if (!$est_organisateur) {
         cat_debug("❌ [voir énigme] user #$user_id n'est pas lié à la chasse #$chasse_id");
         return false;
     }
 
     // ✅ Exception organisateur (chasse non publiée)
-    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
     cat_debug("🧪 [voir énigme] chasse #$chasse_id → statut_validation = $statut_validation");
 
     if (in_array($statut_validation, ['creation', 'correction', 'en_attente'], true)) {
@@ -546,7 +554,7 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
 
     // ✅ Cas organisateur associé à une chasse publiée mais à venir
     if (
-        utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id) &&
+        $est_organisateur &&
         $post_status === 'publish' &&
         $etat_systeme === 'bloquee_chasse'
     ) {


### PR DESCRIPTION
Résumé : Ajuste les contrôles d'accès aux énigmes pour les organisateurs engagés.

- Mémorise le statut d'organisateur associé dès l'entrée de `utilisateur_peut_voir_enigme`.
- Permet aux organisateurs engagés de consulter les énigmes pending lorsque la chasse est en création/correction/attente.
- Ajoute des tests couvrant l'accès d'un organisateur engagé à une énigme pending et les stubs manquants.

Tests :
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dab268f88483328c9ae68459d6db41