### PR TITLE
Corrige l'affichage des dates dans la fiche chasse

### DIFF
--- a/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
+++ b/wp-content/themes/chassesautresor/assets/scss/_chasse.scss
@@ -403,7 +403,7 @@ a.chasse-badge.chasse-badge--region:focus-visible {
     font-variant-numeric: tabular-nums;
 }
 
-.chasse-fiche-container > .meta-row .chasse-date-plage {
+.chasse-date-plage {
     display: inline-flex;
     align-items: center;
     gap: var(--space-xxs);
@@ -426,7 +426,7 @@ a.chasse-badge.chasse-badge--region:focus-visible {
 }
 
 @media (--bp-desktop) {
-    .chasse-fiche-container > .meta-row .chasse-date-plage {
+    .chasse-date-plage {
         .date-short {
             display: none;
         }

--- a/wp-content/themes/chassesautresor/dist/style.css
+++ b/wp-content/themes/chassesautresor/dist/style.css
@@ -1385,30 +1385,30 @@ a.chasse-badge.chasse-badge--region:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
-.chasse-fiche-container > .meta-row .chasse-date-plage {
+.chasse-date-plage {
   display: inline-flex;
   align-items: center;
   gap: var(--space-xxs);
   white-space: nowrap;
 }
-.chasse-fiche-container > .meta-row .chasse-date-plage .date-debut,
-.chasse-fiche-container > .meta-row .chasse-date-plage .date-fin {
+.chasse-date-plage .date-debut,
+.chasse-date-plage .date-fin {
   display: inline-flex;
   gap: var(--space-3xs);
 }
-.chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
+.chasse-date-plage .date-long {
   display: none;
 }
-.chasse-fiche-container > .meta-row .chasse-date-plage .date-short[hidden],
-.chasse-fiche-container > .meta-row .chasse-date-plage .date-long[hidden] {
+.chasse-date-plage .date-short[hidden],
+.chasse-date-plage .date-long[hidden] {
   display: none !important;
 }
 
 @media (min-width: 1024px) {
-  .chasse-fiche-container > .meta-row .chasse-date-plage .date-short {
+  .chasse-date-plage .date-short {
     display: none;
   }
-  .chasse-fiche-container > .meta-row .chasse-date-plage .date-long {
+  .chasse-date-plage .date-long {
     display: inline;
   }
 }

--- a/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
+++ b/wp-content/themes/chassesautresor/template-parts/chasse/chasse-affichage-complet.php
@@ -442,7 +442,7 @@ if ($edition_active && !$est_complet) {
                 data-date-short="<?= esc_attr($date_debut_courte); ?>"
             >
               <span class="date-short" aria-hidden="false"><?= esc_html($date_debut_courte); ?></span>
-              <span class="date-long" aria-hidden="true"><?= esc_html($date_debut_longue); ?></span>
+              <span class="date-long" aria-hidden="true" hidden><?= esc_html($date_debut_longue); ?></span>
             </span>
             <span class="date-separator" aria-hidden="true">–</span>
             <span
@@ -451,7 +451,7 @@ if ($edition_active && !$est_complet) {
                 data-date-short="<?= esc_attr($date_fin_courte); ?>"
             >
               <span class="date-short" aria-hidden="false"><?= esc_html($date_fin_courte); ?></span>
-              <span class="date-long" aria-hidden="true"><?= esc_html($date_fin_longue); ?></span>
+              <span class="date-long" aria-hidden="true" hidden><?= esc_html($date_fin_longue); ?></span>
             </span>
           </span>
         </div>


### PR DESCRIPTION
Résumé : correction de l'affichage des métadonnées de date sur la fiche chasse.

- Harmonise la règle CSS de `.chasse-date-plage` pour éviter l'affichage simultané des formats long et court.
- Met à jour la feuille de style compilée correspondante.

## Tests
- ✅ `npm run build:css`
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dce202b8408332ae85a65be26d0356