### PR TITLE
Met à jour le mot de passe par défaut du site

### DIFF
--- a/wp-content/themes/chassesautresor/inc/site-password.php
+++ b/wp-content/themes/chassesautresor/inc/site-password.php
@@ -40,7 +40,7 @@ function ca_site_password_protection(): void
     }
 
     $field         = 'ca_site_password';
-    $password      = getenv('CA_SITE_PASSWORD') ?: (string) get_option('ca_site_password', 'rosebud');
+    $password      = getenv('CA_SITE_PASSWORD') ?: (string) get_option('ca_site_password', 'citizen');
     $attempt_field = 'ca_site_password_attempts';
     $max_attempts  = 10;
     $attempts      = isset($_COOKIE[$attempt_field]) ? (int) $_COOKIE[$attempt_field] : 0;


### PR DESCRIPTION
Résumé: Mise à jour du mot de passe par défaut pour la protection du site.

- Remplace la valeur de secours « rosebud » par « citizen » pour l'accès protégé.
- Maintient la prise en charge de la variable d'environnement `CA_SITE_PASSWORD` pour la configuration.

**Testing**
- `source ./setup-env.sh`
- `composer install`
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68dcf4e07f0c83329f2059d49f3460d6