### PR TITLE
Supprimer le message redondant du CTA des chasses terminées

### DIFF
--- a/tests/GenererCtaChasseTest.php
+++ b/tests/GenererCtaChasseTest.php
@@ -406,7 +406,7 @@ class GenererCtaChasseTest extends TestCase
         $this->assertSame(
             [
                 'cta_html'    => '<form method="post" action="/traitement-engagement" class="cta-chasse-form"><input type="hidden" name="chasse_id" value="123"><button type="submit" class="bouton-cta bouton-cta--color">Redécouvrir</button></form>',
-                'cta_message' => 'Cette chasse est terminée',
+                'cta_message' => '',
                 'type'        => 'engager',
                 'is_demo'     => false,
             ],

--- a/wp-content/themes/chassesautresor/inc/chasse-functions.php
+++ b/wp-content/themes/chassesautresor/inc/chasse-functions.php
@@ -892,12 +892,7 @@ function generer_cta_chasse(int $chasse_id, ?int $user_id = null): array
         );
         $html .= '</form>';
         $type = 'engager';
-        $message = $date_fin
-            ? sprintf(
-                __('Cette chasse est terminée depuis le %s', 'chassesautresor-com'),
-                date_i18n('d/m/Y', strtotime($date_fin))
-            )
-            : __('Cette chasse est terminée', 'chassesautresor-com');
+        $message = '';
     }
 
         return $response([


### PR DESCRIPTION
Suppression du message redondant affiché pour les chasses terminées.

- Retire l'affichage du message textuel accompagnant le CTA des chasses clôturées.
- Met à jour le test unitaire du générateur de CTA pour refléter l'absence de message.

## Testing
- source ./setup-env.sh
- composer install
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dcd7e216f08332be2215d3ad7e97e7